### PR TITLE
chore(deps): replace bincode with postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,15 +120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,12 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,15 +976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,20 +1011,6 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1679,7 +1641,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
  "serde",
 ]
 
@@ -2350,21 +2311,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,15 +248,6 @@ dependencies = [
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-server",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -531,6 +531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +710,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,10 +769,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
  "clap",
  "futures",
  "openraft",
+ "postcard",
  "prost",
  "serde",
  "serde_json",
@@ -964,6 +991,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1035,20 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1476,9 +1526,9 @@ name = "openraft-toolkit"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bincode",
  "futures",
  "openraft",
+ "postcard",
  "proptest",
  "rocksdb",
  "serde",
@@ -1619,6 +1669,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2287,6 +2350,21 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ authors      = ["Sebastian Thiebaud <sebastian@prismarisk.com>"]
 [workspace.dependencies]
 anyhow             = "1"
 async-trait        = "0.1"
-bincode            = "1"
+postcard           = { version = "1", features = ["use-std"] }
 bytes              = "1"
 clap               = { version = "4", features = ["derive"] }
 crc32c             = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ authors      = ["Sebastian Thiebaud <sebastian@prismarisk.com>"]
 [workspace.dependencies]
 anyhow             = "1"
 async-trait        = "0.1"
-postcard           = { version = "1", features = ["use-std"] }
+postcard           = { version = "1", default-features = false, features = ["use-std"] }
 bytes              = "1"
 clap               = { version = "4", features = ["derive"] }
 crc32c             = "0.6"

--- a/crates/openraft-toolkit/Cargo.toml
+++ b/crates/openraft-toolkit/Cargo.toml
@@ -16,7 +16,7 @@ test-fakes         = []
 
 [dependencies]
 async-trait      = { workspace = true }
-bincode          = { workspace = true }
+postcard         = { workspace = true }
 futures          = { workspace = true }
 openraft         = { workspace = true }
 rocksdb          = { workspace = true, optional = true, features = ["multi-threaded-cf"] }

--- a/crates/openraft-toolkit/src/codec.rs
+++ b/crates/openraft-toolkit/src/codec.rs
@@ -1,6 +1,6 @@
 //! Binary wire codec for openraft RPC payloads and storage records.
 //!
-//! Every payload is encoded as `[version_byte | bincode(value)]`. The leading
+//! Every payload is encoded as `[version_byte | postcard(value)]`. The leading
 //! byte lets us evolve the wire format without an explicit migration when both
 //! sides of an upgrade run mixed versions briefly.
 
@@ -14,12 +14,12 @@ pub enum CodecError {
     #[error("version mismatch: expected {expected}, got {actual}")]
     Version { expected: u8, actual: u8 },
     #[error("decode failed: {0}")]
-    Decode(#[from] bincode::Error),
+    Decode(#[from] postcard::Error),
 }
 
-/// Encode `value` as `[version | bincode(value)]`.
+/// Encode `value` as `[version | postcard(value)]`.
 pub fn encode<T: Serialize>(version: u8, value: &T) -> Result<Vec<u8>, CodecError> {
-    let body = bincode::serialize(value)?;
+    let body = postcard::to_stdvec(value)?;
     let mut out = Vec::with_capacity(1 + body.len());
     out.push(version);
     out.extend_from_slice(&body);
@@ -38,7 +38,7 @@ pub fn decode<T: for<'de> Deserialize<'de>>(
             actual: *first,
         });
     }
-    Ok(bincode::deserialize(rest)?)
+    Ok(postcard::from_bytes(rest)?)
 }
 
 #[cfg(test)]

--- a/crates/openraft-toolkit/src/log_store/meta.rs
+++ b/crates/openraft-toolkit/src/log_store/meta.rs
@@ -3,7 +3,7 @@
 //! The meta CF holds four small openraft values: current vote, last-committed
 //! log id, last-purged log id, last-applied membership. Each is keyed by a
 //! [`MetaLabel`](super::MetaLabel) via the active [`KeySpace`](super::KeySpace).
-//! These helpers serialize values with `bincode` and translate rocksdb errors
+//! These helpers serialize values with `postcard` and translate rocksdb errors
 //! into [`RocksdbLogStoreError`](super::RocksdbLogStoreError).
 
 use rocksdb::{BoundColumnFamily, DB, WriteBatch};
@@ -21,7 +21,7 @@ pub(super) fn read<T: DeserializeOwned, K: KeySpace>(
 ) -> Result<Option<T>, RocksdbLogStoreError> {
     let key = keys.meta_key(label);
     match db.get_pinned_cf(cf, &key)? {
-        Some(bytes) => Ok(Some(bincode::deserialize(&bytes)?)),
+        Some(bytes) => Ok(Some(postcard::from_bytes(&bytes)?)),
         None => Ok(None),
     }
 }
@@ -34,7 +34,7 @@ pub(super) fn put<T: Serialize, K: KeySpace>(
     value: &T,
 ) -> Result<(), RocksdbLogStoreError> {
     let key = keys.meta_key(label);
-    let bytes = bincode::serialize(value)?;
+    let bytes = postcard::to_stdvec(value)?;
     batch.put_cf(cf, &key, &bytes);
     Ok(())
 }

--- a/crates/openraft-toolkit/src/log_store/mod.rs
+++ b/crates/openraft-toolkit/src/log_store/mod.rs
@@ -13,7 +13,7 @@ pub enum RocksdbLogStoreError {
     #[error("rocksdb error: {0}")]
     RocksDb(#[from] rocksdb::Error),
     #[error("decode error: {0}")]
-    Decode(#[from] bincode::Error),
+    Decode(#[from] postcard::Error),
     #[error("column family `{0}` not found")]
     MissingColumnFamily(String),
 }
@@ -159,12 +159,12 @@ fn range_boundary<RB: RangeBounds<u64>>(range: RB) -> (u64, u64) {
     (start, end)
 }
 
-fn bincode_encode<T: Serialize>(value: &T) -> io::Result<Vec<u8>> {
-    bincode::serialize(value).map_err(io::Error::other)
+fn postcard_encode<T: Serialize>(value: &T) -> io::Result<Vec<u8>> {
+    postcard::to_stdvec(value).map_err(io::Error::other)
 }
 
-fn bincode_decode<T: DeserializeOwned>(bytes: &[u8]) -> io::Result<T> {
-    bincode::deserialize(bytes).map_err(io::Error::other)
+fn postcard_decode<T: DeserializeOwned>(bytes: &[u8]) -> io::Result<T> {
+    postcard::from_bytes(bytes).map_err(io::Error::other)
 }
 
 impl<C, K> RocksdbLogStore<C, K>
@@ -196,7 +196,7 @@ where
         if &*k < lo.as_slice() {
             return Ok(None);
         }
-        let entry: C::Entry = bincode_decode(&v)?;
+        let entry: C::Entry = postcard_decode(&v)?;
         Ok(Some(entry.log_id()))
     }
 }
@@ -233,7 +233,7 @@ where
             if &*k >= end_key.as_slice() {
                 break;
             }
-            let entry: C::Entry = bincode_decode(&v)?;
+            let entry: C::Entry = postcard_decode(&v)?;
             out.push(entry);
         }
         Ok(out)
@@ -320,7 +320,7 @@ where
         for entry in entries {
             let (_leader, idx) = entry.log_id_parts();
             let key = self.keys.log_key(idx);
-            let value = bincode_encode(&entry)?;
+            let value = postcard_encode(&entry)?;
             batch.put_cf(&cf_log, &key, &value);
         }
 

--- a/crates/openraft-toolkit/tests/log_store_basic.rs
+++ b/crates/openraft-toolkit/tests/log_store_basic.rs
@@ -120,7 +120,7 @@ async fn save_committed_with_none_clears_existing_record() {
 
 // Corrupt the bytes stored at the Vote key, then verify `read_vote` surfaces
 // the decode error rather than silently returning `None` or panicking. Drives
-// the `bincode::deserialize` error arm in `meta::read` which is unreachable
+// the `postcard::from_bytes` error arm in `meta::read` which is unreachable
 // from any legitimate API call sequence.
 #[tokio::test]
 async fn read_vote_surfaces_decode_error_on_corrupted_meta() {
@@ -131,7 +131,7 @@ async fn read_vote_surfaces_decode_error_on_corrupted_meta() {
     // shared `Arc<DB>` — the public store API has no "write raw bytes" door.
     let key = Flat.meta_key(MetaLabel::Vote);
     let cf = db.cf_handle(META_CF).unwrap();
-    db.put_cf(&cf, &key, b"not a valid bincode-encoded vote")
+    db.put_cf(&cf, &key, b"not a valid postcard-encoded vote")
         .unwrap();
 
     let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
@@ -141,7 +141,7 @@ async fn read_vote_surfaces_decode_error_on_corrupted_meta() {
         .read_vote()
         .await
         .expect_err("read_vote should propagate the decode failure");
-    // The exact message comes from bincode; we just want to confirm an error
+    // The exact message comes from postcard; we just want to confirm an error
     // path actually fires rather than asserting a brittle substring.
     let _ = err.to_string();
 }

--- a/crates/openraft-toolkit/tests/log_store_conformance.rs
+++ b/crates/openraft-toolkit/tests/log_store_conformance.rs
@@ -126,7 +126,7 @@ impl RaftStateMachine<TestTypeConfig> for StubStateMachine {
         snapshot: Cursor<Vec<u8>>,
     ) -> Result<(), io::Error> {
         let bytes = snapshot.into_inner();
-        let payload: SnapshotPayload = bincode::deserialize(&bytes).map_err(io::Error::other)?;
+        let payload: SnapshotPayload = postcard::from_bytes(&bytes).map_err(io::Error::other)?;
         let mut s = self.state.lock().unwrap();
         s.last_applied = payload.last_applied;
         s.last_membership = payload.last_membership;
@@ -158,7 +158,7 @@ impl RaftSnapshotBuilder<TestTypeConfig> for StubStateMachine {
             last_applied: s.last_applied,
             last_membership: s.last_membership.clone(),
         };
-        let bytes = bincode::serialize(&payload).map_err(io::Error::other)?;
+        let bytes = postcard::to_stdvec(&payload).map_err(io::Error::other)?;
         let meta = TestSnapshotMeta {
             last_log_id: s.last_applied,
             last_membership: s.last_membership.clone(),

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,4 @@ skip = [
 ]
 
 [advisories]
-# bincode 1.x is feature-complete per its maintainers (RUSTSEC-2025-0141);
-# the openraft-cluster example keeps using it to stay close to upstream openraft examples.
-ignore = ["RUSTSEC-2025-0141"]
+ignore = []

--- a/examples/openraft-cluster/Cargo.toml
+++ b/examples/openraft-cluster/Cargo.toml
@@ -34,7 +34,7 @@ tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde              = { workspace = true }
 serde_json         = { workspace = true }
-bincode            = { workspace = true }
+postcard           = { workspace = true }
 anyhow             = { workspace = true }
 
 [build-dependencies]

--- a/examples/openraft-cluster/src/network.rs
+++ b/examples/openraft-cluster/src/network.rs
@@ -5,9 +5,9 @@
 //!
 //! Wire format:
 //!   - `AppendEntries` / `Vote`: a `RaftMessage { bytes payload }` where
-//!     `payload` is a bincode-encoded openraft request or response.
+//!     `payload` is a postcard-encoded openraft request or response.
 //!   - `Snapshot`: a *client-streaming* RPC of `SnapshotChunk` messages.
-//!     One `header` chunk (bincode-encoded vote + meta), then `SNAPSHOT_CHUNK_SIZE`
+//!     One `header` chunk (postcard-encoded vote + meta), then `SNAPSHOT_CHUNK_SIZE`
 //!     byte `data` chunks until end-of-stream. The receiver reassembles the
 //!     data buffer and calls `Raft::install_full_snapshot`.
 //!
@@ -120,14 +120,14 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
     ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig>> {
         let mut c = self.client().await?;
         let payload =
-            bincode::serialize(&rpc).map_err(|e| RPCError::Network(NetworkError::new(&*e)))?;
+            postcard::to_stdvec(&rpc).map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         let resp = c
             .append_entries(RaftMessage { payload })
             .await
             .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         let body: AppendEntriesResponse<TypeConfig> =
-            bincode::deserialize(&resp.into_inner().payload)
-                .map_err(|e| RPCError::Network(NetworkError::new(&*e)))?;
+            postcard::from_bytes(&resp.into_inner().payload)
+                .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         Ok(body)
     }
 
@@ -138,19 +138,19 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
     ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig>> {
         let mut c = self.client().await?;
         let payload =
-            bincode::serialize(&rpc).map_err(|e| RPCError::Network(NetworkError::new(&*e)))?;
+            postcard::to_stdvec(&rpc).map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         let resp = c
             .vote(RaftMessage { payload })
             .await
             .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
-        let body: VoteResponse<TypeConfig> = bincode::deserialize(&resp.into_inner().payload)
-            .map_err(|e| RPCError::Network(NetworkError::new(&*e)))?;
+        let body: VoteResponse<TypeConfig> = postcard::from_bytes(&resp.into_inner().payload)
+            .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         Ok(body)
     }
 
     /// Send a snapshot to the target as a stream of `SnapshotChunk`s.
     ///
-    /// Stream layout: one `header` chunk (bincode vote + bincode meta),
+    /// Stream layout: one `header` chunk (postcard vote + postcard meta),
     /// followed by `ceil(data.len() / SNAPSHOT_CHUNK_SIZE)` `data` chunks.
     /// An empty data buffer is permitted and results in zero `data` chunks.
     ///
@@ -165,10 +165,10 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
         _option: RPCOption,
     ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {
         // Pre-encode the header fields. Both are small (Vote + SnapshotMeta).
-        let vote_bytes = bincode::serialize(&vote)
-            .map_err(|e| StreamingError::Network(NetworkError::new(&*e)))?;
-        let meta_bytes = bincode::serialize(&snapshot.meta)
-            .map_err(|e| StreamingError::Network(NetworkError::new(&*e)))?;
+        let vote_bytes = postcard::to_stdvec(&vote)
+            .map_err(|e| StreamingError::Network(NetworkError::new(&e)))?;
+        let meta_bytes = postcard::to_stdvec(&snapshot.meta)
+            .map_err(|e| StreamingError::Network(NetworkError::new(&e)))?;
         let data_bytes = snapshot.snapshot.into_inner();
 
         // Build the chunk stream lazily. We materialize chunks into owned
@@ -209,8 +209,8 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
                     .map_err(|e| StreamingError::Network(NetworkError::new(&e)))?
                     .into_inner();
                 let resp: SnapshotResponse<TypeConfig> =
-                    bincode::deserialize(&inner.payload)
-                        .map_err(|e| StreamingError::Network(NetworkError::new(&*e)))?;
+                    postcard::from_bytes(&inner.payload)
+                        .map_err(|e| StreamingError::Network(NetworkError::new(&e)))?;
                 Ok(resp)
             }
             closed = cancel => {
@@ -235,7 +235,7 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
         request: tonic::Request<RaftMessage>,
     ) -> Result<tonic::Response<RaftMessage>, tonic::Status> {
         let body: AppendEntriesRequest<TypeConfig> =
-            bincode::deserialize(&request.into_inner().payload)
+            postcard::from_bytes(&request.into_inner().payload)
                 .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         let resp = self
             .raft
@@ -243,7 +243,7 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
         let payload =
-            bincode::serialize(&resp).map_err(|e| tonic::Status::internal(e.to_string()))?;
+            postcard::to_stdvec(&resp).map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(tonic::Response::new(RaftMessage { payload }))
     }
 
@@ -251,7 +251,7 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
         &self,
         request: tonic::Request<RaftMessage>,
     ) -> Result<tonic::Response<RaftMessage>, tonic::Status> {
-        let body: VoteRequest<TypeConfig> = bincode::deserialize(&request.into_inner().payload)
+        let body: VoteRequest<TypeConfig> = postcard::from_bytes(&request.into_inner().payload)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         let resp = self
             .raft
@@ -259,7 +259,7 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
         let payload =
-            bincode::serialize(&resp).map_err(|e| tonic::Status::internal(e.to_string()))?;
+            postcard::to_stdvec(&resp).map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(tonic::Response::new(RaftMessage { payload }))
     }
 
@@ -295,10 +295,10 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
             }
         };
 
-        let vote: VoteOf<TypeConfig> = bincode::deserialize(&header.vote)
+        let vote: VoteOf<TypeConfig> = postcard::from_bytes(&header.vote)
             .map_err(|e| tonic::Status::invalid_argument(format!("bad vote: {e}")))?;
         let meta: openraft::type_config::alias::SnapshotMetaOf<TypeConfig> =
-            bincode::deserialize(&header.meta)
+            postcard::from_bytes(&header.meta)
                 .map_err(|e| tonic::Status::invalid_argument(format!("bad meta: {e}")))?;
 
         // Reassemble subsequent data chunks. We don't know the total size up
@@ -336,7 +336,7 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
         let payload =
-            bincode::serialize(&resp).map_err(|e| tonic::Status::internal(e.to_string()))?;
+            postcard::to_stdvec(&resp).map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(tonic::Response::new(RaftMessage { payload }))
     }
 }

--- a/examples/openraft-cluster/src/store/io.rs
+++ b/examples/openraft-cluster/src/store/io.rs
@@ -30,7 +30,7 @@ pub(super) fn atomic_write_raw(path: &Path, bytes: &[u8]) -> io::Result<()> {
 
 pub(super) fn load_vote(dir: &Path) -> io::Result<Option<Vote>> {
     match fs::read(dir.join("vote")) {
-        Ok(b) => bincode::deserialize::<Vote>(&b)
+        Ok(b) => postcard::from_bytes::<Vote>(&b)
             .map(Some)
             .map_err(|e| io::Error::other(e.to_string())),
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
@@ -39,7 +39,7 @@ pub(super) fn load_vote(dir: &Path) -> io::Result<Option<Vote>> {
 }
 
 pub(super) fn save_vote(dir: &Path, vote: &Vote) -> io::Result<()> {
-    let bytes = bincode::serialize(vote).map_err(|e| io::Error::other(e.to_string()))?;
+    let bytes = postcard::to_stdvec(vote).map_err(|e| io::Error::other(e.to_string()))?;
     atomic_write_raw(&dir.join("vote"), &bytes)
 }
 
@@ -51,7 +51,7 @@ pub(super) fn load_log_entries(dir: &Path) -> io::Result<BTreeMap<u64, Entry>> {
         if let Ok(idx) = name.parse::<u64>() {
             let bytes = fs::read(item.path())?;
             let entry: Entry =
-                bincode::deserialize(&bytes).map_err(|e| io::Error::other(e.to_string()))?;
+                postcard::from_bytes(&bytes).map_err(|e| io::Error::other(e.to_string()))?;
             out.insert(idx, entry);
         }
     }
@@ -59,7 +59,7 @@ pub(super) fn load_log_entries(dir: &Path) -> io::Result<BTreeMap<u64, Entry>> {
 }
 
 pub(super) fn save_log_entry(dir: &Path, idx: u64, entry: &Entry) -> io::Result<()> {
-    let bytes = bincode::serialize(entry).map_err(|e| io::Error::other(e.to_string()))?;
+    let bytes = postcard::to_stdvec(entry).map_err(|e| io::Error::other(e.to_string()))?;
     atomic_write_raw(&dir.join("log").join(idx.to_string()), &bytes)
 }
 

--- a/examples/openraft-cluster/src/store/mod.rs
+++ b/examples/openraft-cluster/src/store/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Layout under `dir`:
 //!   dir/
-//!     vote              # bincode-encoded openraft Vote (latest)
+//!     vote              # postcard-encoded openraft Vote (latest)
 //!     log/              # one file per log index, named `<index>`
 //!     state.json        # last_applied LogId + high_water (atomic rewrite)
 //!     snapshot.bin      # most recent snapshot, if any
@@ -19,7 +19,7 @@
 //!   snapshot.rs   — StoredSnapshot, snapshot::install/current free fns,
 //!                   RaftSnapshotBuilder impl
 //!   io.rs         — atomic_write_raw and on-disk format helpers
-//!                   (bincode vote, bincode log entries, JSON state,
+//!                   (postcard vote, postcard log entries, JSON state,
 //!                   raw bytes snapshot + JSON sidecar meta)
 
 mod io;


### PR DESCRIPTION
## Summary

- Replace `bincode` 1 with `postcard` 1 as the serialization codec for the openraft log store, wire payloads, and the example's file-backed storage.
- bincode's GitHub repo was archived on 2025-08-15 (development moved to sourcehut) and its README now explicitly recommends alternatives; postcard is actively maintained, serde-compatible, and ships a written wire-format specification — something bincode never had.
- Wire/disk format breaks (acceptable: openraft-toolkit shipped in #12 and has not yet been released — the cheapest possible time to migrate).

## Why postcard

The hard constraint: openraft owns the types we encode (`VoteOf<C>`, `LogIdOf<C>`, `SnapshotMetaOf<C>`, `C::Entry`) and they derive only `serde::Serialize`/`Deserialize`. Any candidate must work through serde — we cannot add new derive macros to types defined upstream.

That rules out **rkyv** (requires `#[derive(Archive)]` on each encoded type).

The remaining serde-based candidates:
- **bincode 3** — alive on sourcehut, but splits errors into `EncodeError` + `DecodeError`, forcing two new variants in every thiserror enum that previously had `#[from] bincode::Error` (`CodecError`, `RocksdbLogStoreError`). docs.rs also failed to build v3.0.0, so rendered docs are unavailable.
- **postcard** — pure serde, single unified `postcard::Error` that preserves the `#[from]` variant shape, actively maintained, written wire spec, varint encoding with a size profile similar to bincode 1.
- **wincode** — bincode's README recommends it as "bincode-compatible", but its current state and adoption signal couldn't be verified; adopting an unverified new fork as the persistence codec for the Raft log is the wrong shape of risk for too small a win.

Postcard wins on three axes: minimum churn (API closer to bincode 1 than bincode 3 is), active maintenance, and the wire-spec property — useful insurance for any future migration or cross-language interop.

## Mechanical translation

```text
bincode::serialize(&v)            →  postcard::to_stdvec(&v)
bincode::deserialize::<T>(&b)     →  postcard::from_bytes::<T>(&b)
#[from] bincode::Error            →  #[from] postcard::Error
&*e  (Box<bincode::ErrorKind>)    →  &e   (postcard::Error)
```

The &*e collapse is the only idiomatic shift beyond renames — bincode 1's error type was Box<ErrorKind>, postcard's is a plain enum that implements Error directly.

## Format break

Postcard's wire format is not bincode-compatible. Any data previously written with bincode (RocksDB log entries, file-backed votes/snapshots in the example) will fail to decode after this change. The openraft-toolkit crate shipped in #12 and has not yet been released.

## Verification

- cargo check --workspace --all-features passes clean.
- cargo test -p openraft-toolkit --all-features — 44 / 44 tests pass, including openraft 0.10's bundled Suite::test_all against RocksdbLogStore on both Flat and GroupPrefixed keyspaces (tests/log_store_conformance.rs), and read_vote_surfaces_decode_error_on_corrupted_meta which confirms postcard::Error threads correctly through RocksdbLogS