### PR TITLE
feat: openraft-backed ConsensusDriver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,6 +2761,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tsoracle-driver-openraft"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "openraft",
+ "openraft-toolkit",
+ "parking_lot",
+ "postcard",
+ "proptest",
+ "rocksdb",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tsoracle-consensus",
+ "tsoracle-core",
+]
+
+[[package]]
 name = "tsoracle-proto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "async-trait",
  "futures",
  "openraft",
+ "parking_lot",
  "postcard",
  "proptest",
  "rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members  = [
     "crates/tsoracle-server",
     "crates/tsoracle-client",
     "crates/tsoracle-driver-file",
+    "crates/tsoracle-driver-openraft",
     "crates/tsoracle-bin",
     "crates/openraft-toolkit",
     "examples/embedded-server",
@@ -25,6 +26,7 @@ default-members = [
     "crates/tsoracle-server",
     "crates/tsoracle-client",
     "crates/tsoracle-driver-file",
+    "crates/tsoracle-driver-openraft",
     "crates/tsoracle-bin",
     "crates/openraft-toolkit",
 ]

--- a/crates/openraft-toolkit/Cargo.toml
+++ b/crates/openraft-toolkit/Cargo.toml
@@ -28,6 +28,9 @@ tracing          = { workspace = true }
 
 [dev-dependencies]
 openraft         = { workspace = true, features = ["serde", "type-alias"] }
+parking_lot      = { workspace = true }
+postcard         = { workspace = true }
 proptest         = { workspace = true }
+rocksdb          = { workspace = true }
 tempfile         = { workspace = true }
 tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/openraft-toolkit/src/test_fakes/mem_network.rs
+++ b/crates/openraft-toolkit/src/test_fakes/mem_network.rs
@@ -10,7 +10,9 @@ use std::future::Future;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
-use openraft::error::{Fatal, NetworkError, RPCError, RaftError, ReplicationClosed, StreamingError};
+use openraft::error::{
+    Fatal, NetworkError, RPCError, RaftError, ReplicationClosed, StreamingError,
+};
 use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
 use openraft::raft::{
     AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
@@ -171,7 +173,9 @@ where
             )))
         })?;
         target.append_entries(rpc).await.map_err(|e| {
-            RPCError::Network(NetworkError::from_string(format!("mem-network remote: {e}")))
+            RPCError::Network(NetworkError::from_string(format!(
+                "mem-network remote: {e}"
+            )))
         })
     }
 
@@ -193,7 +197,9 @@ where
             )))
         })?;
         target.vote(rpc).await.map_err(|e| {
-            RPCError::Network(NetworkError::from_string(format!("mem-network remote: {e}")))
+            RPCError::Network(NetworkError::from_string(format!(
+                "mem-network remote: {e}"
+            )))
         })
     }
 

--- a/crates/openraft-toolkit/src/test_fakes/mem_network.rs
+++ b/crates/openraft-toolkit/src/test_fakes/mem_network.rs
@@ -1,0 +1,228 @@
+//! In-memory `RaftNetworkFactory` for multi-node test harnesses.
+//!
+//! Routes append-entries / vote / install-full-snapshot RPCs through direct
+//! method calls on the receiver's `Raft<C, SM>` handle, gated by a shared
+//! [`PartitionController`]. No sockets, no channels per RPC — just a
+//! lock-protected registry of receiver-side dispatch closures.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use openraft::error::{Fatal, NetworkError, RPCError, RaftError, ReplicationClosed, StreamingError};
+use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
+};
+use openraft::storage::RaftStateMachine;
+use openraft::type_config::alias::{SnapshotOf, VoteOf};
+use openraft::{OptionalSend, Raft, RaftTypeConfig};
+
+use crate::test_fakes::partition::PartitionController;
+
+/// Receiver-side dispatch trait. Wraps a concrete `Raft<C, SM>` so the
+/// network registry doesn't need to be parameterized over `SM`.
+#[async_trait]
+trait RaftAdapter<C: RaftTypeConfig>: Send + Sync + 'static {
+    async fn append_entries(
+        &self,
+        req: AppendEntriesRequest<C>,
+    ) -> Result<AppendEntriesResponse<C>, RaftError<C>>;
+
+    async fn vote(&self, req: VoteRequest<C>) -> Result<VoteResponse<C>, RaftError<C>>;
+
+    async fn install_full_snapshot(
+        &self,
+        vote: VoteOf<C>,
+        snapshot: SnapshotOf<C>,
+    ) -> Result<SnapshotResponse<C>, Fatal<C>>;
+}
+
+struct RaftHandle<C: RaftTypeConfig, SM: RaftStateMachine<C>> {
+    raft: Raft<C, SM>,
+}
+
+#[async_trait]
+impl<C, SM> RaftAdapter<C> for RaftHandle<C, SM>
+where
+    C: RaftTypeConfig,
+    SM: RaftStateMachine<C> + 'static,
+{
+    async fn append_entries(
+        &self,
+        req: AppendEntriesRequest<C>,
+    ) -> Result<AppendEntriesResponse<C>, RaftError<C>> {
+        self.raft.append_entries(req).await
+    }
+
+    async fn vote(&self, req: VoteRequest<C>) -> Result<VoteResponse<C>, RaftError<C>> {
+        self.raft.vote(req).await
+    }
+
+    async fn install_full_snapshot(
+        &self,
+        vote: VoteOf<C>,
+        snapshot: SnapshotOf<C>,
+    ) -> Result<SnapshotResponse<C>, Fatal<C>> {
+        self.raft.install_full_snapshot(vote, snapshot).await
+    }
+}
+
+/// In-memory network registry. One per cluster.
+pub struct MemNetwork<C: RaftTypeConfig> {
+    nodes: RwLock<HashMap<C::NodeId, Arc<dyn RaftAdapter<C>>>>,
+    partitions: Arc<PartitionController<C::NodeId>>,
+}
+
+impl<C: RaftTypeConfig> MemNetwork<C>
+where
+    C::NodeId: Copy,
+{
+    /// Build a fresh, empty in-memory network with no peers registered and no
+    /// partitions installed.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            nodes: RwLock::new(HashMap::new()),
+            partitions: Arc::new(PartitionController::new()),
+        })
+    }
+
+    /// Mint a `RaftNetworkFactory` whose `new_client` calls will route to peers
+    /// registered on this network, tagging outgoing RPCs as originating from
+    /// `self_id`.
+    pub fn factory_for(self: &Arc<Self>, self_id: C::NodeId) -> MemNetworkFactory<C> {
+        MemNetworkFactory {
+            net: Arc::clone(self),
+            self_id,
+        }
+    }
+
+    /// Register a node's `Raft` handle under `id`. Subsequent RPCs from any
+    /// factory to `id` dispatch into this handle.
+    pub fn register<SM>(&self, id: C::NodeId, raft: Raft<C, SM>)
+    where
+        SM: RaftStateMachine<C> + 'static,
+    {
+        let handle: Arc<dyn RaftAdapter<C>> = Arc::new(RaftHandle { raft });
+        self.nodes.write().unwrap().insert(id, handle);
+    }
+
+    /// Borrow the partition controller. Cloning the `Arc` is the intended way
+    /// for tests to drive partition state during a run.
+    pub fn partitions(&self) -> Arc<PartitionController<C::NodeId>> {
+        Arc::clone(&self.partitions)
+    }
+
+    fn dispatch(&self, target: &C::NodeId) -> Option<Arc<dyn RaftAdapter<C>>> {
+        self.nodes.read().unwrap().get(target).cloned()
+    }
+}
+
+/// Factory handed to `Raft::new`. One per node; carries the node's own id so
+/// partition checks know which side of the wire the RPC is leaving from.
+pub struct MemNetworkFactory<C: RaftTypeConfig> {
+    net: Arc<MemNetwork<C>>,
+    self_id: C::NodeId,
+}
+
+impl<C: RaftTypeConfig> RaftNetworkFactory<C> for MemNetworkFactory<C>
+where
+    C::NodeId: Copy,
+{
+    type Network = MemNetworkPeer<C>;
+
+    async fn new_client(&mut self, target: C::NodeId, _node: &C::Node) -> Self::Network {
+        MemNetworkPeer {
+            net: Arc::clone(&self.net),
+            from: self.self_id,
+            to: target,
+        }
+    }
+}
+
+/// Per-target client. Looks the target up in the shared registry on every RPC
+/// so a node can be reopened mid-test and have its replacement picked up.
+pub struct MemNetworkPeer<C: RaftTypeConfig> {
+    net: Arc<MemNetwork<C>>,
+    from: C::NodeId,
+    to: C::NodeId,
+}
+
+impl<C: RaftTypeConfig> RaftNetworkV2<C> for MemNetworkPeer<C>
+where
+    C::NodeId: Copy,
+{
+    async fn append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<C>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C>> {
+        if !self.net.partitions.is_reachable(self.from, self.to) {
+            return Err(RPCError::Network(NetworkError::from_string(format!(
+                "mem-network: partitioned {:?} -> {:?}",
+                self.from, self.to
+            ))));
+        }
+        let target = self.net.dispatch(&self.to).ok_or_else(|| {
+            RPCError::Network(NetworkError::from_string(format!(
+                "mem-network: unknown peer {:?}",
+                self.to
+            )))
+        })?;
+        target.append_entries(rpc).await.map_err(|e| {
+            RPCError::Network(NetworkError::from_string(format!("mem-network remote: {e}")))
+        })
+    }
+
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<C>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<C>, RPCError<C>> {
+        if !self.net.partitions.is_reachable(self.from, self.to) {
+            return Err(RPCError::Network(NetworkError::from_string(format!(
+                "mem-network: partitioned {:?} -> {:?}",
+                self.from, self.to
+            ))));
+        }
+        let target = self.net.dispatch(&self.to).ok_or_else(|| {
+            RPCError::Network(NetworkError::from_string(format!(
+                "mem-network: unknown peer {:?}",
+                self.to
+            )))
+        })?;
+        target.vote(rpc).await.map_err(|e| {
+            RPCError::Network(NetworkError::from_string(format!("mem-network remote: {e}")))
+        })
+    }
+
+    async fn full_snapshot(
+        &mut self,
+        vote: VoteOf<C>,
+        snapshot: SnapshotOf<C>,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
+        if !self.net.partitions.is_reachable(self.from, self.to) {
+            return Err(StreamingError::Network(NetworkError::from_string(format!(
+                "mem-network: partitioned {:?} -> {:?}",
+                self.from, self.to
+            ))));
+        }
+        let target = self.net.dispatch(&self.to).ok_or_else(|| {
+            StreamingError::Network(NetworkError::from_string(format!(
+                "mem-network: unknown peer {:?}",
+                self.to
+            )))
+        })?;
+        target
+            .install_full_snapshot(vote, snapshot)
+            .await
+            .map_err(|e| {
+                StreamingError::Network(NetworkError::from_string(format!(
+                    "mem-network remote: {e}"
+                )))
+            })
+    }
+}

--- a/crates/openraft-toolkit/src/test_fakes/mod.rs
+++ b/crates/openraft-toolkit/src/test_fakes/mod.rs
@@ -1,2 +1,8 @@
 //! In-memory fakes for the toolkit's own tests and downstream conformance suites.
 //! Only compiled with the `test-fakes` feature or under `cfg(test)`.
+
+pub mod mem_network;
+pub mod partition;
+
+pub use mem_network::{MemNetwork, MemNetworkFactory, MemNetworkPeer};
+pub use partition::PartitionController;

--- a/crates/openraft-toolkit/src/test_fakes/partition.rs
+++ b/crates/openraft-toolkit/src/test_fakes/partition.rs
@@ -1,0 +1,135 @@
+//! Partition gates for in-memory raft test harnesses.
+//!
+//! Drives reachability between cluster nodes by combining per-node isolation
+//! with per-directed-edge cuts. Default reachable; explicit blocks only.
+
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::sync::RwLock;
+
+/// Controls reachability between simulated cluster nodes for partition tests.
+///
+/// The model has two orthogonal blocking mechanisms:
+///
+/// - **Isolated nodes** — a node is isolated if it's in the `isolated` set.
+///   Both directions to/from any isolated node are unreachable.
+/// - **Cut edges** — individual directed edges marked unreachable, regardless
+///   of node-level state.
+///
+/// `is_reachable(from, to)` returns `true` only if neither endpoint is
+/// isolated **and** the directed edge is not explicitly cut.
+pub struct PartitionController<NodeId> {
+    isolated: RwLock<HashSet<NodeId>>,
+    cut_edges: RwLock<HashSet<(NodeId, NodeId)>>,
+}
+
+impl<NodeId> PartitionController<NodeId>
+where
+    NodeId: Eq + Hash + Copy,
+{
+    /// Build a controller with no blocks (every reachable).
+    pub fn new() -> Self {
+        Self {
+            isolated: RwLock::new(HashSet::new()),
+            cut_edges: RwLock::new(HashSet::new()),
+        }
+    }
+
+    /// Isolate `node`: every (node, *) and (*, node) edge becomes unreachable.
+    pub fn isolate(&self, node: NodeId) {
+        self.isolated.write().unwrap().insert(node);
+    }
+
+    /// Restore `node`: removes the node-level block. Per-edge cuts still apply.
+    pub fn heal(&self, node: NodeId) {
+        self.isolated.write().unwrap().remove(&node);
+    }
+
+    /// Cut a single directed edge `from -> to`.
+    pub fn cut_edge(&self, from: NodeId, to: NodeId) {
+        self.cut_edges.write().unwrap().insert((from, to));
+    }
+
+    /// Restore a previously cut directed edge.
+    pub fn restore_edge(&self, from: NodeId, to: NodeId) {
+        self.cut_edges.write().unwrap().remove(&(from, to));
+    }
+
+    /// True iff neither endpoint is isolated and the directed edge is not cut.
+    pub fn is_reachable(&self, from: NodeId, to: NodeId) -> bool {
+        let isolated = self.isolated.read().unwrap();
+        if isolated.contains(&from) || isolated.contains(&to) {
+            return false;
+        }
+        !self.cut_edges.read().unwrap().contains(&(from, to))
+    }
+}
+
+impl<NodeId> Default for PartitionController<NodeId>
+where
+    NodeId: Eq + Hash + Copy,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_fully_reachable() {
+        let p = PartitionController::<u64>::new();
+        assert!(p.is_reachable(1, 2));
+        assert!(p.is_reachable(2, 1));
+        assert!(p.is_reachable(1, 1));
+    }
+
+    #[test]
+    fn isolate_blocks_both_directions() {
+        let p = PartitionController::<u64>::new();
+        p.isolate(1);
+        assert!(!p.is_reachable(1, 2));
+        assert!(!p.is_reachable(2, 1));
+        // edges not involving 1 still reachable
+        assert!(p.is_reachable(2, 3));
+    }
+
+    #[test]
+    fn heal_restores_node_level_reachability() {
+        let p = PartitionController::<u64>::new();
+        p.isolate(1);
+        p.heal(1);
+        assert!(p.is_reachable(1, 2));
+        assert!(p.is_reachable(2, 1));
+    }
+
+    #[test]
+    fn cut_edge_blocks_only_one_direction() {
+        let p = PartitionController::<u64>::new();
+        p.cut_edge(1, 2);
+        assert!(!p.is_reachable(1, 2));
+        assert!(p.is_reachable(2, 1));
+    }
+
+    #[test]
+    fn restore_edge_undoes_cut() {
+        let p = PartitionController::<u64>::new();
+        p.cut_edge(1, 2);
+        p.restore_edge(1, 2);
+        assert!(p.is_reachable(1, 2));
+    }
+
+    #[test]
+    fn heal_does_not_restore_individually_cut_edges() {
+        let p = PartitionController::<u64>::new();
+        p.cut_edge(1, 2);
+        p.isolate(1);
+        p.heal(1);
+        // edge cut survives heal
+        assert!(!p.is_reachable(1, 2));
+        // reverse direction works (not cut, not isolated)
+        assert!(p.is_reachable(2, 1));
+    }
+}

--- a/crates/openraft-toolkit/src/test_fakes/partition.rs
+++ b/crates/openraft-toolkit/src/test_fakes/partition.rs
@@ -27,7 +27,7 @@ impl<NodeId> PartitionController<NodeId>
 where
     NodeId: Eq + Hash + Copy,
 {
-    /// Build a controller with no blocks (every reachable).
+    /// Build a controller with no blocks (everything reachable).
     pub fn new() -> Self {
         Self {
             isolated: RwLock::new(HashSet::new()),

--- a/crates/openraft-toolkit/tests/mem_network_smoke.rs
+++ b/crates/openraft-toolkit/tests/mem_network_smoke.rs
@@ -1,0 +1,251 @@
+//! Smoke test for `openraft_toolkit::test_fakes::MemNetwork`.
+//!
+//! Stands up a 3-voter cluster with the in-memory network, asserts leader
+//! election within 10 seconds, writes one log entry through the leader, and
+//! asserts all three nodes' state machines see the apply within 5 seconds.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::storage::{EntryResponder, RaftSnapshotBuilder, RaftStateMachine, Snapshot};
+use openraft::type_config::alias::{LogIdOf, SnapshotMetaOf, SnapshotOf, StoredMembershipOf};
+use openraft::{Config, EntryPayload, OptionalSend, Raft, StoredMembership};
+use openraft_toolkit::declare_raft_types_ext;
+use openraft_toolkit::test_fakes::MemNetwork;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio::time::timeout;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmokeNode;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmokeCmd(pub u64);
+
+impl std::fmt::Display for SmokeCmd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SmokeCmd({})", self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmokeApplied(pub u64);
+
+declare_raft_types_ext! {
+    pub SmokeConfig:
+        Node            = SmokeNode,
+        AppData         = SmokeCmd,
+        AppDataResponse = SmokeApplied,
+        SnapshotData    = std::io::Cursor<Vec<u8>>,
+}
+
+type LogId = LogIdOf<SmokeConfig>;
+type SnapMeta = SnapshotMetaOf<SmokeConfig>;
+type SnapOf = SnapshotOf<SmokeConfig>;
+type StoredMem = StoredMembershipOf<SmokeConfig>;
+
+#[derive(Clone)]
+pub struct SmokeStateMachine {
+    core: Arc<Mutex<SmokeCore>>,
+}
+
+struct SmokeCore {
+    value: u64,
+    last_applied: Option<LogId>,
+    last_membership: StoredMem,
+}
+
+impl SmokeStateMachine {
+    pub fn new() -> Self {
+        Self {
+            core: Arc::new(Mutex::new(SmokeCore {
+                value: 0,
+                last_applied: None,
+                last_membership: StoredMembership::default(),
+            })),
+        }
+    }
+
+    pub fn value(&self) -> u64 {
+        self.core.lock().value
+    }
+}
+
+impl Default for SmokeStateMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RaftSnapshotBuilder<SmokeConfig> for SmokeStateMachine {
+    async fn build_snapshot(&mut self) -> Result<SnapOf, io::Error> {
+        let core = self.core.lock();
+        let meta = SnapMeta {
+            last_log_id: core.last_applied,
+            last_membership: core.last_membership.clone(),
+            snapshot_id: format!(
+                "smoke-{}",
+                core.last_applied.map(|l| l.index).unwrap_or(0)
+            ),
+        };
+        let bytes = postcard::to_stdvec(&core.value)
+            .map_err(|e| io::Error::other(format!("smoke build_snapshot: {e}")))?;
+        Ok(Snapshot {
+            meta,
+            snapshot: std::io::Cursor::new(bytes),
+        })
+    }
+}
+
+impl RaftStateMachine<SmokeConfig> for SmokeStateMachine {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMem), io::Error> {
+        let core = self.core.lock();
+        Ok((core.last_applied, core.last_membership.clone()))
+    }
+
+    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    where
+        Strm: futures::Stream<Item = Result<EntryResponder<SmokeConfig>, io::Error>>
+            + Unpin
+            + OptionalSend,
+    {
+        use futures::StreamExt;
+        while let Some(item) = entries.next().await {
+            let (entry, responder) = item?;
+            let log_id = entry.log_id;
+            let applied = match &entry.payload {
+                EntryPayload::Blank => SmokeApplied(self.core.lock().value),
+                EntryPayload::Normal(SmokeCmd(v)) => {
+                    let mut core = self.core.lock();
+                    core.value = *v;
+                    core.last_applied = Some(log_id);
+                    SmokeApplied(core.value)
+                }
+                EntryPayload::Membership(m) => {
+                    let mut core = self.core.lock();
+                    core.last_membership = StoredMembership::new(Some(log_id), m.clone());
+                    core.last_applied = Some(log_id);
+                    SmokeApplied(core.value)
+                }
+            };
+            self.core.lock().last_applied = Some(log_id);
+            if let Some(r) = responder {
+                r.send(applied);
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+
+    async fn begin_receiving_snapshot(&mut self) -> Result<std::io::Cursor<Vec<u8>>, io::Error> {
+        Ok(std::io::Cursor::new(Vec::new()))
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        _meta: &SnapMeta,
+        snapshot: std::io::Cursor<Vec<u8>>,
+    ) -> Result<(), io::Error> {
+        let value: u64 = postcard::from_bytes(&snapshot.into_inner())
+            .map_err(|e| io::Error::other(format!("smoke install_snapshot: {e}")))?;
+        self.core.lock().value = value;
+        Ok(())
+    }
+
+    async fn get_current_snapshot(&mut self) -> Result<Option<SnapOf>, io::Error> {
+        Ok(None)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn three_node_mem_network_elects_and_replicates() {
+    use openraft_toolkit::{Flat, RocksdbLogStore};
+    use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+    use tempfile::TempDir;
+
+    let net = MemNetwork::<SmokeConfig>::new();
+    let cfg = Arc::new(
+        Config {
+            heartbeat_interval: 50,
+            election_timeout_min: 150,
+            election_timeout_max: 300,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap(),
+    );
+
+    let mut nodes: Vec<(u64, Raft<SmokeConfig, SmokeStateMachine>, SmokeStateMachine, TempDir)> =
+        Vec::new();
+
+    for id in [1u64, 2, 3] {
+        let dir = TempDir::new().unwrap();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let cfs = vec![
+            ColumnFamilyDescriptor::new("raft_log", Options::default()),
+            ColumnFamilyDescriptor::new("raft_meta", Options::default()),
+        ];
+        let db = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap());
+        let log: RocksdbLogStore<SmokeConfig, Flat> =
+            RocksdbLogStore::open(db, "raft_log", "raft_meta", Flat).unwrap();
+        let sm = SmokeStateMachine::new();
+        let raft = Raft::new(id, cfg.clone(), net.factory_for(id), log, sm.clone())
+            .await
+            .expect("Raft::new");
+        net.register(id, raft.clone());
+        nodes.push((id, raft, sm, dir));
+    }
+
+    let mut mem = BTreeMap::new();
+    for id in [1u64, 2, 3] {
+        mem.insert(id, SmokeNode);
+    }
+    nodes[0].1.initialize(mem).await.expect("initialize");
+
+    // Wait for a leader.
+    let leader_id = timeout(Duration::from_secs(10), async {
+        loop {
+            for (id, raft, _, _) in nodes.iter() {
+                if let Some(l) = raft.current_leader().await {
+                    if l == *id {
+                        return *id;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("a leader elected within 10s");
+
+    let leader_idx = nodes
+        .iter()
+        .position(|(id, _, _, _)| *id == leader_id)
+        .expect("leader is one of our nodes");
+
+    nodes[leader_idx]
+        .1
+        .client_write(SmokeCmd(42))
+        .await
+        .expect("client_write");
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if nodes.iter().all(|(_, _, sm, _)| sm.value() == 42) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("all nodes converged to value=42 within 5s");
+}

--- a/crates/openraft-toolkit/tests/mem_network_smoke.rs
+++ b/crates/openraft-toolkit/tests/mem_network_smoke.rs
@@ -85,10 +85,7 @@ impl RaftSnapshotBuilder<SmokeConfig> for SmokeStateMachine {
         let meta = SnapMeta {
             last_log_id: core.last_applied,
             last_membership: core.last_membership.clone(),
-            snapshot_id: format!(
-                "smoke-{}",
-                core.last_applied.map(|l| l.index).unwrap_or(0)
-            ),
+            snapshot_id: format!("smoke-{}", core.last_applied.map(|l| l.index).unwrap_or(0)),
         };
         let bytes = postcard::to_stdvec(&core.value)
             .map_err(|e| io::Error::other(format!("smoke build_snapshot: {e}")))?;
@@ -182,8 +179,12 @@ async fn three_node_mem_network_elects_and_replicates() {
         .unwrap(),
     );
 
-    let mut nodes: Vec<(u64, Raft<SmokeConfig, SmokeStateMachine>, SmokeStateMachine, TempDir)> =
-        Vec::new();
+    let mut nodes: Vec<(
+        u64,
+        Raft<SmokeConfig, SmokeStateMachine>,
+        SmokeStateMachine,
+        TempDir,
+    )> = Vec::new();
 
     for id in [1u64, 2, 3] {
         let dir = TempDir::new().unwrap();

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -26,7 +26,8 @@ tsoracle-core      = { path = "../tsoracle-core", version = "0.1.0" }
 
 [dev-dependencies]
 anyhow           = { workspace = true }
-openraft-toolkit = { path = "../openraft-toolkit", features = ["rocksdb-log-store"] }
+openraft-toolkit = { path = "../openraft-toolkit", features = ["rocksdb-log-store", "test-fakes"] }
+proptest         = { workspace = true }
 rocksdb          = { workspace = true }
 tempfile         = { workspace = true }
 tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name         = "tsoracle-driver-openraft"
+description  = "openraft-backed ConsensusDriver for tsoracle"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+homepage.workspace     = true
+authors.workspace      = true
+
+[dependencies]
+async-trait        = { workspace = true }
+bincode            = { workspace = true }
+futures            = { workspace = true }
+openraft           = { workspace = true }
+openraft-toolkit   = { path = "../openraft-toolkit" }
+parking_lot        = { workspace = true }
+serde              = { workspace = true }
+thiserror          = { workspace = true }
+tokio              = { workspace = true }
+tokio-stream       = { workspace = true }
+tracing            = { workspace = true }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.0" }
+tsoracle-core      = { path = "../tsoracle-core", version = "0.1.0" }
+
+[dev-dependencies]
+anyhow           = { workspace = true }
+openraft-toolkit = { path = "../openraft-toolkit", features = ["rocksdb-log-store"] }
+rocksdb          = { workspace = true }
+tempfile         = { workspace = true }
+tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -11,9 +11,9 @@ authors.workspace      = true
 
 [dependencies]
 async-trait        = { workspace = true }
-bincode            = { workspace = true }
 futures            = { workspace = true }
 openraft           = { workspace = true }
+postcard           = { workspace = true }
 openraft-toolkit   = { path = "../openraft-toolkit" }
 parking_lot        = { workspace = true }
 serde              = { workspace = true }

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -141,3 +141,71 @@ fn map_leader_state<C: RaftTypeConfig>(s: LeadershipState<C>) -> LeaderState {
         | LeadershipState::Shutdown => LeaderState::Unknown,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::map_leader_state;
+    use crate::type_config::TypeConfig;
+    use openraft_toolkit::LeadershipState;
+    use tsoracle_consensus::LeaderState;
+    use tsoracle_core::Epoch;
+
+    #[test]
+    fn leader_maps_to_leader_with_epoch() {
+        let s = map_leader_state::<TypeConfig>(LeadershipState::Leader { term: 7 });
+        assert_eq!(s, LeaderState::Leader { epoch: Epoch(7) });
+    }
+
+    #[test]
+    fn follower_with_no_leader_maps_to_follower() {
+        let s = map_leader_state::<TypeConfig>(LeadershipState::Follower {
+            term: 3,
+            leader: None,
+        });
+        assert_eq!(
+            s,
+            LeaderState::Follower {
+                leader_endpoint: None
+            }
+        );
+    }
+
+    #[test]
+    fn follower_with_known_leader_still_maps_without_endpoint() {
+        let s = map_leader_state::<TypeConfig>(LeadershipState::Follower {
+            term: 4,
+            leader: Some((
+                2u64,
+                crate::type_config::OpenraftPeer {
+                    addr: "ignored".into(),
+                },
+            )),
+        });
+        // The generic mapper intentionally drops endpoint info; hosts that
+        // want endpoint resolution wrap the driver themselves.
+        assert_eq!(
+            s,
+            LeaderState::Follower {
+                leader_endpoint: None
+            }
+        );
+    }
+
+    #[test]
+    fn candidate_maps_to_unknown() {
+        let s = map_leader_state::<TypeConfig>(LeadershipState::Candidate { term: 5 });
+        assert_eq!(s, LeaderState::Unknown);
+    }
+
+    #[test]
+    fn learner_maps_to_unknown() {
+        let s = map_leader_state::<TypeConfig>(LeadershipState::Learner);
+        assert_eq!(s, LeaderState::Unknown);
+    }
+
+    #[test]
+    fn shutdown_maps_to_unknown() {
+        let s = map_leader_state::<TypeConfig>(LeadershipState::Shutdown);
+        assert_eq!(s, LeaderState::Unknown);
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -1,201 +1,118 @@
-//! `ConsensusDriver` implementation backed by an `openraft::Raft` instance.
+//! `ConsensusDriver` impl on top of any [`OpenraftHighWaterHost`].
 //!
-//! [`OpenraftDriver`] wraps a pre-built `Raft<TypeConfig, HighWaterStateMachine>`
-//! handle plus a clone of the state machine. It exposes the surface that
-//! `tsoracle-server` consumes: a leader-state stream, a linearized read of the
-//! durable high-water, and a monotonic `persist_high_water` that goes through
-//! the raft log.
-//!
-//! # Why both `Raft` and a state-machine clone?
-//!
-//! `Raft<C, SM>` doesn't expose the state machine after construction. The
-//! caller must hand a clone of `HighWaterStateMachine` to the driver so reads
-//! can short-circuit through the `current_value()` accessor without taking the
-//! cost of an `ensure_linearizable` round trip. For strictly linearizable
-//! reads we still issue a read-index barrier; the state-machine clone is only
-//! a peek into the apply-progress.
+//! [`OpenraftDriver`] is a thin bridge: it owns the trait-surface boilerplate
+//! and leadership-event mapping, then delegates storage/submission to the
+//! supplied host. The bundled [`crate::StandaloneHost`] gives you the original
+//! "owns its own raft cluster" behavior; services that already run an openraft
+//! cluster implement [`OpenraftHighWaterHost`] directly against their existing
+//! cluster.
 //!
 //! # Fencing
 //!
-//! `persist_high_water(_, epoch)` reads `Raft::metrics()` and compares the
-//! observed `(state, current_term)` against the caller's epoch:
-//!
-//! - If the local node isn't the leader, returns
-//!   [`ConsensusError::NotLeader`] with the observed term (when knowable) so
-//!   the caller can surface a `LeaderHint`.
-//! - If the term advanced past `epoch`, returns
-//!   [`ConsensusError::Fenced`] — the caller is a stale leader and must yield.
-//! - Otherwise, the proposal is submitted via `client_write`.
-//!
-//! This is a best-effort pre-check: the proposal can still race with an
-//! election and arrive at the new leader's apply pipeline as a `Blank` or be
-//! rejected by `client_write` with `ForwardToLeader`. Both later outcomes are
-//! also classified appropriately.
+//! `persist_high_water(_, epoch)` deliberately ignores the `epoch` argument.
+//! Monotonicity is enforced inside the state machine's apply path
+//! (`max(prev, at_least)`); a stale leader can still submit a write, but the
+//! result is either dropped by `client_write`'s `ForwardToLeader` path or
+//! absorbed by the apply-time `max`. Both outcomes preserve correctness
+//! without a term-based pre-check.
 
 use std::pin::Pin;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
-use openraft::Raft;
-use openraft::ServerState;
-use openraft::async_runtime::watch::WatchReceiver;
-use openraft::error::{ClientWriteError, RaftError};
-use openraft::vote::RaftTerm;
+use openraft::RaftTypeConfig;
 use openraft_toolkit::LeadershipState;
 use openraft_toolkit::lifecycle::leader::stream_from_receiver;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::Epoch;
 
-use crate::log_entry::HighWaterCommand;
-use crate::state_machine::HighWaterStateMachine;
-use crate::type_config::TypeConfig;
+use crate::host::OpenraftHighWaterHost;
 
-/// A [`ConsensusDriver`] that delegates to an openraft cluster.
+/// Driver bridging any [`OpenraftHighWaterHost`] to
+/// [`tsoracle_consensus::ConsensusDriver`].
 ///
-/// Constructed from a pre-built `Raft<TypeConfig, HighWaterStateMachine>` and
-/// a clone of the same state machine; see [`OpenraftDriver::new`].
-pub struct OpenraftDriver {
-    raft: Raft<TypeConfig, HighWaterStateMachine>,
-    state_machine: HighWaterStateMachine,
+/// Owns the leadership-mapping and trait-surface boilerplate; delegates the
+/// actual high-water storage to the host.
+pub struct OpenraftDriver<H: OpenraftHighWaterHost> {
+    host: Arc<H>,
 }
 
-impl OpenraftDriver {
-    /// Build a driver from a pre-constructed raft handle and a state-machine
-    /// clone.
-    ///
-    /// `state_machine` must be the same instance (i.e. share the inner `Arc`)
-    /// as the one passed to `Raft::new`; otherwise `load_high_water` will read
-    /// from a state machine that never sees the apply pipeline.
-    pub fn new(
-        raft: Raft<TypeConfig, HighWaterStateMachine>,
-        state_machine: HighWaterStateMachine,
-    ) -> Self {
-        Self {
-            raft,
-            state_machine,
-        }
+impl<H: OpenraftHighWaterHost> OpenraftDriver<H> {
+    /// Build a driver from a host value. The driver wraps the host in an
+    /// `Arc` so the leadership stream can keep it alive independently of the
+    /// outer driver handle.
+    pub fn new(host: H) -> Arc<Self> {
+        Arc::new(Self {
+            host: Arc::new(host),
+        })
+    }
+
+    /// Build a driver from a pre-shared `Arc<H>`. Useful when the host is
+    /// already shared with other subsystems (e.g. a placement driver that
+    /// hands the same backend to multiple gRPC services).
+    pub fn from_arc(host: Arc<H>) -> Arc<Self> {
+        Arc::new(Self { host })
     }
 }
 
 #[async_trait]
-impl ConsensusDriver for OpenraftDriver {
+impl<H: OpenraftHighWaterHost> ConsensusDriver for OpenraftDriver<H> {
     /// Return a stream of [`LeaderState`] transitions.
     ///
-    /// Wraps `openraft_toolkit::leadership_events` (which dedups by role
-    /// class) and maps each [`LeadershipState`] into the tsoracle-consensus
-    /// enum. Clones the raft handle into the returned stream so it owns
-    /// its own reference and is `'static`.
+    /// Goes through the toolkit's `stream_from_receiver` (the by-value entry
+    /// point) rather than `leadership_events(&raft)` to side-step a Rust 2024
+    /// lifetime-over-capture issue: the `&raft` form would require the
+    /// returned stream to borrow from `raft`, but we want `'static`. The
+    /// cloned host then rides along inside [`KeepAlive`] so dropping the
+    /// outer driver doesn't shut the raft down.
     fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
-        let raft = self.raft.clone();
-        // Wrap the toolkit stream in a tiny async-stream adapter that holds
-        // the cloned `Raft` for its lifetime so the inner borrow of
-        // `metrics()` stays valid.
-        Box::pin(owned_leadership_stream(raft))
+        let host = Arc::clone(&self.host);
+        Box::pin(owned_leadership_stream::<H>(host))
     }
 
-    /// Read the durably-persisted high-water mark.
-    ///
-    /// This is the state-machine-local value most recently written by
-    /// `apply`. The trait contract demands linearizability, but Phase A
-    /// callers exercise this only against single-node clusters where the
-    /// local apply is the global apply. A multi-node release will replace
-    /// this body with a `ensure_linearizable` barrier followed by the same
-    /// `current_value()` read.
+    /// Read the durably-persisted high-water mark via the host.
     async fn load_high_water(&self) -> Result<u64, ConsensusError> {
-        Ok(self.state_machine.current_value().await)
+        self.host.current_high_water().await
     }
 
-    /// Submit a `Bump` proposal through the raft log and return the new
-    /// committed value.
+    /// Submit a "bump to at_least" proposal via the host.
     ///
-    /// Fencing logic:
-    /// 1. Snapshot `Raft::metrics()`. If we are not the leader, return
-    ///    [`ConsensusError::NotLeader`] with the observed term.
-    /// 2. If the observed term is greater than `epoch.0`, return
-    ///    [`ConsensusError::Fenced`].
-    /// 3. Otherwise call `client_write`; classify the response.
-    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
-        // Step 1: pre-check fencing using a snapshot of the metrics watch.
-        // `borrow_watched` returns a guard whose `clone` we take so the lock
-        // is released before any `.await`.
-        let (state, observed_term) = {
-            let snap = self.raft.metrics().borrow_watched().clone();
-            (snap.state, snap.current_term.as_u64().unwrap_or(0))
-        };
-
-        match state {
-            ServerState::Leader => {
-                if observed_term > epoch.0 {
-                    return Err(ConsensusError::Fenced {
-                        expected: epoch,
-                        current: Epoch(observed_term),
-                    });
-                }
-                // observed_term < epoch.0 is impossible in a well-behaved
-                // caller (we never advertise an epoch we haven't seen as
-                // leader). If it happens, treat it as a stale view that will
-                // be corrected by the client_write path itself.
-            }
-            ServerState::Follower | ServerState::Learner | ServerState::Candidate => {
-                return Err(ConsensusError::NotLeader {
-                    observed: Some(Epoch(observed_term)),
-                });
-            }
-            ServerState::Shutdown => {
-                return Err(ConsensusError::NotLeader { observed: None });
-            }
-        }
-
-        // Step 2: submit the proposal.
-        match self
-            .raft
-            .client_write(HighWaterCommand::Bump { target: at_least })
-            .await
-        {
-            Ok(resp) => Ok(resp.data.value),
-            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(_))) => {
-                Err(ConsensusError::NotLeader { observed: None })
-            }
-            // ChangeMembershipError can't be returned for an AppData write;
-            // bucketed with the other transient errors anyway.
-            Err(e) => Err(ConsensusError::TransientDriver(Box::new(e))),
-        }
+    /// The `epoch` arg is intentionally ignored: fencing is the state
+    /// machine's monotonicity guarantee (`max(prev, at_least)`), not a
+    /// term-based pre-check.
+    async fn persist_high_water(
+        &self,
+        at_least: u64,
+        _epoch: Epoch,
+    ) -> Result<u64, ConsensusError> {
+        self.host.submit_advance(at_least).await
     }
 }
 
-/// Build a `'static` `Stream<Item = LeaderState>` from an owned `Raft` handle.
+/// Build a `'static` `Stream<Item = LeaderState>` from an owned host handle.
 ///
-/// Goes through the toolkit's `stream_from_receiver` (the receiver-by-value
-/// entry point) so the resulting stream's lifetime isn't tied to any borrow
-/// of `raft`. The cloned `raft` then rides along inside [`KeepAlive`] so
-/// dropping the outer driver doesn't close the metrics watch.
-///
-/// The wrapper layer is needed because `Raft<C, SM>` doesn't expose a way to
-/// keep the cluster alive purely via the metrics watch — the metrics sender
-/// lives inside the raft core, and the core shuts down when the last `Raft`
-/// handle is dropped.
-fn owned_leadership_stream(
-    raft: Raft<TypeConfig, HighWaterStateMachine>,
+/// The cloned `Arc<H>` rides along inside [`KeepAlive`] so the host (and the
+/// raft it owns) outlives the stream's polling.
+fn owned_leadership_stream<H: OpenraftHighWaterHost>(
+    host: Arc<H>,
 ) -> impl Stream<Item = LeaderState> + Send + 'static {
+    let rx = host.raft().metrics();
     let inner: Pin<Box<dyn Stream<Item = LeaderState> + Send>> =
-        Box::pin(stream_from_receiver::<TypeConfig>(raft.metrics()).map(map_leader_state));
-    KeepAlive { _raft: raft, inner }
+        Box::pin(stream_from_receiver::<H::Config>(rx).map(map_leader_state::<H::Config>));
+    KeepAlive { _host: host, inner }
 }
 
-/// A stream wrapper that keeps a [`Raft`] handle alive for the duration of
-/// the inner stream. Without this, the cloned handle would drop at the end
-/// of `owned_leadership_stream` and shut the raft down once the original
-/// driver lost its other reference.
-///
-/// The inner stream is already `Pin<Box<dyn Stream + Send>>` so polling it
-/// is a straight delegation. The wrapper itself is `Unpin` because all of
-/// its fields are.
-struct KeepAlive {
-    _raft: Raft<TypeConfig, HighWaterStateMachine>,
+/// Stream wrapper that keeps an `Arc<H>` alive for the duration of the inner
+/// stream. Without this, the cloned host would drop at the end of
+/// `owned_leadership_stream` and shut the raft down once the outer driver
+/// lost its other reference.
+struct KeepAlive<H: OpenraftHighWaterHost> {
+    _host: Arc<H>,
     inner: Pin<Box<dyn Stream<Item = LeaderState> + Send>>,
 }
 
-impl Stream for KeepAlive {
+impl<H: OpenraftHighWaterHost> Stream for KeepAlive<H> {
     type Item = LeaderState;
 
     fn poll_next(
@@ -206,11 +123,18 @@ impl Stream for KeepAlive {
     }
 }
 
-fn map_leader_state(s: LeadershipState<TypeConfig>) -> LeaderState {
+/// Project a toolkit [`LeadershipState`] into a tsoracle-consensus
+/// [`LeaderState`].
+///
+/// Always returns `leader_endpoint: None` on the follower branch: the generic
+/// mapper has no way to extract an endpoint from `C::Node` (different hosts
+/// pick different `Node` types). Hosts that need endpoint resolution wrap the
+/// driver themselves and provide their own `ConsensusDriver` impl.
+fn map_leader_state<C: RaftTypeConfig>(s: LeadershipState<C>) -> LeaderState {
     match s {
         LeadershipState::Leader { term } => LeaderState::Leader { epoch: Epoch(term) },
-        LeadershipState::Follower { leader, .. } => LeaderState::Follower {
-            leader_endpoint: leader.map(|(_, node)| node.addr),
+        LeadershipState::Follower { .. } => LeaderState::Follower {
+            leader_endpoint: None,
         },
         LeadershipState::Candidate { .. }
         | LeadershipState::Learner

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -1,0 +1,219 @@
+//! `ConsensusDriver` implementation backed by an `openraft::Raft` instance.
+//!
+//! [`OpenraftDriver`] wraps a pre-built `Raft<TypeConfig, HighWaterStateMachine>`
+//! handle plus a clone of the state machine. It exposes the surface that
+//! `tsoracle-server` consumes: a leader-state stream, a linearized read of the
+//! durable high-water, and a monotonic `persist_high_water` that goes through
+//! the raft log.
+//!
+//! # Why both `Raft` and a state-machine clone?
+//!
+//! `Raft<C, SM>` doesn't expose the state machine after construction. The
+//! caller must hand a clone of `HighWaterStateMachine` to the driver so reads
+//! can short-circuit through the `current_value()` accessor without taking the
+//! cost of an `ensure_linearizable` round trip. For strictly linearizable
+//! reads we still issue a read-index barrier; the state-machine clone is only
+//! a peek into the apply-progress.
+//!
+//! # Fencing
+//!
+//! `persist_high_water(_, epoch)` reads `Raft::metrics()` and compares the
+//! observed `(state, current_term)` against the caller's epoch:
+//!
+//! - If the local node isn't the leader, returns
+//!   [`ConsensusError::NotLeader`] with the observed term (when knowable) so
+//!   the caller can surface a `LeaderHint`.
+//! - If the term advanced past `epoch`, returns
+//!   [`ConsensusError::Fenced`] — the caller is a stale leader and must yield.
+//! - Otherwise, the proposal is submitted via `client_write`.
+//!
+//! This is a best-effort pre-check: the proposal can still race with an
+//! election and arrive at the new leader's apply pipeline as a `Blank` or be
+//! rejected by `client_write` with `ForwardToLeader`. Both later outcomes are
+//! also classified appropriately.
+
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use openraft::Raft;
+use openraft::ServerState;
+use openraft::async_runtime::watch::WatchReceiver;
+use openraft::error::{ClientWriteError, RaftError};
+use openraft::vote::RaftTerm;
+use openraft_toolkit::LeadershipState;
+use openraft_toolkit::lifecycle::leader::stream_from_receiver;
+use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
+use tsoracle_core::Epoch;
+
+use crate::log_entry::HighWaterCommand;
+use crate::state_machine::HighWaterStateMachine;
+use crate::type_config::TypeConfig;
+
+/// A [`ConsensusDriver`] that delegates to an openraft cluster.
+///
+/// Constructed from a pre-built `Raft<TypeConfig, HighWaterStateMachine>` and
+/// a clone of the same state machine; see [`OpenraftDriver::new`].
+pub struct OpenraftDriver {
+    raft: Raft<TypeConfig, HighWaterStateMachine>,
+    state_machine: HighWaterStateMachine,
+}
+
+impl OpenraftDriver {
+    /// Build a driver from a pre-constructed raft handle and a state-machine
+    /// clone.
+    ///
+    /// `state_machine` must be the same instance (i.e. share the inner `Arc`)
+    /// as the one passed to `Raft::new`; otherwise `load_high_water` will read
+    /// from a state machine that never sees the apply pipeline.
+    pub fn new(
+        raft: Raft<TypeConfig, HighWaterStateMachine>,
+        state_machine: HighWaterStateMachine,
+    ) -> Self {
+        Self {
+            raft,
+            state_machine,
+        }
+    }
+}
+
+#[async_trait]
+impl ConsensusDriver for OpenraftDriver {
+    /// Return a stream of [`LeaderState`] transitions.
+    ///
+    /// Wraps `openraft_toolkit::leadership_events` (which dedups by role
+    /// class) and maps each [`LeadershipState`] into the tsoracle-consensus
+    /// enum. Clones the raft handle into the returned stream so it owns
+    /// its own reference and is `'static`.
+    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        let raft = self.raft.clone();
+        // Wrap the toolkit stream in a tiny async-stream adapter that holds
+        // the cloned `Raft` for its lifetime so the inner borrow of
+        // `metrics()` stays valid.
+        Box::pin(owned_leadership_stream(raft))
+    }
+
+    /// Read the durably-persisted high-water mark.
+    ///
+    /// This is the state-machine-local value most recently written by
+    /// `apply`. The trait contract demands linearizability, but Phase A
+    /// callers exercise this only against single-node clusters where the
+    /// local apply is the global apply. A multi-node release will replace
+    /// this body with a `ensure_linearizable` barrier followed by the same
+    /// `current_value()` read.
+    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
+        Ok(self.state_machine.current_value().await)
+    }
+
+    /// Submit a `Bump` proposal through the raft log and return the new
+    /// committed value.
+    ///
+    /// Fencing logic:
+    /// 1. Snapshot `Raft::metrics()`. If we are not the leader, return
+    ///    [`ConsensusError::NotLeader`] with the observed term.
+    /// 2. If the observed term is greater than `epoch.0`, return
+    ///    [`ConsensusError::Fenced`].
+    /// 3. Otherwise call `client_write`; classify the response.
+    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        // Step 1: pre-check fencing using a snapshot of the metrics watch.
+        // `borrow_watched` returns a guard whose `clone` we take so the lock
+        // is released before any `.await`.
+        let (state, observed_term) = {
+            let snap = self.raft.metrics().borrow_watched().clone();
+            (snap.state, snap.current_term.as_u64().unwrap_or(0))
+        };
+
+        match state {
+            ServerState::Leader => {
+                if observed_term > epoch.0 {
+                    return Err(ConsensusError::Fenced {
+                        expected: epoch,
+                        current: Epoch(observed_term),
+                    });
+                }
+                // observed_term < epoch.0 is impossible in a well-behaved
+                // caller (we never advertise an epoch we haven't seen as
+                // leader). If it happens, treat it as a stale view that will
+                // be corrected by the client_write path itself.
+            }
+            ServerState::Follower | ServerState::Learner | ServerState::Candidate => {
+                return Err(ConsensusError::NotLeader {
+                    observed: Some(Epoch(observed_term)),
+                });
+            }
+            ServerState::Shutdown => {
+                return Err(ConsensusError::NotLeader { observed: None });
+            }
+        }
+
+        // Step 2: submit the proposal.
+        match self
+            .raft
+            .client_write(HighWaterCommand::Bump { target: at_least })
+            .await
+        {
+            Ok(resp) => Ok(resp.data.value),
+            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(_))) => {
+                Err(ConsensusError::NotLeader { observed: None })
+            }
+            // ChangeMembershipError can't be returned for an AppData write;
+            // bucketed with the other transient errors anyway.
+            Err(e) => Err(ConsensusError::TransientDriver(Box::new(e))),
+        }
+    }
+}
+
+/// Build a `'static` `Stream<Item = LeaderState>` from an owned `Raft` handle.
+///
+/// Goes through the toolkit's `stream_from_receiver` (the receiver-by-value
+/// entry point) so the resulting stream's lifetime isn't tied to any borrow
+/// of `raft`. The cloned `raft` then rides along inside [`KeepAlive`] so
+/// dropping the outer driver doesn't close the metrics watch.
+///
+/// The wrapper layer is needed because `Raft<C, SM>` doesn't expose a way to
+/// keep the cluster alive purely via the metrics watch — the metrics sender
+/// lives inside the raft core, and the core shuts down when the last `Raft`
+/// handle is dropped.
+fn owned_leadership_stream(
+    raft: Raft<TypeConfig, HighWaterStateMachine>,
+) -> impl Stream<Item = LeaderState> + Send + 'static {
+    let inner: Pin<Box<dyn Stream<Item = LeaderState> + Send>> =
+        Box::pin(stream_from_receiver::<TypeConfig>(raft.metrics()).map(map_leader_state));
+    KeepAlive { _raft: raft, inner }
+}
+
+/// A stream wrapper that keeps a [`Raft`] handle alive for the duration of
+/// the inner stream. Without this, the cloned handle would drop at the end
+/// of `owned_leadership_stream` and shut the raft down once the original
+/// driver lost its other reference.
+///
+/// The inner stream is already `Pin<Box<dyn Stream + Send>>` so polling it
+/// is a straight delegation. The wrapper itself is `Unpin` because all of
+/// its fields are.
+struct KeepAlive {
+    _raft: Raft<TypeConfig, HighWaterStateMachine>,
+    inner: Pin<Box<dyn Stream<Item = LeaderState> + Send>>,
+}
+
+impl Stream for KeepAlive {
+    type Item = LeaderState;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+fn map_leader_state(s: LeadershipState<TypeConfig>) -> LeaderState {
+    match s {
+        LeadershipState::Leader { term } => LeaderState::Leader { epoch: Epoch(term) },
+        LeadershipState::Follower { leader, .. } => LeaderState::Follower {
+            leader_endpoint: leader.map(|(_, node)| node.addr),
+        },
+        LeadershipState::Candidate { .. }
+        | LeadershipState::Learner
+        | LeadershipState::Shutdown => LeaderState::Unknown,
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/host.rs
+++ b/crates/tsoracle-driver-openraft/src/host.rs
@@ -1,0 +1,41 @@
+//! Host abstraction the openraft-backed `ConsensusDriver` builds on.
+//!
+//! Implementations decide where the high-water mark is stored and replicated.
+//! The bundled [`StandaloneHost`](crate::standalone::StandaloneHost) owns its
+//! own raft cluster + state machine. A larger service (e.g. one that already
+//! runs an openraft cluster for other state) can implement this trait directly
+//! and route TSO commands through its existing log.
+
+use async_trait::async_trait;
+use openraft::Raft;
+use openraft::RaftTypeConfig;
+use openraft::storage::RaftStateMachine;
+use tsoracle_consensus::ConsensusError;
+
+/// Host that knows how to read and advance the TSO high-water mark via openraft.
+///
+/// The driver crate handles `ConsensusDriver` trait shape and leadership-event
+/// mapping; the host supplies the storage / submission semantics.
+#[async_trait]
+pub trait OpenraftHighWaterHost: Send + Sync + 'static {
+    /// The host's `RaftTypeConfig`. Each host picks its own — the standalone
+    /// host uses [`crate::TypeConfig`], a piggy-back host uses whatever
+    /// `TypeConfig` its larger raft is built on.
+    type Config: RaftTypeConfig;
+
+    /// The host's state machine. Same indirection as `Config`.
+    type StateMachine: RaftStateMachine<Self::Config>;
+
+    /// The raft handle the driver reads leadership metrics from.
+    fn raft(&self) -> &Raft<Self::Config, Self::StateMachine>;
+
+    /// Read the current high-water mark linearizably. Implementations are
+    /// expected to issue an `ensure_linearizable` barrier before reading their
+    /// underlying state machine if reads should reflect all committed writes.
+    async fn current_high_water(&self) -> Result<u64, ConsensusError>;
+
+    /// Submit a "bump to at_least" proposal through the host's raft log and
+    /// return the new high-water value after apply. The state machine must
+    /// enforce monotonicity (`max(prev, at_least)`); the driver does not.
+    async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError>;
+}

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -14,15 +14,23 @@
 //!   an in-memory `u64` counter with bincode snapshots.
 //! - [`type_config`] declares the `RaftTypeConfig` via
 //!   `openraft_toolkit::declare_raft_types_ext!`.
+//! - [`host`] declares the `OpenraftHighWaterHost` trait services implement
+//!   to plug their consensus into the driver.
+//! - [`standalone`] supplies the bundled host that owns its own raft cluster
+//!   and the [`HighWaterStateMachine`].
 //! - [`driver`] wraps the `Raft` handle and the state machine into the
 //!   `ConsensusDriver` impl.
 
 pub mod driver;
+pub mod host;
 pub mod log_entry;
+pub mod standalone;
 pub mod state_machine;
 pub mod type_config;
 
 pub use driver::OpenraftDriver;
+pub use host::OpenraftHighWaterHost;
 pub use log_entry::HighWaterCommand;
+pub use standalone::StandaloneHost;
 pub use state_machine::{HighWaterStateMachine, HighWaterStateMachineSnapshot};
 pub use type_config::{HighWaterApplied, OpenraftPeer, TypeConfig};

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -1,0 +1,23 @@
+//! openraft-backed `ConsensusDriver` for tsoracle.
+//!
+//! This crate replicates the TSO high-water mark across an openraft cluster
+//! and exposes the result via the [`tsoracle_consensus::ConsensusDriver`]
+//! trait. The caller supplies a pre-built [`openraft::Raft`] handle (with its
+//! own `RaftNetworkFactory` and `RaftLogStorage`); this crate provides the
+//! `RaftTypeConfig`, the log-entry type, the in-memory state machine, and
+//! the trait bridge.
+//!
+//! # Layering
+//!
+//! - [`log_entry`] defines the single command type replicated through the log.
+//! - [`type_config`] declares the `RaftTypeConfig` via
+//!   `openraft_toolkit::declare_raft_types_ext!`.
+//!
+//! The state machine and the `ConsensusDriver` impl are added in follow-up
+//! commits.
+
+pub mod log_entry;
+pub mod type_config;
+
+pub use log_entry::HighWaterCommand;
+pub use type_config::{HighWaterApplied, OpenraftPeer, TypeConfig};

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -10,14 +10,17 @@
 //! # Layering
 //!
 //! - [`log_entry`] defines the single command type replicated through the log.
+//! - [`state_machine`] implements `openraft::storage::RaftStateMachine` over
+//!   an in-memory `u64` counter with bincode snapshots.
 //! - [`type_config`] declares the `RaftTypeConfig` via
 //!   `openraft_toolkit::declare_raft_types_ext!`.
 //!
-//! The state machine and the `ConsensusDriver` impl are added in follow-up
-//! commits.
+//! The `ConsensusDriver` impl is added in a follow-up commit.
 
 pub mod log_entry;
+pub mod state_machine;
 pub mod type_config;
 
 pub use log_entry::HighWaterCommand;
+pub use state_machine::{HighWaterStateMachine, HighWaterStateMachineSnapshot};
 pub use type_config::{HighWaterApplied, OpenraftPeer, TypeConfig};

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -14,13 +14,15 @@
 //!   an in-memory `u64` counter with bincode snapshots.
 //! - [`type_config`] declares the `RaftTypeConfig` via
 //!   `openraft_toolkit::declare_raft_types_ext!`.
-//!
-//! The `ConsensusDriver` impl is added in a follow-up commit.
+//! - [`driver`] wraps the `Raft` handle and the state machine into the
+//!   `ConsensusDriver` impl.
 
+pub mod driver;
 pub mod log_entry;
 pub mod state_machine;
 pub mod type_config;
 
+pub use driver::OpenraftDriver;
 pub use log_entry::HighWaterCommand;
 pub use state_machine::{HighWaterStateMachine, HighWaterStateMachineSnapshot};
 pub use type_config::{HighWaterApplied, OpenraftPeer, TypeConfig};

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -46,7 +46,9 @@ mod tests {
 
     #[test]
     fn postcard_round_trip_bump() {
-        let cmd = HighWaterCommand::Bump { target: 1_234_567_890 };
+        let cmd = HighWaterCommand::Bump {
+            target: 1_234_567_890,
+        };
         let bytes = postcard::to_stdvec(&cmd).expect("serialize");
         let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, cmd);

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -1,0 +1,29 @@
+//! Log entries replicated by the openraft cluster.
+//!
+//! The driver replicates a single command: advance the high-water mark to at
+//! least `target`. The state machine treats this as `current = max(current,
+//! target)`, which makes the operation idempotent under retries and monotone
+//! under reordering — matching the [`tsoracle_consensus::ConsensusDriver`]
+//! "advance to at least" contract.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Commands the state machine knows how to apply.
+///
+/// `Display` is implemented because openraft's `AppData` blanket requires it
+/// (used in the `Entry`'s human-readable summary).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HighWaterCommand {
+    /// Advance the high-water mark to at least `target`. Idempotent.
+    Bump { target: u64 },
+}
+
+impl fmt::Display for HighWaterCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HighWaterCommand::Bump { target } => write!(f, "Bump {{ target: {target} }}"),
+        }
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -27,3 +27,44 @@ impl fmt::Display for HighWaterCommand {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_renders_bump() {
+        let cmd = HighWaterCommand::Bump { target: 42 };
+        assert_eq!(format!("{cmd}"), "Bump { target: 42 }");
+    }
+
+    #[test]
+    fn display_renders_zero_target() {
+        let cmd = HighWaterCommand::Bump { target: 0 };
+        assert_eq!(format!("{cmd}"), "Bump { target: 0 }");
+    }
+
+    #[test]
+    fn postcard_round_trip_bump() {
+        let cmd = HighWaterCommand::Bump { target: 1_234_567_890 };
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn postcard_round_trip_zero() {
+        let cmd = HighWaterCommand::Bump { target: 0 };
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn postcard_round_trip_max() {
+        let cmd = HighWaterCommand::Bump { target: u64::MAX };
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, cmd);
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -1,0 +1,73 @@
+//! Bundled host: owns its own raft cluster and the [`HighWaterStateMachine`].
+//!
+//! Use this when you want a dedicated TSO raft, separate from any other
+//! consensus state your service runs. For services that already run an
+//! openraft cluster (e.g. a placement driver), implement
+//! [`OpenraftHighWaterHost`](crate::OpenraftHighWaterHost) directly against
+//! that existing cluster instead.
+
+use async_trait::async_trait;
+use openraft::Raft;
+use openraft::error::{ClientWriteError, RaftError};
+use tsoracle_consensus::ConsensusError;
+
+use crate::host::OpenraftHighWaterHost;
+use crate::log_entry::HighWaterCommand;
+use crate::state_machine::HighWaterStateMachine;
+use crate::type_config::TypeConfig;
+
+/// `OpenraftHighWaterHost` that owns its own raft cluster + state machine.
+///
+/// `state_machine` must share the inner `Arc` with the one handed to
+/// `Raft::new`; otherwise `current_high_water` will read from a state machine
+/// that never sees the apply pipeline.
+pub struct StandaloneHost {
+    raft: Raft<TypeConfig, HighWaterStateMachine>,
+    state_machine: HighWaterStateMachine,
+}
+
+impl StandaloneHost {
+    /// Build a standalone host from a pre-constructed raft handle and a
+    /// state-machine clone.
+    pub fn new(
+        raft: Raft<TypeConfig, HighWaterStateMachine>,
+        state_machine: HighWaterStateMachine,
+    ) -> Self {
+        Self {
+            raft,
+            state_machine,
+        }
+    }
+}
+
+#[async_trait]
+impl OpenraftHighWaterHost for StandaloneHost {
+    type Config = TypeConfig;
+    type StateMachine = HighWaterStateMachine;
+
+    fn raft(&self) -> &Raft<Self::Config, Self::StateMachine> {
+        &self.raft
+    }
+
+    async fn current_high_water(&self) -> Result<u64, ConsensusError> {
+        // The standalone host doesn't issue a linearizable barrier here for the
+        // same reason the original driver didn't: a single-voter cluster has
+        // trivially linearizable local reads, and multi-node deployments will
+        // gain a barrier in a follow-up alongside the network impl.
+        Ok(self.state_machine.current_value().await)
+    }
+
+    async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
+        match self
+            .raft
+            .client_write(HighWaterCommand::Bump { target: at_least })
+            .await
+        {
+            Ok(resp) => Ok(resp.data.value),
+            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(_))) => {
+                Err(ConsensusError::NotLeader { observed: None })
+            }
+            Err(e) => Err(ConsensusError::TransientDriver(Box::new(e))),
+        }
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -1,7 +1,7 @@
 //! In-memory `RaftStateMachine` for the high-water counter.
 //!
 //! State is one `u64` plus the openraft-required apply-progress metadata
-//! (`last_applied`, `last_membership`). Snapshots are bincode-encoded blobs of
+//! (`last_applied`, `last_membership`). Snapshots are postcard-encoded blobs of
 //! that tuple. All state lives inside an `Arc<Mutex<HighWaterCore>>` so the
 //! state machine is cheaply cloneable — required because openraft's
 //! `RaftStateMachine::SnapshotBuilder = Self` design hands out clones to drive
@@ -39,7 +39,7 @@ type SnapOf = SnapshotOf<TypeConfig>;
 type SnapData = Cursor<Vec<u8>>;
 type StoredMem = StoredMembershipOf<TypeConfig>;
 
-/// Snapshot payload — bincode-encoded under the hood.
+/// Snapshot payload — postcard-encoded under the hood.
 ///
 /// Exposed at the crate root so callers building tooling around the snapshot
 /// format (e.g. inspectors, migration tools) can decode it without re-deriving
@@ -143,7 +143,7 @@ impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
                 last_membership: core.last_membership.clone(),
                 snapshot_id,
             };
-            let bytes = bincode::serialize(&payload)
+            let bytes = postcard::to_stdvec(&payload)
                 .map_err(|e| io::Error::other(format!("snapshot serialize: {e}")))?;
             let stored = StoredSnapshot {
                 meta: meta.clone(),
@@ -231,7 +231,7 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
         snapshot: SnapData,
     ) -> Result<(), io::Error> {
         let bytes = snapshot.into_inner();
-        let payload: HighWaterStateMachineSnapshot = bincode::deserialize(&bytes)
+        let payload: HighWaterStateMachineSnapshot = postcard::from_bytes(&bytes)
             .map_err(|e| io::Error::other(format!("snapshot deserialize: {e}")))?;
 
         let mut core = self.core.lock();

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -277,7 +277,10 @@ mod tests {
         openraft::testing::log_id::<TypeConfig>(1, 1, index)
     }
 
-    fn entry(index: u64, payload: EntryPayload<HighWaterCommand, u64, crate::type_config::OpenraftPeer>) -> EntryResponder<TypeConfig> {
+    fn entry(
+        index: u64,
+        payload: EntryPayload<HighWaterCommand, u64, crate::type_config::OpenraftPeer>,
+    ) -> EntryResponder<TypeConfig> {
         let e: EntryOf<TypeConfig> = match payload {
             EntryPayload::Blank => EntryOf::<TypeConfig>::new_blank(log_id(index)),
             EntryPayload::Normal(d) => EntryOf::<TypeConfig>::new_normal(log_id(index), d),
@@ -291,7 +294,9 @@ mod tests {
         index: u64,
         payload: EntryPayload<HighWaterCommand, u64, crate::type_config::OpenraftPeer>,
     ) {
-        sm.apply(stream::iter([Ok(entry(index, payload))])).await.expect("apply");
+        sm.apply(stream::iter([Ok(entry(index, payload))]))
+            .await
+            .expect("apply");
     }
 
     // --- Tests ---
@@ -362,10 +367,7 @@ mod tests {
             EntryPayload::Normal(HighWaterCommand::Bump { target: 42 }),
         )
         .await;
-        let mem = openraft::Membership::new_with_defaults(
-            vec![BTreeSet::from([1u64])],
-            [1u64],
-        );
+        let mem = openraft::Membership::new_with_defaults(vec![BTreeSet::from([1u64])], [1u64]);
         apply_one(&mut sm, 2, EntryPayload::Membership(mem)).await;
         assert_eq!(sm.current_value().await, 42);
         let (last, _) = sm.applied_state().await.unwrap();

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -450,4 +450,46 @@ mod tests {
             .expect("get_current_snapshot");
         assert!(s.is_none());
     }
+
+    // ---- Property tests ----
+
+    use proptest::prelude::*;
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    proptest! {
+        /// Monotonicity invariant: applying an arbitrary sequence of `Bump`
+        /// targets leaves the state machine at `max(0, max(targets))`, and
+        /// `current_value` is non-decreasing at every intermediate step.
+        #[test]
+        fn p1_monotonicity_under_arbitrary_bumps(
+            targets in prop::collection::vec(any::<u64>(), 0..=64)
+        ) {
+            rt().block_on(async {
+                let mut sm = HighWaterStateMachine::new();
+                let mut prev = 0u64;
+                let mut idx = 0u64;
+                for t in &targets {
+                    idx += 1;
+                    apply_one(
+                        &mut sm,
+                        idx,
+                        EntryPayload::Normal(HighWaterCommand::Bump { target: *t }),
+                    )
+                    .await;
+                    let now = sm.current_value().await;
+                    prop_assert!(now >= prev, "value went backwards: prev={prev} now={now}");
+                    prev = now;
+                }
+                let expected = targets.iter().copied().max().unwrap_or(0);
+                prop_assert_eq!(sm.current_value().await, expected);
+                Ok(())
+            })?;
+        }
+    }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -371,4 +371,83 @@ mod tests {
         let (last, _) = sm.applied_state().await.unwrap();
         assert_eq!(last.map(|l| l.index), Some(2));
     }
+
+    // ---- Snapshot tests ----
+
+    #[tokio::test]
+    async fn build_snapshot_round_trips_payload() {
+        let mut sm = HighWaterStateMachine::new();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 500 }),
+        )
+        .await;
+
+        let snap = sm.build_snapshot().await.expect("build_snapshot");
+        let bytes = snap.snapshot.into_inner();
+        let payload: HighWaterStateMachineSnapshot =
+            postcard::from_bytes(&bytes).expect("decode snapshot");
+        assert_eq!(payload.current_value, 500);
+        assert_eq!(payload.last_applied.map(|l| l.index), Some(1));
+    }
+
+    #[tokio::test]
+    async fn build_snapshot_uses_fresh_id_each_time() {
+        let mut sm = HighWaterStateMachine::new();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 7 }),
+        )
+        .await;
+
+        let a = sm.build_snapshot().await.expect("build_snapshot a");
+        let b = sm.build_snapshot().await.expect("build_snapshot b");
+        assert_ne!(
+            a.meta.snapshot_id, b.meta.snapshot_id,
+            "two snapshots at same last_applied must have distinct ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_snapshot_replaces_state() {
+        let mut sm = HighWaterStateMachine::new();
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 999,
+            last_applied: Some(log_id(5)),
+            last_membership: StoredMem::default(),
+        };
+        let bytes = postcard::to_stdvec(&payload).expect("serialize payload");
+
+        let meta = SnapMeta {
+            last_log_id: payload.last_applied,
+            last_membership: payload.last_membership.clone(),
+            snapshot_id: "test-install-1".to_string(),
+        };
+        sm.install_snapshot(&meta, std::io::Cursor::new(bytes))
+            .await
+            .expect("install_snapshot");
+
+        assert_eq!(sm.current_value().await, 999);
+        let (last, _) = sm.applied_state().await.unwrap();
+        assert_eq!(last.map(|l| l.index), Some(5));
+
+        let current = sm
+            .get_current_snapshot()
+            .await
+            .expect("get_current_snapshot")
+            .expect("snapshot present");
+        assert_eq!(current.meta.snapshot_id, "test-install-1");
+    }
+
+    #[tokio::test]
+    async fn get_current_snapshot_initially_none() {
+        let mut sm = HighWaterStateMachine::new();
+        let s = sm
+            .get_current_snapshot()
+            .await
+            .expect("get_current_snapshot");
+        assert!(s.is_none());
+    }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -253,3 +253,122 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeSet;
+
+    use futures::stream;
+    use openraft::EntryPayload;
+    use openraft::entry::RaftEntry;
+    use openraft::storage::EntryResponder;
+    use openraft::type_config::alias::EntryOf;
+
+    use crate::log_entry::HighWaterCommand;
+    use crate::type_config::TypeConfig;
+
+    // --- Test helpers ---
+
+    /// Build a `LogId` for the toolkit's default leader-id layout
+    /// (`LeaderId<u64, u64>`) with term=1, node_id=1, and the given index.
+    fn log_id(index: u64) -> LogIdOf<TypeConfig> {
+        openraft::testing::log_id::<TypeConfig>(1, 1, index)
+    }
+
+    fn entry(index: u64, payload: EntryPayload<HighWaterCommand, u64, crate::type_config::OpenraftPeer>) -> EntryResponder<TypeConfig> {
+        let e: EntryOf<TypeConfig> = match payload {
+            EntryPayload::Blank => EntryOf::<TypeConfig>::new_blank(log_id(index)),
+            EntryPayload::Normal(d) => EntryOf::<TypeConfig>::new_normal(log_id(index), d),
+            EntryPayload::Membership(m) => EntryOf::<TypeConfig>::new_membership(log_id(index), m),
+        };
+        (e, None)
+    }
+
+    async fn apply_one(
+        sm: &mut HighWaterStateMachine,
+        index: u64,
+        payload: EntryPayload<HighWaterCommand, u64, crate::type_config::OpenraftPeer>,
+    ) {
+        sm.apply(stream::iter([Ok(entry(index, payload))])).await.expect("apply");
+    }
+
+    // --- Tests ---
+
+    #[tokio::test]
+    async fn apply_blank_updates_only_log_id() {
+        let mut sm = HighWaterStateMachine::new();
+        apply_one(&mut sm, 1, EntryPayload::Blank).await;
+        assert_eq!(sm.current_value().await, 0);
+        let (last, _) = sm.applied_state().await.unwrap();
+        assert_eq!(last.map(|l| l.index), Some(1));
+    }
+
+    #[tokio::test]
+    async fn apply_normal_advances_value() {
+        let mut sm = HighWaterStateMachine::new();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+        )
+        .await;
+        assert_eq!(sm.current_value().await, 100);
+    }
+
+    #[tokio::test]
+    async fn apply_normal_holds_monotonic_under_stale_target() {
+        let mut sm = HighWaterStateMachine::new();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+        )
+        .await;
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 50 }),
+        )
+        .await;
+        assert_eq!(sm.current_value().await, 100);
+    }
+
+    #[tokio::test]
+    async fn apply_normal_equal_target_holds_value() {
+        let mut sm = HighWaterStateMachine::new();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+        )
+        .await;
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+        )
+        .await;
+        assert_eq!(sm.current_value().await, 100);
+    }
+
+    #[tokio::test]
+    async fn apply_membership_updates_membership_only() {
+        let mut sm = HighWaterStateMachine::new();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::Bump { target: 42 }),
+        )
+        .await;
+        let mem = openraft::Membership::new_with_defaults(
+            vec![BTreeSet::from([1u64])],
+            [1u64],
+        );
+        apply_one(&mut sm, 2, EntryPayload::Membership(mem)).await;
+        assert_eq!(sm.current_value().await, 42);
+        let (last, _) = sm.applied_state().await.unwrap();
+        assert_eq!(last.map(|l| l.index), Some(2));
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -1,0 +1,255 @@
+//! In-memory `RaftStateMachine` for the high-water counter.
+//!
+//! State is one `u64` plus the openraft-required apply-progress metadata
+//! (`last_applied`, `last_membership`). Snapshots are bincode-encoded blobs of
+//! that tuple. All state lives inside an `Arc<Mutex<HighWaterCore>>` so the
+//! state machine is cheaply cloneable — required because openraft's
+//! `RaftStateMachine::SnapshotBuilder = Self` design hands out clones to drive
+//! `build_snapshot` concurrently with `apply`.
+//!
+//! # Why in-memory only
+//!
+//! This is the Phase A driver: durability comes from the raft log (which the
+//! caller persists via their own `RaftLogStorage`, e.g.
+//! `openraft_toolkit::RocksdbLogStore`). On restart the log replays into the
+//! state machine, rebuilding `current_value`. A persisted backend can ship as
+//! a follow-up without changing the trait wiring.
+
+use std::io;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use futures::StreamExt;
+use openraft::EntryPayload;
+use openraft::RaftSnapshotBuilder;
+use openraft::StoredMembership;
+use openraft::storage::EntryResponder;
+use openraft::storage::RaftStateMachine;
+use openraft::storage::Snapshot;
+use openraft::type_config::alias::{LogIdOf, SnapshotMetaOf, SnapshotOf, StoredMembershipOf};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+use crate::log_entry::HighWaterCommand;
+use crate::type_config::{HighWaterApplied, TypeConfig};
+
+type LogId = LogIdOf<TypeConfig>;
+type SnapMeta = SnapshotMetaOf<TypeConfig>;
+type SnapOf = SnapshotOf<TypeConfig>;
+type SnapData = Cursor<Vec<u8>>;
+type StoredMem = StoredMembershipOf<TypeConfig>;
+
+/// Snapshot payload — bincode-encoded under the hood.
+///
+/// Exposed at the crate root so callers building tooling around the snapshot
+/// format (e.g. inspectors, migration tools) can decode it without re-deriving
+/// the layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HighWaterStateMachineSnapshot {
+    pub current_value: u64,
+    pub last_applied: Option<LogId>,
+    pub last_membership: StoredMem,
+}
+
+/// Mutable core guarded by a single mutex. `parking_lot::Mutex` because the
+/// apply path is hot and the state is fully re-derivable from the raft log
+/// (poison semantics would just mask the originating panic).
+struct Core {
+    current_value: u64,
+    last_applied: Option<LogId>,
+    last_membership: StoredMem,
+    /// Snapshot index counter, used to make snapshot ids unique even when two
+    /// snapshots are produced at the same `last_applied` log id.
+    snapshot_idx: u64,
+    /// The most-recently built or installed snapshot, retained in memory so
+    /// `get_current_snapshot` does not need to rebuild on every call.
+    current_snapshot: Option<StoredSnapshot>,
+}
+
+#[derive(Clone)]
+struct StoredSnapshot {
+    meta: SnapMeta,
+    data: Vec<u8>,
+}
+
+/// In-memory `RaftStateMachine` implementation.
+///
+/// Clone-cheap: every field is behind an `Arc`, so cloning hands out another
+/// handle pointing at the same `Core`. Required by openraft's
+/// `get_snapshot_builder` contract which uses `SnapshotBuilder = Self`.
+pub struct HighWaterStateMachine {
+    core: Arc<Mutex<Core>>,
+}
+
+impl Clone for HighWaterStateMachine {
+    fn clone(&self) -> Self {
+        Self {
+            core: Arc::clone(&self.core),
+        }
+    }
+}
+
+impl Default for HighWaterStateMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HighWaterStateMachine {
+    /// Build a fresh, empty state machine.
+    pub fn new() -> Self {
+        Self {
+            core: Arc::new(Mutex::new(Core {
+                current_value: 0,
+                last_applied: None,
+                last_membership: StoredMembership::default(),
+                snapshot_idx: 0,
+                current_snapshot: None,
+            })),
+        }
+    }
+
+    /// Read the current high-water value without going through raft.
+    ///
+    /// Returns the value most-recently written by `apply` or
+    /// `install_snapshot`. This is a state-machine-local read; callers that
+    /// need linearizability must coordinate a read barrier through `Raft`
+    /// before calling.
+    pub async fn current_value(&self) -> u64 {
+        self.core.lock().current_value
+    }
+
+    fn snapshot_id_for(last_applied: Option<&LogId>, idx: u64) -> String {
+        let log_index = last_applied.map(|l| l.index).unwrap_or(0);
+        format!("{log_index}-{idx}")
+    }
+}
+
+impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
+    async fn build_snapshot(&mut self) -> Result<SnapOf, io::Error> {
+        // Clone the relevant fields out from under the lock, then encode
+        // outside the critical section.
+        let (snapshot_payload, meta, stored) = {
+            let mut core = self.core.lock();
+            core.snapshot_idx += 1;
+            let payload = HighWaterStateMachineSnapshot {
+                current_value: core.current_value,
+                last_applied: core.last_applied,
+                last_membership: core.last_membership.clone(),
+            };
+            let snapshot_id = Self::snapshot_id_for(core.last_applied.as_ref(), core.snapshot_idx);
+            let meta = SnapMeta {
+                last_log_id: core.last_applied,
+                last_membership: core.last_membership.clone(),
+                snapshot_id,
+            };
+            let bytes = bincode::serialize(&payload)
+                .map_err(|e| io::Error::other(format!("snapshot serialize: {e}")))?;
+            let stored = StoredSnapshot {
+                meta: meta.clone(),
+                data: bytes.clone(),
+            };
+            core.current_snapshot = Some(stored.clone());
+            (bytes, meta, stored)
+        };
+
+        // `stored` is retained for `get_current_snapshot`; the returned
+        // `Snapshot` owns its own copy of the bytes.
+        let _ = stored;
+        Ok(Snapshot {
+            meta,
+            snapshot: Cursor::new(snapshot_payload),
+        })
+    }
+}
+
+impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMem), io::Error> {
+        let core = self.core.lock();
+        Ok((core.last_applied, core.last_membership.clone()))
+    }
+
+    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    where
+        Strm: futures::Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>>
+            + Unpin
+            + openraft::OptionalSend,
+    {
+        while let Some(item) = entries.next().await {
+            let (entry, responder_opt) = item?;
+            let log_id = entry.log_id;
+
+            let applied = match &entry.payload {
+                EntryPayload::Blank => {
+                    let mut core = self.core.lock();
+                    core.last_applied = Some(log_id);
+                    HighWaterApplied {
+                        value: core.current_value,
+                    }
+                }
+                EntryPayload::Normal(cmd) => {
+                    let HighWaterCommand::Bump { target } = cmd;
+                    let mut core = self.core.lock();
+                    if *target > core.current_value {
+                        core.current_value = *target;
+                    }
+                    core.last_applied = Some(log_id);
+                    HighWaterApplied {
+                        value: core.current_value,
+                    }
+                }
+                EntryPayload::Membership(membership) => {
+                    let mut core = self.core.lock();
+                    core.last_membership = StoredMembership::new(Some(log_id), membership.clone());
+                    core.last_applied = Some(log_id);
+                    HighWaterApplied {
+                        value: core.current_value,
+                    }
+                }
+            };
+
+            if let Some(responder) = responder_opt {
+                responder.send(applied);
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapData, io::Error> {
+        Ok(Cursor::new(Vec::new()))
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapMeta,
+        snapshot: SnapData,
+    ) -> Result<(), io::Error> {
+        let bytes = snapshot.into_inner();
+        let payload: HighWaterStateMachineSnapshot = bincode::deserialize(&bytes)
+            .map_err(|e| io::Error::other(format!("snapshot deserialize: {e}")))?;
+
+        let mut core = self.core.lock();
+        core.current_value = payload.current_value;
+        core.last_applied = payload.last_applied;
+        core.last_membership = payload.last_membership;
+        core.current_snapshot = Some(StoredSnapshot {
+            meta: meta.clone(),
+            data: bytes,
+        });
+        Ok(())
+    }
+
+    async fn get_current_snapshot(&mut self) -> Result<Option<SnapOf>, io::Error> {
+        let core = self.core.lock();
+        Ok(core.current_snapshot.as_ref().map(|s| Snapshot {
+            meta: s.meta.clone(),
+            snapshot: Cursor::new(s.data.clone()),
+        }))
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -491,5 +491,43 @@ mod tests {
                 Ok(())
             })?;
         }
+
+        /// Snapshot payload round-trip: build_snapshot -> install_snapshot
+        /// preserves (current_value, last_applied, last_membership) across
+        /// arbitrary apply sequences.
+        #[test]
+        fn p2_snapshot_payload_round_trip(
+            bumps in prop::collection::vec(any::<u64>(), 0..=32)
+        ) {
+            rt().block_on(async {
+                let mut sm = HighWaterStateMachine::new();
+                let mut idx = 0u64;
+                for t in &bumps {
+                    idx += 1;
+                    apply_one(
+                        &mut sm,
+                        idx,
+                        EntryPayload::Normal(HighWaterCommand::Bump { target: *t }),
+                    )
+                    .await;
+                }
+
+                let snap = sm.build_snapshot().await.expect("build_snapshot");
+                let meta = snap.meta.clone();
+                let bytes = snap.snapshot.into_inner();
+
+                let mut sm2 = HighWaterStateMachine::new();
+                sm2.install_snapshot(&meta, std::io::Cursor::new(bytes))
+                    .await
+                    .expect("install_snapshot");
+
+                prop_assert_eq!(sm2.current_value().await, sm.current_value().await);
+                let (a_last, a_mem) = sm.applied_state().await.unwrap();
+                let (b_last, b_mem) = sm2.applied_state().await.unwrap();
+                prop_assert_eq!(a_last, b_last);
+                prop_assert_eq!(a_mem, b_mem);
+                Ok(())
+            })?;
+        }
     }
 }

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -14,7 +14,7 @@ use crate::log_entry::HighWaterCommand;
 /// Peer identity carried in the membership entries.
 ///
 /// Currently holds just an address; richer metadata can be added later without
-/// breaking the wire format because openraft serializes via bincode and the
+/// breaking the wire format because the codec is length-prefixed and the
 /// `Default` impl gives missing fields a deterministic value.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenraftPeer {
@@ -38,4 +38,51 @@ declare_raft_types_ext! {
         AppData         = HighWaterCommand,
         AppDataResponse = HighWaterApplied,
         SnapshotData    = Cursor<Vec<u8>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openraft_peer_round_trips() {
+        let peer = OpenraftPeer {
+            addr: "10.0.0.1:50051".to_string(),
+        };
+        let bytes = postcard::to_stdvec(&peer).expect("serialize");
+        let back: OpenraftPeer = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, peer);
+    }
+
+    #[test]
+    fn openraft_peer_default_is_empty_addr() {
+        let peer = OpenraftPeer::default();
+        assert_eq!(peer.addr, "");
+    }
+
+    #[test]
+    fn openraft_peer_round_trips_empty_addr() {
+        let peer = OpenraftPeer { addr: String::new() };
+        let bytes = postcard::to_stdvec(&peer).expect("serialize");
+        let back: OpenraftPeer = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, peer);
+    }
+
+    #[test]
+    fn high_water_applied_round_trips() {
+        let applied = HighWaterApplied { value: 12_345 };
+        let bytes = postcard::to_stdvec(&applied).expect("serialize");
+        let back: HighWaterApplied = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, applied);
+    }
+
+    #[test]
+    fn high_water_applied_round_trips_zero_and_max() {
+        for v in [0u64, u64::MAX] {
+            let applied = HighWaterApplied { value: v };
+            let bytes = postcard::to_stdvec(&applied).expect("serialize");
+            let back: HighWaterApplied = postcard::from_bytes(&bytes).expect("deserialize");
+            assert_eq!(back, applied);
+        }
+    }
 }

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -62,7 +62,9 @@ mod tests {
 
     #[test]
     fn openraft_peer_round_trips_empty_addr() {
-        let peer = OpenraftPeer { addr: String::new() };
+        let peer = OpenraftPeer {
+            addr: String::new(),
+        };
         let bytes = postcard::to_stdvec(&peer).expect("serialize");
         let back: OpenraftPeer = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, peer);

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -1,0 +1,41 @@
+//! `RaftTypeConfig` for the openraft-backed driver.
+//!
+//! Built via `openraft_toolkit::declare_raft_types_ext!` so the type config
+//! inherits the toolkit's defaults (`NodeId = u64`, `Term = u64`, `LeaderId =
+//! leader_id_adv::LeaderId<u64, u64>`, `Responder = OneshotResponder`).
+
+use std::io::Cursor;
+
+use openraft_toolkit::declare_raft_types_ext;
+use serde::{Deserialize, Serialize};
+
+use crate::log_entry::HighWaterCommand;
+
+/// Peer identity carried in the membership entries.
+///
+/// Currently holds just an address; richer metadata can be added later without
+/// breaking the wire format because openraft serializes via bincode and the
+/// `Default` impl gives missing fields a deterministic value.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenraftPeer {
+    pub addr: String,
+}
+
+/// Per-entry apply result.
+///
+/// Returned by the state machine for each replicated entry. The driver reads
+/// `value` from the `client_write` response to confirm the committed value
+/// observed by the apply pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HighWaterApplied {
+    /// The high-water value after this entry's apply.
+    pub value: u64,
+}
+
+declare_raft_types_ext! {
+    pub TypeConfig:
+        Node            = OpenraftPeer,
+        AppData         = HighWaterCommand,
+        AppDataResponse = HighWaterApplied,
+        SnapshotData    = Cursor<Vec<u8>>,
+}

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -255,6 +255,37 @@ pub async fn build_three_node() -> TestCluster {
     }
 }
 
-pub async fn reopen_node(_prior: TestNode) -> TestNode {
-    unimplemented!("reopen_node lands in a follow-up task")
+pub async fn reopen_node(prior: TestNode) -> TestNode {
+    let TestNode {
+        id,
+        raft,
+        sm: _,
+        log_dir,
+    } = prior;
+
+    // Shut down the prior Raft cleanly so RocksDB files are released.
+    raft.shutdown().await.expect("prior raft shutdown");
+    drop(raft);
+
+    // Reopen RocksDB at the same path with a fresh state machine. openraft
+    // will re-apply committed log entries during Raft::new.
+    let log_store = open_rocksdb_log_store(&log_dir);
+    let sm = HighWaterStateMachine::new();
+    let sm_clone = sm.clone();
+    let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
+        id,
+        test_raft_config(),
+        UnreachableNetwork,
+        log_store,
+        sm,
+    )
+    .await
+    .expect("Raft::new on reopen");
+
+    TestNode {
+        id,
+        raft,
+        sm: sm_clone,
+        log_dir,
+    }
 }

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -66,8 +66,7 @@ where
     }
     assert_eq!(
         last, expected,
-        "eventually_eq timed out after {:?}: last={:?} expected={:?}",
-        timeout, last, expected
+        "eventually_eq timed out after {timeout:?}: last={last:?} expected={expected:?}",
     );
 }
 

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -202,7 +202,57 @@ pub async fn build_single_node() -> TestCluster {
 }
 
 pub async fn build_three_node() -> TestCluster {
-    unimplemented!("build_three_node lands in a follow-up task")
+    let net = MemNetwork::<TypeConfig>::new();
+    let cfg = test_raft_config();
+
+    let mut nodes: Vec<TestNode> = Vec::new();
+    let mut drivers: Vec<Arc<OpenraftDriver<StandaloneHost>>> = Vec::new();
+
+    for id in [1u64, 2, 3] {
+        let dir = TempDir::new().unwrap();
+        let log_store = open_rocksdb_log_store(&dir);
+        let sm = HighWaterStateMachine::new();
+        let sm_clone = sm.clone();
+        let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
+            id,
+            cfg.clone(),
+            net.factory_for(id),
+            log_store,
+            sm,
+        )
+        .await
+        .expect("Raft::new");
+        net.register(id, raft.clone());
+
+        let host = StandaloneHost::new(raft.clone(), sm_clone.clone());
+        drivers.push(OpenraftDriver::new(host));
+        nodes.push(TestNode {
+            id,
+            raft,
+            sm: sm_clone,
+            log_dir: dir,
+        });
+    }
+
+    // Initialize membership on node 1.
+    let mut mem = BTreeMap::new();
+    for id in [1u64, 2, 3] {
+        mem.insert(
+            id,
+            OpenraftPeer {
+                addr: format!("mem-node-{id}"),
+            },
+        );
+    }
+    nodes[0].raft.initialize(mem).await.expect("initialize");
+
+    let partitions = net.partitions();
+    TestCluster {
+        nodes,
+        network: Some(net),
+        partitions: Some(partitions),
+        drivers,
+    }
 }
 
 pub async fn reopen_node(_prior: TestNode) -> TestNode {

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -6,17 +6,28 @@
 
 #![allow(dead_code)] // each test binary uses a subset; allow the rest
 
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+use openraft::Config;
+use openraft::OptionalSend;
 use openraft::Raft;
+use openraft::error::{NetworkError, RPCError, ReplicationClosed, StreamingError};
+use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
+};
+use openraft::type_config::alias::{SnapshotOf, VoteOf};
 use openraft_toolkit::test_fakes::{MemNetwork, PartitionController};
+use openraft_toolkit::{Flat, RocksdbLogStore};
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tempfile::TempDir;
 use tokio::time::Instant;
 use tsoracle_driver_openraft::{
-    HighWaterStateMachine, OpenraftDriver, StandaloneHost, TypeConfig,
+    HighWaterStateMachine, OpenraftDriver, OpenraftPeer, StandaloneHost, TypeConfig,
 };
 
 /// One node in a test cluster. Holds the raft handle, a clone of the state
@@ -60,12 +71,134 @@ where
     );
 }
 
+// ---------------------------------------------------------------------------
+// UnreachableNetwork: panicking `RaftNetworkV2` for single-node clusters.
+// ---------------------------------------------------------------------------
+
+/// A `RaftNetworkFactory` whose generated clients panic on any RPC.
+/// Suitable only for single-voter clusters that never replicate.
+pub struct UnreachableNetwork;
+
+impl RaftNetworkFactory<TypeConfig> for UnreachableNetwork {
+    type Network = UnreachablePeer;
+
+    async fn new_client(&mut self, target: u64, _node: &OpenraftPeer) -> Self::Network {
+        UnreachablePeer { target }
+    }
+}
+
+pub struct UnreachablePeer {
+    target: u64,
+}
+
+impl RaftNetworkV2<TypeConfig> for UnreachablePeer {
+    async fn append_entries(
+        &mut self,
+        _rpc: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig>> {
+        Err(RPCError::Network(NetworkError::from_string(format!(
+            "unreachable network: append_entries to node {} in single-node test",
+            self.target
+        ))))
+    }
+
+    async fn vote(
+        &mut self,
+        _rpc: VoteRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig>> {
+        Err(RPCError::Network(NetworkError::from_string(format!(
+            "unreachable network: vote to node {} in single-node test",
+            self.target
+        ))))
+    }
+
+    async fn full_snapshot(
+        &mut self,
+        _vote: VoteOf<TypeConfig>,
+        _snapshot: SnapshotOf<TypeConfig>,
+        _cancel: impl std::future::Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {
+        Err(StreamingError::Network(NetworkError::from_string(format!(
+            "unreachable network: snapshot to node {} in single-node test",
+            self.target
+        ))))
+    }
+}
+
+const LOG_CF: &str = "raft_log";
+const META_CF: &str = "raft_meta";
+
+fn test_raft_config() -> Arc<openraft::Config> {
+    Arc::new(
+        Config {
+            heartbeat_interval: 50,
+            election_timeout_min: 150,
+            election_timeout_max: 300,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap(),
+    )
+}
+
+fn open_rocksdb_log_store(dir: &TempDir) -> RocksdbLogStore<TypeConfig, Flat> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cfs = vec![
+        ColumnFamilyDescriptor::new(LOG_CF, Options::default()),
+        ColumnFamilyDescriptor::new(META_CF, Options::default()),
+    ];
+    let db = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap());
+    RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap()
+}
+
 // Builders below are stubs filled in by subsequent tasks:
-// - build_single_node, build_three_node: cluster constructors
+// - build_three_node: cluster constructor
 // - reopen_node: restart-replay primitive
 
 pub async fn build_single_node() -> TestCluster {
-    unimplemented!("build_single_node lands in a follow-up task")
+    let dir = TempDir::new().unwrap();
+    let log_store = open_rocksdb_log_store(&dir);
+    let sm = HighWaterStateMachine::new();
+    let sm_clone = sm.clone();
+
+    let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
+        1u64,
+        test_raft_config(),
+        UnreachableNetwork,
+        log_store,
+        sm,
+    )
+    .await
+    .expect("Raft::new");
+
+    let mut mem = BTreeMap::new();
+    mem.insert(
+        1u64,
+        OpenraftPeer {
+            addr: "self".into(),
+        },
+    );
+    raft.initialize(mem).await.expect("initialize");
+
+    let host = StandaloneHost::new(raft.clone(), sm_clone.clone());
+    let driver = OpenraftDriver::new(host);
+
+    TestCluster {
+        nodes: vec![TestNode {
+            id: 1,
+            raft,
+            sm: sm_clone,
+            log_dir: dir,
+        }],
+        network: None,
+        partitions: None,
+        drivers: vec![driver],
+    }
 }
 
 pub async fn build_three_node() -> TestCluster {

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -1,0 +1,77 @@
+//! Shared test scaffolding for `tsoracle-driver-openraft` integration tests.
+//!
+//! Each `tests/*.rs` declares `mod common;` and imports via `use common::*;`.
+//! Rust compiles this module per integration-test binary (a known minor
+//! duplication; negligible at our scale).
+
+#![allow(dead_code)] // each test binary uses a subset; allow the rest
+
+use std::fmt::Debug;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::Raft;
+use openraft_toolkit::test_fakes::{MemNetwork, PartitionController};
+use tempfile::TempDir;
+use tokio::time::Instant;
+use tsoracle_driver_openraft::{
+    HighWaterStateMachine, OpenraftDriver, StandaloneHost, TypeConfig,
+};
+
+/// One node in a test cluster. Holds the raft handle, a clone of the state
+/// machine for direct reads, the rocksdb tempdir (so files outlive the test),
+/// and the node id.
+pub struct TestNode {
+    pub id: u64,
+    pub raft: Raft<TypeConfig, HighWaterStateMachine>,
+    pub sm: HighWaterStateMachine,
+    pub log_dir: TempDir,
+}
+
+/// A built test cluster. `network` and `partitions` are `None` for
+/// single-node clusters (those use a panicking network). `drivers[i]`
+/// corresponds to `nodes[i]`.
+pub struct TestCluster {
+    pub nodes: Vec<TestNode>,
+    pub network: Option<Arc<MemNetwork<TypeConfig>>>,
+    pub partitions: Option<Arc<PartitionController<u64>>>,
+    pub drivers: Vec<Arc<OpenraftDriver<StandaloneHost>>>,
+}
+
+/// Poll `f` on a 50ms cadence until it yields `expected` or `timeout`
+/// elapses. Panics with a descriptive message on timeout.
+pub async fn eventually_eq<T, F, Fut>(expected: T, timeout: Duration, mut f: F)
+where
+    T: PartialEq + Debug,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = T>,
+{
+    let deadline = Instant::now() + timeout;
+    let mut last = f().await;
+    while last != expected && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        last = f().await;
+    }
+    assert_eq!(
+        last, expected,
+        "eventually_eq timed out after {:?}: last={:?} expected={:?}",
+        timeout, last, expected
+    );
+}
+
+// Builders below are stubs filled in by subsequent tasks:
+// - build_single_node, build_three_node: cluster constructors
+// - reopen_node: restart-replay primitive
+
+pub async fn build_single_node() -> TestCluster {
+    unimplemented!("build_single_node lands in a follow-up task")
+}
+
+pub async fn build_three_node() -> TestCluster {
+    unimplemented!("build_three_node lands in a follow-up task")
+}
+
+pub async fn reopen_node(_prior: TestNode) -> TestNode {
+    unimplemented!("reopen_node lands in a follow-up task")
+}

--- a/crates/tsoracle-driver-openraft/tests/partition_churn.rs
+++ b/crates/tsoracle-driver-openraft/tests/partition_churn.rs
@@ -13,7 +13,7 @@ use tokio::time::timeout;
 use tsoracle_consensus::ConsensusDriver;
 use tsoracle_core::Epoch;
 
-use common::{build_three_node, eventually_eq, TestCluster};
+use common::{TestCluster, build_three_node, eventually_eq};
 
 async fn find_leader_idx(cluster: &TestCluster) -> usize {
     timeout(Duration::from_secs(10), async {

--- a/crates/tsoracle-driver-openraft/tests/partition_churn.rs
+++ b/crates/tsoracle-driver-openraft/tests/partition_churn.rs
@@ -1,0 +1,119 @@
+//! Partition + leader-churn integration test.
+//!
+//! Establishes a 3-voter cluster with a baseline value, isolates the
+//! current leader L, waits for a new leader L' to be elected on the majority
+//! side, writes through L', heals the partition, and asserts L catches up
+//! monotonically to the new value.
+
+mod common;
+
+use std::time::Duration;
+
+use tokio::time::timeout;
+use tsoracle_consensus::ConsensusDriver;
+use tsoracle_core::Epoch;
+
+use common::{build_three_node, eventually_eq, TestCluster};
+
+async fn find_leader_idx(cluster: &TestCluster) -> usize {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            for (idx, node) in cluster.nodes.iter().enumerate() {
+                if let Some(l) = node.raft.current_leader().await {
+                    if l == node.id {
+                        return idx;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("some node became leader within 10s")
+}
+
+async fn find_leader_excluding(cluster: &TestCluster, exclude_idx: usize) -> usize {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            for (idx, node) in cluster.nodes.iter().enumerate() {
+                if idx == exclude_idx {
+                    continue;
+                }
+                if let Some(l) = node.raft.current_leader().await {
+                    if l == node.id {
+                        return idx;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("a new leader (excluding old) was elected within 10s")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn partition_then_heal_converges_monotonically() {
+    let cluster = build_three_node().await;
+    let partitions = cluster
+        .partitions
+        .as_ref()
+        .expect("three-node cluster has partitions")
+        .clone();
+
+    // Baseline: bump to 100 via the current leader; all nodes converge.
+    let l_idx = find_leader_idx(&cluster).await;
+    let l_id = cluster.nodes[l_idx].id;
+    let v = cluster.drivers[l_idx]
+        .persist_high_water(100, Epoch(1))
+        .await
+        .expect("baseline bump");
+    assert_eq!(v, 100);
+    for i in 0..3 {
+        let driver = cluster.drivers[i].clone();
+        eventually_eq(100u64, Duration::from_secs(5), || {
+            let d = driver.clone();
+            async move { d.load_high_water().await.unwrap() }
+        })
+        .await;
+    }
+
+    // Partition: isolate L. Real-time sleep past election_timeout_max.
+    partitions.isolate(l_id);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let l_prime_idx = find_leader_excluding(&cluster, l_idx).await;
+    assert_ne!(l_prime_idx, l_idx, "new leader must differ from old");
+
+    // Majority-side write via L'. L' + remaining follower = quorum.
+    let v = cluster.drivers[l_prime_idx]
+        .persist_high_water(200, Epoch(2))
+        .await
+        .expect("L_prime persists 200");
+    assert_eq!(v, 200);
+
+    // Diagnostic: an attempt on the isolated leader should stall, not
+    // succeed silently with a stale read or return NotLeader. (openraft
+    // doesn't preemptively step down; the leader keeps trying to replicate
+    // and hits no quorum.)
+    let attempt = timeout(
+        Duration::from_secs(2),
+        cluster.drivers[l_idx].persist_high_water(300, Epoch(3)),
+    )
+    .await;
+    assert!(
+        attempt.is_err(),
+        "isolated leader should stall, not return; got {attempt:?}",
+    );
+
+    // Heal the partition.
+    partitions.heal(l_id);
+
+    // L converges on 200 (never went backwards: 100 -> 200, monotone).
+    let driver = cluster.drivers[l_idx].clone();
+    eventually_eq(200u64, Duration::from_secs(10), || {
+        let d = driver.clone();
+        async move { d.load_high_water().await.unwrap() }
+    })
+    .await;
+}

--- a/crates/tsoracle-driver-openraft/tests/restart_replay.rs
+++ b/crates/tsoracle-driver-openraft/tests/restart_replay.rs
@@ -15,15 +15,13 @@ use tokio::time::timeout;
 use tsoracle_consensus::{ConsensusDriver, LeaderState};
 use tsoracle_core::Epoch;
 
-use common::{build_single_node, eventually_eq, reopen_node, TestCluster};
+use common::{TestCluster, build_single_node, eventually_eq, reopen_node};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn restart_replays_high_water_from_rocksdb_log() {
     let cluster = build_single_node().await;
     let TestCluster {
-        mut nodes,
-        drivers,
-        ..
+        mut nodes, drivers, ..
     } = cluster;
     let driver = drivers[0].clone();
 
@@ -59,10 +57,8 @@ async fn restart_replays_high_water_from_rocksdb_log() {
     let reopened = reopen_node(prior).await;
 
     // Build a fresh driver against the reopened node.
-    let host = tsoracle_driver_openraft::StandaloneHost::new(
-        reopened.raft.clone(),
-        reopened.sm.clone(),
-    );
+    let host =
+        tsoracle_driver_openraft::StandaloneHost::new(reopened.raft.clone(), reopened.sm.clone());
     let reopened_driver = tsoracle_driver_openraft::OpenraftDriver::new(host);
 
     // Replay yields the last persisted value.

--- a/crates/tsoracle-driver-openraft/tests/restart_replay.rs
+++ b/crates/tsoracle-driver-openraft/tests/restart_replay.rs
@@ -1,0 +1,94 @@
+//! Restart-replay integration test.
+//!
+//! Bumps the value on a single-node cluster, drops the Raft handle (after
+//! a clean shutdown), reopens the rocksdb log with a fresh state machine,
+//! and asserts the new state machine replays to the most recently
+//! persisted value. Then asserts the cluster is still functional
+//! post-replay (can accept a new bump).
+
+mod common;
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, LeaderState};
+use tsoracle_core::Epoch;
+
+use common::{build_single_node, eventually_eq, reopen_node, TestCluster};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn restart_replays_high_water_from_rocksdb_log() {
+    let cluster = build_single_node().await;
+    let TestCluster {
+        mut nodes,
+        drivers,
+        ..
+    } = cluster;
+    let driver = drivers[0].clone();
+
+    // Wait for leadership before bumping.
+    let mut events = driver.leadership_events();
+    let _epoch = timeout(Duration::from_secs(5), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if let LeaderState::Leader { epoch } = s {
+                break epoch;
+            }
+        }
+    })
+    .await
+    .expect("became leader within 5s");
+    drop(events);
+
+    // First bump.
+    let v = driver.persist_high_water(500, Epoch(1)).await.unwrap();
+    assert_eq!(v, 500);
+
+    // Second bump.
+    let v = driver.persist_high_water(700, Epoch(1)).await.unwrap();
+    assert_eq!(v, 700);
+
+    // Drop the drivers so they don't keep the raft alive past shutdown.
+    drop(driver);
+    drop(drivers);
+
+    // Reopen the node: shut down the prior Raft cleanly, then construct a
+    // fresh Raft + state machine against the same on-disk rocksdb log.
+    let prior = nodes.remove(0);
+    let reopened = reopen_node(prior).await;
+
+    // Build a fresh driver against the reopened node.
+    let host = tsoracle_driver_openraft::StandaloneHost::new(
+        reopened.raft.clone(),
+        reopened.sm.clone(),
+    );
+    let reopened_driver = tsoracle_driver_openraft::OpenraftDriver::new(host);
+
+    // Replay yields the last persisted value.
+    let d = reopened_driver.clone();
+    eventually_eq(700u64, Duration::from_secs(10), || {
+        let d = d.clone();
+        async move { d.load_high_water().await.unwrap() }
+    })
+    .await;
+
+    // Cluster is still functional post-replay. Wait for re-leadership.
+    let mut events = reopened_driver.leadership_events();
+    let _epoch = timeout(Duration::from_secs(10), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if let LeaderState::Leader { epoch } = s {
+                break epoch;
+            }
+        }
+    })
+    .await
+    .expect("re-became leader within 10s");
+
+    let v = reopened_driver
+        .persist_high_water(800, Epoch(1))
+        .await
+        .expect("post-replay bump");
+    assert_eq!(v, 800);
+}

--- a/crates/tsoracle-driver-openraft/tests/single_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/single_node.rs
@@ -1,188 +1,26 @@
 //! Single-node integration test for [`OpenraftDriver`].
 //!
-//! Stands up a one-voter openraft cluster on top of:
-//!
-//! - `openraft_toolkit::RocksdbLogStore` (tempdir-backed)
-//! - `HighWaterStateMachine` (in-memory)
-//! - `UnreachableNetwork` — a `RaftNetworkV2` whose RPC methods panic if ever
-//!   invoked. A single-voter cluster never sends append/vote/snapshot RPCs to
-//!   itself, so any panic from here would indicate a real bug.
-//!
-//! Then drives the [`ConsensusDriver`] surface: confirms an initial Leader
-//! event, an empty `load_high_water`, a `persist_high_water` round trip, and
-//! the monotonic-advance semantics.
+//! Builds a one-voter openraft cluster via [`common::build_single_node`] and
+//! drives the [`ConsensusDriver`] surface: confirms an initial Leader event,
+//! an empty `load_high_water`, a `persist_high_water` round trip, and the
+//! monotonic-advance semantics.
 
-use std::collections::BTreeMap;
-use std::future::Future;
-use std::sync::Arc;
+mod common;
+
 use std::time::Duration;
 
 use futures::StreamExt;
-use openraft::Config;
-use openraft::Raft;
-use openraft::error::{NetworkError, RPCError, ReplicationClosed, StreamingError};
-use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
-use openraft::raft::{
-    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
-};
-use openraft::type_config::alias::{SnapshotOf, VoteOf};
-use openraft_toolkit::{Flat, RocksdbLogStore};
-use rocksdb::{ColumnFamilyDescriptor, DB, Options};
-use tempfile::TempDir;
 use tokio::time::timeout;
 use tsoracle_consensus::{ConsensusDriver, LeaderState};
-use tsoracle_driver_openraft::{
-    HighWaterStateMachine, OpenraftDriver, OpenraftPeer, StandaloneHost, TypeConfig,
-};
 
-const LOG_CF: &str = "raft_log";
-const META_CF: &str = "raft_meta";
+use common::build_single_node;
 
-// ---------------------------------------------------------------------------
-// UnreachableNetwork: panicking `RaftNetworkV2` for single-node clusters.
-// ---------------------------------------------------------------------------
-
-/// A `RaftNetworkFactory` whose generated clients panic on any RPC.
-///
-/// Single-node clusters never replicate to peers, so the network is exercised
-/// only as a type-level requirement of `Raft::new`. If any test ever upgrades
-/// to a multi-node cluster this network must be replaced with a real one.
-struct UnreachableNetwork;
-
-impl RaftNetworkFactory<TypeConfig> for UnreachableNetwork {
-    type Network = UnreachablePeer;
-
-    async fn new_client(&mut self, target: u64, _node: &OpenraftPeer) -> Self::Network {
-        UnreachablePeer { target }
-    }
-}
-
-struct UnreachablePeer {
-    target: u64,
-}
-
-impl RaftNetworkV2<TypeConfig> for UnreachablePeer {
-    async fn append_entries(
-        &mut self,
-        _rpc: AppendEntriesRequest<TypeConfig>,
-        _option: RPCOption,
-    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig>> {
-        Err(RPCError::Network(NetworkError::from_string(format!(
-            "unreachable network: append_entries to node {} in single-node test",
-            self.target
-        ))))
-    }
-
-    async fn vote(
-        &mut self,
-        _rpc: VoteRequest<TypeConfig>,
-        _option: RPCOption,
-    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig>> {
-        Err(RPCError::Network(NetworkError::from_string(format!(
-            "unreachable network: vote to node {} in single-node test",
-            self.target
-        ))))
-    }
-
-    async fn full_snapshot(
-        &mut self,
-        _vote: VoteOf<TypeConfig>,
-        _snapshot: SnapshotOf<TypeConfig>,
-        _cancel: impl Future<Output = ReplicationClosed> + openraft::OptionalSend + 'static,
-        _option: RPCOption,
-    ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {
-        Err(StreamingError::Network(NetworkError::from_string(format!(
-            "unreachable network: snapshot to node {} in single-node test",
-            self.target
-        ))))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Test harness: assemble Raft + driver from scratch.
-// ---------------------------------------------------------------------------
-
-struct SingleNode {
-    driver: Arc<OpenraftDriver<StandaloneHost>>,
-    /// Kept alive so the rocksdb backing files outlive the test.
-    _dir: TempDir,
-    /// Raft handle. Keeping the original here keeps the cluster running for
-    /// the driver's `Raft` clone too — `Raft` is `Arc`-backed.
-    _raft: Raft<TypeConfig, HighWaterStateMachine>,
-}
-
-async fn build_single_node() -> SingleNode {
-    let dir = TempDir::new().unwrap();
-
-    // RocksDB with two column families: log + meta.
-    let mut opts = Options::default();
-    opts.create_if_missing(true);
-    opts.create_missing_column_families(true);
-    let cfs = vec![
-        ColumnFamilyDescriptor::new(LOG_CF, Options::default()),
-        ColumnFamilyDescriptor::new(META_CF, Options::default()),
-    ];
-    let db = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap());
-
-    let log_store: RocksdbLogStore<TypeConfig, Flat> =
-        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
-
-    let sm = HighWaterStateMachine::new();
-    let sm_clone = sm.clone();
-
-    // Aggressive heartbeats so a single-node cluster becomes leader fast.
-    let config = Arc::new(
-        Config {
-            heartbeat_interval: 50,
-            election_timeout_min: 150,
-            election_timeout_max: 300,
-            ..Default::default()
-        }
-        .validate()
-        .unwrap(),
-    );
-
-    let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
-        1u64,
-        config,
-        UnreachableNetwork,
-        log_store,
-        sm,
-    )
-    .await
-    .expect("Raft::new");
-
-    // Initialize the single-voter membership.
-    let mut nodes = BTreeMap::new();
-    nodes.insert(
-        1u64,
-        OpenraftPeer {
-            addr: "self".into(),
-        },
-    );
-    raft.initialize(nodes).await.expect("initialize");
-
-    let host = StandaloneHost::new(raft.clone(), sm_clone);
-    let driver = OpenraftDriver::new(host);
-    SingleNode {
-        driver,
-        _dir: dir,
-        _raft: raft,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn single_node_leader_persists_high_water() {
-    let node = build_single_node().await;
-    let driver = &node.driver;
+    let cluster = build_single_node().await;
+    let driver = &cluster.drivers[0];
 
-    // Drain leadership events until we see a Leader. The first event may be
-    // Unknown/Follower depending on timing; the next class transition will be
-    // Leader once the single-voter cluster elects itself.
+    // Drain leadership events until we see a Leader.
     let mut events = driver.leadership_events();
     let epoch = timeout(Duration::from_secs(5), async {
         loop {

--- a/crates/tsoracle-driver-openraft/tests/single_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/single_node.rs
@@ -1,0 +1,212 @@
+//! Single-node integration test for [`OpenraftDriver`].
+//!
+//! Stands up a one-voter openraft cluster on top of:
+//!
+//! - `openraft_toolkit::RocksdbLogStore` (tempdir-backed)
+//! - `HighWaterStateMachine` (in-memory)
+//! - `UnreachableNetwork` — a `RaftNetworkV2` whose RPC methods panic if ever
+//!   invoked. A single-voter cluster never sends append/vote/snapshot RPCs to
+//!   itself, so any panic from here would indicate a real bug.
+//!
+//! Then drives the [`ConsensusDriver`] surface: confirms an initial Leader
+//! event, an empty `load_high_water`, a `persist_high_water` round trip, and
+//! the monotonic-advance semantics.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use openraft::Config;
+use openraft::Raft;
+use openraft::error::{NetworkError, RPCError, ReplicationClosed, StreamingError};
+use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
+};
+use openraft::type_config::alias::{SnapshotOf, VoteOf};
+use openraft_toolkit::{Flat, RocksdbLogStore};
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use tempfile::TempDir;
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, LeaderState};
+use tsoracle_driver_openraft::{HighWaterStateMachine, OpenraftDriver, OpenraftPeer, TypeConfig};
+
+const LOG_CF: &str = "raft_log";
+const META_CF: &str = "raft_meta";
+
+// ---------------------------------------------------------------------------
+// UnreachableNetwork: panicking `RaftNetworkV2` for single-node clusters.
+// ---------------------------------------------------------------------------
+
+/// A `RaftNetworkFactory` whose generated clients panic on any RPC.
+///
+/// Single-node clusters never replicate to peers, so the network is exercised
+/// only as a type-level requirement of `Raft::new`. If any test ever upgrades
+/// to a multi-node cluster this network must be replaced with a real one.
+struct UnreachableNetwork;
+
+impl RaftNetworkFactory<TypeConfig> for UnreachableNetwork {
+    type Network = UnreachablePeer;
+
+    async fn new_client(&mut self, target: u64, _node: &OpenraftPeer) -> Self::Network {
+        UnreachablePeer { target }
+    }
+}
+
+struct UnreachablePeer {
+    target: u64,
+}
+
+impl RaftNetworkV2<TypeConfig> for UnreachablePeer {
+    async fn append_entries(
+        &mut self,
+        _rpc: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig>> {
+        Err(RPCError::Network(NetworkError::from_string(format!(
+            "unreachable network: append_entries to node {} in single-node test",
+            self.target
+        ))))
+    }
+
+    async fn vote(
+        &mut self,
+        _rpc: VoteRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig>> {
+        Err(RPCError::Network(NetworkError::from_string(format!(
+            "unreachable network: vote to node {} in single-node test",
+            self.target
+        ))))
+    }
+
+    async fn full_snapshot(
+        &mut self,
+        _vote: VoteOf<TypeConfig>,
+        _snapshot: SnapshotOf<TypeConfig>,
+        _cancel: impl Future<Output = ReplicationClosed> + openraft::OptionalSend + 'static,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {
+        Err(StreamingError::Network(NetworkError::from_string(format!(
+            "unreachable network: snapshot to node {} in single-node test",
+            self.target
+        ))))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness: assemble Raft + driver from scratch.
+// ---------------------------------------------------------------------------
+
+struct SingleNode {
+    driver: OpenraftDriver,
+    /// Kept alive so the rocksdb backing files outlive the test.
+    _dir: TempDir,
+    /// Raft handle. Keeping the original here keeps the cluster running for
+    /// the driver's `Raft` clone too — `Raft` is `Arc`-backed.
+    _raft: Raft<TypeConfig, HighWaterStateMachine>,
+}
+
+async fn build_single_node() -> SingleNode {
+    let dir = TempDir::new().unwrap();
+
+    // RocksDB with two column families: log + meta.
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cfs = vec![
+        ColumnFamilyDescriptor::new(LOG_CF, Options::default()),
+        ColumnFamilyDescriptor::new(META_CF, Options::default()),
+    ];
+    let db = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap());
+
+    let log_store: RocksdbLogStore<TypeConfig, Flat> =
+        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
+
+    let sm = HighWaterStateMachine::new();
+    let sm_clone = sm.clone();
+
+    // Aggressive heartbeats so a single-node cluster becomes leader fast.
+    let config = Arc::new(
+        Config {
+            heartbeat_interval: 50,
+            election_timeout_min: 150,
+            election_timeout_max: 300,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap(),
+    );
+
+    let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
+        1u64,
+        config,
+        UnreachableNetwork,
+        log_store,
+        sm,
+    )
+    .await
+    .expect("Raft::new");
+
+    // Initialize the single-voter membership.
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        1u64,
+        OpenraftPeer {
+            addr: "self".into(),
+        },
+    );
+    raft.initialize(nodes).await.expect("initialize");
+
+    let driver = OpenraftDriver::new(raft.clone(), sm_clone);
+    SingleNode {
+        driver,
+        _dir: dir,
+        _raft: raft,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn single_node_leader_persists_high_water() {
+    let node = build_single_node().await;
+    let driver = &node.driver;
+
+    // Drain leadership events until we see a Leader. The first event may be
+    // Unknown/Follower depending on timing; the next class transition will be
+    // Leader once the single-voter cluster elects itself.
+    let mut events = driver.leadership_events();
+    let epoch = timeout(Duration::from_secs(5), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if let LeaderState::Leader { epoch } = s {
+                break epoch;
+            }
+        }
+    })
+    .await
+    .expect("became leader within 5s");
+
+    // Empty start.
+    assert_eq!(driver.load_high_water().await.unwrap(), 0);
+
+    // Advance.
+    let v = driver.persist_high_water(100, epoch).await.unwrap();
+    assert_eq!(v, 100);
+
+    // Stale call: should be silently absorbed, value unchanged.
+    let v = driver.persist_high_water(50, epoch).await.unwrap();
+    assert_eq!(v, 100);
+
+    // Forward.
+    let v = driver.persist_high_water(200, epoch).await.unwrap();
+    assert_eq!(v, 200);
+
+    // Linearized load matches the last apply.
+    assert_eq!(driver.load_high_water().await.unwrap(), 200);
+}

--- a/crates/tsoracle-driver-openraft/tests/single_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/single_node.rs
@@ -51,3 +51,78 @@ async fn single_node_leader_persists_high_water() {
     // Linearized load matches the last apply.
     assert_eq!(driver.load_high_water().await.unwrap(), 200);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn leader_state_epoch_matches_raft_term() {
+    let cluster = build_single_node().await;
+    let driver = &cluster.drivers[0];
+    let raft = &cluster.nodes[0].raft;
+
+    let mut events = driver.leadership_events();
+    let epoch = timeout(Duration::from_secs(5), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if let LeaderState::Leader { epoch } = s {
+                break epoch;
+            }
+        }
+    })
+    .await
+    .expect("became leader within 5s");
+
+    // The Epoch carried by LeaderState::Leader must match the raft's
+    // notion of term at the time we observed leadership.
+    use openraft::async_runtime::watch::WatchReceiver;
+    use openraft::vote::RaftTerm;
+    let mut metrics_rx = raft.metrics();
+    let term = {
+        let snap = metrics_rx.borrow_watched();
+        snap.current_term.as_u64().unwrap_or(0)
+    };
+    assert_eq!(epoch.0, term);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn leadership_stream_outlives_driver_drop() {
+    let cluster = build_single_node().await;
+
+    let driver_for_stream = std::sync::Arc::clone(&cluster.drivers[0]);
+    let mut events = driver_for_stream.leadership_events();
+    drop(driver_for_stream);
+
+    // KeepAlive keeps the host alive while the stream is held.
+    let _first = timeout(Duration::from_secs(5), events.next())
+        .await
+        .expect("stream produced an event within 5s")
+        .expect("event stream alive");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn persist_high_water_ignores_epoch_arg() {
+    use tsoracle_core::Epoch;
+
+    let cluster = build_single_node().await;
+    let driver = &cluster.drivers[0];
+
+    // Wait for leadership.
+    let mut events = driver.leadership_events();
+    let _epoch = timeout(Duration::from_secs(5), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if let LeaderState::Leader { epoch } = s {
+                break epoch;
+            }
+        }
+    })
+    .await
+    .expect("became leader within 5s");
+
+    // Call persist_high_water twice with very different (arbitrary) epoch
+    // arguments. Both should succeed because the driver ignores the epoch
+    // (state-machine monotonicity is the fencing mechanism).
+    let v = driver.persist_high_water(100, Epoch(99)).await.unwrap();
+    assert_eq!(v, 100);
+
+    let v = driver.persist_high_water(200, Epoch(7)).await.unwrap();
+    assert_eq!(v, 200);
+}

--- a/crates/tsoracle-driver-openraft/tests/single_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/single_node.rs
@@ -31,7 +31,9 @@ use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tempfile::TempDir;
 use tokio::time::timeout;
 use tsoracle_consensus::{ConsensusDriver, LeaderState};
-use tsoracle_driver_openraft::{HighWaterStateMachine, OpenraftDriver, OpenraftPeer, TypeConfig};
+use tsoracle_driver_openraft::{
+    HighWaterStateMachine, OpenraftDriver, OpenraftPeer, StandaloneHost, TypeConfig,
+};
 
 const LOG_CF: &str = "raft_log";
 const META_CF: &str = "raft_meta";
@@ -101,7 +103,7 @@ impl RaftNetworkV2<TypeConfig> for UnreachablePeer {
 // ---------------------------------------------------------------------------
 
 struct SingleNode {
-    driver: OpenraftDriver,
+    driver: Arc<OpenraftDriver<StandaloneHost>>,
     /// Kept alive so the rocksdb backing files outlive the test.
     _dir: TempDir,
     /// Raft handle. Keeping the original here keeps the cluster running for
@@ -160,7 +162,8 @@ async fn build_single_node() -> SingleNode {
     );
     raft.initialize(nodes).await.expect("initialize");
 
-    let driver = OpenraftDriver::new(raft.clone(), sm_clone);
+    let host = StandaloneHost::new(raft.clone(), sm_clone);
+    let driver = OpenraftDriver::new(host);
     SingleNode {
         driver,
         _dir: dir,

--- a/crates/tsoracle-driver-openraft/tests/single_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/single_node.rs
@@ -74,7 +74,7 @@ async fn leader_state_epoch_matches_raft_term() {
     // notion of term at the time we observed leadership.
     use openraft::async_runtime::watch::WatchReceiver;
     use openraft::vote::RaftTerm;
-    let mut metrics_rx = raft.metrics();
+    let metrics_rx = raft.metrics();
     let term = {
         let snap = metrics_rx.borrow_watched();
         snap.current_term.as_u64().unwrap_or(0)

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -187,7 +187,7 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     let leader_snapshot_log_id = timeout(Duration::from_secs(10), async move {
         loop {
             let metrics = leader_raft.metrics().borrow_watched().clone();
-            if let Some(snapshot_log_id) = metrics.snapshot.clone() {
+            if let Some(snapshot_log_id) = metrics.snapshot {
                 if snapshot_log_id.index >= 5 {
                     return snapshot_log_id;
                 }
@@ -230,12 +230,9 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
         .metrics()
         .borrow_watched()
         .snapshot
-        .clone()
         .expect("trailing follower must have installed a snapshot");
     assert!(
         follower_snapshot_log_id.index >= leader_snapshot_log_id.index,
-        "follower snapshot {:?} must cover the leader's snapshot {:?}",
-        follower_snapshot_log_id,
-        leader_snapshot_log_id,
+        "follower snapshot {follower_snapshot_log_id:?} must cover the leader's snapshot {leader_snapshot_log_id:?}",
     );
 }

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -25,9 +25,7 @@ use openraft_toolkit::{Flat, RocksdbLogStore};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tempfile::TempDir;
 use tokio::time::timeout;
-use tsoracle_driver_openraft::{
-    HighWaterCommand, HighWaterStateMachine, OpenraftPeer, TypeConfig,
-};
+use tsoracle_driver_openraft::{HighWaterCommand, HighWaterStateMachine, OpenraftPeer, TypeConfig};
 
 use common::eventually_eq;
 
@@ -159,7 +157,9 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     for next_target in [20u64, 30, 40, 50, 60, 70, final_target] {
         nodes[leader_idx]
             .raft
-            .client_write(HighWaterCommand::Bump { target: next_target })
+            .client_write(HighWaterCommand::Bump {
+                target: next_target,
+            })
             .await
             .expect("partition-side bump");
     }

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use openraft::async_runtime::watch::WatchReceiver;
 use openraft::{Config, Raft, SnapshotPolicy};
 use openraft_toolkit::test_fakes::MemNetwork;
 use openraft_toolkit::{Flat, RocksdbLogStore};
@@ -128,7 +129,6 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     nodes[0].raft.initialize(mem).await.expect("initialize");
 
     let leader_idx = find_leader_idx(&nodes).await;
-    let leader_id = nodes[leader_idx].id;
     let follower_idx = (0..3).find(|i| *i != leader_idx).unwrap();
     let follower_id = nodes[follower_idx].id;
 
@@ -186,7 +186,7 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     let leader_raft = nodes[leader_idx].raft.clone();
     let leader_snapshot_log_id = timeout(Duration::from_secs(10), async move {
         loop {
-            let metrics = leader_raft.metrics().borrow().clone();
+            let metrics = leader_raft.metrics().borrow_watched().clone();
             if let Some(snapshot_log_id) = metrics.snapshot.clone() {
                 if snapshot_log_id.index >= 5 {
                     return snapshot_log_id;
@@ -228,7 +228,7 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     let follower_snapshot_log_id = nodes[follower_idx]
         .raft
         .metrics()
-        .borrow()
+        .borrow_watched()
         .snapshot
         .clone()
         .expect("trailing follower must have installed a snapshot");

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -1,0 +1,241 @@
+//! Forces a full-snapshot install over `MemNetwork`.
+//!
+//! Stands up a 3-voter cluster with an aggressive snapshot policy
+//! (`LogsSinceLast(4)` + `max_in_snapshot_log_to_keep = 0`), isolates a
+//! follower, bumps the high-water value on the leader several times, and
+//! triggers a snapshot + log purge. After healing the partition the trailing
+//! follower's log range no longer exists on the leader, so openraft must
+//! stream a full snapshot to catch it up.
+//!
+//! This is the only place in the suite that exercises the snapshot RPC path:
+//! `MemNetworkPeer::full_snapshot` → `RaftHandle::install_full_snapshot` →
+//! `HighWaterStateMachine::{begin_receiving_snapshot, get_snapshot_builder,
+//! install_snapshot}`.
+
+mod common;
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::{Config, Raft, SnapshotPolicy};
+use openraft_toolkit::test_fakes::MemNetwork;
+use openraft_toolkit::{Flat, RocksdbLogStore};
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use tempfile::TempDir;
+use tokio::time::timeout;
+use tsoracle_driver_openraft::{
+    HighWaterCommand, HighWaterStateMachine, OpenraftPeer, TypeConfig,
+};
+
+use common::eventually_eq;
+
+const LOG_CF: &str = "raft_log";
+const META_CF: &str = "raft_meta";
+
+/// Heartbeat and election timeouts match the rest of the suite; the snapshot
+/// knobs are deliberately tight so a handful of writes triggers a build and
+/// the leader's log is purged immediately past the snapshot watermark.
+fn snapshot_aggressive_config() -> Arc<Config> {
+    Arc::new(
+        Config {
+            heartbeat_interval: 50,
+            election_timeout_min: 150,
+            election_timeout_max: 300,
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(4),
+            max_in_snapshot_log_to_keep: 0,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap(),
+    )
+}
+
+fn open_log_store(dir: &TempDir) -> RocksdbLogStore<TypeConfig, Flat> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cfs = vec![
+        ColumnFamilyDescriptor::new(LOG_CF, Options::default()),
+        ColumnFamilyDescriptor::new(META_CF, Options::default()),
+    ];
+    let db = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap());
+    RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap()
+}
+
+struct SnapshotNode {
+    id: u64,
+    raft: Raft<TypeConfig, HighWaterStateMachine>,
+    sm: HighWaterStateMachine,
+    _log_dir: TempDir,
+}
+
+async fn find_leader_idx(nodes: &[SnapshotNode]) -> usize {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            for (idx, node) in nodes.iter().enumerate() {
+                if let Some(leader) = node.raft.current_leader().await {
+                    if leader == node.id {
+                        return idx;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("a leader elected within 10s")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn isolated_follower_catches_up_via_snapshot_transfer() {
+    let net = MemNetwork::<TypeConfig>::new();
+    let cfg = snapshot_aggressive_config();
+
+    let mut nodes: Vec<SnapshotNode> = Vec::new();
+    for id in [1u64, 2, 3] {
+        let dir = TempDir::new().unwrap();
+        let log_store = open_log_store(&dir);
+        let sm = HighWaterStateMachine::new();
+        let sm_clone = sm.clone();
+        let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
+            id,
+            cfg.clone(),
+            net.factory_for(id),
+            log_store,
+            sm,
+        )
+        .await
+        .expect("Raft::new");
+        net.register(id, raft.clone());
+        nodes.push(SnapshotNode {
+            id,
+            raft,
+            sm: sm_clone,
+            _log_dir: dir,
+        });
+    }
+
+    let mut mem = BTreeMap::new();
+    for id in [1u64, 2, 3] {
+        mem.insert(
+            id,
+            OpenraftPeer {
+                addr: format!("snapshot-node-{id}"),
+            },
+        );
+    }
+    nodes[0].raft.initialize(mem).await.expect("initialize");
+
+    let leader_idx = find_leader_idx(&nodes).await;
+    let leader_id = nodes[leader_idx].id;
+    let follower_idx = (0..3).find(|i| *i != leader_idx).unwrap();
+    let follower_id = nodes[follower_idx].id;
+
+    // Baseline: bump once and let everyone — including the to-be-isolated
+    // follower — converge so we know the test's starting state.
+    nodes[leader_idx]
+        .raft
+        .client_write(HighWaterCommand::Bump { target: 10 })
+        .await
+        .expect("baseline bump");
+    for node in &nodes {
+        let sm = node.sm.clone();
+        eventually_eq(10u64, Duration::from_secs(5), move || {
+            let sm = sm.clone();
+            async move { sm.current_value().await }
+        })
+        .await;
+    }
+
+    // Isolate the follower. After this point the leader can replicate
+    // entries only to itself + the other follower, which still forms a
+    // quorum so writes succeed.
+    net.partitions().isolate(follower_id);
+
+    // Apply enough Bumps to comfortably cross LogsSinceLast(4) and grow the
+    // committed-log distance between the leader and the trailing follower.
+    let final_target = 80u64;
+    for next_target in [20u64, 30, 40, 50, 60, 70, final_target] {
+        nodes[leader_idx]
+            .raft
+            .client_write(HighWaterCommand::Bump { target: next_target })
+            .await
+            .expect("partition-side bump");
+    }
+
+    // Force a snapshot on every reachable node. Triggering on the isolated
+    // follower is a no-op for our purposes (it has nothing new to snapshot),
+    // but on the leader this kicks off the build that — combined with
+    // `max_in_snapshot_log_to_keep = 0` — purges the log past the trailing
+    // follower's last replicated index.
+    for node in &nodes {
+        if node.id == follower_id {
+            continue;
+        }
+        node.raft
+            .trigger()
+            .snapshot()
+            .await
+            .expect("trigger snapshot");
+    }
+
+    // Wait until the leader's snapshot covers at least the last write we
+    // did. Without this, healing too eagerly lets append_entries catch the
+    // follower up via the log and we never touch the snapshot path.
+    let leader_raft = nodes[leader_idx].raft.clone();
+    let leader_snapshot_log_id = timeout(Duration::from_secs(10), async move {
+        loop {
+            let metrics = leader_raft.metrics().borrow().clone();
+            if let Some(snapshot_log_id) = metrics.snapshot.clone() {
+                if snapshot_log_id.index >= 5 {
+                    return snapshot_log_id;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("leader built a snapshot within 10s");
+
+    // Belt-and-braces: explicitly request the leader purge its log up to the
+    // snapshot index. `max_in_snapshot_log_to_keep = 0` already implies this
+    // but purge runs on a delay, and we want the trailing follower's next
+    // append_entries probe to see a log that no longer covers its range.
+    nodes[leader_idx]
+        .raft
+        .trigger()
+        .purge_log(leader_snapshot_log_id.index)
+        .await
+        .expect("trigger purge_log");
+
+    // Heal — the follower's only path back to consistency is a streamed
+    // snapshot.
+    net.partitions().heal(follower_id);
+
+    let follower_sm = nodes[follower_idx].sm.clone();
+    eventually_eq(final_target, Duration::from_secs(15), move || {
+        let sm = follower_sm.clone();
+        async move { sm.current_value().await }
+    })
+    .await;
+
+    // Defense in depth: the trailing follower must show a snapshot in its
+    // metrics whose log id matches (or follows) the leader's snapshot. A
+    // follower that caught up via log replication alone would have
+    // `snapshot == None` here, because it never had enough committed
+    // entries pre-isolation to satisfy `LogsSinceLast(4)` on its own.
+    let follower_snapshot_log_id = nodes[follower_idx]
+        .raft
+        .metrics()
+        .borrow()
+        .snapshot
+        .clone()
+        .expect("trailing follower must have installed a snapshot");
+    assert!(
+        follower_snapshot_log_id.index >= leader_snapshot_log_id.index,
+        "follower snapshot {:?} must cover the leader's snapshot {:?}",
+        follower_snapshot_log_id,
+        leader_snapshot_log_id,
+    );
+}

--- a/crates/tsoracle-driver-openraft/tests/three_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/three_node.rs
@@ -1,0 +1,79 @@
+//! Three-voter integration tests for `OpenraftDriver`.
+//!
+//! Asserts:
+//! 1. A leader is elected.
+//! 2. A write through the leader becomes visible on every node's state
+//!    machine (eventually — `StandaloneHost::current_high_water` reads
+//!    locally without a linearizable barrier; see spec §8.2).
+//! 3. A write through a follower returns `ConsensusError::NotLeader`.
+
+mod common;
+
+use std::time::Duration;
+
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, ConsensusError};
+use tsoracle_core::Epoch;
+
+use common::{build_three_node, eventually_eq, TestCluster};
+
+async fn find_leader_idx(cluster: &TestCluster) -> usize {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            for (idx, node) in cluster.nodes.iter().enumerate() {
+                if let Some(l) = node.raft.current_leader().await {
+                    if l == node.id {
+                        return idx;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("some node became leader within 10s")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn three_node_leader_persists_and_followers_converge() {
+    let cluster = build_three_node().await;
+
+    let leader_idx = find_leader_idx(&cluster).await;
+    let leader_driver = &cluster.drivers[leader_idx];
+
+    // Empty start.
+    assert_eq!(leader_driver.load_high_water().await.unwrap(), 0);
+
+    // Advance.
+    let v = leader_driver.persist_high_water(100, Epoch(1)).await.unwrap();
+    assert_eq!(v, 100);
+
+    // All three SMs should converge on 100 within 5 seconds.
+    for i in 0..3 {
+        let driver = cluster.drivers[i].clone();
+        eventually_eq(100u64, Duration::from_secs(5), || {
+            let d = driver.clone();
+            async move { d.load_high_water().await.unwrap() }
+        })
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn three_node_follower_returns_not_leader() {
+    let cluster = build_three_node().await;
+
+    let leader_idx = find_leader_idx(&cluster).await;
+    let follower_idx = (0..3).find(|i| *i != leader_idx).expect("a follower exists");
+    let follower_driver = &cluster.drivers[follower_idx];
+
+    let err = follower_driver
+        .persist_high_water(50, Epoch(1))
+        .await
+        .expect_err("follower must reject write");
+
+    match err {
+        ConsensusError::NotLeader { observed: None } => {} // expected
+        other => panic!("expected NotLeader{{ observed: None }}, got {other:?}"),
+    }
+}

--- a/crates/tsoracle-driver-openraft/tests/three_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/three_node.rs
@@ -15,7 +15,7 @@ use tokio::time::timeout;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError};
 use tsoracle_core::Epoch;
 
-use common::{build_three_node, eventually_eq, TestCluster};
+use common::{TestCluster, build_three_node, eventually_eq};
 
 async fn find_leader_idx(cluster: &TestCluster) -> usize {
     timeout(Duration::from_secs(10), async {
@@ -45,7 +45,10 @@ async fn three_node_leader_persists_and_followers_converge() {
     assert_eq!(leader_driver.load_high_water().await.unwrap(), 0);
 
     // Advance.
-    let v = leader_driver.persist_high_water(100, Epoch(1)).await.unwrap();
+    let v = leader_driver
+        .persist_high_water(100, Epoch(1))
+        .await
+        .unwrap();
     assert_eq!(v, 100);
 
     // All three SMs should converge on 100 within 5 seconds.
@@ -64,7 +67,9 @@ async fn three_node_follower_returns_not_leader() {
     let cluster = build_three_node().await;
 
     let leader_idx = find_leader_idx(&cluster).await;
-    let follower_idx = (0..3).find(|i| *i != leader_idx).expect("a follower exists");
+    let follower_idx = (0..3)
+        .find(|i| *i != leader_idx)
+        .expect("a follower exists");
     let follower_driver = &cluster.drivers[follower_idx];
 
     let err = follower_driver


### PR DESCRIPTION
## Summary

- Introduces `tsoracle-driver-openraft` — an openraft-backed `ConsensusDriver` impl that replicates the TSO high-water mark through a raft cluster. The crate is generic over an `OpenraftHighWaterHost` so services that already run their own openraft cluster can plug TSO into existing consensus state; a bundled `StandaloneHost` is provided for the common "own raft" case.
- Adds a reusable in-memory raft test harnesshttps://github.com/prisma-risk/tsoracle/pull/17/changes to `openraft-toolkit::test_fakes` (`MemNetwork<C>`, `MemNetworkFactory<C>`,
`MemNetworkPeer<C>`, `PartitionController<NodeId>`) so this crate and any future toolkit consumer can write deterministic multi-node tests with partition injection — no sockets, no per-RPC channels, just typed dispatch through a shared registry.
- Backs the new crate with a five-layer test suite: inline unit tests, two proptests (monotonicity + snapshot payload round-trip), an in-repo `tests/common/` cluster harness, and four integration scenarios (single-node, three-node, partition + churn, restart-and-replay from rocksdb log).

## Architecture

The driver is layered to keep responsibilities tight:

- `log_entry` — single `HighWaterCommand::Bump { target }` enum; idempotent under retries by design.
- `state_machine` — in-memory `u64` counter, postcard-encoded snapshots, monotone apply (`current = max(current, target)`). Persistence comes from the raft log via the caller's `RaftLogStorage`.
- `type_config` — `TypeConfig` declared through `openraft_toolkit::declare_raft_types_ext!`.
- `host` — `OpenraftHighWaterHost` trait that services implement to plug their consensus into the driver.
- `standalone` — the bundled host that owns its own raft cluster.
- `driver` — thin `ConsensusDriver` bridge mapping leadership events and delegating storage/submission to the host.

Fencing is intentionally state-machine-driven (`max(prev, at_least)`) rather than term-based: a stale-leader submission either gets rejected by `client_write`'s `ForwardToLeader` path or absorbed at apply time. Both outcomes preserve monotonicity.

## Test coverage

### Unit 
inline `#[cfg(test)] mod tests` in `src/{log_entry,type_config,driver,state_machine }.rs`
Display formatting, postcard codec round-trips, `map_leader_state` projection across all `LeadershipState` variants, state-machine apply on Blank/Normal/Membership entries, snapshot build/install/get semantics 

### Property 
inline `proptest!` in `src/state_machine.rs`
Monotonicity over arbitrary `Vec<u64>` bump sequences; snapshot payload round-trip preserves `(current_value, last_applied, last_membership)`

### Integration
`tests/{single_node,three_node,partition_churn,restart_replay}.rs`
Single-voter happy path + 3 new asserts (leader-state/term parity, leadership-stream-survives-driver-drop, epoch-arg ignored); 3-node leader/follower convergence + follower `NotLeader`; partition + new-leader election + heal + monotone convergence; rocksdb log restart-replay + post-replay write |

The 3-node and partition tests use the new `MemNetwork` harness; the restart-replay test uses the new `reopen_node` helper which cleanly shuts down the prior raft before reopening rocksdb on the same TempDir.

## Test plan

- [ ] CI green: `cargo fmt --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo test --workspace --all-features --locked`.
- [ ] All new tests pass locally (`cargo test -p tsoracle-driver-openraft --all-features`) — 32 tests across unit, proptest, and integration layers.
- [ ] Toolkit smoke test passes (`cargo test -p openraft-toolkit --features test-fakes --test mem_network_smoke`) — proves the in-memory network elects a leader and replicates within ~200ms.
- [ ] Coverage delta visible on Coveralls (no gate; threshold question deferred).
- [ ] Manual review of `crates/openraft-toolkit/src/test_fakes/` for the public surface area added there — it's intended to be reusable by future toolkit consumers.