### PR TITLE
chore(hooks): add tracked pre-commit hook for fmt and clippy

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Pre-commit hook: blocks the commit unless `cargo fmt --check` and clippy pass.
+#
+# Enable once per clone with `make install-hooks` (or
+# `git config core.hooksPath .githooks`). Bypass intentionally with
+# `git commit --no-verify`. CI runs the same checks regardless, so a bypassed
+# commit will still be caught upstream.
+
+set -euo pipefail
+
+echo "pre-commit: cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "pre-commit: cargo clippy"
+cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,16 @@ cargo build --workspace --all-features
 cargo test  --workspace --all-features
 ```
 
+### Pre-commit hook
+
+A tracked pre-commit hook in [`.githooks/pre-commit`](.githooks/pre-commit) runs the first two of those checks (`cargo fmt --check` and clippy) and blocks the commit on failure. Enable it once per clone:
+
+```bash
+make install-hooks
+```
+
+That writes `core.hooksPath = .githooks` into your local `.git/config`. Bypass with `git commit --no-verify` when you know what you're doing — CI runs the same checks regardless, so a bypassed commit will still fail upstream.
+
 If you touched anything under `crates/tsoracle-proto/proto/`:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ WORKSPACE_VERSION := $(shell grep -E '^version[[:space:]]*=' Cargo.toml | head -
 
 .PHONY: all ci check fmt fmt-check lint fix build test doc \
         proto proto-lint proto-fmt proto-fmt-check proto-breaking \
-        deny coverage clean help \
+        deny coverage clean help install-hooks \
         bench bench-throughput-sweep bench-latency \
         release-bump release-dry-run release-publish release-tag
 
@@ -70,6 +70,13 @@ doc:
 
 clean:
 	$(CARGO) clean
+
+# Point this clone's git at the tracked .githooks/ directory so the pre-commit
+# hook runs `cargo fmt --check` and clippy before every commit. One-time setup
+# per clone; the config write is local to .git/config and not tracked.
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo "core.hooksPath -> .githooks (bypass with 'git commit --no-verify')"
 
 # Protobuf -------------------------------------------------------------------
 # Mirrors the `buf` job in .github/workflows/ci.yml.
@@ -255,6 +262,8 @@ help:
 	@echo "  bench            Run the bench-minimal characterization workload."
 	@echo "  bench-throughput-sweep  Run bench across clients=1..1024 (--json files)."
 	@echo "  bench-latency    Run bench at clients=1 for latency-focused output."
+	@echo ""
+	@echo "  install-hooks    Point this clone's git at .githooks/ (pre-commit fmt+lint)."
 	@echo ""
 	@echo "Release flow (run in order; see CONTRIBUTING.md):"
 	@echo "  release-bump     1) Bump workspace + intra-workspace dep refs, commit."


### PR DESCRIPTION
## Summary

- Adds tracked `.githooks/pre-commit` that runs `cargo fmt --all -- --check` then `cargo clippy --workspace --all-targets --all-features -- -D warnings`, halting on the first failure via `set -euo pipefail`.
- Adds `make install-hooks` (sets `core.hooksPath = .githooks` in local `.git/config`) — opt-in per clone, not auto-installed.
- Documents both in CONTRIBUTING.md under a new "Pre-commit hook" subsection.

## Why

Catches the two fastest CI failures (formatting and clippy) locally before the push/CI roundtrip. Tracking the script in `.githooks/` instead of `.git/hooks/` makes it visible in code review and evolves with the repo, and `core.hooksPath` is per-clone local config so contributors opt in explicitly.

`cargo test` is intentionally **not** in the hook — a full workspace test is too slow to run on every commit and hooks that are routinely bypassed don't enforce anything. CI continues to run fmt + clippy + build + test, so `--no-verify` only delays a failure rather than hiding it.

## Test plan

- [x] Direct invocation on a clean tree → exit 0 (~2s on a warm cache)
- [x] Direct invocation with an injected fmt violation → exit 1 (clippy correctly skipped because `set -e` halts after fmt-check)
- [x] `make install-hooks` writes `core.hooksPath = .githooks` to local `.git/config`
- [x] End-to-end: `git commit` with a fmt violation through the configured hook → `git commit` exits 1, no commit created (HEAD unchanged)
- [x] End-to-end: the commit on this branch itself was made with the hook active — hook output visible above the commit summary, confirming the contributor UX