### PR TITLE
fix(driver-openraft): linearizable read in StandaloneHost::current_high_water

### DIFF
--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -8,7 +8,8 @@
 
 use async_trait::async_trait;
 use openraft::Raft;
-use openraft::error::{ClientWriteError, RaftError};
+use openraft::ReadPolicy;
+use openraft::error::{ClientWriteError, LinearizableReadError, RaftError};
 use tsoracle_consensus::ConsensusError;
 
 use crate::host::OpenraftHighWaterHost;
@@ -50,10 +51,24 @@ impl OpenraftHighWaterHost for StandaloneHost {
     }
 
     async fn current_high_water(&self) -> Result<u64, ConsensusError> {
-        // The standalone host doesn't issue a linearizable barrier here for the
-        // same reason the original driver didn't: a single-voter cluster has
-        // trivially linearizable local reads, and multi-node deployments will
-        // gain a barrier in a follow-up alongside the network impl.
+        // Issue the openraft read barrier so the local SM read below reflects
+        // every committed write from any prior leader at any prior epoch —
+        // the contract on `ConsensusDriver::load_high_water`. The fence in
+        // `tsoracle-server/src/fence.rs` is the load-bearing reader; a stale
+        // value there would let a new leader's `serving_floor + 1` land below
+        // a timestamp the prior leader could have served.
+        //
+        // `ForwardToLeader` maps to `NotLeader` so the server's step-down
+        // path triggers cleanly (same shape as `submit_advance` below); any
+        // other RaftError is transient (quorum loss, leadership churn).
+        if let Err(e) = self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await {
+            return match e {
+                RaftError::APIError(LinearizableReadError::ForwardToLeader(_)) => {
+                    Err(ConsensusError::NotLeader { observed: None })
+                }
+                _ => Err(ConsensusError::TransientDriver(Box::new(e))),
+            };
+        }
         Ok(self.state_machine.current_value().await)
     }
 

--- a/crates/tsoracle-driver-openraft/tests/partition_churn.rs
+++ b/crates/tsoracle-driver-openraft/tests/partition_churn.rs
@@ -70,10 +70,10 @@ async fn partition_then_heal_converges_monotonically() {
         .expect("baseline bump");
     assert_eq!(v, 100);
     for i in 0..3 {
-        let driver = cluster.drivers[i].clone();
+        let sm = cluster.nodes[i].sm.clone();
         eventually_eq(100u64, Duration::from_secs(5), || {
-            let d = driver.clone();
-            async move { d.load_high_water().await.unwrap() }
+            let sm = sm.clone();
+            async move { sm.current_value().await }
         })
         .await;
     }
@@ -110,10 +110,11 @@ async fn partition_then_heal_converges_monotonically() {
     partitions.heal(l_id);
 
     // L converges on 200 (never went backwards: 100 -> 200, monotone).
-    let driver = cluster.drivers[l_idx].clone();
+    // L is now a follower after the partition heal, so read its SM directly.
+    let sm = cluster.nodes[l_idx].sm.clone();
     eventually_eq(200u64, Duration::from_secs(10), || {
-        let d = driver.clone();
-        async move { d.load_high_water().await.unwrap() }
+        let sm = sm.clone();
+        async move { sm.current_value().await }
     })
     .await;
 }

--- a/crates/tsoracle-driver-openraft/tests/restart_replay.rs
+++ b/crates/tsoracle-driver-openraft/tests/restart_replay.rs
@@ -61,11 +61,14 @@ async fn restart_replays_high_water_from_rocksdb_log() {
         tsoracle_driver_openraft::StandaloneHost::new(reopened.raft.clone(), reopened.sm.clone());
     let reopened_driver = tsoracle_driver_openraft::OpenraftDriver::new(host);
 
-    // Replay yields the last persisted value.
-    let d = reopened_driver.clone();
+    // Replay yields the last persisted value. Read the SM directly: the
+    // node may briefly be a follower/learner during post-restart election,
+    // and `load_high_water` requires a linearizable barrier the SM can't
+    // satisfy then.
+    let sm = reopened.sm.clone();
     eventually_eq(700u64, Duration::from_secs(10), || {
-        let d = d.clone();
-        async move { d.load_high_water().await.unwrap() }
+        let sm = sm.clone();
+        async move { sm.current_value().await }
     })
     .await;
 

--- a/crates/tsoracle-driver-openraft/tests/three_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/three_node.rs
@@ -51,12 +51,14 @@ async fn three_node_leader_persists_and_followers_converge() {
         .unwrap();
     assert_eq!(v, 100);
 
-    // All three SMs should converge on 100 within 5 seconds.
+    // All three SMs should converge on 100 within 5 seconds. Read each
+    // node's SM directly: `load_high_water` requires a linearizable barrier
+    // that followers cannot satisfy locally.
     for i in 0..3 {
-        let driver = cluster.drivers[i].clone();
+        let sm = cluster.nodes[i].sm.clone();
         eventually_eq(100u64, Duration::from_secs(5), || {
-            let d = driver.clone();
-            async move { d.load_high_water().await.unwrap() }
+            let sm = sm.clone();
+            async move { sm.current_value().await }
         })
         .await;
     }


### PR DESCRIPTION
## Summary
- Adds `Raft::ensure_linearizable(ReadPolicy::ReadIndex)` to `StandaloneHost::current_high_water` before the local SM read, satisfying the `ConsensusDriver::load_high_water` linearizability contract under multi-node membership.
- `ForwardToLeader` from `ensure_linearizable` maps to `ConsensusError::NotLeader { observed: None }` (matching the `submit_advance` error mapping); other `RaftError` variants stay `TransientDriver`.
- Updates four convergence-check sites in the integration tests (`partition_churn.rs` ×2, `restart_replay.rs`, `three_node.rs`) that were reading `load_high_water` on follower nodes. Convergence is a state-machine property; the tests now read each node's SM directly via `TestNode::sm`.

## Why
The fence in `tsoracle-server/src/fence.rs` calls `consensus.load_high_water()` on every leadership transition and feeds the result into `serving_floor = max(prior_max + 1, now)`. A stale read there lets the new leader serve a `physical_ms` the prior leader could have already used, breaking timestamp monotonicity. Single-voter clusters satisfy linearizability trivially; multi-node clusters did not before this change. 

## Test plan
- [x] `cargo test -p tsoracle-driver-openraft` — all 36 tests pass (single_node ×4, three_node ×2, restart_replay, snapshot_transfer, partition_churn, 27 unit/property tests).
- [x] `cargo clippy -p tsoracle-driver-openraft --all-targets -- -D warnings` clean.
- [x] Pre-commit hook ran workspace-wide \`cargo fmt --check\` and \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean.

