### PR TITLE
docs(examples): address final-review findings from PR #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ tsoracle is a small, embeddable Rust implementation. The consensus layer is left
 
 - [examples/embedded-server](examples/embedded-server) — embed `tsoracle-server` with the file driver in your own binary, with graceful shutdown.
 - [examples/failover-demo](examples/failover-demo) — pedagogy: watch the failover fence keep timestamps strictly monotonic across simulated leadership changes, in-process, no openraft.
-For HA, use [`tsoracle-driver-openraft`](crates/tsoracle-driver-openraft/); see [`examples/openraft-standalone`](examples/openraft-standalone/) (your own dedicated raft) and [`examples/openraft-piggyback`](examples/openraft-piggyback/) (share your service's existing raft).
+- For HA, use [`tsoracle-driver-openraft`](crates/tsoracle-driver-openraft/); see [`examples/openraft-standalone`](examples/openraft-standalone/) (your own dedicated raft) and [`examples/openraft-piggyback`](examples/openraft-piggyback/) (share your service's existing raft).
 
 Each example is its own crate. Build with `cargo run -p example-<name>`.
 

--- a/docs/testing-and-examples.md
+++ b/docs/testing-and-examples.md
@@ -58,7 +58,7 @@ To observe failover: find the current leader in the logs (`grep "Leader" .data/n
 cargo run -p example-openraft-piggyback
 ```
 
-The demo boots a 3-node in-process cluster via `openraft_toolkit::test_fakes::MemNetwork`, runs a tsoracle server on each (loopback ports 55561–55563), and walks through: host KV writes that land in the host SM without touching the TSO field, GetTs bursts that are allocator-served (high-water does *not* advance per call), and a failover that asserts the freshness invariant survives (`new_high_water > old_high_water` AND `next_ts > last_pre_failover_ts`). Runs in roughly 3 seconds; the same `run_demo()` function backs `tests/smoke.rs`.
+The demo boots a 3-node in-process cluster via `openraft_toolkit::test_fakes::MemNetwork`, runs a tsoracle server on each (each bound to an OS-assigned loopback port via `TcpListener::bind("127.0.0.1:0")`), and walks through: host KV writes that land in the host SM without touching the TSO field, GetTs bursts that are allocator-served (high-water does *not* advance per call), and a failover that asserts the freshness invariant survives (`new_high_water > old_high_water` AND `next_ts > last_pre_failover_ts`). Runs in roughly 3 seconds; the same `run_demo()` function backs `tests/smoke.rs`.
 
 The envelope pattern at the heart of the example:
 

--- a/examples/openraft-piggyback/README.md
+++ b/examples/openraft-piggyback/README.md
@@ -12,7 +12,7 @@ The demo runs in roughly 3 seconds and prints a scripted walk-through of the int
 
 ## What the demo shows
 
-1. **Boot.** Three openraft nodes connected by `openraft_toolkit::MemNetwork` (no tonic, no peer discovery). Each runs a `tsoracle::Server` bound to a unique loopback port (55561, 55562, 55563).
+1. **Boot.** Three openraft nodes connected by `openraft_toolkit::MemNetwork` (no tonic, no peer discovery). Each runs a `tsoracle::Server` bound to an OS-assigned loopback port (`TcpListener::bind("127.0.0.1:0")`), so the demo and its smoke test can run repeatedly without port-conflict flake.
 2. **Post-fence high-water.** Once the tsoracle-server leader-watch task fires on the new leader, the fence in `tsoracle-server/src/fence.rs` persists `serving_floor + failover_advance`. The demo prints this value and labels it "post-fence; this is when consensus actually persisted."
 3. **Host KV writes ride the same raft.** Directly calling `leader_raft.client_write(HostCommand::Kv(Put { ... }))` lands an entry in the host's log. The demo asserts that the apply result's `tso` field is `None` (KV writes do not touch the TSO half) and prints a KV dump.
 4. **Steady-state TSO is allocator-served.** A burst of `GetTs` calls through `tsoracle_client::Client` returns strictly monotonic timestamps, **without** the durable high-water moving. That's not a bug: high-water advances on fences and on window-extension; steady-state `GetTs` hits the allocator. See [`docs/key-subsystems.md`](../../docs/key-subsystems.md) ("Steady-state window extension") for the rationale.

--- a/examples/openraft-piggyback/src/demo.rs
+++ b/examples/openraft-piggyback/src/demo.rs
@@ -185,10 +185,12 @@ async fn build_client(nodes: &[Node]) -> anyhow::Result<TsoClient> {
     Ok(TsoClient::connect(endpoints).await?)
 }
 
-/// Print + return the leader's current high-water, going through the same
-/// barrier-then-read path the production code uses (we just call the host's
-/// state machine directly here because the demo holds the handle; production
-/// code would go through `ConsensusDriver::load_high_water`).
+/// Demo helper: return the leader's current high-water by reading its SM
+/// directly. This is NOT the production read path — production code goes
+/// through `ConsensusDriver::load_high_water`, which `PiggybackHost`
+/// implements with an `ensure_linearizable` barrier. The shortcut is safe
+/// here because we already confirmed leadership via `current_leader()` and
+/// the demo runs single-threaded against committed in-process state.
 async fn high_water_of_leader(nodes: &[Node]) -> u64 {
     for node in nodes {
         if let Some(leader_id) = node.raft.current_leader().await {


### PR DESCRIPTION
## Summary
Three documentation/UX fixes that fell out of the final cross-commit review of #20 but didn't make it into the merge.

- **README.md, docs/testing-and-examples.md, examples/openraft-piggyback/README.md** — drop the stale fixed loopback port numbers (`55561`/`55562`/`55563`). The piggyback demo binds via `TcpListener::bind("127.0.0.1:0")` (OS-assigned ports) so the demo and its smoke test can run repeatedly without port-conflict flake — the docs were still pointing at the pre-fix numbers.
- **README.md** — add the leading `- ` on the HA bullet (line 92). Without it, GitHub-flavored Markdown lazy-continues the line as part of the failover-demo bullet above, visually merging the two entries.
- **examples/openraft-piggyback/src/demo.rs** — clarify the doc comment on `high_water_of_leader` to distinguish the demo's direct-SM shortcut from the production `ConsensusDriver::load_high_water` barrier path (the previous comment claimed they were the same, which was misleading).

## Test plan
- [x] `cargo build --workspace` clean.
- [x] Pre-commit hook (workspace `cargo fmt --check` + `cargo clippy --workspace --all-targets --all-features -- -D warnings`) clean.
- [ ] Spot-check rendered README on GitHub once merged: the HA line should appear as its own bullet.