### PR TITLE
feat: add failpoint testing for driver-file and server paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,12 @@ cargo build --workspace --all-features
 cargo test  --workspace --all-features
 ```
 
+The `--all-features` flag activates the `failpoints` Cargo feature on each opting-in crate, so the failpoint suite (see [`docs/failpoint-testing.md`](docs/failpoint-testing.md)) is part of the normal `cargo test` run. To run just the failpoint suite:
+
+```bash
+make test-failpoints
+```
+
 ### Pre-commit hook
 
 A tracked pre-commit hook in [`.githooks/pre-commit`](.githooks/pre-commit) runs the first two of those checks (`cargo fmt --check` and clippy) and blocks the commit on failure. Enable it once per clone:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fail"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1504,7 @@ name = "openraft-toolkit"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "fail",
  "futures",
  "openraft",
  "parking_lot",
@@ -2773,6 +2785,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "crc32c",
+ "fail",
  "futures",
  "libc",
  "parking_lot",
@@ -2824,6 +2837,7 @@ name = "tsoracle-server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "fail",
  "futures",
  "parking_lot",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ authors      = ["Sebastian Thiebaud <sebastian@prismarisk.com>"]
 [workspace.dependencies]
 anyhow             = "1"
 async-trait        = "0.1"
+fail               = { version = "0.5", default-features = false }
 postcard           = { version = "1", default-features = false, features = ["use-std"] }
 bytes              = "1"
 clap               = { version = "4", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RELEASE_CRATES := \
 # enforce that the tag, HEAD's commit message, and the bumped version all agree.
 WORKSPACE_VERSION := $(shell grep -E '^version[[:space:]]*=' Cargo.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 
-.PHONY: all ci check fmt fmt-check lint fix build test doc \
+.PHONY: all ci check fmt fmt-check lint fix build test test-failpoints doc \
         proto proto-lint proto-fmt proto-fmt-check proto-breaking \
         deny coverage clean help install-hooks \
         bench bench-throughput-sweep bench-latency \
@@ -64,6 +64,15 @@ build:
 
 test:
 	$(CARGO) test --workspace --all-features
+
+# Run just the failpoint suite (fault-injection tests gated by the
+# `failpoints` Cargo feature on each opting-in crate). See
+# docs/failpoint-testing.md for the model.
+test-failpoints:
+	$(CARGO) test --workspace \
+	  --features tsoracle-driver-file/failpoints \
+	  --features tsoracle-server/failpoints,tsoracle-server/test-fakes \
+	  --features openraft-toolkit/failpoints,openraft-toolkit/rocksdb-log-store
 
 doc:
 	RUSTDOCFLAGS="-D warnings" $(CARGO) doc --workspace --no-deps --all-features

--- a/crates/openraft-toolkit/Cargo.toml
+++ b/crates/openraft-toolkit/Cargo.toml
@@ -13,6 +13,7 @@ authors.workspace      = true
 default            = ["rocksdb-log-store"]
 rocksdb-log-store  = ["dep:rocksdb"]
 test-fakes         = []
+failpoints         = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
 async-trait      = { workspace = true }
@@ -25,6 +26,7 @@ thiserror        = { workspace = true }
 tokio            = { workspace = true }
 tokio-stream     = { workspace = true }
 tracing          = { workspace = true }
+fail             = { workspace = true, optional = true }
 
 [dev-dependencies]
 openraft         = { workspace = true, features = ["serde", "type-alias"] }

--- a/crates/openraft-toolkit/src/failpoint.rs
+++ b/crates/openraft-toolkit/src/failpoint.rs
@@ -1,0 +1,23 @@
+//! Per-crate failpoint wrapper. See `docs/failpoint-testing.md`.
+
+#[cfg(feature = "failpoints")]
+#[macro_export]
+macro_rules! failpoint {
+    ($name:expr) => {
+        fail::fail_point!($name)
+    };
+    ($name:expr, $closure:expr) => {
+        fail::fail_point!($name, $closure)
+    };
+}
+
+#[cfg(not(feature = "failpoints"))]
+#[macro_export]
+macro_rules! failpoint {
+    ($name:expr) => {
+        ()
+    };
+    ($name:expr, $closure:expr) => {
+        ()
+    };
+}

--- a/crates/openraft-toolkit/src/lib.rs
+++ b/crates/openraft-toolkit/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[macro_use]
+mod failpoint;
+
 pub mod codec;
 pub mod macros;
 

--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -100,4 +100,16 @@ mod tests {
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["a:1", "b:1", "c:1"]);
     }
+
+    #[test]
+    fn clear_leader_drops_cached_leader() {
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()]);
+        pool.set_leader("b:1".into());
+        assert_eq!(pool.cached_leader().as_deref(), Some("b:1"));
+        pool.clear_leader();
+        assert!(pool.cached_leader().is_none());
+        // With the cache cleared, round-robin order falls back to the
+        // configured order — the cleared leader is not re-prepended.
+        assert_eq!(pool.iter_round_robin(), vec!["a:1", "b:1"]);
+    }
 }

--- a/crates/tsoracle-client/tests/e2e.rs
+++ b/crates/tsoracle-client/tests/e2e.rs
@@ -3,7 +3,7 @@ use tokio::net::TcpListener;
 use tokio::sync::watch;
 use tokio::time::sleep;
 use tonic::transport::Endpoint;
-use tsoracle_client::Client;
+use tsoracle_client::{Client, ClientError};
 use tsoracle_core::Epoch;
 use tsoracle_server::{Server, ServingState, test_fakes::InMemoryDriver};
 
@@ -159,6 +159,63 @@ async fn client_follows_leader_hint_on_first_call() {
     let _ = sdb_tx.send(());
     let _ = server_a_task.await;
     let _ = server_b_task.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_surfaces_error_when_only_endpoint_is_a_hintless_follower() {
+    // A follower with no known leader replies FailedPrecondition with an empty
+    // LeaderHint. The retry loop must clear its cached leader (the cache is
+    // now stale), exhaust the worklist, and surface the RPC error — not loop
+    // on the same dead endpoint or swallow the status.
+    let driver = Arc::new(InMemoryDriver::new());
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_addr = listener.local_addr().unwrap();
+    let mut state_rx = server.state_rx.clone();
+
+    let (sd_tx, sd_rx) = tokio::sync::oneshot::channel::<()>();
+    let serve = tokio::spawn(async move {
+        server
+            .serve_with_listener(listener, async {
+                let _ = sd_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    driver.become_follower(None);
+    wait_until(&mut state_rx, |s| {
+        matches!(
+            s,
+            ServingState::NotServing {
+                leader_endpoint: None
+            }
+        )
+    })
+    .await;
+    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
+
+    let client = Client::connect(vec![local_addr.to_string()]).await.unwrap();
+    let err = client
+        .get_ts()
+        .await
+        .expect_err("hintless follower must surface NOT_LEADER");
+    match err {
+        ClientError::Rpc(status) => {
+            assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+        }
+        other => panic!("expected ClientError::Rpc(FailedPrecondition), got {other:?}"),
+    }
+
+    let _ = sd_tx.send(());
+    let _ = serve.await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/tsoracle-driver-file/Cargo.toml
+++ b/crates/tsoracle-driver-file/Cargo.toml
@@ -13,7 +13,8 @@ keywords      = ["tsoracle", "wal", "storage", "fsync", "driver"]
 categories    = ["database-implementations", "filesystem"]
 
 [features]
-default = []
+default    = []
+failpoints = ["dep:fail", "fail/failpoints"]
 
 [package.metadata.docs.rs]
 all-features = false
@@ -21,6 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait        = { workspace = true }
+fail               = { workspace = true, optional = true }
 crc32c             = { workspace = true }
 futures            = { workspace = true }
 libc               = "0.2"
@@ -35,3 +37,8 @@ tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.0" }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio    = { workspace = true, features = ["test-util"] }
+
+[[test]]
+name              = "failpoints"
+path              = "tests/failpoints.rs"
+required-features = ["failpoints"]

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -94,6 +94,16 @@ impl FileDriver {
 }
 
 fn write_record(dir: &Path, high_water: u64) -> Result<(), FileDriverError> {
+    crate::failpoint!(
+        "file_driver::before_write",
+        |arg: Option<String>| -> Result<(), FileDriverError> {
+            let _ = arg; // currently only one action shape; future tags can match here
+            Err(FileDriverError::Io(std::io::Error::other(
+                "failpoint: file_driver::before_write",
+            )))
+        }
+    );
+
     let tmp = dir.join("state.tmp");
     let final_path = dir.join("state");
     let bytes = record::encode(high_water);
@@ -107,7 +117,19 @@ fn write_record(dir: &Path, high_water: u64) -> Result<(), FileDriverError> {
     file.sync_all()?;
     drop(file);
 
+    crate::failpoint!(
+        "file_driver::after_tmp_fsync_before_rename",
+        |arg: Option<String>| -> Result<(), FileDriverError> {
+            let _ = arg;
+            Err(FileDriverError::Io(std::io::Error::other(
+                "failpoint: file_driver::after_tmp_fsync_before_rename",
+            )))
+        }
+    );
+
     fs::rename(&tmp, &final_path)?;
+
+    crate::failpoint!("file_driver::after_rename_before_dir_fsync");
 
     // Fsync the directory so the rename is durable.
     let dir_file = fs::File::open(dir)?;
@@ -154,13 +176,7 @@ impl ConsensusDriver for FileDriver {
 
         let dir = self.dir.clone();
         tokio::task::spawn_blocking(move || {
-            #[cfg(test)]
-            {
-                let hook = SLOW_WRITE_HOOK.lock().unwrap().clone();
-                if let Some(hook) = hook {
-                    hook();
-                }
-            }
+            crate::failpoint!("file_driver::write_blocked");
             write_record(&dir, target)
         })
         .await
@@ -180,20 +196,6 @@ impl ConsensusDriver for FileDriver {
     }
 }
 
-// Test-only hook: lets a unit test pause the writer thread inside
-// `spawn_blocking`, just before `write_record`, so we can observe that
-// `load_high_water` is not blocked by an in-flight persist. Always `None`
-// outside of `cfg(test)` and incurs zero cost in release builds.
-#[cfg(test)]
-pub(crate) static SLOW_WRITE_HOOK: std::sync::Mutex<Option<Arc<dyn Fn() + Send + Sync>>> =
-    std::sync::Mutex::new(None);
-
-// Serializes unit tests that exercise the writer path. The hook above is a
-// process-global slot, so tests that install it must not race other tests
-// that call `persist_high_water` (those would see the hook and hang).
-#[cfg(test)]
-pub(crate) static PERSIST_TEST_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -208,7 +210,6 @@ mod tests {
 
     #[tokio::test]
     async fn persist_then_reload() {
-        let _serial = PERSIST_TEST_SERIAL.lock().await;
         let dir = tempdir().unwrap();
         let driver = FileDriver::open_or_init(dir.path()).unwrap();
         let actual = driver.persist_high_water(12345, Epoch::ZERO).await.unwrap();
@@ -220,7 +221,6 @@ mod tests {
 
     #[tokio::test]
     async fn persist_is_monotonic() {
-        let _serial = PERSIST_TEST_SERIAL.lock().await;
         let dir = tempdir().unwrap();
         let driver = FileDriver::open_or_init(dir.path()).unwrap();
         assert_eq!(
@@ -235,84 +235,6 @@ mod tests {
             driver.persist_high_water(200, Epoch::ZERO).await.unwrap(),
             200
         );
-    }
-
-    /// Regression guard for the bug the AtomicU64 refactor fixed: with the
-    /// old `Mutex<u64>` held across `write_record`, a `load_high_water` call
-    /// during an in-flight persist would park on the state lock for the full
-    /// duration of fsync. We install a hook that holds the writer inside
-    /// `spawn_blocking` just before `write_record`, then check that a
-    /// concurrent reader completes.
-    ///
-    /// Failure mode if the regression returns: `load_high_water` would block
-    /// on the same sync mutex held by the writer. The `tokio::time::timeout`
-    /// below catches *async* regressions cleanly, but a sync-mutex regression
-    /// (exactly the original bug) hangs the task off-runtime — the timer
-    /// driver never gets to poll the timeout future. In that case this test
-    /// hangs until CI's per-test or per-binary timeout fires, which is the
-    /// signal we rely on for detection. Run under `cargo nextest` or shell
-    /// `timeout` in CI to bound it.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn load_is_not_blocked_by_in_flight_persist() {
-        use std::sync::mpsc::sync_channel;
-        use std::time::Duration;
-
-        let _serial = PERSIST_TEST_SERIAL.lock().await;
-
-        let dir = tempdir().unwrap();
-        let driver = FileDriver::open_or_init(dir.path()).unwrap();
-
-        // The hook signals via `entered_tx` once the writer reaches it, then
-        // blocks on `release_rx` until the test lets it proceed. Channels of
-        // capacity 1 are enough — the hook fires exactly once per call.
-        let (entered_tx, entered_rx) = sync_channel::<()>(1);
-        let (release_tx, release_rx) = sync_channel::<()>(1);
-        let release_rx = std::sync::Mutex::new(release_rx);
-
-        // RAII guard so the hook clears even if an assertion below panics —
-        // otherwise a leaked hook would hang every later writer test.
-        struct HookGuard;
-        impl Drop for HookGuard {
-            fn drop(&mut self) {
-                *SLOW_WRITE_HOOK.lock().unwrap() = None;
-            }
-        }
-        *SLOW_WRITE_HOOK.lock().unwrap() = Some(Arc::new(move || {
-            entered_tx.send(()).unwrap();
-            release_rx.lock().unwrap().recv().unwrap();
-        }));
-        let _hook_guard = HookGuard;
-
-        let writer = {
-            let driver = driver.clone();
-            tokio::spawn(async move { driver.persist_high_water(100, Epoch::ZERO).await })
-        };
-
-        // Deterministic wait: block until the writer is inside the hook.
-        // Running the sync recv inside `spawn_blocking` keeps it off a
-        // runtime worker thread.
-        tokio::task::spawn_blocking(move || entered_rx.recv().unwrap())
-            .await
-            .unwrap();
-
-        // Writer is parked at the "about to fsync" point. A reader must not
-        // wait on it. The 500ms timeout below only fires for async-blocking
-        // regressions; the sync-mutex regression this guards against shows
-        // up as a hang (see the doc comment).
-        let read = tokio::time::timeout(Duration::from_millis(500), driver.load_high_water())
-            .await
-            .expect("load_high_water was blocked by an in-flight persist");
-        assert_eq!(
-            read.unwrap(),
-            0,
-            "writer has not published yet; reader should see the prior value"
-        );
-
-        // Release the writer and verify it completes and publishes 100.
-        release_tx.send(()).unwrap();
-        let persisted = writer.await.unwrap().unwrap();
-        assert_eq!(persisted, 100);
-        assert_eq!(driver.load_high_water().await.unwrap(), 100);
     }
 
     #[tokio::test]

--- a/crates/tsoracle-driver-file/src/failpoint.rs
+++ b/crates/tsoracle-driver-file/src/failpoint.rs
@@ -1,0 +1,28 @@
+//! Per-crate failpoint wrapper. See `docs/failpoint-testing.md` for the
+//! conventions enforced here: source sites never reference `fail::` directly;
+//! they go through `crate::failpoint!`.
+//!
+//! With `feature = "failpoints"` off, both forms expand to `()` and the
+//! `fail` crate is not in the build graph.
+
+#[cfg(feature = "failpoints")]
+#[macro_export]
+macro_rules! failpoint {
+    ($name:expr) => {
+        fail::fail_point!($name)
+    };
+    ($name:expr, $closure:expr) => {
+        fail::fail_point!($name, $closure)
+    };
+}
+
+#[cfg(not(feature = "failpoints"))]
+#[macro_export]
+macro_rules! failpoint {
+    ($name:expr) => {
+        ()
+    };
+    ($name:expr, $closure:expr) => {
+        ()
+    };
+}

--- a/crates/tsoracle-driver-file/src/lib.rs
+++ b/crates/tsoracle-driver-file/src/lib.rs
@@ -20,6 +20,8 @@
 //!
 //! [`ConsensusDriver`]: tsoracle_consensus::ConsensusDriver
 
+#[macro_use]
+mod failpoint;
 mod driver;
 pub mod record;
 

--- a/crates/tsoracle-driver-file/tests/failpoints.rs
+++ b/crates/tsoracle-driver-file/tests/failpoints.rs
@@ -1,0 +1,171 @@
+#![cfg(feature = "failpoints")]
+
+use std::sync::Arc;
+use std::sync::mpsc::sync_channel;
+use std::time::Duration;
+use tsoracle_consensus::{ConsensusDriver, ConsensusError};
+use tsoracle_core::Epoch;
+use tsoracle_driver_file::FileDriver;
+
+/// Body-level serialization: the `fail` registry is process-global; even with
+/// `FailScenario::setup` snapshotting between tests, multiple test bodies
+/// sharing the same registered name will interleave their configurations.
+/// Mirrors the old `PERSIST_TEST_SERIAL` pattern.
+static FAILPOINT_TEST_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Regression guard for the AtomicU64 refactor: `load_high_water` must not
+/// park behind an in-flight `persist_high_water`. Uses `fail::cfg_callback`
+/// to install a callback that signals arrival and then blocks until released,
+/// preserving the deterministic handshake the original `SLOW_WRITE_HOOK`
+/// provided. Plain `pause` would block the writer but give the reader no
+/// signal that the writer has reached the failpoint, so the timeout-bounded
+/// read could race-pass before the writer arrives.
+///
+/// Failure mode if the regression returns: `load_high_water` blocks on the
+/// same sync mutex held by the writer. The `tokio::time::timeout` below
+/// catches *async* regressions cleanly, but a sync-mutex regression hangs
+/// the task off-runtime — the timer driver never gets to poll the timeout.
+/// In that case the test hangs until CI's per-test timeout fires.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_is_not_blocked_by_in_flight_persist() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let dir = tempfile::tempdir().unwrap();
+    let driver = FileDriver::open_or_init(dir.path()).unwrap();
+
+    let (entered_tx, entered_rx) = sync_channel::<()>(1);
+    let (release_tx, release_rx) = sync_channel::<()>(1);
+    let release_rx = std::sync::Mutex::new(release_rx);
+
+    fail::cfg_callback("file_driver::write_blocked", move || {
+        entered_tx.send(()).unwrap();
+        release_rx.lock().unwrap().recv().unwrap();
+    })
+    .unwrap();
+
+    let writer = {
+        let driver = Arc::clone(&driver);
+        tokio::spawn(async move { driver.persist_high_water(100, Epoch::ZERO).await })
+    };
+
+    // Deterministic wait: the writer has reached the failpoint when this
+    // channel send arrives. Running the sync recv in spawn_blocking keeps
+    // it off a runtime worker thread.
+    tokio::task::spawn_blocking(move || entered_rx.recv().unwrap())
+        .await
+        .unwrap();
+
+    // Writer is parked. A reader must not wait on it. The 500ms timeout
+    // only catches async-blocking regressions; sync-mutex regressions
+    // (the original bug) show up as a hang.
+    let read = tokio::time::timeout(Duration::from_millis(500), driver.load_high_water())
+        .await
+        .expect("load_high_water was blocked by an in-flight persist");
+    assert_eq!(
+        read.unwrap(),
+        0,
+        "writer has not published yet; reader should see the prior value"
+    );
+
+    release_tx.send(()).unwrap();
+    let persisted = writer.await.unwrap().unwrap();
+    assert_eq!(persisted, 100);
+    assert_eq!(driver.load_high_water().await.unwrap(), 100);
+}
+
+/// `file_driver::before_write` fires at the top of `write_record`, before
+/// the tmpfile is opened. A `return(io)` action makes `write_record`
+/// produce `Err(FileDriverError::Io(_))`; `persist_high_water` wraps that
+/// into `ConsensusError::PermanentDriver`. After the failed persist, no
+/// state file (or stale state file) is left behind — reopen sees the
+/// prior high-water.
+#[tokio::test]
+async fn reopen_after_crash_before_write_returns_prior_high_water() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let driver = FileDriver::open_or_init(dir.path()).unwrap();
+        driver.persist_high_water(100, Epoch::ZERO).await.unwrap();
+
+        fail::cfg("file_driver::before_write", "return(io)").unwrap();
+        let result = driver.persist_high_water(200, Epoch::ZERO).await;
+        assert!(
+            matches!(result, Err(ConsensusError::PermanentDriver(_))),
+            "expected PermanentDriver, got {result:?}"
+        );
+        fail::cfg("file_driver::before_write", "off").unwrap();
+    }
+
+    let reopened = FileDriver::open_or_init(dir.path()).unwrap();
+    assert_eq!(
+        reopened.load_high_water().await.unwrap(),
+        100,
+        "reopen should see prior high-water; the failed persist must not have rewritten state"
+    );
+}
+
+/// `file_driver::after_tmp_fsync_before_rename` fires after the tmpfile
+/// fsync but before `fs::rename`. A `return(io)` action causes the rename
+/// to be skipped; the tmpfile may exist on disk but the canonical `state`
+/// file is unchanged. Reopen reads `state` and ignores `state.tmp`.
+#[tokio::test]
+async fn reopen_after_crash_between_tmp_fsync_and_rename_returns_prior_high_water() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let driver = FileDriver::open_or_init(dir.path()).unwrap();
+        driver.persist_high_water(100, Epoch::ZERO).await.unwrap();
+
+        fail::cfg("file_driver::after_tmp_fsync_before_rename", "return(io)").unwrap();
+        let result = driver.persist_high_water(200, Epoch::ZERO).await;
+        assert!(
+            matches!(result, Err(ConsensusError::PermanentDriver(_))),
+            "expected PermanentDriver, got {result:?}"
+        );
+        fail::cfg("file_driver::after_tmp_fsync_before_rename", "off").unwrap();
+    }
+
+    let reopened = FileDriver::open_or_init(dir.path()).unwrap();
+    assert_eq!(reopened.load_high_water().await.unwrap(), 100);
+}
+
+/// `file_driver::after_rename_before_dir_fsync` fires after `fs::rename`
+/// but before the directory fsync. A `panic` action terminates the
+/// `spawn_blocking` worker; `persist_high_water` surfaces it as
+/// `PermanentDriver`. Reopen sees the new high-water in practice (the
+/// rename's metadata is in the kernel page cache; we have not crashed
+/// the OS), but the assertion is loosened to "monotonic either way" —
+/// the test asserts the loaded value is >= 100 and <= 200, because a
+/// future change to the underlying filesystem semantics shouldn't break
+/// this test.
+#[tokio::test]
+async fn reopen_after_crash_between_rename_and_dir_fsync_is_monotonic() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let driver = FileDriver::open_or_init(dir.path()).unwrap();
+        driver.persist_high_water(100, Epoch::ZERO).await.unwrap();
+
+        fail::cfg("file_driver::after_rename_before_dir_fsync", "panic").unwrap();
+        let result = driver.persist_high_water(200, Epoch::ZERO).await;
+        assert!(
+            matches!(result, Err(ConsensusError::PermanentDriver(_))),
+            "spawn_blocking panic should surface as PermanentDriver, got {result:?}"
+        );
+        fail::cfg("file_driver::after_rename_before_dir_fsync", "off").unwrap();
+    }
+
+    let reopened = FileDriver::open_or_init(dir.path()).unwrap();
+    let loaded = reopened.load_high_water().await.unwrap();
+    assert!(
+        (100..=200).contains(&loaded),
+        "expected loaded value in 100..=200, got {loaded}"
+    );
+}

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -14,6 +14,7 @@ categories    = ["network-programming", "database"]
 
 [features]
 default    = ["tls-rustls", "tracing"]
+failpoints = ["dep:fail", "fail/failpoints"]
 tls-rustls = ["tonic/tls-aws-lc"]
 tls-native = ["tonic/tls-native-roots"]
 tracing    = ["dep:tracing"]
@@ -26,6 +27,7 @@ rustdoc-args   = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait        = { workspace = true }
+fail               = { workspace = true, optional = true }
 futures            = { workspace = true }
 parking_lot        = { workspace = true }
 prost              = { workspace = true }
@@ -68,3 +70,8 @@ required-features = ["test-fakes"]
 [[test]]
 name = "serve_with_listener"
 required-features = ["test-fakes"]
+
+[[test]]
+name              = "failpoints"
+path              = "tests/failpoints.rs"
+required-features = ["failpoints", "test-fakes"]

--- a/crates/tsoracle-server/src/failpoint.rs
+++ b/crates/tsoracle-server/src/failpoint.rs
@@ -1,0 +1,28 @@
+//! Per-crate failpoint wrapper. See `docs/failpoint-testing.md` for the
+//! conventions enforced here: source sites never reference `fail::` directly;
+//! they go through `crate::failpoint!`.
+//!
+//! With `feature = "failpoints"` off, both forms expand to `()` and the
+//! `fail` crate is not in the build graph.
+
+#[cfg(feature = "failpoints")]
+#[macro_export]
+macro_rules! failpoint {
+    ($name:expr) => {
+        fail::fail_point!($name)
+    };
+    ($name:expr, $closure:expr) => {
+        fail::fail_point!($name, $closure)
+    };
+}
+
+#[cfg(not(feature = "failpoints"))]
+#[macro_export]
+macro_rules! failpoint {
+    ($name:expr) => {
+        ()
+    };
+    ($name:expr, $closure:expr) => {
+        ()
+    };
+}

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -13,6 +13,8 @@
 use futures::StreamExt;
 use std::sync::Arc;
 
+#[cfg(feature = "failpoints")]
+use tsoracle_consensus::ConsensusError;
 use tsoracle_consensus::LeaderState;
 
 use crate::server::{Server, ServerError, ServingState};
@@ -38,6 +40,18 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                 // the +1 below.
                 let prior_max = server.consensus.load_high_water().await?;
 
+                crate::failpoint!(
+                    "server::fence::after_load_before_persist",
+                    |arg: Option<String>| -> Result<(), ServerError> {
+                        let _ = arg;
+                        Err(ServerError::Consensus(ConsensusError::TransientDriver(
+                            Box::new(std::io::Error::other(
+                                "failpoint: server::fence::after_load_before_persist",
+                            )),
+                        )))
+                    }
+                );
+
                 // Compute the serving floor and the requested ceiling.
                 // serving_floor is the first physical_ms the new leader may
                 // issue at — strictly above any timestamp the prior leader
@@ -53,6 +67,8 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                     .consensus
                     .persist_high_water(requested, epoch)
                     .await?;
+
+                crate::failpoint!("server::fence::after_persist_before_publish");
 
                 // Seed the allocator with both bounds. The floor pins the
                 // lower bound; committed_ceiling = actual is the post-persist

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -18,6 +18,8 @@
 //! [`docs`] module contains the docs.rs-rendered operations chapter; the
 //! repo's `docs/key-subsystems.md` covers the same internals in depth.
 
+#[macro_use]
+mod failpoint;
 mod fence;
 mod leader_hint;
 mod server;

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -47,6 +47,7 @@ pub struct TsoServiceImpl {
 #[tonic::async_trait]
 impl TsoService for TsoServiceImpl {
     async fn get_ts(&self, req: Request<GetTsRequest>) -> Result<Response<GetTsResponse>, Status> {
+        crate::failpoint!("server::service::before_allocate");
         let count = req.into_inner().count;
         if count == 0 {
             return Err(Status::invalid_argument("count must be >= 1"));
@@ -137,6 +138,7 @@ impl TsoServiceImpl {
         // Drain barrier: leader-watch's write() waits behind this read until
         // our commit applies (or is silently dropped by the epoch check).
         let _gate = self.server.extension_gate.read().await;
+        crate::failpoint!("server::service::extension_gate_held");
 
         let (requested, epoch) = {
             let allocator = self.server.allocator.lock();

--- a/crates/tsoracle-server/tests/failpoints.rs
+++ b/crates/tsoracle-server/tests/failpoints.rs
@@ -1,0 +1,251 @@
+#![cfg(all(feature = "failpoints", feature = "test-fakes"))]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::watch;
+use tonic::transport::Endpoint;
+use tsoracle_core::Epoch;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::{Server, ServerError, ServingState};
+
+static FAILPOINT_TEST_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Block until `state_rx` reports the expected `ServingState`.
+async fn wait_until<F>(rx: &mut watch::Receiver<ServingState>, predicate: F)
+where
+    F: Fn(&ServingState) -> bool,
+{
+    loop {
+        if predicate(&rx.borrow_and_update()) {
+            return;
+        }
+        rx.changed()
+            .await
+            .expect("state stream closed before reaching expected state");
+    }
+}
+
+/// Bridge the residual race between "state_rx published Serving" and tonic's
+/// accept future having been polled. Probes by opening a real gRPC channel
+/// until one succeeds.
+async fn wait_for_grpc_handshake(addr: SocketAddr, budget: Duration) {
+    let deadline = Instant::now() + budget;
+    let endpoint: Endpoint = format!("http://{addr}").parse().unwrap();
+    loop {
+        if endpoint.connect().await.is_ok() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("tonic never accepted gRPC handshake within {budget:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// `server::fence::after_load_before_persist` fires inside `run_leader_watch`,
+/// between `consensus.load_high_water()` and `consensus.persist_high_water()`.
+/// A `return(transient)` action produces `Err(ServerError::Consensus(...))`,
+/// which causes the leader-watch task to terminate. The server calls
+/// `step_down_due_to_consensus_rejection` before the join handle resolves,
+/// so the test can observe the error via the JoinHandle.
+#[tokio::test]
+async fn fence_aborted_after_load_does_not_advance_to_serving() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+    let (_routes, watch_handle) = server.into_router();
+
+    fail::cfg(
+        "server::fence::after_load_before_persist",
+        "return(transient)",
+    )
+    .unwrap();
+
+    // Trigger a leadership transition; the fence will hit the failpoint.
+    driver.become_leader(Epoch(1));
+
+    // The watch handle resolves with the ServerError.
+    let result = tokio::time::timeout(Duration::from_secs(2), watch_handle)
+        .await
+        .expect("watch task did not terminate within 2s")
+        .expect("watch task panicked");
+
+    assert!(
+        matches!(result, Err(ServerError::Consensus(_))),
+        "expected ServerError::Consensus, got {result:?}"
+    );
+
+    // The driver's stored high-water must not have advanced: the failpoint
+    // fires before `persist_high_water` is called.
+    assert_eq!(driver.current_high_water(), 0);
+}
+
+/// `server::fence::after_persist_before_publish` fires after
+/// `persist_high_water` returns, before `try_on_leadership_gained` and
+/// the `state_tx.send(Serving)`. A `panic` action terminates the
+/// leader-watch task. The durable high-water has already advanced
+/// (verifiable via `driver.current_high_water()`), but serving state
+/// stays NotServing because the publish step never ran.
+#[tokio::test]
+async fn fence_panic_after_persist_advances_durable_but_not_serving() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+    let (_routes, watch_handle) = server.into_router();
+
+    fail::cfg("server::fence::after_persist_before_publish", "panic").unwrap();
+
+    driver.become_leader(Epoch(1));
+
+    // The panic surfaces as a JoinError (task panicked); the wrapper in
+    // into_router catches the panic via `ServerError::WatchPanic { payload }`.
+    // tokio::spawn's JoinHandle resolves Err when the task panics. But the
+    // wrapper we have catches the inner result, returning it. Inspect what
+    // we actually get:
+    let result = tokio::time::timeout(Duration::from_secs(2), watch_handle)
+        .await
+        .expect("watch task did not terminate within 2s");
+    // A panic inside the task: JoinHandle resolves to Err(JoinError).
+    assert!(
+        result.is_err(),
+        "expected the panic to surface as a JoinError, got {result:?}"
+    );
+
+    // The persist happened before the panic, so the driver's stored
+    // high-water has advanced past zero.
+    assert!(
+        driver.current_high_water() > 0,
+        "persist should have advanced the driver's stored value before the panic"
+    );
+}
+
+/// `server::service::before_allocate` fires at the top of `get_ts`,
+/// before the allocator lock. A `sleep(ms)` action delays the request by
+/// that many milliseconds; the client observes the delay. This site is
+/// used for timing-shape tests only — its closure-form return would be
+/// `Result<Response<GetTsResponse>, Status>` and would bypass the
+/// production `ConsensusError -> Status` classification path.
+#[tokio::test]
+async fn before_allocate_sleep_delays_get_ts() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+    let mut state_rx = server.state_rx.clone();
+    let (routes, _watch_handle) = server.into_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let serve = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_routes(routes)
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+    });
+
+    driver.become_leader(Epoch(1));
+    wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
+    wait_for_grpc_handshake(addr, Duration::from_secs(5)).await;
+
+    let endpoint = format!("http://{addr}");
+    let client = tsoracle_client::Client::connect(vec![endpoint])
+        .await
+        .unwrap();
+
+    fail::cfg("server::service::before_allocate", "sleep(150)").unwrap();
+    let start = Instant::now();
+    let result = client.get_ts().await;
+    let elapsed = start.elapsed();
+    fail::cfg("server::service::before_allocate", "off").unwrap();
+
+    let err = result.err();
+    assert!(
+        err.is_none(),
+        "get_ts failed under sleep(150) failpoint: {err:?} (elapsed {elapsed:?})"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(120),
+        "expected at least 120ms delay (sleep was 150ms), saw {elapsed:?}"
+    );
+
+    drop(client);
+    serve.abort();
+}
+
+/// `server::service::extension_gate_held` fires at the top of the
+/// extension-gate read branch in `get_ts`, after the read guard is bound.
+/// A `sleep(ms)` action delays the request while holding the gate read;
+/// the client observes the delay. This wiring test proves the failpoint
+/// is reachable from the gate path. The deeper invariant (held-gate
+/// request must not observe state from after a concurrent fence) is
+/// covered by `crates/tsoracle-client/tests/freshness.rs`.
+#[tokio::test]
+async fn extension_gate_held_sleep_delays_get_ts() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    // A 1ms failover_advance ensures the initial fence window expires almost
+    // immediately, so the first get_ts hits WindowExhausted and calls
+    // extend_window — which acquires the extension_gate read lock and hits
+    // the failpoint.
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .failover_advance(Duration::from_millis(1))
+        .build()
+        .unwrap();
+    let mut state_rx = server.state_rx.clone();
+    let (routes, _watch_handle) = server.into_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let serve = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_routes(routes)
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+    });
+
+    driver.become_leader(Epoch(1));
+    wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
+    wait_for_grpc_handshake(addr, Duration::from_secs(5)).await;
+
+    let endpoint = format!("http://{addr}");
+    let client = tsoracle_client::Client::connect(vec![endpoint])
+        .await
+        .unwrap();
+
+    fail::cfg("server::service::extension_gate_held", "sleep(150)").unwrap();
+    let start = Instant::now();
+    let result = client.get_ts().await;
+    let elapsed = start.elapsed();
+    fail::cfg("server::service::extension_gate_held", "off").unwrap();
+
+    let err = result.err();
+    assert!(
+        err.is_none(),
+        "get_ts failed under sleep(150) failpoint: {err:?} (elapsed {elapsed:?})"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(120),
+        "expected at least 120ms delay (sleep was 150ms), saw {elapsed:?}"
+    );
+
+    drop(client);
+    serve.abort();
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ For the **API reference**, see [docs.rs/tsoracle-server](https://docs.rs/tsoracl
 - **[Consensus Integration](consensus-integration.md)** — the `ConsensusDriver` trait, per-method recipes, worked openraft example, single-leader requirement.
 - **[Operations](operations.md)** — sizing `window_ahead`/`failover_advance`, monitoring hooks, deployment topologies, client retry behavior.
 - **[Testing and Examples](testing-and-examples.md)** — walkthroughs of `embedded-server`, `failover-demo`, `openraft-standalone`, `openraft-piggyback`, plus the workspace testing strategy.
+- **[Failpoint Testing](failpoint-testing.md)** — fault-injection points for crash-recovery, fence, and service-path tests; the feature-gating model and contributor guidance.
 
 ## Where to start
 

--- a/docs/failpoint-testing.md
+++ b/docs/failpoint-testing.md
@@ -1,0 +1,108 @@
+# Failpoint testing
+
+Failpoint testing lets a test inject a panic, an error return, a pause, or a sleep at a named site in production code. The injection is gated by a Cargo feature so release builds physically cannot reach any failpoint. tsoracle uses the [`fail`](https://docs.rs/fail/0.5/) crate (the same library used by TiKV, sled, etcd-rs, and openraft itself).
+
+## When to add a failpoint
+
+Add a failpoint when an invariant only manifests under a timing window or a partial-failure scenario that is otherwise impossible to provoke in a unit test. Crash-recovery, leader-transition correctness, and consensus apply-then-crash safety are the canonical examples. Don't add a failpoint when the same property is testable with the existing in-memory driver or via proptest.
+
+## Feature gating
+
+Two crates currently opt in via a per-crate `failpoints` Cargo feature: `tsoracle-driver-file` and `tsoracle-server`. The `openraft-toolkit` crate has the feature wired but no sites yet (sites for that crate are tracked as a follow-up). The feature is off by default. Run the failpoint suite with:
+
+    make test-failpoints
+
+The Makefile target enables `tsoracle-driver-file/failpoints`, `tsoracle-server/failpoints`, `tsoracle-server/test-fakes` (needed for `InMemoryDriver`), `openraft-toolkit/failpoints`, and `openraft-toolkit/rocksdb-log-store`. The default CI test job runs `cargo test --workspace --all-features --locked`, which activates all of these features automatically, so the failpoint suite is part of the normal CI gate.
+
+Release builds of the `tsoracle` binary do not include the `failpoints` feature on any crate. The `fail` crate is an optional dependency at the per-crate level (`fail = { workspace = true, optional = true }`) and the per-crate `failpoints` feature is what pulls it into the build graph; without the feature, `fail` is not linked.
+
+## The wrapper macro
+
+Each opting-in crate has a `failpoint` module with a small `failpoint!` macro. Source sites use the crate's macro via `crate::failpoint!(...)` and never reference `fail::` directly. The macro has two forms — the right form depends on whether the site needs to produce a typed return value:
+
+```rust
+// Single-arg form. Supports `panic`, `pause`, `sleep(ms)`, `print`, `off`.
+// Configuring this site with `return` or `return(...)` panics at runtime
+// with "Return is not supported for the fail point" — the bare macro has
+// no way to know the enclosing function's return type and refuses to guess.
+crate::failpoint!("file_driver::write_blocked");
+
+// Closure form. The closure receives `Option<String>` (the action grammar's
+// `return` passes `None`; `return(string)` passes `Some(string)`), and the
+// closure must return the *exact* return type of the function the macro is
+// called in. The macro `return`s the closure's value from the enclosing
+// function. This is what makes failpoint returns type-safe.
+crate::failpoint!("file_driver::before_write", |arg: Option<String>| -> Result<(), FileDriverError> {
+    let _ = arg;  // multi-tag dispatch can match here in the future
+    Err(FileDriverError::Io(std::io::Error::other("failpoint: file_driver::before_write")))
+});
+```
+
+With `feature = "failpoints"` off, both forms expand to `()` — zero code, no dependency on `fail`.
+
+## Naming convention
+
+`{crate_short}::{module}::{temporal_phrase}` where `crate_short` is the crate name with the `tsoracle-` or `openraft-` prefix dropped and snake-cased, `module` is the file the site lives in, and `temporal_phrase` is one of `before_X`, `after_X`, or `after_X_before_Y`. The form `during_X` is banned because it is ambiguous about where inside `X` the point sits. Names are stable; renaming a failpoint is treated like renaming a public API symbol.
+
+## Current sites
+
+### `tsoracle-driver-file` — 4 sites in `crates/tsoracle-driver-file/src/driver.rs`
+
+| Site name | Position | Useful actions | Test |
+|---|---|---|---|
+| `file_driver::before_write` | Top of `write_record`, before tmpfile open. | `return(io)` via the closure form; `panic`. | `reopen_after_crash_before_write_returns_prior_high_water` |
+| `file_driver::after_tmp_fsync_before_rename` | After `file.sync_all()` on `state.tmp`, before `fs::rename`. | `panic`; `return(io)` via the closure form. | `reopen_after_crash_between_tmp_fsync_and_rename_returns_prior_high_water` |
+| `file_driver::after_rename_before_dir_fsync` | After `fs::rename`, before `libc::fsync(fd)` on the directory. | `panic`. | `reopen_after_crash_between_rename_and_dir_fsync_is_monotonic` |
+| `file_driver::write_blocked` | At the top of the `spawn_blocking` closure inside `persist_high_water`. | `pause` / `sleep(ms)` (this site is intended for timing tests, not error injection). | `load_is_not_blocked_by_in_flight_persist` — uses `fail::cfg_callback` for a deterministic entry signal. |
+
+### `tsoracle-server` — 4 sites across `crates/tsoracle-server/src/{fence,service}.rs`
+
+| Site name | Position | Useful actions | Test |
+|---|---|---|---|
+| `server::fence::after_load_before_persist` | In `run_leader_watch`, between `consensus.load_high_water()` and `consensus.persist_high_water()`. | `panic`, `sleep(ms)`, `return(transient)` via the closure form (closure produces `Err(ServerError::Consensus(ConsensusError::TransientDriver(_)))`). | `fence_aborted_after_load_does_not_advance_to_serving` |
+| `server::fence::after_persist_before_publish` | In `run_leader_watch`, after `persist_high_water` returns, before `try_on_leadership_gained` and the `state_tx.send(Serving)`. | `panic`. | `fence_panic_after_persist_advances_durable_but_not_serving` |
+| `server::service::before_allocate` | In `Service::get_ts`, before the allocator lock is taken. | `sleep(ms)`, `pause`. Used for timing-shape tests only — closure-form `return` would produce a `Status` directly and bypass the production `ConsensusError → Status` classification path. | `before_allocate_sleep_delays_get_ts` |
+| `server::service::extension_gate_held` | In `Service::extend_window`, immediately after the `extension_gate.read().await` guard is bound. | `pause`, `sleep(ms)`. | `extension_gate_held_sleep_delays_get_ts` |
+
+### `openraft-toolkit`
+
+The crate has the `failpoints` feature, the wrapper macro, and the lib.rs mount wired, but no sites yet. The original spec specified two sites (`openraft_toolkit::log_store::before_write_batch` and `openraft_toolkit::log_store::after_write_before_sync`); their tests require a non-trivial setup against the openraft 0.10 `RaftLogStorage::append` API and were deferred to a follow-up spec.
+
+## Writing a failpoint test
+
+Tests live in `crates/<crate>/tests/failpoints.rs`. The file is `#![cfg(feature = "failpoints")]` at the top; a `[[test]]` entry in `Cargo.toml` declares the required features (so cargo silently skips the binary when the features are off rather than failing the compile).
+
+Each test:
+
+1. Acquires a process-global `FAILPOINT_TEST_SERIAL: tokio::sync::Mutex<()>` to serialize test bodies inside the binary. The `fail` registry is process-global; without body-level serialization, configured actions interleave across tests.
+2. Sets up a `fail::FailScenario::setup()` RAII guard. The guard snapshots the registry on entry and restores it on drop — this is `fail`'s built-in protection against tests leaking configured actions into each other.
+3. Calls `fail::cfg("name", "action")` to configure the failpoint.
+4. Exercises the code path.
+5. Calls `fail::cfg("name", "off")` to clear the action (the `FailScenario` drop would also clear it, but explicit teardown makes the test scope obvious).
+6. Asserts the observable invariant.
+
+For deterministic entry signaling (when the test needs to know the failpoint fired *before* taking some other action), use `fail::cfg_callback` — see `tsoracle-driver-file/tests/failpoints.rs::load_is_not_blocked_by_in_flight_persist` for the canonical pattern with the `entered_tx` / `release_rx` handshake.
+
+Tests that need a real tonic listener and `tsoracle_client::Client` (the two `service::*` tests do) must wait deterministically for `ServingState::Serving` and for tonic's accept loop to be polled. `crates/tsoracle-server/tests/failpoints.rs` defines local `wait_until(state_rx, predicate)` and `wait_for_grpc_handshake(addr, budget)` helpers mirroring the pattern in `tests/e2e.rs`. Don't reach for `tokio::time::sleep(...)` as a warm-up — it is not deterministic across machine load.
+
+## Action grammar crib sheet
+
+- `off` — disable the failpoint. Always allowed.
+- `panic` — panic the calling thread. Inside `spawn_blocking` or a `tokio::spawn` task, the panic surfaces as `JoinError` to whoever awaits the handle.
+- `pause` — block the calling thread until `off` is configured for this failpoint. Note: `pause` gives the test no signal that the failpoint has been *reached*; use `cfg_callback` when a deterministic entry signal is needed.
+- `sleep(N)` — sleep N milliseconds. The implementation is `std::thread::sleep`, which blocks the OS thread. Keep N modest (under a few hundred ms) to avoid tripping tonic's connection timeouts during request-path tests.
+- `return` / `return(string)` — closure form only. With a single-arg site, configuring `return` panics at runtime.
+- `print(text)` — log a message without altering control flow.
+
+For probabilistic (`50%return(...)`) and call-counted (`5*panic`) actions, see `https://docs.rs/fail/latest/fail/`. We do not currently commit usage examples for them.
+
+## Adding a new site
+
+1. Pick a name following `{crate_short}::{module}::{temporal_phrase}`.
+2. Decide single-arg vs. closure form. If the site needs to return a typed value, the closure form is required. If the action will only be `panic`, `pause`, `sleep`, or `print`, single-arg suffices.
+3. Insert `crate::failpoint!(...)` at the source position. The crate must already have the `failpoints` feature, the `failpoint` module, and the `#[macro_use]` mount in `lib.rs` — see `tsoracle-driver-file` as the canonical reference.
+4. Add a test in `crates/<crate>/tests/failpoints.rs`. Follow the pattern in this doc.
+5. Run `make test-failpoints` locally and confirm everything still passes.
+6. Document the new site in this file's "Current sites" table.
+
+Renaming an existing site is a breaking change for any test or operator script that referenced it. Treat it like renaming a public API symbol — bundle the rename with the changes that motivate it, and mention it in the PR description.

--- a/docs/testing-and-examples.md
+++ b/docs/testing-and-examples.md
@@ -81,6 +81,7 @@ tsoracle's tests are organized along the same layering as the code:
 - **`tsoracle-client/tests/e2e.rs`** — client integration against a real server with the in-memory driver.
 - **`tsoracle-client/tests/freshness.rs`** — explicit test of the [freshness invariant](getting-started.md#the-freshness-invariant): concurrent waiters never receive timestamps allocated before they entered the driver.
 - **`tsoracle-bin/tests/smoke.rs`** — black-box test of the `tsoracle` CLI: spawn the binary, send a `GetTs`, check the response, terminate.
+- **`crates/{tsoracle-driver-file, tsoracle-server}/tests/failpoints.rs`** — fault-injection tests gated by each crate's `failpoints` Cargo feature. Inject panics, sleeps, and typed-error returns at named sites in `write_record`, the leader-watch fence, and the service path; assert the observable invariants on reopen / on the `JoinHandle` / on client-visible RPC behavior. See [Failpoint Testing](failpoint-testing.md) for the feature-gating model, the eight current sites, the wrapper macro shape, and contributor guidance for adding new sites.
 
 The `test-fakes` feature on `tsoracle-server` is the linchpin: it exposes `InMemoryDriver` (which would otherwise be `pub(crate)`), letting integration tests in dependent crates exercise leader transitions on a real tonic-mounted server without needing a real consensus library. The [failover-demo example](#failover-demo-example) uses the same affordance as a pedagogy tool.
 


### PR DESCRIPTION
## Summary

- Adds fault-injection testing via the `fail` crate, with 8 failpoint sites across `tsoracle-driver-file` (write_record crash boundaries) and `tsoracle-server` (leader-watch fence + service path). Each opting-in crate has its own `failpoints` Cargo feature (off by default) and a `failpoint!` wrapper macro that expands to nothing without the feature, so release builds physically cannot contain failpoint code.
- Removes the ad-hoc `SLOW_WRITE_HOOK` / `PERSIST_TEST_SERIAL` machinery in `tsoracle-driver-file`. The `load_is_not_blocked_by_in_flight_persist` test is rewritten against `file_driver::write_blocked` using `fail::cfg_callback` to preserve the deterministic entry handshake the original test relied on.
- `make test-failpoints` runs the suite. The existing CI `test` job already runs `cargo test --workspace --all-features`, so the suite is part of the normal PR gate.

### Sites and invariants

- `file_driver::before_write`, `::after_tmp_fsync_before_rename`, `::after_rename_before_dir_fsync` — crash at each persist-pipeline boundary leaves the canonical state file consistent on reopen.
- `file_driver::write_blocked` — generalizes the old hook; a concurrent `load_high_water` is not parked behind an in-flight `persist_high_water`.
- `server::fence::after_load_before_persist`, `::after_persist_before_publish` — a fault in the leader-watch task does not advance serving state, and observably preserves the durable-vs-serving split.
- `server::service::before_allocate`, `::extension_gate_held` — wiring tests for the request and extension-gate paths.

The closure form of the macro produces the enclosing function's exact return type (`Result<(), FileDriverError>`, `Result<(), ServerError>`, etc.) so failpoint-induced returns are type-safe.

### Out of scope (deferred to a follow-up)

`openraft-toolkit` gains the feature + wrapper wiring but no sites yet. The originally-planned `log_store::before_write_batch` and `::after_write_before_sync` sites need non-trivial test scaffolding against the openraft 0.10 `RaftLogStorage::append` API and warrant their own design pass.

## Test plan

- [x] `cargo test --workspace --all-features --locked` — full suite green (failpoint tests included).
- [x] `make test-failpoints` — runs only the failpoint suite (10 tests across `tsoracle-driver-file` and `tsoracle-server`).
- [x] `cargo test -p tsoracle-driver-file` — existing tests pass with `failpoints` off; `tests/failpoints.rs` is silently skipped.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] Sanity-check `docs/failpoint-testing.md` renders correctly on the branch.