### PR TITLE
fix(server): poison serving state when leader-watch panics in into_router

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -82,6 +82,8 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                 // Publish serving, then release the drain guard.
                 let _ = server.state_tx.send(ServingState::Serving);
                 drop(drain_guard);
+
+                crate::failpoint!("server::fence::after_serving_published");
             }
             LeaderState::Follower { leader_endpoint } => {
                 server.allocator.lock().on_leadership_lost();

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -168,15 +168,39 @@ impl Server {
 
         let watch_server = server.clone();
         let watch_handle = tokio::spawn(async move {
-            let result = crate::fence::run_leader_watch(watch_server.clone()).await;
-            if let Err(ref _e) = result {
-                // Poison BEFORE returning so embedders who do not observe
-                // the JoinHandle still get fail-safe behavior.
-                watch_server.step_down_due_to_consensus_rejection(None);
-                #[cfg(feature = "tracing")]
-                tracing::error!(error = %_e, "leader-watch terminated; serving disabled");
+            use futures::FutureExt;
+            // catch_unwind so a panic in run_leader_watch still routes through
+            // the poisoning path. Without this, embedders who mount into_router
+            // directly and never observe the JoinHandle would see
+            // ServingState::Serving remain published while the watch task is
+            // dead — the inverse of the fail-safe guarantee documented above.
+            // The panic is re-raised after poisoning so serve / serve_with_*
+            // continue to translate it into ServerError::WatchPanic via
+            // join_to_server_result.
+            let outcome =
+                std::panic::AssertUnwindSafe(crate::fence::run_leader_watch(watch_server.clone()))
+                    .catch_unwind()
+                    .await;
+            match outcome {
+                Ok(result) => {
+                    if let Err(ref _e) = result {
+                        // Poison BEFORE returning so embedders who do not observe
+                        // the JoinHandle still get fail-safe behavior.
+                        watch_server.step_down_due_to_consensus_rejection(None);
+                        #[cfg(feature = "tracing")]
+                        tracing::error!(error = %_e, "leader-watch terminated; serving disabled");
+                    }
+                    result
+                }
+                Err(panic_payload) => {
+                    // Mirror the Err branch: poison BEFORE re-raising so
+                    // handle-dropping embedders still observe NotServing.
+                    watch_server.step_down_due_to_consensus_rejection(None);
+                    #[cfg(feature = "tracing")]
+                    tracing::error!("leader-watch panicked; serving disabled");
+                    std::panic::resume_unwind(panic_payload);
+                }
             }
-            result
         });
 
         let service = TsoServiceImpl { server };

--- a/crates/tsoracle-server/tests/failpoints.rs
+++ b/crates/tsoracle-server/tests/failpoints.rs
@@ -108,15 +108,17 @@ async fn fence_panic_after_persist_advances_durable_but_not_serving() {
 
     driver.become_leader(Epoch(1));
 
-    // The panic surfaces as a JoinError (task panicked); the wrapper in
-    // into_router catches the panic via `ServerError::WatchPanic { payload }`.
-    // tokio::spawn's JoinHandle resolves Err when the task panics. But the
-    // wrapper we have catches the inner result, returning it. Inspect what
-    // we actually get:
+    // The wrapper in into_router catches the panic, calls step_down to poison
+    // serving state, then resumes_unwind — so the panic still propagates out
+    // of the spawned task and JoinHandle resolves Err(JoinError::is_panic()).
+    // Handle observers (serve_with_shutdown / serve_with_listener) translate
+    // that into ServerError::WatchPanic via join_to_server_result; raw
+    // observers see the JoinError directly, as we do here. The poisoning
+    // guarantee for handle droppers is covered separately by
+    // panic_after_serving_published_poisons_state_when_handle_dropped.
     let result = tokio::time::timeout(Duration::from_secs(2), watch_handle)
         .await
         .expect("watch task did not terminate within 2s");
-    // A panic inside the task: JoinHandle resolves to Err(JoinError).
     assert!(
         result.is_err(),
         "expected the panic to surface as a JoinError, got {result:?}"
@@ -128,6 +130,81 @@ async fn fence_panic_after_persist_advances_durable_but_not_serving() {
         driver.current_high_water() > 0,
         "persist should have advanced the driver's stored value before the panic"
     );
+}
+
+/// `server::fence::after_serving_published` fires immediately after the
+/// fence publishes `ServingState::Serving` and releases the `extension_gate`
+/// drain guard. A `panic` action verifies the fail-safe documented on
+/// `Server::into_router`: when the leader-watch task panics from a `Serving`
+/// state, the `catch_unwind` wrapper in `into_router` calls
+/// `step_down_due_to_consensus_rejection` before resuming the unwind, so
+/// embedders who mount `into_router` directly and drop the `JoinHandle`
+/// still see serving state transition to `NotServing` and subsequent RPCs
+/// fail fast with `FAILED_PRECONDITION`. Without the wrapper, state would
+/// remain published as `Serving` and `GetTs` would succeed against the
+/// allocator seeded just before the panic — the regression this test pins.
+#[tokio::test]
+async fn panic_after_serving_published_poisons_state_when_handle_dropped() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+    let (routes, watch_handle) = server.into_router();
+
+    // Drop (detach) the JoinHandle: the embedder shape #27 names. Drop, not
+    // abort — aborting would cancel the task before it ever runs.
+    drop(watch_handle);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let serve = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_routes(routes)
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+    });
+
+    fail::cfg("server::fence::after_serving_published", "panic").unwrap();
+    driver.become_leader(Epoch(1));
+
+    wait_for_grpc_handshake(addr, Duration::from_secs(5)).await;
+
+    let mut client =
+        tsoracle_proto::v1::tso_service_client::TsoServiceClient::connect(format!("http://{addr}"))
+            .await
+            .unwrap();
+
+    // After the panic, the catch_unwind branch calls step_down, which
+    // publishes NotServing. Without the fix, state would stay Serving and
+    // GetTs would succeed against the allocator (seeded by
+    // try_on_leadership_gained before the failpoint fires). Polling rather
+    // than observing watch::Receiver transitions because rapid Serving →
+    // NotServing transitions can collapse on a slow receiver — see
+    // tokio::sync::watch's "only latest value retained" semantics.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let result = client
+            .get_ts(tsoracle_proto::v1::GetTsRequest { count: 1 })
+            .await;
+        match result {
+            Ok(_) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "GetTs continued to succeed after watch-task panic — \
+                     serving state was never poisoned (the regression #27 pins)"
+                );
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            Err(status) if status.code() == tonic::Code::FailedPrecondition => break,
+            Err(status) => panic!("unexpected gRPC status: {status:?}"),
+        }
+    }
+
+    serve.abort();
 }
 
 /// `server::service::before_allocate` fires at the top of `get_ts`,


### PR DESCRIPTION
Closes #27.

## Bug
The spawned leader-watch task in `Server::into_router` only called `step_down_due_to_consensus_rejection` on the `Err` branch of `run_leader_watch`. If the task panicked instead, the step-down was skipped and `ServingState::Serving` stayed published while the watch was dead — the inverse of the "fail-safe even when the handle is not observed" guarantee documented on `into_router` (`crates/tsoracle-server/src/server.rs:158-162`).

The gap affected embedders mounting the tsoracle service alongside their own services via `into_router` who never observe the `JoinHandle`. `serve` / `serve_with_shutdown` / `serve_with_listener` were already safe because their `join_to_server_result` translator surfaces the panic as `ServerError::WatchPanic`.

## Fix
Wrap the awaited future in `std::panic::AssertUnwindSafe(...).catch_unwind()` inside the spawned task body. On panic, call `step_down_due_to_consensus_rejection(None)` to publish `NotServing`, then `std::panic::resume_unwind(payload)` to re-raise.

This was the deliberately conservative of the two return-shape options in #27: re-raising preserves byte-identical behavior for `serve` / `serve_with_shutdown` / `serve_with_listener` (their `join_to_server_result` keeps translating the panic to `WatchPanic`), and the existing `fence_panic_after_persist_advances_durable_but_not_serving` test stays valid without modification. The only new property is the poisoning step that runs before the re-raise.

`AssertUnwindSafe` is sound here because the only state shared across the unwind boundary is `Arc<Server>` and we explicitly reset its `state_tx` / allocator via `step_down`. `parking_lot::Mutex` and `tokio::sync::{Mutex, RwLock}` don't poison on panic, so the post-panic `step_down` call is safe regardless of which lock the task held when it crashed.

## Test scaffolding
- New failpoint site `server::fence::after_serving_published` in `fence.rs:86`, immediately after the fence publishes `ServingState::Serving` and drops the drain guard. This is the only location from which a panic can fire *from a Serving state*, which is what the regression test needs to distinguish fixed vs. unfixed behavior — existing failpoints (`after_load_before_persist`, `after_persist_before_publish`) all fire before Serving is published, so a test using them couldn't tell whether step_down ran or whether Serving was simply never published.
- New test `panic_after_serving_published_poisons_state_when_handle_dropped` in `tests/failpoints.rs`: mounts `into_router` directly, drops the `JoinHandle`, panics the watch via the new failpoint, then polls a real gRPC `GetTs` until it returns `FAILED_PRECONDITION` (2s deadline). Polling rather than observing `state_rx` because rapid `Serving → NotServing` transitions can collapse on a slow `watch::Receiver` (only-latest-value semantics).
- Updated the comment on `fence_panic_after_persist_advances_durable_but_not_serving` — the previous text claimed the wrapper translates to `ServerError::WatchPanic`, which has never been accurate; that translation lives in `join_to_server_result`, only invoked by handle observers.

## Test plan
- [x] `cargo test -p tsoracle-server --features "failpoints,test-fakes" --test failpoints` — all 5 tests pass (4 pre-existing + the new one)
- [x] `cargo test -p tsoracle-server --features test-fakes` — all other tsoracle-server tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p tsoracle-server --all-targets --all-features --locked -- -D warnings` — clean
- [x] Verified the new test **fails on unfixed code** with the expected custom assertion message ("GetTs continued to succeed after watch-task panic — serving state was never poisoned (the regression #27 pins)") — confirms it's a real regression test, not a false positive
- [ ] CI re-runs fmt, clippy, and the full workspace test matrix