### PR TITLE
chore(perf): add performance-critical-path guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
 
+  critical-path:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: guard
+        run: CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,10 @@ Example:
 let key = MetadataKey::from_bytes(KEY.as_bytes()).expect("valid key");
 ```
 
+## Performance-critical-path rules
+
+A handful of files sit on the request-handling hot path. They carry a `// #[PerformanceCriticalPath]` marker as their first line, and CI's `critical-path` job ([`scripts/check-critical-path.sh`](scripts/check-critical-path.sh)) enforces a small set of source-level rules against them — no `tracing::info!`/`warn!`/`error!`, no `println!`, no synchronous I/O, no long synchronous compute. See [`docs/performance-critical-path.md`](docs/performance-critical-path.md) for the full rule set, the marker-placement contract, and the current marked-file list. If your edit touches a marked file, run `CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh` locally before pushing.
+
 ## Working with git
 
 - **Write commit messages like an email to your teammates.** This repo follows [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`), optionally with a scope (`feat(server): ...`). See [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for guidance on the body itself — explain *why*, not *what*.

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -1,3 +1,4 @@
+// #[PerformanceCriticalPath]
 //! Coalesces concurrent waiters into one outgoing GetTs RPC.
 //!
 //! The driver never retains pre-fetched timestamps. Each waiter receives

--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -1,3 +1,4 @@
+// #[PerformanceCriticalPath]
 //! The window allocator state machine. Sync, no I/O.
 
 use crate::{Epoch, LOGICAL_MAX, PHYSICAL_MS_MAX, Timestamp};

--- a/crates/tsoracle-driver-file/src/lib.rs
+++ b/crates/tsoracle-driver-file/src/lib.rs
@@ -1,3 +1,4 @@
+// #[PerformanceCriticalPath]
 //! Single-node, fsync-durable [`ConsensusDriver`] implementation for tsoracle.
 //!
 //! Persists the committed high-water as a 17-byte CRC-checked record

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -1,3 +1,4 @@
+// #[PerformanceCriticalPath]
 //! openraft-backed `ConsensusDriver` for tsoracle.
 //!
 //! This crate replicates the TSO high-water mark across an openraft cluster

--- a/docs/performance-critical-path.md
+++ b/docs/performance-critical-path.md
@@ -13,7 +13,7 @@ This is a comment marker, not a proc macro. Enforcement is by review plus a CI g
 3. **No `println!`.** Same volume problem as info logs, plus it bypasses the `tracing` filter entirely.
 4. **No long synchronous compute.** Anything measured in milliseconds belongs on a background worker. The hot path is for routing, packing, and enqueue — not compute.
 
-Two rules calc-graph's equivalent doc enforces are delegated to other mechanisms here, rather than re-enforced by the grep guard:
+Two related rules are intentionally not enforced by this guard — they live in other layers of the build:
 
 - **No panics on recoverable paths.** Enforced at the workspace level by the [panic policy](../CONTRIBUTING.md#panic-policy-unwrap-and-expect) (`clippy::unwrap_used` + `clippy::expect_used` as `warn`, with `cargo clippy ... -- -D warnings` making the warning fatal).
 - **No `std::sync::Mutex` held across an `.await`.** Planned: enable `clippy::await_holding_lock = "deny"` workspace-wide as a follow-up. The clippy lint is precise — it knows the difference between a sync mutex held across an await point (a real bug) and one held synchronously (fine) — whereas a grep-based "no `std::sync::Mutex::new` in this file" rule false-positives on legitimate non-async uses.

--- a/docs/performance-critical-path.md
+++ b/docs/performance-critical-path.md
@@ -1,0 +1,54 @@
+# Performance-critical-path rules
+
+A handful of files in this workspace sit on the request-handling hot path: every `GetTs` / `GetTsBatch` RPC, every window extension, every Raft propose/apply touches them. Regressions in these files surface as elevated end-to-end latency or reduced batch throughput, not as test failures, so we enforce a small set of source-level rules on top of the regular clippy/build checks. Files on the critical path carry this marker as the first line of the file:
+
+    // #[PerformanceCriticalPath]
+
+This is a comment marker, not a proc macro. Enforcement is by review plus a CI guard ([`scripts/check-critical-path.sh`](../scripts/check-critical-path.sh)). If you are editing a marked file, the rules below apply.
+
+## Rules
+
+1. **No synchronous I/O on the hot path.** Disk, gRPC, RocksDB, and other control-plane I/O must be behind a bounded async boundary. If a function in a marked file needs I/O, await a previously-started future or spawn the work onto a background task; never call a blocking op inline. This rule is not grep-enforceable — it depends on review.
+2. **No `tracing::info!` or higher log levels.** Use `tracing::debug!` or lower. Hot-path logs at info-or-higher volume fill dashboards and force synchronous writes when the subscriber is configured to flush. The guard rejects `tracing::info!`/`warn!`/`error!`, the bare `info!`/`warn!`/`error!` shortcut (via `use tracing::info;`), and the matching `_span!` macros.
+3. **No `println!`.** Same volume problem as info logs, plus it bypasses the `tracing` filter entirely.
+4. **No long synchronous compute.** Anything measured in milliseconds belongs on a background worker. The hot path is for routing, packing, and enqueue — not compute.
+
+Two rules calc-graph's equivalent doc enforces are delegated to other mechanisms here, rather than re-enforced by the grep guard:
+
+- **No panics on recoverable paths.** Enforced at the workspace level by the [panic policy](../CONTRIBUTING.md#panic-policy-unwrap-and-expect) (`clippy::unwrap_used` + `clippy::expect_used` as `warn`, with `cargo clippy ... -- -D warnings` making the warning fatal).
+- **No `std::sync::Mutex` held across an `.await`.** Planned: enable `clippy::await_holding_lock = "deny"` workspace-wide as a follow-up. The clippy lint is precise — it knows the difference between a sync mutex held across an await point (a real bug) and one held synchronously (fine) — whereas a grep-based "no `std::sync::Mutex::new` in this file" rule false-positives on legitimate non-async uses.
+
+## CI guard
+
+[`scripts/check-critical-path.sh`](../scripts/check-critical-path.sh) runs in CI as the `critical-path` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). It:
+
+- Finds every `crates/**/*.rs` whose first 10 lines contain `#[PerformanceCriticalPath]`.
+- For each, greps for the banned patterns listed in the script (the `BANNED` array).
+- Prints violations with line numbers.
+
+**CI runs in strict mode** — the workflow exports `CRITICAL_PATH_STRICT=1`, so any violation fails the build. The script itself defaults to warn-only when `CRITICAL_PATH_STRICT` is unset, which is convenient for local iteration while preparing a new marker candidate. To mirror CI locally, run `CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh`.
+
+New files added to the marker list must be compliant before marking — the guard does not accept pre-existing violations on newly-marked files, even in warn-only mode. "Warn-only" is a timing buffer for the initial rollout of a new banned pattern, not a license to ship non-compliant annotations.
+
+To adjust the list of banned patterns or the strict-mode toggle, edit the script and update this doc in the same commit.
+
+## Marker placement
+
+Place the marker on line 1, above any module-level doc comment (`//!`), any inner attribute (`#![...]`), and any `use` statement. The guard only scans the first 10 lines, so the marker must sit at the top — pushing it below a long module doc silently disables enforcement. The marker is a plain `//` line comment, not Rust syntax; it does not interfere with the file's `//!` module doc (which still attaches to the module) or with any `#![cfg_attr(...)]` inner attribute (such as the [panic-policy attribute](../CONTRIBUTING.md#panic-policy-unwrap-and-expect) in each library crate's `lib.rs`).
+
+The marker is per-file. If you split a marked module into child files, mark every child file that remains on the hot path — the guard does not inherit markers through `mod`.
+
+After placing the marker, verify `CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh` is clean on that file and add the path to the list below in the same commit.
+
+## Current critical-path files
+
+Files in this list are compliant with the rules above — the guard is green against them today.
+
+- [`crates/tsoracle-core/src/allocator.rs`](../crates/tsoracle-core/src/allocator.rs) — the window allocator state machine. Every `try_grant` and `would_grant` call goes through here.
+- [`crates/tsoracle-driver-file/src/lib.rs`](../crates/tsoracle-driver-file/src/lib.rs) — single-node fsync-durable driver. The fsync on window extension is the durability boundary for non-replicated deployments.
+- [`crates/tsoracle-driver-openraft/src/lib.rs`](../crates/tsoracle-driver-openraft/src/lib.rs) — openraft-backed driver. The propose/apply path for replicated deployments.
+- [`crates/tsoracle-client/src/driver.rs`](../crates/tsoracle-client/src/driver.rs) — client-side coalescing driver. Every concurrent waiter passes through `driver_task`'s select loop.
+
+## Files considered but intentionally unmarked
+
+- [`crates/tsoracle-server/src/server.rs`](../crates/tsoracle-server/src/server.rs) — contains a one-shot `tracing::error!` on the leader-watch death path (line 177 at the time of this writing). The call fires at most once per process lifetime and is not on the per-request path, but the grep-based guard cannot distinguish it from per-request logging. Mark this file in a follow-up after splitting the request handlers into their own module or after deciding to downgrade the death-rattle log.

--- a/scripts/check-critical-path.sh
+++ b/scripts/check-critical-path.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Enforces the rules in docs/performance-critical-path.md against every file
+# whose first 10 lines contain the `#[PerformanceCriticalPath]` marker.
+#
+# Modes (controlled by env var CRITICAL_PATH_STRICT):
+#   - unset or "0": warn-only. Prints violations, exits 0.
+#   - "1":          strict. Prints violations, exits 1.
+#
+# CI sets CRITICAL_PATH_STRICT=1; warn-only is for local iteration while a
+# new marker candidate is being prepared for compliance.
+
+set -euo pipefail
+
+# Banned patterns. Extended regex via `grep -E`. Both the fully-qualified
+# `tracing::info!` form and the bare `info!(...)` / `warn!(...)` /
+# `error!(...)` shortcut (via `use tracing::info;`) are banned — otherwise
+# a file that imports `tracing::warn` would silently pass the guard while
+# violating the no-info-or-higher-logging rule. Info-or-higher spans are
+# banned for the same reason.
+#
+# Not in this list (intentionally):
+#   - `std::sync::Mutex` across `.await`: enforced by `clippy::await_holding_lock`
+#     at the workspace level (see root `Cargo.toml`). The clippy lint is precise;
+#     a grep substitute would false-positive on legitimate non-async uses.
+#   - `.unwrap()` / `.expect()`: enforced by the workspace panic policy
+#     (`clippy::unwrap_used` and `clippy::expect_used` — see CONTRIBUTING.md).
+declare -a BANNED=(
+  'tracing::info!'
+  'tracing::warn!'
+  'tracing::error!'
+  '(^|[^:[:alnum:]_])info!\('
+  '(^|[^:[:alnum:]_])warn!\('
+  '(^|[^:[:alnum:]_])error!\('
+  'tracing::info_span!'
+  'tracing::warn_span!'
+  'tracing::error_span!'
+  '(^|[^:[:alnum:]_])info_span!\('
+  '(^|[^:[:alnum:]_])warn_span!\('
+  '(^|[^:[:alnum:]_])error_span!\('
+  'println!'
+)
+
+# The scan window for the marker. Files where the marker sits below this many
+# lines silently fall out of enforcement — see docs/performance-critical-path.md
+# for the placement rule.
+SCAN_WINDOW=10
+
+# Locate repo root so the guard works from CI and from subdirectories.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+# Find candidate files. We only scan under `crates/` since production code lives
+# there. `mapfile` is not available on macOS bash 3.2, so we use a
+# newline-terminated while-read loop — no path in this repo contains whitespace
+# or newlines.
+MARKED=()
+while IFS= read -r f; do
+  [[ -n "$f" ]] && MARKED+=("$f")
+done < <(
+  find crates -name '*.rs' -print \
+    | while IFS= read -r candidate; do
+        if head -n "$SCAN_WINDOW" "$candidate" | grep -q '#\[PerformanceCriticalPath\]'; then
+          printf '%s\n' "$candidate"
+        fi
+      done
+)
+
+if [[ ${#MARKED[@]} -eq 0 ]]; then
+  echo "No files carry the #[PerformanceCriticalPath] marker." >&2
+  exit 0
+fi
+
+FAIL=0
+for file in "${MARKED[@]}"; do
+  for pat in "${BANNED[@]}"; do
+    if grep -nE "$pat" "$file" >/dev/null 2>&1; then
+      echo "VIOLATION: $file contains banned pattern '$pat'"
+      grep -nE "$pat" "$file" | sed 's/^/    /'
+      FAIL=1
+    fi
+  done
+done
+
+if [[ $FAIL -eq 1 ]]; then
+  echo ""
+  echo "See docs/performance-critical-path.md for the rules."
+  if [[ "${CRITICAL_PATH_STRICT:-0}" == "1" ]]; then
+    exit 1
+  fi
+  echo "(warn-only mode; exit 0 — set CRITICAL_PATH_STRICT=1 to enforce)"
+  exit 0
+fi
+
+echo "Critical-path guard: all ${#MARKED[@]} marked files clean."


### PR DESCRIPTION
## Summary

- Adds a CI guard (`scripts/check-critical-path.sh` + a new `critical-path` job in `.github/workflows/ci.yml`) that scans files carrying `// #[PerformanceCriticalPath]` for hot-path-incompatible patterns: `tracing::info!`/`warn!`/`error!`, their `_span!` siblings, the bare `info!`/`warn!`/`error!` shortcut via `use tracing::*`, and `println!`. CI exports `CRITICAL_PATH_STRICT=1` so any violation fails the build; locally the script defaults to warn-only to ease iteration on new marker candidates.
- Marks 4 files in the initial set: `crates/tsoracle-core/src/allocator.rs`, `crates/tsoracle-driver-file/src/lib.rs`, `crates/tsoracle-driver-openraft/src/lib.rs`, `crates/tsoracle-client/src/driver.rs`. `crates/tsoracle-server/src/server.rs` is a candidate but deferred — it has a one-shot `tracing::error!` on the leader-watch death path (line 177) that the grep guard cannot distinguish from per-request logging.
- Two related rules are intentionally not enforced by this guard — they live in other layers of the build:
  - "No panics on recoverable paths" is already enforced by the workspace panic policy (#28).
  - "No `std::sync::Mutex` held across an `.await`" is deferred to `clippy::await_holding_lock = "deny"` as a follow-up. The clippy lint is precise — it knows the difference between a sync mutex held across an await point (a real bug) and one held synchronously (fine) — whereas a grep substitute would false-positive on legitimate non-async uses.
- New `docs/performance-critical-path.md` is the long-form policy (rules, marker-placement contract, current marked-file list, planned follow-ups). `CONTRIBUTING.md` gains a short pointer next to the panic-policy section.

## Test plan

- [x] `CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh` — finds 4 markers, no violations.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean.
- [x] `cargo test --workspace --all-features --locked` — full suite passes.
- [ ] CI `critical-path` job runs and reports green.
- [x] CI `test`, `buf`, `deny`, `coverage` jobs continue to pass.
- [x] Sanity-check the guard's strict mode by temporarily adding `tracing::info!("test");` to one of the marked files and confirming the `critical-path` job goes red.