### PR TITLE
ci(buf): pass GITHUB_TOKEN to buf-setup-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: buf lint
         run: buf lint crates/tsoracle-proto/proto
       - name: buf format


### PR DESCRIPTION
## Summary

The `buf` job in CI intermittently fails at the `bufbuild/buf-setup-action@v1` step with `API rate limit exceeded`. Example: https://github.com/prisma-risk/tsoracle/actions/runs/26214488427/job/77133271507.

The action queries the GitHub releases API to locate and download the `buf` binary. Without a token it falls back to the unauthenticated rate limit — **60 req/hr scoped to the runner's egress IP**, shared with every other unauthenticated caller on the GitHub-hosted runner pool. When the runner draws an IP whose quota is already exhausted, the release lookup 403s and the step fails before `buf lint` / `buf format` / `buf breaking` ever run.

This passes the workflow's auto-issued `GITHUB_TOKEN` to the action, which:
- Raises the limit to **1,000 req/hr/repo** (authenticated bucket).
- Keys the quota to the repo identity instead of the shared runner IP, eliminating the cross-tenant contention.

`GITHUB_TOKEN` is provided to every workflow automatically — no secret configuration needed. The default workflow `contents: read` permission is sufficient, since the action only reads public releases.

## Test plan

- [ ] CI passes on this PR (i.e., the `buf` job's `buf-setup-action` step succeeds with the token).
- [ ] Re-run the `buf` job a couple of times to confirm it's no longer flaky.