### PR TITLE
feat(openraft-toolkit): add failpoint sites in RocksdbLogStore::append

### DIFF
--- a/crates/openraft-toolkit/Cargo.toml
+++ b/crates/openraft-toolkit/Cargo.toml
@@ -36,3 +36,8 @@ proptest         = { workspace = true }
 rocksdb          = { workspace = true }
 tempfile         = { workspace = true }
 tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+
+[[test]]
+name              = "failpoints"
+path              = "tests/failpoints.rs"
+required-features = ["failpoints", "rocksdb-log-store"]

--- a/crates/openraft-toolkit/src/log_store/mod.rs
+++ b/crates/openraft-toolkit/src/log_store/mod.rs
@@ -333,7 +333,17 @@ where
         }
 
         let wo = Self::write_sync_opts();
+        crate::failpoint!("openraft_toolkit::log_store::before_write_batch");
         let result = self.db.write_opt(batch, &wo).map_err(io::Error::other);
+
+        crate::failpoint!(
+            "openraft_toolkit::log_store::after_write_before_sync",
+            |_arg: Option<String>| -> Result<(), io::Error> {
+                Err(io::Error::other(
+                    "failpoint: openraft_toolkit::log_store::after_write_before_sync",
+                ))
+            }
+        );
 
         match &result {
             Ok(()) => callback.io_completed(Ok(())),

--- a/crates/openraft-toolkit/tests/failpoints.rs
+++ b/crates/openraft-toolkit/tests/failpoints.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "failpoints")]
+
+use std::sync::Arc;
+
+use openraft::entry::RaftEntry;
+use openraft::storage::{IOFlushed, RaftLogStorage};
+use openraft::{Entry, LogId};
+use openraft_toolkit::{Flat, RocksdbLogStore};
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use tempfile::TempDir;
+
+mod common;
+use common::{TestLeaderId, TestTypeConfig};
+
+const LOG_CF: &str = "raft_log";
+const META_CF: &str = "raft_meta";
+
+/// Body-level serialization: the `fail` registry is process-global; even with
+/// `FailScenario::setup` snapshotting between tests, multiple test bodies
+/// sharing the same registered name will interleave their configurations.
+/// Mirrors the pattern in `tsoracle-driver-file/tests/failpoints.rs`.
+static FAILPOINT_TEST_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+fn open_db(dir: &TempDir) -> Arc<DB> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cfs = vec![
+        ColumnFamilyDescriptor::new(LOG_CF, Options::default()),
+        ColumnFamilyDescriptor::new(META_CF, Options::default()),
+    ];
+    Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap())
+}
+
+fn blank_entry_at(index: u64) -> Entry<TestLeaderId, common::TestAppData, u64, common::TestPeer> {
+    Entry::new_blank(LogId::new(
+        TestLeaderId {
+            term: 1,
+            node_id: 1,
+        },
+        index,
+    ))
+}
+
+/// `openraft_toolkit::log_store::before_write_batch` fires immediately before
+/// `db.write_opt(batch, ...)`. A `panic` action terminates the task before the
+/// batch reaches RocksDB; after reopening the store, the log column family
+/// must still be empty. If a regression moves the failpoint to after the
+/// write, this test fails because `last_log_id` becomes `Some(_)`.
+///
+/// The append runs inside `tokio::spawn` so the panic surfaces as a
+/// `JoinError` we can assert on, instead of unwinding the test task itself.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn panic_at_before_write_batch_leaves_log_empty() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+
+    fail::cfg("openraft_toolkit::log_store::before_write_batch", "panic").unwrap();
+
+    let writer_db = Arc::clone(&db);
+    let join = tokio::spawn(async move {
+        let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+            RocksdbLogStore::open(writer_db, LOG_CF, META_CF, Flat).unwrap();
+        store
+            .append(std::iter::once(blank_entry_at(1)), IOFlushed::noop())
+            .await
+    });
+    let join_err = join
+        .await
+        .expect_err("expected the panic action to surface as a JoinError");
+    assert!(
+        join_err.is_panic(),
+        "expected JoinError::is_panic(), got {join_err:?}"
+    );
+
+    fail::cfg("openraft_toolkit::log_store::before_write_batch", "off").unwrap();
+
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
+    let state = store.get_log_state().await.unwrap();
+    assert!(
+        state.last_log_id.is_none(),
+        "panic at before_write_batch must fire before db.write_opt; \
+         expected empty log but get_log_state returned last_log_id = {:?}",
+        state.last_log_id,
+    );
+}
+
+/// `openraft_toolkit::log_store::after_write_before_sync` fires after the
+/// rocksdb write returns and before `callback.io_completed(...)`. A `return`
+/// action makes `append` produce `Err(io::Error)` while the WriteBatch has
+/// already been applied — the entry is durable on disk even though the
+/// openraft IO-completion notification never fired. After reopening the
+/// store the entry is observable via `get_log_state`. If a regression moves
+/// the failpoint to before the write, this test fails because the log stays
+/// empty.
+#[tokio::test]
+async fn return_at_after_write_before_sync_persists_entry() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock().await;
+    let _scenario = fail::FailScenario::setup();
+
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(Arc::clone(&db), LOG_CF, META_CF, Flat).unwrap();
+
+    fail::cfg(
+        "openraft_toolkit::log_store::after_write_before_sync",
+        "return",
+    )
+    .unwrap();
+    let result = store
+        .append(std::iter::once(blank_entry_at(42)), IOFlushed::noop())
+        .await;
+    fail::cfg(
+        "openraft_toolkit::log_store::after_write_before_sync",
+        "off",
+    )
+    .unwrap();
+    assert!(
+        result.is_err(),
+        "expected return action to surface as Err from append, got {result:?}"
+    );
+
+    drop(store);
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
+    let state = store.get_log_state().await.unwrap();
+    assert_eq!(
+        state.last_log_id.as_ref().map(|id| id.index),
+        Some(42),
+        "return at after_write_before_sync must fire after db.write_opt; \
+         expected last_log_id index = 42 but get_log_state returned {:?}",
+        state.last_log_id,
+    );
+}

--- a/docs/failpoint-testing.md
+++ b/docs/failpoint-testing.md
@@ -8,7 +8,7 @@ Add a failpoint when an invariant only manifests under a timing window or a part
 
 ## Feature gating
 
-Two crates currently opt in via a per-crate `failpoints` Cargo feature: `tsoracle-driver-file` and `tsoracle-server`. The `openraft-toolkit` crate has the feature wired but no sites yet (sites for that crate are tracked as a follow-up). The feature is off by default. Run the failpoint suite with:
+Three crates currently opt in via a per-crate `failpoints` Cargo feature: `tsoracle-driver-file`, `tsoracle-server`, and `openraft-toolkit`. The feature is off by default. Run the failpoint suite with:
 
     make test-failpoints
 
@@ -64,9 +64,12 @@ With `feature = "failpoints"` off, both forms expand to `()` — zero code, no d
 | `server::service::before_allocate` | In `Service::get_ts`, before the allocator lock is taken. | `sleep(ms)`, `pause`. Used for timing-shape tests only — closure-form `return` would produce a `Status` directly and bypass the production `ConsensusError → Status` classification path. | `before_allocate_sleep_delays_get_ts` |
 | `server::service::extension_gate_held` | In `Service::extend_window`, immediately after the `extension_gate.read().await` guard is bound. | `pause`, `sleep(ms)`. | `extension_gate_held_sleep_delays_get_ts` |
 
-### `openraft-toolkit`
+### `openraft-toolkit` — 2 sites in `crates/openraft-toolkit/src/log_store/mod.rs`
 
-The crate has the `failpoints` feature, the wrapper macro, and the lib.rs mount wired, but no sites yet. The original spec specified two sites (`openraft_toolkit::log_store::before_write_batch` and `openraft_toolkit::log_store::after_write_before_sync`); their tests require a non-trivial setup against the openraft 0.10 `RaftLogStorage::append` API and were deferred to a follow-up spec.
+| Site name | Position | Useful actions | Test |
+|---|---|---|---|
+| `openraft_toolkit::log_store::before_write_batch` | In `RocksdbLogStore::append`, immediately before `self.db.write_opt(batch, &wo)`. | `panic`. | `panic_at_before_write_batch_leaves_log_empty` |
+| `openraft_toolkit::log_store::after_write_before_sync` | In `RocksdbLogStore::append`, between the rocksdb write and the `callback.io_completed(...)` notification. | `return` via the closure form (closure produces `Err(io::Error)`); `panic`. | `return_at_after_write_before_sync_persists_entry` |
 
 ## Writing a failpoint test
 


### PR DESCRIPTION
## Summary
- Adds two failpoint sites in `RocksdbLogStore::append`: `openraft_toolkit::log_store::before_write_batch` (immediately before `db.write_opt`) and `openraft_toolkit::log_store::after_write_before_sync` (between the rocksdb write and `callback.io_completed`). Closes #24.
- Adds `crates/openraft-toolkit/tests/failpoints.rs` with one test per site — `panic` action for the first, closure-form `return` action for the second — gated via a new `[[test]]` block with `required-features = ["failpoints", "rocksdb-log-store"]` so the file is silently skipped when the feature is off.
- Updates `docs/failpoint-testing.md`: replaces the "feature wired but no sites yet" notice with a real Current Sites row for the crate, and bumps the opt-in count from two to three crates.

## Design notes
- The first site uses the single-arg macro form (panic-only); the second uses the closure form so a `return` action can produce a typed `Err(io::Error)` matching `append`'s signature. The closure-form `return` simulates "the durable write succeeded but the openraft state machine never learned about it", which is the most pernicious crash window the site was designed to expose.
- The two tests are complementary inverses. Panic at `before_write_batch` proves the WriteBatch was *not* applied (reopening shows `last_log_id: None`); return at `after_write_before_sync` proves it *was* (reopening shows `last_log_id.index == 42`). Swapping the two sites' positions in `append` flips both tests red — that's how the assertions catch a position regression, not just an action regression.
- Panic test runs `append` inside `tokio::spawn` so the unwind surfaces as `JoinError::is_panic()` rather than poisoning the test task; serialization via a process-global `FAILPOINT_TEST_SERIAL` mutex and `fail::FailScenario::setup` RAII guard match the convention established by `tsoracle-driver-file/tests/failpoints.rs`.

## Test plan
- [x] `make test-failpoints` — both new tests pass alongside the existing driver-file and server failpoint suites.
- [x] `cargo test -p openraft-toolkit --features failpoints,rocksdb-log-store,test-fakes` — `panic_at_before_write_batch_leaves_log_empty ok`, `return_at_after_write_before_sync_persists_entry ok`, all other tests still green.
- [x] `cargo check -p openraft-toolkit --no-default-features` — failpoint sites compile to `()` when the feature is off.
- [x] `cargo check --workspace --all-features --locked` — clean.
- [x] `cargo clippy -p openraft-toolkit --tests --features failpoints,rocksdb-log-store,test-fakes -- -D warnings` and `cargo fmt --check` — both clean.