### PR TITLE
feat(stress): in-process raft topology for the stress harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,8 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "humantime-serde",
+ "openraft",
+ "openraft-toolkit",
  "parking_lot",
  "rand 0.9.4",
  "serde",
@@ -2369,6 +2371,7 @@ dependencies = [
  "tsoracle-client",
  "tsoracle-consensus",
  "tsoracle-core",
+ "tsoracle-driver-openraft",
  "tsoracle-server",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
  "openraft-toolkit",
  "parking_lot",
  "rand 0.9.4",
+ "rocksdb",
  "serde",
  "serde_json",
  "tempfile",

--- a/Makefile
+++ b/Makefile
@@ -134,9 +134,9 @@ COV_IGNORE_OPENRAFT_LIFECYCLE := crates/openraft-toolkit/src/lifecycle/(bootstra
 # end-to-end by `benchmarks/stress/tests/smoke.rs`.
 COV_IGNORE_STRESS_BIN := benchmarks/stress/src/bin/stress
 
-# `unimplemented!()` placeholders for future topology variants — intentionally
-# unreachable from any current test path.
-COV_IGNORE_STRESS_TOPO_STUBS := benchmarks/stress/src/topology/(raft|process)
+# `unimplemented!()` placeholders for topology variants not yet implemented —
+# intentionally unreachable from any current test path.
+COV_IGNORE_STRESS_TOPO_STUBS := benchmarks/stress/src/topology/process
 
 COV_IGNORE := ($(COV_IGNORE_OPENRAFT_LIFECYCLE)|$(COV_IGNORE_STRESS_BIN)|$(COV_IGNORE_STRESS_TOPO_STUBS))\.rs
 

--- a/benchmarks/stress/Cargo.toml
+++ b/benchmarks/stress/Cargo.toml
@@ -26,8 +26,10 @@ humantime-serde    = { workspace = true }
 openraft           = { workspace = true }
 parking_lot       = { workspace = true }
 rand               = { workspace = true }
+rocksdb            = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
 serde_json         = { workspace = true }
+tempfile           = { workspace = true }
 tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "net", "signal"] }
 tonic              = { workspace = true }
 tracing            = { workspace = true }

--- a/benchmarks/stress/Cargo.toml
+++ b/benchmarks/stress/Cargo.toml
@@ -23,6 +23,7 @@ clap               = { workspace = true, features = ["derive"] }
 hdrhistogram       = { workspace = true }
 humantime          = { workspace = true }
 humantime-serde    = { workspace = true }
+openraft           = { workspace = true }
 parking_lot       = { workspace = true }
 rand               = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
@@ -32,10 +33,12 @@ tonic              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+openraft-toolkit         = { path = "../../crates/openraft-toolkit",         version = "0.1.0", features = ["test-fakes"] }
 tsoracle-server    = { path = "../../crates/tsoracle-server",    version = "0.1.0", features = ["test-fakes"] }
 tsoracle-client    = { path = "../../crates/tsoracle-client",    version = "0.1.0" }
 tsoracle-core      = { path = "../../crates/tsoracle-core",      version = "0.1.0" }
 tsoracle-consensus = { path = "../../crates/tsoracle-consensus", version = "0.1.0" }
+tsoracle-driver-openraft = { path = "../../crates/tsoracle-driver-openraft", version = "0.1.0" }
 
 fail = { workspace = true, optional = true }
 

--- a/benchmarks/stress/README.md
+++ b/benchmarks/stress/README.md
@@ -16,7 +16,7 @@ This crate is a peer of `benchmarks/minimal`, not a replacement. `bench-minimal`
 - `inject-violation` self-test as a positive CI control.
 - Mem-topology smoke test in `tests/smoke.rs` (≤ 30 s).
 
-`--topology raft` and `--topology process` are stubbed with `unimplemented!()` and will land in follow-up changes.
+`--topology raft` runs a real in-process openraft cluster sharing a `MemNetwork`. `--topology process` remains stubbed with `unimplemented!()` and will land in a follow-up change.
 
 ## Run
 
@@ -26,6 +26,13 @@ cargo run -p stress --release -- run --topology mem --scenario killer-loop --dur
 cargo run -p stress --release -- run --topology mem --scenario steady --duration 10s --schedule-out /tmp/sched.json
 cargo run -p stress --release -- replay /tmp/sched.json
 cargo run -p stress --release -- inject-violation --topology mem    # must exit 1
+```
+
+`--topology raft` runs a real openraft cluster (in-process, sharing a `MemNetwork`) so chaos exercises actual leader re-election rather than synthetic driver transitions.
+
+```bash
+# 3-node openraft cluster, in-process, sharing a MemNetwork.
+cargo run -p stress --release -- run --topology raft --scenario killer-loop --duration 30s --nodes 3 --clients 32 --batch-size 4
 ```
 
 Build with the `stress-failpoints` feature to enable in-process failpoint chaos (the `failpoint-cycle` scenario only does useful work with this on):
@@ -63,6 +70,7 @@ These are landed-but-incomplete. Neither affects any of the four invariants; the
 
 - `--json-stream` is plumbed as a CLI flag but not honored by the report path. Honor it when a real dashboard consumer exists.
 - `--ops`-bounded runs are accepted by CLI / validate() but `lib::run` only honors `--duration`. Adding an `--ops` budget needs a shared atomic + stop trigger; defer until needed.
+- The topology controller emits `ChaosEvent`s to the supervisor, but they are not yet collected into the final `Report.chaos_events` field (currently hardcoded empty in `lib::run`). Plumbing those events end-to-end is a small follow-up.
 
 ## See also
 

--- a/benchmarks/stress/src/lib.rs
+++ b/benchmarks/stress/src/lib.rs
@@ -59,6 +59,7 @@ use crate::schedule::{RandomParams, Schedule};
 use crate::supervisor::Supervisor;
 use crate::topology::ChaosController;
 use crate::topology::mem::MemTopology;
+use crate::topology::raft::RaftTopology;
 use crate::types::ClientId;
 
 /// Tuple returned by topology spawn helpers below: the chaos controller, the
@@ -127,7 +128,34 @@ pub fn run(cfg: StressConfig) -> Result<Report, anyhow::Error> {
             let server_handle = topo.server_handle;
             (Box::new(topo.controller), endpoints, server_handle)
         }
-        TopologyKind::Raft => anyhow::bail!("raft topology not yet implemented"),
+        TopologyKind::Raft => {
+            let topo = server_rt.block_on(RaftTopology::spawn(cfg.nodes, grace))?;
+            let endpoints = topo.controller.endpoints();
+            // `RaftTopology` returns one server `JoinHandle<()>` per node,
+            // whereas `SpawnedTopology` carries a single
+            // `JoinHandle<Result<(), tsoracle_server::ServerError>>`. We treat
+            // the first node's handle as the "primary" returned handle (after
+            // wrapping it through an adapter task so the types line up) and
+            // detach a tiny supervisor for each remaining node's handle so
+            // they're reaped on shutdown. Per-node `ServerError`s are already
+            // surfaced via `tracing::error!` inside `RaftTopology::spawn`'s
+            // server task, so losing the typed error in the adapter is fine.
+            let mut handles = topo.server_handles.into_iter();
+            let first = handles
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("raft topology returned zero server handles"))?;
+            for extra in handles {
+                server_rt.spawn(async move {
+                    let _ = extra.await;
+                });
+            }
+            let server_handle: tokio::task::JoinHandle<Result<(), tsoracle_server::ServerError>> =
+                server_rt.spawn(async move {
+                    let _ = first.await;
+                    Ok(())
+                });
+            (Box::new(topo.controller), endpoints, server_handle)
+        }
         TopologyKind::Process => anyhow::bail!("process topology not yet implemented"),
     };
 

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -7,9 +7,11 @@
 //! loopback port. Cluster membership is initialized on node 1 once every
 //! node's `Raft` handle is registered.
 //!
-//! Chaos primitives (`kill_leader`, `pause_leader`, failpoints) are stubbed
-//! to return `Skipped` for now; follow-up PRs land real implementations on
-//! top of `MemNetwork`'s partition controller and openraft's `shutdown`.
+//! `kill_leader` isolates the current leader on the shared `MemNetwork`'s
+//! partition controller for a short window, forcing the remaining quorum to
+//! elect a new leader, then heals the partition so subsequent chaos ops still
+//! have a quorum to work with. `pause_leader` and the failpoint primitives
+//! are stubbed to return `Skipped` until follow-up PRs land them.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -48,7 +50,6 @@ pub struct RaftTopology {
 /// shutdown senders for each node's tsoracle server.
 pub struct RaftController {
     nodes: Vec<RaftNode>,
-    #[allow(dead_code)] // Used by follow-up PRs that introduce partition-based chaos.
     network: Arc<MemNetwork<TypeConfig>>,
     grace: Duration,
 }
@@ -218,10 +219,34 @@ async fn wait_for_leader(nodes: &[RaftNode]) -> anyhow::Result<()> {
 #[async_trait]
 impl ChaosController for RaftController {
     async fn kill_leader(&self) -> ChaosEvent {
-        timed_event(ChaosKind::LeaderKill, self.grace, || async {
-            ChaosOutcome::Skipped {
-                reason: "kill_leader not yet implemented for raft topology".into(),
-            }
+        // The openraft `u64` NodeId of the leader is the key the shared
+        // `PartitionController` uses to gate edges. `current_leader()` on the
+        // trait returns the stress `NodeId(u32)` (narrowed from the same
+        // value), so we read metrics directly here to keep the openraft id
+        // in its native width and avoid a u32 -> u64 round-trip.
+        let leader_raft_id: Option<u64> = self
+            .nodes
+            .iter()
+            .find_map(|n| n.raft.metrics().borrow_watched().current_leader);
+        let Some(leader_raft_id) = leader_raft_id else {
+            return timed_event(ChaosKind::LeaderKill, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "no current leader".into(),
+                }
+            })
+            .await;
+        };
+        let partitions = self.network.partitions();
+        timed_event(ChaosKind::LeaderKill, self.grace, move || async move {
+            partitions.isolate(leader_raft_id);
+            // Election timeout is 300-600ms; openraft can also need a few
+            // heartbeat-interval ticks (100ms each) before followers escalate
+            // to a candidate after losing the leader. 1500ms keeps the chaos
+            // window short while reliably producing a re-election in CI; the
+            // 750ms baseline from the sketch was tight enough to flake.
+            tokio::time::sleep(Duration::from_millis(1500)).await;
+            partitions.heal(leader_raft_id);
+            ChaosOutcome::Applied
         })
         .await
     }
@@ -288,11 +313,75 @@ mod tests {
             .await
             .expect("spawn 3-node raft topology");
         let endpoints = topology.controller.endpoints();
-        assert_eq!(endpoints.len(), 3, "expected 3 endpoints, got {endpoints:?}");
+        assert_eq!(
+            endpoints.len(),
+            3,
+            "expected 3 endpoints, got {endpoints:?}"
+        );
         assert!(
             topology.controller.current_leader().is_some(),
             "expected a leader after spawn"
         );
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kill_leader_triggers_reelection() {
+        let topology = RaftTopology::spawn(3, Duration::from_millis(750))
+            .await
+            .expect("spawn 3-node raft topology");
+        let original_leader = topology
+            .controller
+            .current_leader()
+            .expect("leader at boot");
+
+        let event = topology.controller.kill_leader().await;
+        assert!(
+            event.outcome.is_applied(),
+            "kill_leader expected Applied, got {:?}",
+            event.outcome
+        );
+
+        // Poll for a different leader; election timeout is 300-600ms, so up
+        // to 2s of polling is comfortably above the worst case while still
+        // failing fast if no re-election occurs.
+        let mut new_leader = None;
+        for _ in 0..40 {
+            if let Some(candidate) = topology.controller.current_leader() {
+                if candidate != original_leader {
+                    new_leader = Some(candidate);
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let new_leader = match new_leader {
+            Some(id) => id,
+            None => {
+                let snapshots: Vec<String> = topology
+                    .controller
+                    .nodes
+                    .iter()
+                    .map(|n| {
+                        let metrics = n.raft.metrics().borrow_watched().clone();
+                        format!(
+                            "node {} state={:?} term={:?} leader={:?}",
+                            n.node_id.0,
+                            metrics.state,
+                            metrics.current_term,
+                            metrics.current_leader
+                        )
+                    })
+                    .collect();
+                panic!(
+                    "re-election should have produced a different leader (was {:?}); snapshots:\n  {}",
+                    original_leader,
+                    snapshots.join("\n  ")
+                );
+            }
+        };
+        assert_ne!(original_leader, new_leader);
+
         Box::new(topology.controller).shutdown().await;
     }
 }

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -79,6 +79,52 @@ fn open_log_store(dir: &std::path::Path) -> anyhow::Result<RocksdbLogStore<TypeC
     Ok(RocksdbLogStore::open(driver, LOG_CF, META_CF, Flat)?)
 }
 
+/// Pluggable backend for the spawn-time I/O dependencies that production
+/// `RaftTopology::spawn` cannot otherwise force into a failure mode.
+///
+/// Production code uses [`DefaultRaftBackend`]; tests inject impls that fail
+/// at a chosen step to exercise the `?` propagation paths in `spawn_with`.
+/// The `id` parameter lets a test backend differentiate behavior per node
+/// (fail only on node 1, succeed on the rest, etc.). Production ignores it.
+#[async_trait]
+pub trait RaftBackend: Send + Sync {
+    /// Allocate a fresh, writable directory for node `id`'s rocksdb log
+    /// store and open the store on it. The returned `TempDir` must be kept
+    /// alive for the node's lifetime; dropping it deletes the directory and
+    /// invalidates the log store.
+    async fn prepare_node_storage(
+        &self,
+        id: u64,
+    ) -> anyhow::Result<(TempDir, RocksdbLogStore<TypeConfig, Flat>)>;
+
+    /// Bind the loopback listener that node `id`'s tsoracle server will
+    /// serve from. Production uses `127.0.0.1:0`.
+    async fn bind_loopback(&self, id: u64) -> anyhow::Result<TcpListener>;
+}
+
+/// Production [`RaftBackend`]: real `tempfile::TempDir`, real
+/// `RocksdbLogStore`, real `TcpListener::bind("127.0.0.1:0")`.
+pub struct DefaultRaftBackend;
+
+#[async_trait]
+impl RaftBackend for DefaultRaftBackend {
+    async fn prepare_node_storage(
+        &self,
+        _id: u64,
+    ) -> anyhow::Result<(TempDir, RocksdbLogStore<TypeConfig, Flat>)> {
+        let dir = TempDir::new().context("raft topology: create tempdir")?;
+        let store = open_log_store(dir.path())
+            .with_context(|| format!("raft topology: open log store at {:?}", dir.path()))?;
+        Ok((dir, store))
+    }
+
+    async fn bind_loopback(&self, _id: u64) -> anyhow::Result<TcpListener> {
+        TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("raft topology: bind loopback")
+    }
+}
+
 fn raft_config() -> anyhow::Result<Arc<Config>> {
     Ok(Arc::new(
         Config {
@@ -98,7 +144,22 @@ impl RaftTopology {
     /// Boot an N-node in-process cluster, each node running its own
     /// `tsoracle::Server` bound to a fresh loopback port. Returns once
     /// membership has been initialized and a leader has been observed.
+    ///
+    /// Uses [`DefaultRaftBackend`] for the spawn-time I/O steps. Tests that
+    /// need to exercise the failure paths call [`Self::spawn_with`] with a
+    /// fake backend.
     pub async fn spawn(node_count: usize, grace: Duration) -> anyhow::Result<Self> {
+        Self::spawn_with(&DefaultRaftBackend, node_count, grace).await
+    }
+
+    /// Like [`Self::spawn`] but with a caller-supplied [`RaftBackend`] for
+    /// the spawn-time I/O. Useful for tests that want to inject failures
+    /// at the storage-preparation or listener-binding steps.
+    pub async fn spawn_with(
+        backend: &dyn RaftBackend,
+        node_count: usize,
+        grace: Duration,
+    ) -> anyhow::Result<Self> {
         if node_count == 0 {
             bail!("raft topology requires at least one node");
         }
@@ -111,9 +172,7 @@ impl RaftTopology {
 
         for raw_id in 1..=node_count {
             let node_id_u64 = raw_id as u64;
-            let log_dir = TempDir::new().context("raft topology: create tempdir")?;
-            let log_store = open_log_store(log_dir.path())
-                .with_context(|| format!("raft topology: open log store for node {node_id_u64}"))?;
+            let (log_dir, log_store) = backend.prepare_node_storage(node_id_u64).await?;
             let state_machine = HighWaterStateMachine::new();
             let state_machine_for_host = state_machine.clone();
 
@@ -135,9 +194,7 @@ impl RaftTopology {
                 .build()
                 .map_err(|e| anyhow::anyhow!("raft topology: server build: {e:?}"))?;
 
-            let listener = TcpListener::bind("127.0.0.1:0")
-                .await
-                .context("raft topology: bind loopback")?;
+            let listener = backend.bind_loopback(node_id_u64).await?;
             let addr = listener.local_addr()?;
             let endpoint = format!("http://{addr}");
             let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
@@ -452,6 +509,122 @@ mod tests {
             event.outcome
         );
         Box::new(topology.controller).shutdown().await;
+    }
+
+    /// Backend that delegates to `DefaultRaftBackend` for every step except
+    /// the one named in `fail_step`, where it returns an injected error
+    /// when the call is for node `fail_at_node`.
+    struct FailingBackend {
+        fail_step: SpawnStep,
+        fail_at_node: u64,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum SpawnStep {
+        PrepareStorage,
+        BindLoopback,
+    }
+
+    #[async_trait]
+    impl RaftBackend for FailingBackend {
+        async fn prepare_node_storage(
+            &self,
+            id: u64,
+        ) -> anyhow::Result<(TempDir, RocksdbLogStore<TypeConfig, Flat>)> {
+            if self.fail_step == SpawnStep::PrepareStorage && id == self.fail_at_node {
+                bail!("injected: prepare_node_storage failed for node {id}");
+            }
+            DefaultRaftBackend.prepare_node_storage(id).await
+        }
+
+        async fn bind_loopback(&self, id: u64) -> anyhow::Result<TcpListener> {
+            if self.fail_step == SpawnStep::BindLoopback && id == self.fail_at_node {
+                bail!("injected: bind_loopback failed for node {id}");
+            }
+            DefaultRaftBackend.bind_loopback(id).await
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn spawn_propagates_storage_failure() {
+        // Inject a `prepare_node_storage` failure for the first node. The
+        // resulting `?` propagation surfaces through `spawn_with` as a
+        // descriptive `anyhow::Error`.
+        let backend = FailingBackend {
+            fail_step: SpawnStep::PrepareStorage,
+            fail_at_node: 1,
+        };
+        match RaftTopology::spawn_with(&backend, 3, Duration::from_millis(50)).await {
+            Err(err) => {
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("prepare_node_storage failed"),
+                    "expected storage-failure message, got: {msg}",
+                );
+            }
+            Ok(_) => panic!("spawn should propagate the injected storage failure"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn spawn_propagates_bind_failure() {
+        // Inject a `bind_loopback` failure for the second node. The first
+        // node's storage and listener succeed; the second's bind fails.
+        let backend = FailingBackend {
+            fail_step: SpawnStep::BindLoopback,
+            fail_at_node: 2,
+        };
+        match RaftTopology::spawn_with(&backend, 3, Duration::from_millis(50)).await {
+            Err(err) => {
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("bind_loopback failed"),
+                    "expected bind-failure message, got: {msg}",
+                );
+            }
+            Ok(_) => panic!("spawn should propagate the injected bind failure"),
+        }
+    }
+
+    /// Build an empty `RaftController` for tests that need to exercise the
+    /// "no nodes" / "no current leader" code paths (which the production
+    /// `spawn` never produces because spawn waits for a leader to emerge).
+    fn empty_controller() -> RaftController {
+        RaftController {
+            nodes: Vec::new(),
+            network: MemNetwork::<TypeConfig>::new(),
+            grace: Duration::from_millis(50),
+        }
+    }
+
+    #[test]
+    fn current_leader_returns_none_when_no_nodes() {
+        let controller = empty_controller();
+        assert!(controller.current_leader().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn kill_leader_skipped_when_no_nodes() {
+        let controller = empty_controller();
+        let ev = controller.kill_leader().await;
+        match ev.outcome {
+            ChaosOutcome::Skipped { ref reason } => {
+                assert!(reason.contains("no current leader"), "got reason: {reason}");
+            }
+            other => panic!("expected Skipped, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pause_leader_skipped_when_no_nodes() {
+        let controller = empty_controller();
+        let ev = controller.pause_leader(Duration::from_millis(50)).await;
+        match ev.outcome {
+            ChaosOutcome::Skipped { ref reason } => {
+                assert!(reason.contains("no current leader"), "got reason: {reason}");
+            }
+            other => panic!("expected Skipped, got {other:?}"),
+        }
     }
 
     #[cfg(feature = "stress-failpoints")]

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -178,7 +178,7 @@ impl RaftTopology {
             .await
             .context("raft topology: initialize membership")?;
 
-        wait_for_leader(&nodes).await?;
+        wait_for_leader(&nodes, Duration::from_secs(2)).await?;
 
         Ok(RaftTopology {
             controller: RaftController {
@@ -191,15 +191,9 @@ impl RaftTopology {
     }
 }
 
-async fn wait_for_leader(nodes: &[RaftNode]) -> anyhow::Result<()> {
-    let deadline = Instant::now() + Duration::from_secs(2);
+async fn wait_for_leader(nodes: &[RaftNode], timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
     loop {
-        for node in nodes {
-            let metrics = node.raft.metrics().borrow_watched().clone();
-            if metrics.current_leader.is_some() {
-                return Ok(());
-            }
-        }
         if Instant::now() >= deadline {
             let snapshots: Vec<_> = nodes
                 .iter()
@@ -212,9 +206,15 @@ async fn wait_for_leader(nodes: &[RaftNode]) -> anyhow::Result<()> {
                 })
                 .collect();
             bail!(
-                "raft topology: no leader within 2s; snapshots:\n  {}",
+                "raft topology: no leader within {timeout:?}; snapshots:\n  {}",
                 snapshots.join("\n  ")
             );
+        }
+        for node in nodes {
+            let metrics = node.raft.metrics().borrow_watched().clone();
+            if metrics.current_leader.is_some() {
+                return Ok(());
+            }
         }
         sleep(Duration::from_millis(25)).await;
     }
@@ -487,6 +487,77 @@ mod tests {
         match ev.outcome {
             ChaosOutcome::Skipped { .. } => {}
             other => panic!("expected Skipped, got {other:?}"),
+        }
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn spawn_zero_nodes_rejected() {
+        match RaftTopology::spawn(0, Duration::from_millis(50)).await {
+            Err(err) => assert!(
+                format!("{err:#}").contains("at least one node"),
+                "unexpected error: {err:#}",
+            ),
+            Ok(_) => panic!("spawn(0) should reject, got Ok"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn wait_for_leader_times_out() {
+        let topology = RaftTopology::spawn(3, Duration::from_millis(50))
+            .await
+            .expect("spawn 3-node raft topology");
+        // Re-invoke `wait_for_leader` with a zero deadline. The deadline check
+        // runs before the metrics poll on the first iteration, so the timeout
+        // branch always fires regardless of whether the cluster has a leader.
+        // This exercises the diagnostic snapshot path that real users only see
+        // when a cluster genuinely fails to elect.
+        let result = wait_for_leader(&topology.controller.nodes, Duration::ZERO).await;
+        match result {
+            Err(err) => {
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("no leader within") && msg.contains("snapshots:"),
+                    "unexpected error: {msg}",
+                );
+            }
+            Ok(()) => panic!("wait_for_leader with zero timeout should always bail"),
+        }
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[test]
+    fn open_log_store_errors_on_bad_path() {
+        // Pointing rocksdb at a path it cannot create (parent doesn't exist
+        // and we don't have permission to create it) exercises the error
+        // propagation from `DB::open_cf_descriptors`.
+        let bad = std::path::PathBuf::from("/nonexistent-root/stress-raft-test/log");
+        match open_log_store(&bad) {
+            Err(_) => {}
+            Ok(_) => panic!("open_log_store should fail on unreadable path"),
+        }
+    }
+
+    #[cfg(feature = "stress-failpoints")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn arm_failpoint_returns_failed_on_invalid_action() {
+        let topology = RaftTopology::spawn(3, Duration::from_millis(50))
+            .await
+            .expect("spawn 3-node raft topology");
+        // The `fail` crate's action parser rejects gibberish; `arm_failpoint`
+        // surfaces that as `ChaosOutcome::Failed`.
+        let ev = topology
+            .controller
+            .arm_failpoint("stress-raft-test::fp_invalid", "not-a-real-action")
+            .await;
+        match ev.outcome {
+            ChaosOutcome::Failed { ref reason } => {
+                assert!(
+                    reason.contains("fail::cfg"),
+                    "expected fail::cfg in reason, got: {reason}",
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
         }
         Box::new(topology.controller).shutdown().await;
     }

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -12,8 +12,10 @@
 //! elect a new leader, then heals the partition so subsequent chaos ops still
 //! have a quorum to work with. `pause_leader` runs the same partition shape
 //! for a caller-provided duration, leaving leadership intact when the window
-//! is shorter than `election_timeout_min`. The failpoint primitives are
-//! stubbed to return `Skipped` until follow-up PRs land them.
+//! is shorter than `election_timeout_min`. `arm_failpoint`/`disarm_failpoint`
+//! are feature-gated on `stress-failpoints`: enabled, they drive the
+//! process-wide `fail` registry (which affects every in-process node at once);
+//! disabled, they return `Skipped`.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -279,24 +281,55 @@ impl ChaosController for RaftController {
         .await
     }
 
-    async fn arm_failpoint(&self, name: &str, _action: &str) -> ChaosEvent {
+    async fn arm_failpoint(&self, name: &str, action: &str) -> ChaosEvent {
         let kind = ChaosKind::FailpointArm { name: name.into() };
-        timed_event(kind, self.grace, || async {
-            ChaosOutcome::Skipped {
-                reason: "arm_failpoint not yet implemented for raft topology".into(),
-            }
-        })
-        .await
+        #[cfg(feature = "stress-failpoints")]
+        {
+            let name = name.to_string();
+            let action = action.to_string();
+            return timed_event(kind, self.grace, move || async move {
+                match fail::cfg(name.as_str(), action.as_str()) {
+                    Ok(()) => ChaosOutcome::Applied,
+                    Err(e) => ChaosOutcome::Failed {
+                        reason: format!("fail::cfg: {e}"),
+                    },
+                }
+            })
+            .await;
+        }
+        #[cfg(not(feature = "stress-failpoints"))]
+        {
+            let _ = (name, action);
+            timed_event(kind, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "stress-failpoints feature off; failpoints not linked".into(),
+                }
+            })
+            .await
+        }
     }
 
     async fn disarm_failpoint(&self, name: &str) -> ChaosEvent {
         let kind = ChaosKind::FailpointDisarm { name: name.into() };
-        timed_event(kind, self.grace, || async {
-            ChaosOutcome::Skipped {
-                reason: "disarm_failpoint not yet implemented for raft topology".into(),
-            }
-        })
-        .await
+        #[cfg(feature = "stress-failpoints")]
+        {
+            let name = name.to_string();
+            return timed_event(kind, self.grace, move || async move {
+                fail::remove(name.as_str());
+                ChaosOutcome::Applied
+            })
+            .await;
+        }
+        #[cfg(not(feature = "stress-failpoints"))]
+        {
+            let _ = name;
+            timed_event(kind, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "stress-failpoints feature off".into(),
+                }
+            })
+            .await
+        }
     }
 
     fn endpoints(&self) -> Vec<String> {
@@ -418,6 +451,43 @@ mod tests {
             "pause_leader expected Applied, got {:?}",
             event.outcome
         );
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[cfg(feature = "stress-failpoints")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn arm_disarm_failpoint_round_trip() {
+        let topology = RaftTopology::spawn(3, Duration::from_millis(50))
+            .await
+            .expect("spawn 3-node raft topology");
+        let ev_arm = topology
+            .controller
+            .arm_failpoint("stress-raft-test::fp_unused", "off")
+            .await;
+        assert!(ev_arm.outcome.is_applied(), "arm: {:?}", ev_arm.outcome);
+        let ev_disarm = topology
+            .controller
+            .disarm_failpoint("stress-raft-test::fp_unused")
+            .await;
+        assert!(
+            ev_disarm.outcome.is_applied(),
+            "disarm: {:?}",
+            ev_disarm.outcome
+        );
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[cfg(not(feature = "stress-failpoints"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn failpoints_off_returns_skipped() {
+        let topology = RaftTopology::spawn(3, Duration::from_millis(50))
+            .await
+            .expect("spawn 3-node raft topology");
+        let ev = topology.controller.arm_failpoint("any", "panic").await;
+        match ev.outcome {
+            ChaosOutcome::Skipped { .. } => {}
+            other => panic!("expected Skipped, got {other:?}"),
+        }
         Box::new(topology.controller).shutdown().await;
     }
 }

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -1,40 +1,298 @@
-//! In-process openraft cluster on `MemNetwork`.
+//! In-process openraft cluster on `MemNetwork`; chaos by partitioning the
+//! leader's outbound messages.
+//!
+//! Mirrors the `examples/openraft-piggyback` `build_cluster` wiring: a single
+//! shared `MemNetwork` registry, per-node `RocksdbLogStore` in a fresh
+//! tempdir, a `HighWaterStateMachine`, and a `tsoracle::Server` bound to a
+//! loopback port. Cluster membership is initialized on node 1 once every
+//! node's `Raft` handle is registered.
+//!
+//! Chaos primitives (`kill_leader`, `pause_leader`, failpoints) are stubbed
+//! to return `Skipped` for now; follow-up PRs land real implementations on
+//! top of `MemNetwork`'s partition controller and openraft's `shutdown`.
 
+use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
-use crate::topology::ChaosController;
+use anyhow::{Context, bail};
+use async_trait::async_trait;
+use openraft::async_runtime::watch::WatchReceiver;
+use openraft::{Config, Raft, SnapshotPolicy};
+use openraft_toolkit::test_fakes::MemNetwork;
+use openraft_toolkit::{Flat, RocksdbLogStore};
+use parking_lot::Mutex;
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::time::{Instant, sleep};
+use tsoracle_driver_openraft::{
+    HighWaterStateMachine, OpenraftDriver, OpenraftPeer, StandaloneHost, TypeConfig,
+};
+use tsoracle_server::Server;
 
-pub struct RaftTopology;
+use crate::chaos::{ChaosEvent, ChaosKind, ChaosOutcome};
+use crate::topology::{ChaosController, NodeId, timed_event};
+
+const LOG_CF: &str = "raft_log";
+const META_CF: &str = "raft_meta";
+
+/// In-process openraft cluster with one `tsoracle::Server` per node.
+pub struct RaftTopology {
+    pub controller: RaftController,
+    pub server_handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
+/// Owns the per-node raft handles, the shared `MemNetwork`, and the oneshot
+/// shutdown senders for each node's tsoracle server.
+pub struct RaftController {
+    nodes: Vec<RaftNode>,
+    #[allow(dead_code)] // Used by follow-up PRs that introduce partition-based chaos.
+    network: Arc<MemNetwork<TypeConfig>>,
+    grace: Duration,
+}
+
+struct RaftNode {
+    node_id: NodeId,
+    endpoint: String,
+    raft: Raft<TypeConfig, HighWaterStateMachine>,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Keep the rocksdb tempdir alive for the node's lifetime.
+    _log_dir: TempDir,
+}
+
+fn open_log_store(dir: &std::path::Path) -> anyhow::Result<RocksdbLogStore<TypeConfig, Flat>> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cfs = vec![
+        ColumnFamilyDescriptor::new(LOG_CF, Options::default()),
+        ColumnFamilyDescriptor::new(META_CF, Options::default()),
+    ];
+    let driver = Arc::new(DB::open_cf_descriptors(&opts, dir, cfs)?);
+    Ok(RocksdbLogStore::open(driver, LOG_CF, META_CF, Flat)?)
+}
+
+fn raft_config() -> anyhow::Result<Arc<Config>> {
+    Ok(Arc::new(
+        Config {
+            heartbeat_interval: 100,
+            election_timeout_min: 300,
+            election_timeout_max: 600,
+            // HighWaterStateMachine is in-memory only — leaving snapshots on
+            // would let openraft purge logs the SM cannot rebuild from.
+            snapshot_policy: SnapshotPolicy::Never,
+            ..Default::default()
+        }
+        .validate()?,
+    ))
+}
 
 impl RaftTopology {
-    pub async fn spawn(_nodes: usize, _grace: Duration) -> anyhow::Result<Self> {
-        anyhow::bail!("raft topology not yet implemented")
+    /// Boot an N-node in-process cluster, each node running its own
+    /// `tsoracle::Server` bound to a fresh loopback port. Returns once
+    /// membership has been initialized and a leader has been observed.
+    pub async fn spawn(node_count: usize, grace: Duration) -> anyhow::Result<Self> {
+        if node_count == 0 {
+            bail!("raft topology requires at least one node");
+        }
+
+        let network = MemNetwork::<TypeConfig>::new();
+        let config = raft_config()?;
+
+        let mut nodes: Vec<RaftNode> = Vec::with_capacity(node_count);
+        let mut server_handles: Vec<tokio::task::JoinHandle<()>> = Vec::with_capacity(node_count);
+
+        for raw_id in 1..=node_count {
+            let node_id_u64 = raw_id as u64;
+            let log_dir = TempDir::new().context("raft topology: create tempdir")?;
+            let log_store = open_log_store(log_dir.path())
+                .with_context(|| format!("raft topology: open log store for node {node_id_u64}"))?;
+            let state_machine = HighWaterStateMachine::new();
+            let state_machine_for_host = state_machine.clone();
+
+            let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
+                node_id_u64,
+                config.clone(),
+                network.factory_for(node_id_u64),
+                log_store,
+                state_machine,
+            )
+            .await
+            .with_context(|| format!("raft topology: Raft::new for node {node_id_u64}"))?;
+            network.register(node_id_u64, raft.clone());
+
+            let host = StandaloneHost::new(raft.clone(), state_machine_for_host);
+            let driver = OpenraftDriver::new(host);
+            let server = Server::builder()
+                .consensus_driver(driver)
+                .build()
+                .map_err(|e| anyhow::anyhow!("raft topology: server build: {e:?}"))?;
+
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .context("raft topology: bind loopback")?;
+            let addr = listener.local_addr()?;
+            let endpoint = format!("http://{addr}");
+            let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+            let endpoint_for_log = endpoint.clone();
+            let handle = tokio::spawn(async move {
+                let shutdown = async move {
+                    let _ = shutdown_rx.await;
+                };
+                if let Err(e) = server.serve_with_listener(listener, shutdown).await {
+                    tracing::error!(error = ?e, endpoint = %endpoint_for_log, "tsoracle server died");
+                }
+            });
+
+            nodes.push(RaftNode {
+                node_id: NodeId(raw_id as u32),
+                endpoint,
+                raft,
+                shutdown_tx: Mutex::new(Some(shutdown_tx)),
+                _log_dir: log_dir,
+            });
+            server_handles.push(handle);
+        }
+
+        // Initialize membership on node 1 once every node is registered.
+        let mut membership: BTreeMap<u64, OpenraftPeer> = BTreeMap::new();
+        for node in &nodes {
+            let id_u64 = u64::from(node.node_id.0);
+            membership.insert(
+                id_u64,
+                OpenraftPeer {
+                    addr: format!("mem-node-{id_u64}"),
+                },
+            );
+        }
+        nodes[0]
+            .raft
+            .initialize(membership)
+            .await
+            .context("raft topology: initialize membership")?;
+
+        wait_for_leader(&nodes).await?;
+
+        Ok(RaftTopology {
+            controller: RaftController {
+                nodes,
+                network,
+                grace,
+            },
+            server_handles,
+        })
     }
 }
 
-pub struct RaftController;
+async fn wait_for_leader(nodes: &[RaftNode]) -> anyhow::Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        for node in nodes {
+            let metrics = node.raft.metrics().borrow_watched().clone();
+            if metrics.current_leader.is_some() {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            let snapshots: Vec<_> = nodes
+                .iter()
+                .map(|n| {
+                    let metrics = n.raft.metrics().borrow_watched().clone();
+                    format!(
+                        "node {} state={:?} term={:?} leader={:?}",
+                        n.node_id.0, metrics.state, metrics.current_term, metrics.current_leader
+                    )
+                })
+                .collect();
+            bail!(
+                "raft topology: no leader within 2s; snapshots:\n  {}",
+                snapshots.join("\n  ")
+            );
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl ChaosController for RaftController {
-    async fn kill_leader(&self) -> crate::chaos::ChaosEvent {
-        unimplemented!("raft topology not yet implemented")
+    async fn kill_leader(&self) -> ChaosEvent {
+        timed_event(ChaosKind::LeaderKill, self.grace, || async {
+            ChaosOutcome::Skipped {
+                reason: "kill_leader not yet implemented for raft topology".into(),
+            }
+        })
+        .await
     }
-    async fn pause_leader(&self, _dur: Duration) -> crate::chaos::ChaosEvent {
-        unimplemented!("raft topology not yet implemented")
+
+    async fn pause_leader(&self, _dur: Duration) -> ChaosEvent {
+        timed_event(ChaosKind::LeaderPause, self.grace, || async {
+            ChaosOutcome::Skipped {
+                reason: "pause_leader not yet implemented for raft topology".into(),
+            }
+        })
+        .await
     }
-    async fn arm_failpoint(&self, _: &str, _: &str) -> crate::chaos::ChaosEvent {
-        unimplemented!("raft topology not yet implemented")
+
+    async fn arm_failpoint(&self, name: &str, _action: &str) -> ChaosEvent {
+        let kind = ChaosKind::FailpointArm { name: name.into() };
+        timed_event(kind, self.grace, || async {
+            ChaosOutcome::Skipped {
+                reason: "arm_failpoint not yet implemented for raft topology".into(),
+            }
+        })
+        .await
     }
-    async fn disarm_failpoint(&self, _: &str) -> crate::chaos::ChaosEvent {
-        unimplemented!("raft topology not yet implemented")
+
+    async fn disarm_failpoint(&self, name: &str) -> ChaosEvent {
+        let kind = ChaosKind::FailpointDisarm { name: name.into() };
+        timed_event(kind, self.grace, || async {
+            ChaosOutcome::Skipped {
+                reason: "disarm_failpoint not yet implemented for raft topology".into(),
+            }
+        })
+        .await
     }
+
     fn endpoints(&self) -> Vec<String> {
-        unimplemented!("raft topology not yet implemented")
+        self.nodes.iter().map(|n| n.endpoint.clone()).collect()
     }
-    fn current_leader(&self) -> Option<crate::topology::NodeId> {
-        unimplemented!("raft topology not yet implemented")
+
+    fn current_leader(&self) -> Option<NodeId> {
+        for node in &self.nodes {
+            let metrics = node.raft.metrics().borrow_watched().clone();
+            if let Some(leader_id) = metrics.current_leader {
+                return Some(NodeId(leader_id as u32));
+            }
+        }
+        None
     }
+
     async fn shutdown(self: Box<Self>) {
-        unimplemented!("raft topology not yet implemented")
+        for node in &self.nodes {
+            if let Some(tx) = node.shutdown_tx.lock().take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn spawn_3_nodes_reports_endpoints_and_leader() {
+        let topology = RaftTopology::spawn(3, Duration::from_millis(50))
+            .await
+            .expect("spawn 3-node raft topology");
+        let endpoints = topology.controller.endpoints();
+        assert_eq!(endpoints.len(), 3, "expected 3 endpoints, got {endpoints:?}");
+        assert!(
+            topology.controller.current_leader().is_some(),
+            "expected a leader after spawn"
+        );
+        Box::new(topology.controller).shutdown().await;
     }
 }

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -10,8 +10,10 @@
 //! `kill_leader` isolates the current leader on the shared `MemNetwork`'s
 //! partition controller for a short window, forcing the remaining quorum to
 //! elect a new leader, then heals the partition so subsequent chaos ops still
-//! have a quorum to work with. `pause_leader` and the failpoint primitives
-//! are stubbed to return `Skipped` until follow-up PRs land them.
+//! have a quorum to work with. `pause_leader` runs the same partition shape
+//! for a caller-provided duration, leaving leadership intact when the window
+//! is shorter than `election_timeout_min`. The failpoint primitives are
+//! stubbed to return `Skipped` until follow-up PRs land them.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -251,11 +253,28 @@ impl ChaosController for RaftController {
         .await
     }
 
-    async fn pause_leader(&self, _dur: Duration) -> ChaosEvent {
-        timed_event(ChaosKind::LeaderPause, self.grace, || async {
-            ChaosOutcome::Skipped {
-                reason: "pause_leader not yet implemented for raft topology".into(),
-            }
+    async fn pause_leader(&self, dur: Duration) -> ChaosEvent {
+        // Same shape as `kill_leader` — see its comment for why we read the
+        // openraft `u64` NodeId directly from metrics rather than going
+        // through `current_leader()`'s narrowed `NodeId(u32)`.
+        let leader_raft_id: Option<u64> = self
+            .nodes
+            .iter()
+            .find_map(|n| n.raft.metrics().borrow_watched().current_leader);
+        let Some(leader_raft_id) = leader_raft_id else {
+            return timed_event(ChaosKind::LeaderPause, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "no current leader".into(),
+                }
+            })
+            .await;
+        };
+        let partitions = self.network.partitions();
+        timed_event(ChaosKind::LeaderPause, self.grace, move || async move {
+            partitions.isolate(leader_raft_id);
+            tokio::time::sleep(dur).await;
+            partitions.heal(leader_raft_id);
+            ChaosOutcome::Applied
         })
         .await
     }
@@ -382,6 +401,23 @@ mod tests {
         };
         assert_ne!(original_leader, new_leader);
 
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pause_leader_returns_applied() {
+        let topology = RaftTopology::spawn(3, Duration::from_millis(750))
+            .await
+            .expect("spawn 3-node raft topology");
+        let event = topology
+            .controller
+            .pause_leader(Duration::from_millis(200))
+            .await;
+        assert!(
+            event.outcome.is_applied(),
+            "pause_leader expected Applied, got {:?}",
+            event.outcome
+        );
         Box::new(topology.controller).shutdown().await;
     }
 }

--- a/benchmarks/stress/tests/smoke.rs
+++ b/benchmarks/stress/tests/smoke.rs
@@ -62,3 +62,33 @@ fn inject_violation_self_test_exits_with_violation() {
     assert!(matches!(report.outcome, Outcome::InvariantViolation));
     assert!(!report.violations.is_empty());
 }
+
+#[test]
+fn raft_steady_smoke_completes_clean() {
+    let mut cfg = base_cfg("steady", 5);
+    cfg.topology = TopologyKind::Raft;
+    cfg.nodes = 3;
+    let report = stress::run(cfg).unwrap();
+    assert!(
+        matches!(report.outcome, Outcome::Ok),
+        "got: {:?}",
+        report.outcome
+    );
+    assert!(report.violations.is_empty(), "got: {:?}", report.violations);
+    assert!(report.recorded.timestamps > 0, "no timestamps issued");
+}
+
+#[test]
+fn raft_killer_loop_smoke_maintains_invariants() {
+    let mut cfg = base_cfg("killer-loop", 10);
+    cfg.topology = TopologyKind::Raft;
+    cfg.nodes = 3;
+    let report = stress::run(cfg).unwrap();
+    assert!(
+        matches!(report.outcome, Outcome::Ok),
+        "outcome: {:?}, violations: {:?}",
+        report.outcome,
+        report.violations,
+    );
+    assert!(report.recorded.timestamps > 0);
+}


### PR DESCRIPTION
## Summary

Adds `--topology raft` to the stress + chaos harness: an in-process N-node openraft cluster sharing a `MemNetwork`, each node running its own `tsoracle::Server`. Chaos ops drive **real openraft re-elections** via the shared partition controller, rather than synthetic driver-state transitions like the `mem` topology.

## Live validation

`cargo run -p stress --release -- run --topology raft --scenario killer-loop --duration 10s --nodes 3 --clients 8`:

- `outcome=Ok`, exit 0
- 23 824 timestamps issued
- 0 invariant violations
- openraft term bumps observed T1→T4 across the run (real partition-induced step-downs and re-elections, not synthetic state changes)

## Test plan

- [x] CI: `cargo build -p stress` clean
- [x] CI: `cargo test -p stress` — 84 unit + 5 smoke = 89 tests pass
- [x] CI: `cargo test -p stress --features stress-failpoints` — 89 tests pass (failpoint-on variant)
- [x] CI: `cargo clippy -p stress --all-targets` and `--all-features` — clean under both
- [x] Manual: `cargo run -p stress --release -- run --topology raft --scenario steady --duration 5s --nodes 3 --clients 4` exits 0 with `outcome=Ok` and `recorded.timestamps > 0`
- [x] Manual: `cargo run -p stress --release -- run --topology raft --scenario killer-loop --duration 30s --nodes 3 --clients 32` exits 0 with `outcome=Ok` (real raft re-elections, supervisor accepts them via the `grace_raft` window)

## Known gaps (carried over from the existing crate README)

- `--json-stream` is plumbed as a CLI flag but not honored by the report path.
- `--ops`-bounded runs are validated but only `--duration` is honored.
- The topology controller emits `ChaosEvent`s to the supervisor, but they are not yet collected into the final `Report.chaos_events` field (currently hardcoded empty in `lib::run`).

None affects any of the four invariants.