### PR TITLE
fix(server): remove leader-hint metadata-key expect

### DIFF
--- a/crates/tsoracle-server/src/leader_hint.rs
+++ b/crates/tsoracle-server/src/leader_hint.rs
@@ -2,21 +2,52 @@
 
 use prost::Message;
 use tonic::Status;
-use tonic::metadata::{BinaryMetadataValue, MetadataKey};
+use tonic::metadata::errors::InvalidMetadataKey;
+use tonic::metadata::{BinaryMetadataKey, BinaryMetadataValue, MetadataKey};
 use tsoracle_proto::v1::LeaderHint;
 
 pub const KEY: &str = "tsoracle-leader-hint-bin";
 
+/// Confirms [`KEY`] is a valid binary metadata key.
+///
+/// Called from [`ServerBuilder::build`](crate::server::ServerBuilder::build)
+/// so an invalid `KEY` (only reachable via developer error) surfaces as a
+/// startup failure rather than as a silent runtime degradation in which the
+/// `tsoracle-leader-hint-bin` trailer is dropped from every NOT_LEADER
+/// response.
+pub fn validate_key() -> Result<(), InvalidMetadataKey> {
+    BinaryMetadataKey::from_bytes(KEY.as_bytes()).map(|_| ())
+}
+
 pub fn not_leader_status(hint: LeaderHint) -> Status {
-    let mut status = Status::failed_precondition("not leader");
-    let bytes = hint.encode_to_vec();
-    let value = BinaryMetadataValue::from_bytes(&bytes);
-    #[expect(
-        clippy::expect_used,
-        reason = "`KEY` is a `const &'static str` of valid ASCII; `MetadataKey::from_bytes` cannot fail here. Tracked by #5."
-    )]
-    let key = MetadataKey::from_bytes(KEY.as_bytes()).expect("valid key");
-    status.metadata_mut().insert_bin(key, value);
+    with_leader_hint(Status::failed_precondition("not leader"), hint, KEY)
+}
+
+/// Inserts a [`LeaderHint`] trailer keyed by `key_str` and returns `status`.
+///
+/// If `key_str` is not a valid binary metadata key, logs at `error!` and
+/// returns `status` without the trailer. The client's retry path tolerates a
+/// missing trailer (it round-robins over configured endpoints instead of
+/// jumping directly to the hinted leader), so a corrupted key degrades
+/// latency rather than correctness. [`validate_key`] additionally gates this
+/// at startup so the no-trailer fallback only ever runs in a worst-case
+/// developer-error scenario.
+fn with_leader_hint(mut status: Status, hint: LeaderHint, key_str: &str) -> Status {
+    match BinaryMetadataKey::from_bytes(key_str.as_bytes()) {
+        Ok(key) => {
+            let bytes = hint.encode_to_vec();
+            let value = BinaryMetadataValue::from_bytes(&bytes);
+            status.metadata_mut().insert_bin(key, value);
+        }
+        Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                key = key_str,
+                error = %_error,
+                "leader-hint metadata key invalid; omitting trailer from NOT_LEADER response"
+            );
+        }
+    }
     status
 }
 
@@ -41,5 +72,27 @@ mod tests {
         let decoded = decode_leader_hint(&status).expect("present");
         assert_eq!(decoded.leader_endpoint, hint.leader_endpoint);
         assert_eq!(decoded.leader_epoch, hint.leader_epoch);
+    }
+
+    #[test]
+    fn validate_key_accepts_real_key() {
+        validate_key().expect("KEY is a valid binary metadata key");
+    }
+
+    #[test]
+    fn invalid_key_omits_trailer_but_preserves_status() {
+        let hint = LeaderHint {
+            leader_endpoint: Some("10.0.0.7:50551".into()),
+            leader_epoch: Some(42),
+        };
+        // Spaces and uppercase make this key invalid for HTTP header
+        // construction; it also lacks the required `-bin` suffix.
+        let status = with_leader_hint(
+            Status::failed_precondition("not leader"),
+            hint,
+            "Invalid Key",
+        );
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+        assert!(decode_leader_hint(&status).is_none());
     }
 }

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -18,6 +18,13 @@ use crate::service::TsoServiceImpl;
 pub enum BuildError {
     #[error("consensus_driver is required")]
     MissingConsensusDriver,
+    /// Surfaced when [`crate::leader_hint::KEY`] fails [`crate::leader_hint::validate_key`].
+    /// Today the key is a valid `const &'static str`, so this variant is
+    /// developer-error insurance: a future edit that breaks the key triggers
+    /// a startup failure rather than silently stripping the trailer from
+    /// every NOT_LEADER response.
+    #[error("invalid leader-hint metadata key: {0}")]
+    InvalidLeaderHintKey(#[from] tonic::metadata::errors::InvalidMetadataKey),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -77,6 +84,7 @@ impl ServerBuilder {
         self
     }
     pub fn build(self) -> Result<Server, BuildError> {
+        crate::leader_hint::validate_key()?;
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
         let (state_tx, state_rx) = watch::channel(ServingState::NotServing {


### PR DESCRIPTION
## Summary
- Closes #5. Removes the `expect("valid key")` from `not_leader_status` and replaces it with a two-layer panic-safe design.
- **Startup gate:** `leader_hint::validate_key` runs first in `ServerBuilder::build`. A future invalid `KEY` const surfaces as `BuildError::InvalidLeaderHintKey` rather than as a silent runtime regression in which the `tsoracle-leader-hint-bin` trailer is dropped from every NOT_LEADER response.
- **Defensive runtime:** `not_leader_status` matches on `BinaryMetadataKey::from_bytes`. On Ok it inserts the trailer (byte-identical to the previous behavior for the real `KEY`); on Err it logs at `error!` and returns the Status without the trailer — the client's retry loop already tolerates a missing hint by falling back to round-robin over configured endpoints, so a corrupted key degrades latency rather than correctness.
- The `tracing::error!` call follows the existing `#[cfg(feature = "tracing")]` convention used in `server.rs`.
- Removes the `#[expect(clippy::expect_used, reason = "... Tracked by #5.")]` carve-out — the workspace-wide `expect_used` lint now applies uniformly to this module.

## Test plan
- [x] `cargo test -p tsoracle-server --features test-fakes` — 18 passing (5 lib + 13 integration), including `returns_not_leader_with_hint` (e2e) and the 5-test `leadership_churn` suite that exercises FAILED_PRECONDITION + LeaderHint paths
- [x] `cargo clippy --workspace --all-targets --features tsoracle-server/test-fakes -- -D warnings` clean
- [x] `cargo fmt --check` + `cargo clippy` pre-commit hook clean
- [x] New unit tests: `validate_key_accepts_real_key` (guards against future invalid `KEY` edits) and `invalid_key_omits_trailer_but_preserves_status` (exercises the runtime no-trailer fallback)

## Acceptance criteria (from #5)
- [x] No unconditional `expect("valid key")` panic in runtime metadata key creation.
- [x] Behavior remains backward compatible for valid keys — confirmed by the e2e and leadership-churn integration suites.
- [x] Failure mode (if key invalid) is explicit and test-covered — `BuildError::InvalidLeaderHintKey` (with `thiserror` Display) at startup; `tracing::error!` + no-trailer fallback at runtime; unit tests cover both paths.