### PR TITLE
refactor(test): introduce shared bootstrap helper for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,15 @@ COV_IGNORE_STRESS_BIN := benchmarks/stress/src/bin/stress
 # unreachable from any current test path.
 COV_IGNORE_STRESS_TOPO_STUBS := benchmarks/stress/src/topology/(raft|process)
 
-COV_IGNORE := ($(COV_IGNORE_OPENRAFT_LIFECYCLE)|$(COV_IGNORE_STRESS_BIN)|$(COV_IGNORE_STRESS_TOPO_STUBS))\.rs
+# Shared integration-test bootstrap helper. Gated by `test-support` (and
+# `cfg(test)`); never ships in the published library. Lives in `src/` only
+# because Cargo doesn't let multiple crates share `tests/common/mod.rs`.
+# Exercised implicitly by every test that calls `boot_server` /
+# `wait_for_grpc_handshake`; measuring it as production source would punish
+# legitimate "rare race" retry paths that local CI never trips.
+COV_IGNORE_TEST_SUPPORT := crates/tsoracle-server/src/test_support
+
+COV_IGNORE := ($(COV_IGNORE_OPENRAFT_LIFECYCLE)|$(COV_IGNORE_STRESS_BIN)|$(COV_IGNORE_STRESS_TOPO_STUBS)|$(COV_IGNORE_TEST_SUPPORT))\.rs
 
 # Shared exclude flags so `coverage` (lcov for CI) and `coverage-html` (local
 # browsable report) cannot drift apart on which crates participate.

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -37,4 +37,4 @@ tsoracle-proto = { path = "../tsoracle-proto", version = "0.1.0" }
 [dev-dependencies]
 tokio                 = { workspace = true, features = ["test-util"] }
 proptest              = { workspace = true }
-tsoracle-server       = { path = "../tsoracle-server", version = "0.1.0", features = ["test-fakes"] }
+tsoracle-server       = { path = "../tsoracle-server", version = "0.1.0", features = ["test-support"] }

--- a/crates/tsoracle-client/tests/e2e.rs
+++ b/crates/tsoracle-client/tests/e2e.rs
@@ -1,51 +1,11 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration, time::Instant};
-use tokio::net::TcpListener;
-use tokio::sync::watch;
-use tokio::time::sleep;
-use tonic::transport::Endpoint;
+use std::{sync::Arc, time::Duration};
 use tsoracle_client::{Client, ClientError};
 use tsoracle_core::Epoch;
-use tsoracle_server::{Server, ServingState, test_fakes::InMemoryDriver};
-
-async fn wait_until<F>(rx: &mut watch::Receiver<ServingState>, predicate: F)
-where
-    F: Fn(&ServingState) -> bool,
-{
-    loop {
-        if predicate(&rx.borrow_and_update()) {
-            return;
-        }
-        rx.changed()
-            .await
-            .expect("state stream closed before reaching expected state");
-    }
-}
-
-/// Bridge the residual race between "state_rx published the expected state"
-/// and "tonic's accept future has been polled and is handling HTTP/2".
-async fn wait_for_grpc_handshake(
-    addr: SocketAddr,
-    budget: Duration,
-) -> Result<(), tonic::transport::Error> {
-    let deadline = Instant::now() + budget;
-    let endpoint: Endpoint = format!("http://{addr}").parse().unwrap();
-    let mut last_err: Option<tonic::transport::Error> = None;
-    loop {
-        match endpoint.connect().await {
-            Ok(channel) => {
-                drop(channel);
-                return Ok(());
-            }
-            Err(err) => {
-                if Instant::now() >= deadline {
-                    return Err(last_err.unwrap_or(err));
-                }
-                last_err = Some(err);
-                sleep(Duration::from_millis(25)).await;
-            }
-        }
-    }
-}
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{
+    boot_server, wait_for_grpc_handshake, wait_until, wait_until_serving,
+};
+use tsoracle_server::{Server, ServingState};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn client_gets_timestamps_against_leader() {
@@ -56,32 +16,21 @@ async fn client_gets_timestamps_against_leader() {
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let mut state_rx = server.state_rx.clone();
-
-    let (sd_tx, sd_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = sd_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let mut booted = boot_server(server).await;
 
     driver.become_leader(Epoch(1));
-    wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
-    let client = Client::connect(vec![local_addr.to_string()]).await.unwrap();
+    let client = Client::connect(vec![booted.addr.to_string()])
+        .await
+        .unwrap();
     let ts = client.get_ts().await.unwrap();
     assert!(ts.physical_ms() > 1_700_000_000_000);
 
-    let _ = sd_tx.send(());
-    let _ = serve.await;
+    booted.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -102,35 +51,12 @@ async fn client_follows_leader_hint_on_first_call() {
         .build()
         .unwrap();
 
-    let listener_a = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr_a = listener_a.local_addr().unwrap();
-    let listener_b = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr_b = listener_b.local_addr().unwrap();
-    let mut state_rx_a = server_a.state_rx.clone();
-    let mut state_rx_b = server_b.state_rx.clone();
+    let mut booted_a = boot_server(server_a).await;
+    let mut booted_b = boot_server(server_b).await;
 
-    let (sda_tx, sda_rx) = tokio::sync::oneshot::channel::<()>();
-    let (sdb_tx, sdb_rx) = tokio::sync::oneshot::channel::<()>();
-    let server_a_task = tokio::spawn(async move {
-        server_a
-            .serve_with_listener(listener_a, async {
-                let _ = sda_rx.await;
-            })
-            .await
-            .unwrap();
-    });
-    let server_b_task = tokio::spawn(async move {
-        server_b
-            .serve_with_listener(listener_b, async {
-                let _ = sdb_rx.await;
-            })
-            .await
-            .unwrap();
-    });
-
-    driver_a.become_follower(Some(addr_b.to_string()));
+    driver_a.become_follower(Some(booted_b.addr.to_string()));
     driver_b.become_leader(Epoch(1));
-    wait_until(&mut state_rx_a, |s| {
+    wait_until(&mut booted_a.state_rx, |s| {
         matches!(
             s,
             ServingState::NotServing {
@@ -139,26 +65,26 @@ async fn client_follows_leader_hint_on_first_call() {
         )
     })
     .await;
-    wait_until(&mut state_rx_b, |s| matches!(s, ServingState::Serving)).await;
-    wait_for_grpc_handshake(addr_a, Duration::from_secs(5))
+    wait_until_serving(&mut booted_b.state_rx).await;
+    wait_for_grpc_handshake(booted_a.addr, Duration::from_secs(5))
         .await
         .expect("server A never accepted gRPC handshake");
-    wait_for_grpc_handshake(addr_b, Duration::from_secs(5))
+    wait_for_grpc_handshake(booted_b.addr, Duration::from_secs(5))
         .await
         .expect("server B never accepted gRPC handshake");
 
     // Client only knows about A.
-    let client = Client::connect(vec![addr_a.to_string()]).await.unwrap();
+    let client = Client::connect(vec![booted_a.addr.to_string()])
+        .await
+        .unwrap();
     let ts = client
         .get_ts()
         .await
         .expect("must follow hint on this call");
     assert!(ts.physical_ms() > 1_700_000_000_000);
 
-    let _ = sda_tx.send(());
-    let _ = sdb_tx.send(());
-    let _ = server_a_task.await;
-    let _ = server_b_task.await;
+    booted_a.shutdown().await.unwrap();
+    booted_b.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -174,22 +100,10 @@ async fn client_surfaces_error_when_only_endpoint_is_a_hintless_follower() {
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let mut state_rx = server.state_rx.clone();
-
-    let (sd_tx, sd_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = sd_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let mut booted = boot_server(server).await;
 
     driver.become_follower(None);
-    wait_until(&mut state_rx, |s| {
+    wait_until(&mut booted.state_rx, |s| {
         matches!(
             s,
             ServingState::NotServing {
@@ -198,11 +112,13 @@ async fn client_surfaces_error_when_only_endpoint_is_a_hintless_follower() {
         )
     })
     .await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
-    let client = Client::connect(vec![local_addr.to_string()]).await.unwrap();
+    let client = Client::connect(vec![booted.addr.to_string()])
+        .await
+        .unwrap();
     let err = client
         .get_ts()
         .await
@@ -214,8 +130,7 @@ async fn client_surfaces_error_when_only_endpoint_is_a_hintless_follower() {
         other => panic!("expected ClientError::Rpc(FailedPrecondition), got {other:?}"),
     }
 
-    let _ = sd_tx.send(());
-    let _ = serve.await;
+    booted.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -227,27 +142,19 @@ async fn concurrent_requests_coalesce() {
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let mut state_rx = server.state_rx.clone();
-
-    let (sd_tx, sd_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = sd_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let mut booted = boot_server(server).await;
 
     driver.become_leader(Epoch(1));
-    wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
-    let client = Arc::new(Client::connect(vec![local_addr.to_string()]).await.unwrap());
+    let client = Arc::new(
+        Client::connect(vec![booted.addr.to_string()])
+            .await
+            .unwrap(),
+    );
 
     // Fire 32 concurrent get_ts; with a 1ms flush, many should ride the same RPC.
     let mut handles = Vec::new();
@@ -266,6 +173,5 @@ async fn concurrent_requests_coalesce() {
     sorted.dedup();
     assert_eq!(sorted.len(), 32, "all 32 timestamps must be unique");
 
-    let _ = sd_tx.send(());
-    let _ = serve.await;
+    booted.shutdown().await.unwrap();
 }

--- a/crates/tsoracle-client/tests/freshness.rs
+++ b/crates/tsoracle-client/tests/freshness.rs
@@ -4,11 +4,12 @@
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::net::TcpListener;
 use tokio::time::sleep;
 use tsoracle_client::{Client, ClientError};
 use tsoracle_core::Epoch;
-use tsoracle_server::{Server, ServingState, test_fakes::InMemoryDriver};
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{boot_server, wait_until_serving};
 
 fn unix_ms_now() -> u64 {
     std::time::SystemTime::now()
@@ -47,23 +48,7 @@ async fn timestamps_are_at_or_after_enqueue_time() {
         .build()
         .unwrap();
 
-    // Bind in the test (not in a helper that drops the listener) so there is
-    // no rebind window between "pick a port" and "server claims it". Clone
-    // state_rx before moving server into the spawn so we can observe the
-    // serving handshake from the outside.
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let mut state_rx = server.state_rx.clone();
-
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = shutdown_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let mut booted = boot_server(server).await;
 
     driver.become_leader(Epoch(1));
 
@@ -72,17 +57,13 @@ async fn timestamps_are_at_or_after_enqueue_time() {
     // This is a sanity gate: if the server never reaches Serving, the loop
     // below would otherwise spin until budget exhaustion with a less specific
     // error.
-    loop {
-        if matches!(*state_rx.borrow_and_update(), ServingState::Serving) {
-            break;
-        }
-        state_rx
-            .changed()
-            .await
-            .expect("state stream closed before reaching Serving");
-    }
+    wait_until_serving(&mut booted.state_rx).await;
 
-    let client = Arc::new(Client::connect(vec![local_addr.to_string()]).await.unwrap());
+    let client = Arc::new(
+        Client::connect(vec![booted.addr.to_string()])
+            .await
+            .unwrap(),
+    );
 
     // Bridge the small remaining gap between "state == Serving" and "tonic's
     // accept loop has been polled and is handling HTTP/2". Once one call
@@ -108,8 +89,7 @@ async fn timestamps_are_at_or_after_enqueue_time() {
         }
     }
 
-    let _ = shutdown_tx.send(());
-    let _ = serve.await;
+    booted.shutdown().await.unwrap();
 }
 
 fn rand_jitter() -> bool {

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -19,6 +19,7 @@ tls-rustls = ["tonic/tls-aws-lc"]
 tls-native = ["tonic/tls-native-roots"]
 tracing    = ["dep:tracing"]
 test-fakes = []
+test-support = ["test-fakes"]
 reflection = ["dep:tonic-reflection", "tsoracle-proto/reflection"]
 
 [package.metadata.docs.rs]
@@ -49,7 +50,7 @@ tsoracle-client = { path = "../tsoracle-client", version = "0.1.0" }
 
 [[test]]
 name = "e2e"
-required-features = ["test-fakes"]
+required-features = ["test-support"]
 
 [[test]]
 name = "leader_watch"
@@ -57,21 +58,21 @@ required-features = ["test-fakes"]
 
 [[test]]
 name = "embedded_router"
-required-features = ["test-fakes"]
+required-features = ["test-support"]
 
 [[test]]
 name = "extension_stampede"
-required-features = ["test-fakes"]
+required-features = ["test-support"]
 
 [[test]]
 name = "leadership_churn"
-required-features = ["test-fakes"]
+required-features = ["test-support"]
 
 [[test]]
 name = "serve_with_listener"
-required-features = ["test-fakes"]
+required-features = ["test-support"]
 
 [[test]]
 name              = "failpoints"
 path              = "tests/failpoints.rs"
-required-features = ["failpoints", "test-fakes"]
+required-features = ["failpoints", "test-support"]

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -36,5 +36,8 @@ pub use server::{BuildError, Server, ServerBuilder, ServerError, ServingState};
 #[cfg(any(test, feature = "test-fakes"))]
 pub mod test_fakes;
 
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
+
 #[doc(hidden)]
 pub use leader_hint::decode_leader_hint as __priv_decode_leader_hint;

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -59,18 +59,13 @@ impl BootedServer {
     /// already exited (for example because its leader-watch task died),
     /// the receiver is gone and the send returns `Err` — that is the
     /// expected outcome for those failure-mode tests, and the task's
-    /// recorded result is surfaced regardless.
+    /// recorded result is surfaced regardless. A panicked or cancelled
+    /// task surfaces via `.expect` so the test fails loudly.
     pub async fn shutdown(self) -> Result<(), ServerError> {
         let _ = self.shutdown_tx.send(());
-        match self.serve_handle.await {
-            Ok(result) => result,
-            Err(join_err) => {
-                if join_err.is_panic() {
-                    std::panic::resume_unwind(join_err.into_panic());
-                }
-                panic!("server task was cancelled before shutdown");
-            }
-        }
+        self.serve_handle
+            .await
+            .expect("server task panicked or was cancelled before shutdown")
     }
 }
 
@@ -115,18 +110,13 @@ pub struct BootedRouter {
 }
 
 impl BootedRouter {
-    /// Send the shutdown signal and join the spawned task.
+    /// Send the shutdown signal and join the spawned task. A panicked or
+    /// cancelled router task surfaces via `.expect` so the test fails loudly.
     pub async fn shutdown(self) -> Result<(), tonic::transport::Error> {
         let _ = self.shutdown_tx.send(());
-        match self.serve_handle.await {
-            Ok(result) => result,
-            Err(join_err) => {
-                if join_err.is_panic() {
-                    std::panic::resume_unwind(join_err.into_panic());
-                }
-                panic!("router task was cancelled before shutdown");
-            }
-        }
+        self.serve_handle
+            .await
+            .expect("router task panicked or was cancelled before shutdown")
     }
 
     /// Abort the spawned task without graceful shutdown. Failpoints tests

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -1,0 +1,222 @@
+//! Bootstrap helpers for integration tests that spin up a [`crate::Server`]
+//! on `127.0.0.1:0`, drive it to a known state, and tear it down explicitly.
+//!
+//! Tests across `tsoracle-server` and `tsoracle-client` repeatedly bind a
+//! random TCP port, spawn `serve_with_listener` (or the `into_router` +
+//! tonic pair), and poll the [`ServingState`] watch channel before making
+//! RPCs. This module collapses that boilerplate behind two `boot_*`
+//! functions plus a small set of wait helpers, leaving each test's
+//! per-scenario configuration (builder knobs, custom drivers, leader vs
+//! follower) intact at the call site.
+
+// This module compiles only for tests or behind the `test-support` feature.
+// The crate-level lint that warns against `unwrap`/`expect` in non-test
+// builds still applies under `feature = "test-support"` without `cfg(test)`,
+// so we opt out here — expressive panics are the right idiom for test
+// helpers that fail loudly on bring-up errors.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use tokio::net::TcpListener;
+use tokio::sync::{oneshot, watch};
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::service::Routes;
+use tonic::transport::{Endpoint, Server as TonicServer};
+
+use crate::{Server, ServerError, ServingState};
+
+/// A running [`Server`] with its captured bind address, observable
+/// [`ServingState`], a graceful-shutdown signal, and the spawned task's
+/// `JoinHandle`.
+///
+/// Dropping a `BootedServer` does not shut the server down — the spawned
+/// task continues until the test process exits. Most tests should call
+/// [`BootedServer::shutdown`] to send the shutdown signal and join the
+/// task. Tests that probe failure modes where shutdown never fires
+/// (`futures::future::pending`-style waits, watch-task panics) can move
+/// `serve_handle` out directly and observe its outcome.
+pub struct BootedServer {
+    /// Address bound on `127.0.0.1` with an OS-picked port.
+    pub addr: SocketAddr,
+    /// Live receiver for the server's [`ServingState`]. Tests typically
+    /// use [`wait_until`] / [`wait_until_serving`] /
+    /// [`wait_until_not_serving`] against this; immutable borrows after
+    /// waiting (e.g. `matches!(*state_rx.borrow(), ServingState::Serving)`)
+    /// work fine because `watch::Receiver` exposes both.
+    pub state_rx: watch::Receiver<ServingState>,
+    /// Handle for the task running [`Server::serve_with_listener`].
+    pub serve_handle: JoinHandle<Result<(), ServerError>>,
+    shutdown_tx: oneshot::Sender<()>,
+}
+
+impl BootedServer {
+    /// Send the shutdown signal and join the spawned task. Returns the
+    /// server's exit result. The send is best-effort: if the server has
+    /// already exited (for example because its leader-watch task died),
+    /// the receiver is gone and the send returns `Err` — that is the
+    /// expected outcome for those failure-mode tests, and the task's
+    /// recorded result is surfaced regardless.
+    pub async fn shutdown(self) -> Result<(), ServerError> {
+        let _ = self.shutdown_tx.send(());
+        match self.serve_handle.await {
+            Ok(result) => result,
+            Err(join_err) => {
+                if join_err.is_panic() {
+                    std::panic::resume_unwind(join_err.into_panic());
+                }
+                panic!("server task was cancelled before shutdown");
+            }
+        }
+    }
+}
+
+/// Bind `127.0.0.1:0`, capture the OS-picked port, and spawn `server` on it
+/// via [`Server::serve_with_listener`] with an explicit oneshot shutdown
+/// channel.
+///
+/// The caller drives the server to the desired [`ServingState`] by
+/// manipulating its [`tsoracle_consensus::ConsensusDriver`] and then awaits
+/// readiness through [`wait_until_serving`] / [`wait_for_grpc_handshake`].
+pub async fn boot_server(server: Server) -> BootedServer {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind 127.0.0.1:0 for test server");
+    let addr = listener
+        .local_addr()
+        .expect("local_addr on freshly bound listener");
+    let state_rx = server.state_rx.clone();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let serve_handle = tokio::spawn(async move {
+        server
+            .serve_with_listener(listener, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+    BootedServer {
+        addr,
+        state_rx,
+        serve_handle,
+        shutdown_tx,
+    }
+}
+
+/// Companion to [`BootedServer`] for tests that opt out of
+/// [`Server::serve_with_listener`] — typically because they invoke
+/// [`Server::into_router`] to manipulate or detach the leader-watch handle.
+pub struct BootedRouter {
+    pub addr: SocketAddr,
+    pub serve_handle: JoinHandle<Result<(), tonic::transport::Error>>,
+    shutdown_tx: oneshot::Sender<()>,
+}
+
+impl BootedRouter {
+    /// Send the shutdown signal and join the spawned task.
+    pub async fn shutdown(self) -> Result<(), tonic::transport::Error> {
+        let _ = self.shutdown_tx.send(());
+        match self.serve_handle.await {
+            Ok(result) => result,
+            Err(join_err) => {
+                if join_err.is_panic() {
+                    std::panic::resume_unwind(join_err.into_panic());
+                }
+                panic!("router task was cancelled before shutdown");
+            }
+        }
+    }
+
+    /// Abort the spawned task without graceful shutdown. Failpoints tests
+    /// that intentionally crash the watch task use this — the abort signal
+    /// must not mask the failure being observed.
+    pub fn abort(self) {
+        self.serve_handle.abort();
+    }
+}
+
+/// Bind `127.0.0.1:0` and spawn `routes` under a fresh `tonic::Server`
+/// via `serve_with_incoming_shutdown`. The shutdown future fires on the
+/// oneshot held by the returned [`BootedRouter`].
+pub async fn boot_router(routes: Routes) -> BootedRouter {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind 127.0.0.1:0 for test router");
+    let addr = listener
+        .local_addr()
+        .expect("local_addr on freshly bound listener");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let serve_handle = tokio::spawn(async move {
+        TonicServer::builder()
+            .add_routes(routes)
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+    BootedRouter {
+        addr,
+        serve_handle,
+        shutdown_tx,
+    }
+}
+
+/// Block until `state_rx` reports a value satisfying `predicate`.
+///
+/// Panics if the watch sender is dropped before `predicate` ever holds —
+/// that means the server's state stream closed unexpectedly and the test
+/// would otherwise wedge.
+pub async fn wait_until<F>(rx: &mut watch::Receiver<ServingState>, predicate: F)
+where
+    F: Fn(&ServingState) -> bool,
+{
+    loop {
+        if predicate(&rx.borrow_and_update()) {
+            return;
+        }
+        rx.changed()
+            .await
+            .expect("state stream closed before reaching expected state");
+    }
+}
+
+/// Convenience: wait for [`ServingState::Serving`].
+pub async fn wait_until_serving(rx: &mut watch::Receiver<ServingState>) {
+    wait_until(rx, |s| matches!(s, ServingState::Serving)).await;
+}
+
+/// Convenience: wait for any [`ServingState::NotServing`] variant.
+pub async fn wait_until_not_serving(rx: &mut watch::Receiver<ServingState>) {
+    wait_until(rx, |s| matches!(s, ServingState::NotServing { .. })).await;
+}
+
+/// Bridge the residual race between `ServingState::Serving` and tonic's
+/// accept future having been polled. Probes by opening a real gRPC channel
+/// (with bounded retry) until one succeeds.
+pub async fn wait_for_grpc_handshake(
+    addr: SocketAddr,
+    budget: Duration,
+) -> Result<(), tonic::transport::Error> {
+    let deadline = Instant::now() + budget;
+    let endpoint: Endpoint = format!("http://{addr}")
+        .parse()
+        .expect("constructed endpoint URI must parse");
+    let mut last_err: Option<tonic::transport::Error> = None;
+    loop {
+        match endpoint.connect().await {
+            Ok(channel) => {
+                drop(channel);
+                return Ok(());
+            }
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    return Err(last_err.unwrap_or(err));
+                }
+                last_err = Some(err);
+                sleep(Duration::from_millis(25)).await;
+            }
+        }
+    }
+}

--- a/crates/tsoracle-server/tests/e2e.rs
+++ b/crates/tsoracle-server/tests/e2e.rs
@@ -1,55 +1,11 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration, time::Instant};
-use tokio::net::TcpListener;
-use tokio::sync::watch;
-use tokio::time::sleep;
-use tonic::transport::Endpoint;
+use std::{sync::Arc, time::Duration};
 use tsoracle_core::Epoch;
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
-use tsoracle_server::{Server, ServingState, test_fakes::InMemoryDriver};
-
-/// Block until `state_rx` reports the expected `ServingState`. Replaces
-/// `sleep(50ms)` — a real readiness signal rather than a hopeful delay.
-async fn wait_until<F>(rx: &mut watch::Receiver<ServingState>, predicate: F)
-where
-    F: Fn(&ServingState) -> bool,
-{
-    loop {
-        if predicate(&rx.borrow_and_update()) {
-            return;
-        }
-        rx.changed()
-            .await
-            .expect("state stream closed before reaching expected state");
-    }
-}
-
-/// Bridge the residual race between "state_rx published the expected state"
-/// and "tonic's accept future has been polled and is handling HTTP/2".
-/// Probes by opening a real gRPC channel; once one succeeds, the test's own
-/// client connection will too.
-async fn wait_for_grpc_handshake(
-    addr: SocketAddr,
-    budget: Duration,
-) -> Result<(), tonic::transport::Error> {
-    let deadline = Instant::now() + budget;
-    let endpoint: Endpoint = format!("http://{addr}").parse().unwrap();
-    let mut last_err: Option<tonic::transport::Error> = None;
-    loop {
-        match endpoint.connect().await {
-            Ok(channel) => {
-                drop(channel);
-                return Ok(());
-            }
-            Err(err) => {
-                if Instant::now() >= deadline {
-                    return Err(last_err.unwrap_or(err));
-                }
-                last_err = Some(err);
-                sleep(Duration::from_millis(25)).await;
-            }
-        }
-    }
-}
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{
+    boot_server, wait_for_grpc_handshake, wait_until, wait_until_serving,
+};
+use tsoracle_server::{Server, ServingState};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn end_to_end_get_ts() {
@@ -62,27 +18,15 @@ async fn end_to_end_get_ts() {
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let mut state_rx = server.state_rx.clone();
-
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve_handle = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = shutdown_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let mut booted = boot_server(server).await;
 
     driver.become_leader(Epoch(1));
-    wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
-    let mut client = TsoServiceClient::connect(format!("http://{local_addr}"))
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let resp = client
@@ -96,8 +40,7 @@ async fn end_to_end_get_ts() {
     // physical_ms must be at least wall-clock-now (the failover fence advances above it).
     assert!(resp.physical_ms > 1_700_000_000_000);
 
-    let _ = shutdown_tx.send(());
-    let _ = serve_handle.await;
+    booted.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -110,24 +53,12 @@ async fn returns_not_leader_with_hint() {
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let mut state_rx = server.state_rx.clone();
-
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve_handle = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = shutdown_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let mut booted = boot_server(server).await;
 
     driver.become_follower(Some("10.9.8.7:50551".into()));
     // Wait for the follower hint to actually be visible in state — distinct
     // from the initial NotServing { leader_endpoint: None }.
-    wait_until(&mut state_rx, |s| {
+    wait_until(&mut booted.state_rx, |s| {
         matches!(
             s,
             ServingState::NotServing {
@@ -136,11 +67,11 @@ async fn returns_not_leader_with_hint() {
         )
     })
     .await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
-    let mut client = TsoServiceClient::connect(format!("http://{local_addr}"))
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let status = client.get_ts(GetTsRequest { count: 1 }).await.unwrap_err();
@@ -148,6 +79,5 @@ async fn returns_not_leader_with_hint() {
     let hint = decode(&status).expect("trailer present");
     assert_eq!(hint.leader_endpoint.as_deref(), Some("10.9.8.7:50551"));
 
-    let _ = shutdown_tx.send(());
-    let _ = serve_handle.await;
+    booted.shutdown().await.unwrap();
 }

--- a/crates/tsoracle-server/tests/embedded_router.rs
+++ b/crates/tsoracle-server/tests/embedded_router.rs
@@ -1,49 +1,9 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration, time::Instant};
-use tokio::net::TcpListener;
-use tokio::sync::watch;
-use tokio::time::sleep;
-use tonic::transport::{Endpoint, Server as TonicServer, server::TcpIncoming};
+use std::{sync::Arc, time::Duration};
 use tsoracle_core::Epoch;
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
-use tsoracle_server::{Server, ServingState, test_fakes::InMemoryDriver};
-
-async fn wait_until<F>(rx: &mut watch::Receiver<ServingState>, predicate: F)
-where
-    F: Fn(&ServingState) -> bool,
-{
-    loop {
-        if predicate(&rx.borrow_and_update()) {
-            return;
-        }
-        rx.changed()
-            .await
-            .expect("state stream closed before reaching expected state");
-    }
-}
-
-async fn wait_for_grpc_handshake(
-    addr: SocketAddr,
-    budget: Duration,
-) -> Result<(), tonic::transport::Error> {
-    let deadline = Instant::now() + budget;
-    let endpoint: Endpoint = format!("http://{addr}").parse().unwrap();
-    let mut last_err: Option<tonic::transport::Error> = None;
-    loop {
-        match endpoint.connect().await {
-            Ok(channel) => {
-                drop(channel);
-                return Ok(());
-            }
-            Err(err) => {
-                if Instant::now() >= deadline {
-                    return Err(last_err.unwrap_or(err));
-                }
-                last_err = Some(err);
-                sleep(Duration::from_millis(25)).await;
-            }
-        }
-    }
-}
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{boot_router, wait_for_grpc_handshake, wait_until_serving};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn embedded_router_serves_via_caller_owned_listener() {
@@ -58,28 +18,15 @@ async fn embedded_router_serves_via_caller_owned_listener() {
     let mut state_rx = tsoracle.state_rx.clone();
     let (router, _leader_watch) = tsoracle.into_router();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let incoming = TcpIncoming::from(listener);
-
-    let (sd_tx, sd_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve = tokio::spawn(async move {
-        TonicServer::builder()
-            .add_routes(router)
-            .serve_with_incoming_shutdown(incoming, async {
-                let _ = sd_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let booted = boot_router(router).await;
 
     driver.become_leader(Epoch(1));
-    wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_until_serving(&mut state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
-    let mut client = TsoServiceClient::connect(format!("http://{local_addr}"))
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let resp = client
@@ -90,6 +37,5 @@ async fn embedded_router_serves_via_caller_owned_listener() {
     assert_eq!(resp.count, 1);
     assert_eq!(resp.epoch, 1);
 
-    let _ = sd_tx.send(());
-    let _ = serve.await;
+    booted.shutdown().await.unwrap();
 }

--- a/crates/tsoracle-server/tests/extension_stampede.rs
+++ b/crates/tsoracle-server/tests/extension_stampede.rs
@@ -9,18 +9,16 @@
 
 use core::pin::Pin;
 use futures::Stream;
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
-use tokio::net::TcpListener;
+use std::time::Duration;
 use tokio::sync::Barrier;
-use tokio::time::sleep;
-use tonic::transport::Endpoint;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::{Epoch, testing::MockClock};
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
-use tsoracle_server::{Server, ServingState, test_fakes::InMemoryDriver};
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{boot_server, wait_for_grpc_handshake, wait_until_serving};
 
 /// Wraps `InMemoryDriver` to count `persist_high_water` calls and inject a
 /// configurable delay, so concurrent stampeders pile up inside the extension
@@ -64,39 +62,6 @@ impl ConsensusDriver for StampedeProbeDriver {
     }
 }
 
-async fn wait_until_serving(rx: &mut tokio::sync::watch::Receiver<ServingState>) {
-    loop {
-        if matches!(*rx.borrow_and_update(), ServingState::Serving) {
-            return;
-        }
-        rx.changed().await.unwrap();
-    }
-}
-
-async fn wait_for_grpc_handshake(
-    addr: SocketAddr,
-    budget: Duration,
-) -> Result<(), tonic::transport::Error> {
-    let deadline = Instant::now() + budget;
-    let endpoint: Endpoint = format!("http://{addr}").parse().unwrap();
-    let mut last_err: Option<tonic::transport::Error> = None;
-    loop {
-        match endpoint.connect().await {
-            Ok(channel) => {
-                drop(channel);
-                return Ok(());
-            }
-            Err(err) => {
-                if Instant::now() >= deadline {
-                    return Err(last_err.unwrap_or(err));
-                }
-                last_err = Some(err);
-                sleep(Duration::from_millis(25)).await;
-            }
-        }
-    }
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn extension_stampede_coalesces_to_single_persist() {
     const STAMPEDE_SIZE: usize = 50;
@@ -116,23 +81,11 @@ async fn extension_stampede_coalesces_to_single_persist() {
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let mut state_rx = server.state_rx.clone();
-
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve_handle = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = shutdown_rx.await;
-            })
-            .await
-            .unwrap();
-    });
+    let mut booted = boot_server(server).await;
 
     in_memory.become_leader(Epoch(1));
-    wait_until_serving(&mut state_rx).await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
@@ -143,7 +96,7 @@ async fn extension_stampede_coalesces_to_single_persist() {
     // attempt hits WindowExhausted.
     clock.set(10_000);
 
-    let client = TsoServiceClient::connect(format!("http://{local_addr}"))
+    let client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let barrier = Arc::new(Barrier::new(STAMPEDE_SIZE));
@@ -172,6 +125,5 @@ async fn extension_stampede_coalesces_to_single_persist() {
          stampeders, observed {extensions} — single-flight is not engaged"
     );
 
-    let _ = shutdown_tx.send(());
-    let _ = serve_handle.await;
+    booted.shutdown().await.unwrap();
 }

--- a/crates/tsoracle-server/tests/failpoints.rs
+++ b/crates/tsoracle-server/tests/failpoints.rs
@@ -1,47 +1,15 @@
-#![cfg(all(feature = "failpoints", feature = "test-fakes"))]
+#![cfg(all(feature = "failpoints", feature = "test-support"))]
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::watch;
-use tonic::transport::Endpoint;
 use tsoracle_core::Epoch;
 use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{
+    boot_router, wait_for_grpc_handshake, wait_until, wait_until_serving,
+};
 use tsoracle_server::{Server, ServerError, ServingState};
 
 static FAILPOINT_TEST_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-/// Block until `state_rx` reports the expected `ServingState`.
-async fn wait_until<F>(rx: &mut watch::Receiver<ServingState>, predicate: F)
-where
-    F: Fn(&ServingState) -> bool,
-{
-    loop {
-        if predicate(&rx.borrow_and_update()) {
-            return;
-        }
-        rx.changed()
-            .await
-            .expect("state stream closed before reaching expected state");
-    }
-}
-
-/// Bridge the residual race between "state_rx published Serving" and tonic's
-/// accept future having been polled. Probes by opening a real gRPC channel
-/// until one succeeds.
-async fn wait_for_grpc_handshake(addr: SocketAddr, budget: Duration) {
-    let deadline = Instant::now() + budget;
-    let endpoint: Endpoint = format!("http://{addr}").parse().unwrap();
-    loop {
-        if endpoint.connect().await.is_ok() {
-            return;
-        }
-        if Instant::now() >= deadline {
-            panic!("tonic never accepted gRPC handshake within {budget:?}");
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-}
 
 /// `server::fence::after_load_before_persist` fires inside `run_leader_watch`,
 /// between `consensus.load_high_water()` and `consensus.persist_high_water()`.
@@ -159,24 +127,21 @@ async fn panic_after_serving_published_poisons_state_when_handle_dropped() {
     // abort — aborting would cancel the task before it ever runs.
     drop(watch_handle);
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let serve = tokio::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_routes(routes)
-            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
-            .await
-    });
+    let booted = boot_router(routes).await;
 
     fail::cfg("server::fence::after_serving_published", "panic").unwrap();
     driver.become_leader(Epoch(1));
 
-    wait_for_grpc_handshake(addr, Duration::from_secs(5)).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
 
-    let mut client =
-        tsoracle_proto::v1::tso_service_client::TsoServiceClient::connect(format!("http://{addr}"))
-            .await
-            .unwrap();
+    let mut client = tsoracle_proto::v1::tso_service_client::TsoServiceClient::connect(format!(
+        "http://{}",
+        booted.addr
+    ))
+    .await
+    .unwrap();
 
     // After the panic, the catch_unwind branch calls step_down, which
     // publishes NotServing. Without the fix, state would stay Serving and
@@ -204,7 +169,7 @@ async fn panic_after_serving_published_poisons_state_when_handle_dropped() {
         }
     }
 
-    serve.abort();
+    booted.abort();
 }
 
 /// `server::service::before_allocate` fires at the top of `get_ts`,
@@ -226,20 +191,15 @@ async fn before_allocate_sleep_delays_get_ts() {
     let mut state_rx = server.state_rx.clone();
     let (routes, _watch_handle) = server.into_router();
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let serve = tokio::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_routes(routes)
-            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
-            .await
-    });
+    let booted = boot_router(routes).await;
 
     driver.become_leader(Epoch(1));
-    wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
-    wait_for_grpc_handshake(addr, Duration::from_secs(5)).await;
+    wait_until_serving(&mut state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
 
-    let endpoint = format!("http://{addr}");
+    let endpoint = format!("http://{}", booted.addr);
     let client = tsoracle_client::Client::connect(vec![endpoint])
         .await
         .unwrap();
@@ -261,7 +221,7 @@ async fn before_allocate_sleep_delays_get_ts() {
     );
 
     drop(client);
-    serve.abort();
+    booted.abort();
 }
 
 /// `server::service::extension_gate_held` fires at the top of the
@@ -289,20 +249,15 @@ async fn extension_gate_held_sleep_delays_get_ts() {
     let mut state_rx = server.state_rx.clone();
     let (routes, _watch_handle) = server.into_router();
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let serve = tokio::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_routes(routes)
-            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
-            .await
-    });
+    let booted = boot_router(routes).await;
 
     driver.become_leader(Epoch(1));
     wait_until(&mut state_rx, |s| matches!(s, ServingState::Serving)).await;
-    wait_for_grpc_handshake(addr, Duration::from_secs(5)).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
 
-    let endpoint = format!("http://{addr}");
+    let endpoint = format!("http://{}", booted.addr);
     let client = tsoracle_client::Client::connect(vec![endpoint])
         .await
         .unwrap();
@@ -324,5 +279,5 @@ async fn extension_gate_held_sleep_delays_get_ts() {
     );
 
     drop(client);
-    serve.abort();
+    booted.abort();
 }

--- a/crates/tsoracle-server/tests/leadership_churn.rs
+++ b/crates/tsoracle-server/tests/leadership_churn.rs
@@ -16,17 +16,17 @@
 use core::pin::Pin;
 use futures::Stream;
 use parking_lot::Mutex;
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
-use tokio::net::TcpListener;
-use tokio::time::sleep;
-use tonic::transport::Endpoint;
+use std::time::Duration;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::{Epoch, testing::MockClock};
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
-use tsoracle_server::{Server, ServerError, ServingState, test_fakes::InMemoryDriver};
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{
+    BootedServer, boot_server, wait_for_grpc_handshake, wait_until_not_serving, wait_until_serving,
+};
+use tsoracle_server::{Server, ServerError, ServingState};
 
 /// Wraps `InMemoryDriver` and lets a test inject one specific error from the
 /// next `persist_high_water` call after the leader-transition fence has been
@@ -110,60 +110,12 @@ impl ConsensusDriver for FaultyLoadDriver {
     }
 }
 
-async fn wait_until_serving(rx: &mut tokio::sync::watch::Receiver<ServingState>) {
-    loop {
-        if matches!(*rx.borrow_and_update(), ServingState::Serving) {
-            return;
-        }
-        rx.changed().await.unwrap();
-    }
-}
-
-async fn wait_until_not_serving(rx: &mut tokio::sync::watch::Receiver<ServingState>) {
-    loop {
-        if matches!(*rx.borrow_and_update(), ServingState::NotServing { .. }) {
-            return;
-        }
-        rx.changed().await.unwrap();
-    }
-}
-
-async fn wait_for_grpc_handshake(
-    addr: SocketAddr,
-    budget: Duration,
-) -> Result<(), tonic::transport::Error> {
-    let deadline = Instant::now() + budget;
-    let endpoint: Endpoint = format!("http://{addr}").parse().unwrap();
-    let mut last_err: Option<tonic::transport::Error> = None;
-    loop {
-        match endpoint.connect().await {
-            Ok(channel) => {
-                drop(channel);
-                return Ok(());
-            }
-            Err(err) => {
-                if Instant::now() >= deadline {
-                    return Err(last_err.unwrap_or(err));
-                }
-                last_err = Some(err);
-                sleep(Duration::from_millis(25)).await;
-            }
-        }
-    }
-}
-
 /// Boot a server with the given driver, drive it to `Serving`, and force the
 /// clock past the seeded high-water so the next `GetTs` triggers an extension.
 async fn boot_serving<D: ConsensusDriver + 'static>(
     driver: Arc<D>,
     in_memory_for_leader: &InMemoryDriver,
-) -> (
-    SocketAddr,
-    Arc<MockClock>,
-    tokio::sync::watch::Receiver<ServingState>,
-    tokio::task::JoinHandle<Result<(), ServerError>>,
-    tokio::sync::oneshot::Sender<()>,
-) {
+) -> (BootedServer, Arc<MockClock>) {
     let clock = Arc::new(MockClock::new(1_000));
     let server = Server::builder()
         .consensus_driver(driver)
@@ -173,23 +125,11 @@ async fn boot_serving<D: ConsensusDriver + 'static>(
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    let state_rx = server.state_rx.clone();
-    let mut state_rx_for_wait = state_rx.clone();
-
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let serve_handle = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = shutdown_rx.await;
-            })
-            .await
-    });
+    let mut booted = boot_server(server).await;
 
     in_memory_for_leader.become_leader(Epoch(1));
-    wait_until_serving(&mut state_rx_for_wait).await;
-    wait_for_grpc_handshake(local_addr, Duration::from_secs(5))
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");
 
@@ -197,7 +137,7 @@ async fn boot_serving<D: ConsensusDriver + 'static>(
     // WindowExhausted and triggers extend_window.
     clock.set(1_000_000);
 
-    (local_addr, clock, state_rx, serve_handle, shutdown_tx)
+    (booted, clock)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -210,10 +150,9 @@ async fn extend_window_maps_not_leader_to_failed_precondition_with_hint() {
         },
     ));
 
-    let (addr, _clock, mut state_rx, serve_handle, shutdown_tx) =
-        boot_serving(faulty.clone(), &in_memory).await;
+    let (mut booted, _clock) = boot_serving(faulty.clone(), &in_memory).await;
 
-    let mut client = TsoServiceClient::connect(format!("http://{addr}"))
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let status = client
@@ -233,7 +172,7 @@ async fn extend_window_maps_not_leader_to_failed_precondition_with_hint() {
     assert!(hint.leader_endpoint.is_none());
 
     // Allocator must have been cleared (no current epoch).
-    wait_until_not_serving(&mut state_rx).await;
+    wait_until_not_serving(&mut booted.state_rx).await;
 
     // A second request should now hit the fast NOT_LEADER gate (no second
     // consensus call), so persist count stays at the same value as after the
@@ -246,8 +185,7 @@ async fn extend_window_maps_not_leader_to_failed_precondition_with_hint() {
         "post-step_down requests must not contact consensus"
     );
 
-    let _ = shutdown_tx.send(());
-    let _ = serve_handle.await;
+    booted.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -261,10 +199,9 @@ async fn extend_window_maps_fenced_to_failed_precondition_with_hint() {
         },
     ));
 
-    let (addr, _clock, mut state_rx, serve_handle, shutdown_tx) =
-        boot_serving(faulty.clone(), &in_memory).await;
+    let (mut booted, _clock) = boot_serving(faulty.clone(), &in_memory).await;
 
-    let mut client = TsoServiceClient::connect(format!("http://{addr}"))
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let status = client
@@ -276,10 +213,9 @@ async fn extend_window_maps_fenced_to_failed_precondition_with_hint() {
     let _hint = tsoracle_server::__priv_decode_leader_hint(&status)
         .expect("leader hint metadata must be present for Fenced");
 
-    wait_until_not_serving(&mut state_rx).await;
+    wait_until_not_serving(&mut booted.state_rx).await;
 
-    let _ = shutdown_tx.send(());
-    let _ = serve_handle.await;
+    booted.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -290,10 +226,9 @@ async fn extend_window_maps_transient_driver_to_unavailable() {
         ConsensusError::TransientDriver(Box::new(std::io::Error::other("flap"))),
     ));
 
-    let (addr, _clock, state_rx, serve_handle, shutdown_tx) =
-        boot_serving(faulty.clone(), &in_memory).await;
+    let (booted, _clock) = boot_serving(faulty.clone(), &in_memory).await;
 
-    let mut client = TsoServiceClient::connect(format!("http://{addr}"))
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let status = client
@@ -308,10 +243,9 @@ async fn extend_window_maps_transient_driver_to_unavailable() {
     );
     // Crucially: transient driver errors must NOT step the server down —
     // there is no evidence the epoch is stale.
-    assert!(matches!(*state_rx.borrow(), ServingState::Serving));
+    assert!(matches!(*booted.state_rx.borrow(), ServingState::Serving));
 
-    let _ = shutdown_tx.send(());
-    let _ = serve_handle.await;
+    booted.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -322,10 +256,9 @@ async fn extend_window_maps_permanent_driver_to_internal() {
         ConsensusError::PermanentDriver(Box::new(std::io::Error::other("corrupted"))),
     ));
 
-    let (addr, _clock, state_rx, serve_handle, shutdown_tx) =
-        boot_serving(faulty.clone(), &in_memory).await;
+    let (booted, _clock) = boot_serving(faulty.clone(), &in_memory).await;
 
-    let mut client = TsoServiceClient::connect(format!("http://{addr}"))
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
         .await
         .unwrap();
     let status = client
@@ -340,10 +273,9 @@ async fn extend_window_maps_permanent_driver_to_internal() {
     );
     // Permanent driver errors do not step the server down either: the
     // server has no proof the epoch is stale, only that the driver is sick.
-    assert!(matches!(*state_rx.borrow(), ServingState::Serving));
+    assert!(matches!(*booted.state_rx.borrow(), ServingState::Serving));
 
-    let _ = shutdown_tx.send(());
-    let _ = serve_handle.await;
+    booted.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -356,25 +288,20 @@ async fn serve_with_shutdown_exits_when_watch_returns_error() {
         .clock(Arc::new(MockClock::new(1_000)))
         .build()
         .unwrap();
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let state_rx = server.state_rx.clone();
 
-    // No user shutdown — pending forever. The only way out is for the watch
-    // task to die, which should trigger our tonic-cancel and propagate the
-    // error. Uses serve_with_listener so we own the bound socket and don't
-    // race the server's rebind.
-    let serve_handle = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, futures::future::pending::<()>())
-            .await
-    });
+    // No user shutdown — the only way out is for the watch task to die,
+    // triggering tonic-cancel inside `serve_with_listener`. We move
+    // `serve_handle` out and observe it directly; the rest of `booted`
+    // (including its still-armed shutdown oneshot) stays in scope so the
+    // sender isn't dropped — dropping it would close `shutdown_rx` and
+    // resolve the user-shutdown future, masking the watch-task-death exit
+    // path this test pins.
+    let booted = boot_server(server).await;
+    let state_rx = booted.state_rx.clone();
 
     in_memory.become_leader(Epoch(1));
 
-    // serve_with_shutdown should complete with Err — load_high_water fails
-    // on the leader transition, run_leader_watch returns Err, the spawn
-    // wrapper poisons state and returns the error.
-    let outcome = tokio::time::timeout(Duration::from_secs(5), serve_handle)
+    let outcome = tokio::time::timeout(Duration::from_secs(5), booted.serve_handle)
         .await
         .expect("serve_with_shutdown must return when watch dies")
         .expect("join")

--- a/crates/tsoracle-server/tests/serve_with_listener.rs
+++ b/crates/tsoracle-server/tests/serve_with_listener.rs
@@ -3,9 +3,11 @@
 //! clients connect.
 
 use std::sync::Arc;
-use tokio::net::TcpListener;
+use std::time::Duration;
 use tsoracle_core::Epoch;
-use tsoracle_server::{Server, ServingState, test_fakes::InMemoryDriver};
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{boot_server, wait_for_grpc_handshake, wait_until_serving};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn serve_with_listener_uses_caller_owned_socket() {
@@ -17,34 +19,16 @@ async fn serve_with_listener_uses_caller_owned_socket() {
         .build()
         .unwrap();
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let local_addr = listener.local_addr().unwrap();
-    assert_ne!(local_addr.port(), 0, "OS must have picked a real port");
+    let mut booted = boot_server(server).await;
+    assert_ne!(booted.addr.port(), 0, "OS must have picked a real port");
 
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    // Clone state_rx before moving server into the spawn.
-    let mut state_rx = server.state_rx.clone();
-    let server_handle = tokio::spawn(async move {
-        server
-            .serve_with_listener(listener, async {
-                let _ = shutdown_rx.await;
-            })
-            .await
-    });
-
-    // Wait for the server to reach Serving rather than sleeping a fixed delay.
-    loop {
-        if matches!(*state_rx.borrow_and_update(), ServingState::Serving) {
-            break;
-        }
-        state_rx
-            .changed()
-            .await
-            .expect("state stream closed before Serving");
-    }
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
 
     // Make a real client call against the captured port.
-    let endpoint = format!("http://{local_addr}");
+    let endpoint = format!("http://{}", booted.addr);
     let client = tsoracle_client::Client::connect(vec![endpoint])
         .await
         .expect("client connect");
@@ -57,7 +41,5 @@ async fn serve_with_listener_uses_caller_owned_socket() {
     );
 
     drop(client);
-    let _ = shutdown_tx.send(());
-    let result = server_handle.await.expect("join");
-    assert!(result.is_ok(), "server exited Err: {result:?}");
+    booted.shutdown().await.expect("server exited Err");
 }


### PR DESCRIPTION
## Summary

Adds `tsoracle_server::test_support` behind a new `test-support` feature, then migrates every `TcpListener::bind("127.0.0.1:0")` site across the `tsoracle-server` and `tsoracle-client` integration tests to use it. Closes both #11 and #23 in one change (the helper #11 would have produced is the same helper #23 needed to fold into).

## What the helper covers

- `boot_server(server) -> BootedServer` — bind, capture local addr, spawn `Server::serve_with_listener` with an explicit oneshot shutdown.
- `boot_router(routes) -> BootedRouter` — equivalent for tests that opt out of `serve_with_listener` (e.g. `into_router` + tonic). Exposes `shutdown()` *and* `abort()`, the latter for failpoints tests that intentionally bypass graceful shutdown.
- `wait_until` / `wait_until_serving` / `wait_until_not_serving` / `wait_for_grpc_handshake` — the four wait/probe helpers previously copy-pasted across six files.

Module sits at `crates/tsoracle-server/src/test_support.rs`, mirroring the existing `test_fakes` module pattern. The `test-support` feature implies `test-fakes`, so `[[test]]` `required-features` only need to list `test-support`. `tsoracle-client` already had a dev-dep on `tsoracle-server` with `test-fakes`; bumped to `test-support`.

## Migration coverage

16 bind sites migrated across 8 files:

| File | Sites | Pattern |
|---|---|---|
| `tsoracle-server/tests/serve_with_listener.rs` | 1 | `boot_server` |
| `tsoracle-server/tests/e2e.rs` | 2 | `boot_server` |
| `tsoracle-server/tests/extension_stampede.rs` | 1 | `boot_server` |
| `tsoracle-server/tests/embedded_router.rs` | 1 | `boot_router` |
| `tsoracle-server/tests/leadership_churn.rs` | 2 | `boot_server` |
| `tsoracle-server/tests/failpoints.rs` | **3** | `boot_router` + `abort()` |
| `tsoracle-client/tests/e2e.rs` | 5 | `boot_server` |
| `tsoracle-client/tests/freshness.rs` | 1 | `boot_server` |

#23's strict acceptance criterion (no direct `TcpListener::bind` remains in `failpoints.rs`) is satisfied — including the third site at `failpoints.rs:292` that postdates #23's filing.

`tsoracle-server/tests/leader_watch.rs` has no bind site and stays on `test-fakes` only. `tsoracle-bin/tests/smoke.rs` is intentionally untouched: it uses `TcpListener::bind` to *reserve* a port for a production-binary subprocess, which is a fundamentally different shape from the in-process server bootstrap.

Net diff: `+397 / -593` across 12 files (`+222` of the additions are the new helper module).

## Design notes

- `boot_server` takes an *already-built* `Server`. Tests still configure their `Server::builder()` (window_ahead, failover_advance, clock, custom drivers). A higher-level `boot_in_memory_leader()` sugar was considered and rejected — every site has meaningful per-call config, so sugar would only fit the simplest tests and create two ways to do the same thing.
- `BootedServer::state_rx` is a public field, not a method, because tests need both `&mut` access (for `wait_until_*`) and `&` access (for `assert!(matches!(*state_rx.borrow(), Serving))`). Standard Rust borrow patterns handle both.
- `serve_with_shutdown_exits_when_watch_returns_error` in `leadership_churn.rs` uses a subtle partial-move-out-of-public-fields idiom (commented in-file): it moves `serve_handle` out of `booted` but keeps `booted` in scope so the private `shutdown_tx` is *not* dropped. Dropping it would close `shutdown_rx` and resolve the user-shutdown branch, masking the watch-task-death exit path the test pins.
- Failpoints tests deliberately call `BootedRouter::abort()` rather than `shutdown()` — a clean shutdown could race with the panic-propagation logic they're verifying.

## Test plan

- [x] `cargo test -p tsoracle-server --features test-support --features failpoints` (3 unit + 17 integration tests pass, including all 5 failpoints)
- [x] `cargo test -p tsoracle-client` (12 unit + 5 integration tests pass)
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo clippy -p tsoracle-server --features test-support --features failpoints --tests -- -D warnings`
- [x] `cargo clippy -p tsoracle-client --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `grep -rn 'TcpListener::bind' crates/{tsoracle-server,tsoracle-client}/tests` returns zero hits

Closes #11
Closes #23