### PR TITLE
chore: pre-seed per-crate CHANGELOG.md files

### DIFF
--- a/crates/tsoracle-bin/CHANGELOG.md
+++ b/crates/tsoracle-bin/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-client/CHANGELOG.md
+++ b/crates/tsoracle-client/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-consensus/CHANGELOG.md
+++ b/crates/tsoracle-consensus/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-core/CHANGELOG.md
+++ b/crates/tsoracle-core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-driver-file/CHANGELOG.md
+++ b/crates/tsoracle-driver-file/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-driver-openraft/CHANGELOG.md
+++ b/crates/tsoracle-driver-openraft/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-openraft-toolkit/CHANGELOG.md
+++ b/crates/tsoracle-openraft-toolkit/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-proto/CHANGELOG.md
+++ b/crates/tsoracle-proto/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.

--- a/crates/tsoracle-server/CHANGELOG.md
+++ b/crates/tsoracle-server/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-21
+
+Initial release.


### PR DESCRIPTION
## Summary

Backfill `CHANGELOG.md` in each of the nine publishable crates so release-plz stops warning about missing files on every run and so future GitHub Releases get non-empty bodies.

Each file uses the [Keep a Changelog](https://keepachangelog.com/spec/v1.1.0/) skeleton with two sections:
- `[Unreleased]` — where release-plz appends entries derived from conventional commits as they land on `main`.
- `[0.1.0] - 2026-05-21` — a single-line "Initial release" entry corresponding to the bootstrap publish.

Without this, release-plz logs `failed to parse changelog at path .../CHANGELOG.md: can't read changelog file` for each crate and the auto-generated GitHub Release body for every 0.1.0 tag is empty. The release pipeline itself is unaffected — this PR is hygiene, not a bug fix.

## Files added

- `crates/tsoracle-proto/CHANGELOG.md`
- `crates/tsoracle-core/CHANGELOG.md`
- `crates/tsoracle-openraft-toolkit/CHANGELOG.md`
- `crates/tsoracle-consensus/CHANGELOG.md`
- `crates/tsoracle-driver-file/CHANGELOG.md`
- `crates/tsoracle-driver-openraft/CHANGELOG.md`
- `crates/tsoracle-server/CHANGELOG.md`
- `crates/tsoracle-client/CHANGELOG.md`
- `crates/tsoracle-bin/CHANGELOG.md`

## Test plan

- [x] CI green on this PR
- [ ] After merge: confirm release-plz no longer emits `failed to parse changelog at path` warnings on its next run