### PR TITLE
fix(driver-openraft): declare rocksdb multi-threaded-cf feature explicitly

### DIFF
--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -35,7 +35,7 @@ postcard           = { workspace = true }
 # unification re-enables it for their builds.
 tsoracle-openraft-toolkit   = { path = "../tsoracle-openraft-toolkit", version = "0.1.0", default-features = false }
 parking_lot        = { workspace = true }
-rocksdb            = { workspace = true, optional = true }
+rocksdb            = { workspace = true, optional = true, features = ["multi-threaded-cf"] }
 serde              = { workspace = true }
 thiserror          = { workspace = true }
 tokio              = { workspace = true }


### PR DESCRIPTION
## Summary

- `tsoracle-driver-openraft`'s `snapshot_store::RocksdbSnapshotStore::cf_handle` returns `Arc<rocksdb::BoundColumnFamily<'_>>`, which is the `cf_handle` shape only when the `rocksdb` crate's `multi-threaded-cf` feature is on. Without it, `DB::cf_handle` returns `Option<&ColumnFamily>` and the crate fails to compile with an E0308 type mismatch at `crates/tsoracle-driver-openraft/src/snapshot_store.rs:141`.
- Workspace builds masked this because `tsoracle-openraft-toolkit` enables `rocksdb/multi-threaded-cf` on the shared workspace dep (`crates/tsoracle-openraft-toolkit/Cargo.toml:31`), and Cargo's feature unification leaks that feature into every workspace member that also names `rocksdb`. `make release-dry-run` packages this crate in isolation, the leak vanishes, the lib build sees single-threaded `cf_handle`, and the compile fails.
- This is a real consumer-visible bug too: anyone depending on `tsoracle-driver-openraft` (with its default `rocksdb-snapshot-store` feature) but not also pulling `tsoracle-openraft-toolkit/rocksdb-log-store` into the same compile graph would hit the same error.

The fix declares the `multi-threaded-cf` feature on this crate's own `rocksdb` dep so the lib's API expectations match what published-crate consumers will see, without relying on accidental feature unification from siblings.

## Discovery

Surfaced by `make release-dry-run`, which runs `cargo publish --dry-run` over each publishable crate in dep order and so builds each crate's packaged tarball in isolation. The exact rustc error before the fix:

```
error[E0308]: mismatched types
   --> src/snapshot_store.rs:141:13
expected `Result<Arc<BoundColumnFamily<'_>>, _>`, found `Result<&ColumnFamily, _>`
```

After the fix, `cargo publish --dry-run -p tsoracle-driver-openraft --allow-dirty` packages and compiles cleanly.

## Known follow-up (out of scope here)

`make release-dry-run` still fails further down the chain, on `tsoracle-server`, with an unrelated, pre-existing issue: the published `tsoracle-proto@0.1.0` on crates.io does not declare a `reflection` feature, but local `tsoracle-proto/Cargo.toml:18` adds `reflection = []` and `tsoracle-server/Cargo.toml:24` references `tsoracle-proto/reflection`. This will resolve when `tsoracle-proto` is next published (via the normal release-plz flow) with the feature. Tracking that separately to keep this PR focused.

## Test plan

- [x] `cargo publish --dry-run -p tsoracle-driver-openraft` (with the fix committed) — packages and compiles cleanly
- [x] `make release-dry-run` packages every crate up to and including `tsoracle-driver-openraft`; remaining failure is on `tsoracle-server` and unrelated to this change
- [x] Pre-commit hooks (`cargo fmt --check`, `cargo clippy`) pass