### PR TITLE
chore(release-plz): exclude tsoracle bin from release management

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,3 +30,19 @@ publish_no_verify = false
 # Off for now; flip to `true` (and `cargo install cargo-semver-checks`) once we
 # want automated semver-compat guarding on the release PR.
 semver_check = false
+
+# tsoracle (the bin) was published to crates.io as 0.1.0 from a commit whose
+# workspace `Cargo.toml` listed `examples/embedded-server` (et al.) as members
+# before those directories existed in the tree. `cargo package` fails at that
+# historical commit, which means release-plz cannot run its file-equality
+# comparison against the published version — and that error aborts the entire
+# release-pr step for the whole workspace, not just this one crate.
+#
+# Excluding the bin from release-plz management lets the other crates ride the
+# release-pr / release pipeline normally. To re-enable: manually
+# `cargo publish` a new `tsoracle` version from a commit where the workspace
+# `cargo metadata` succeeds (i.e. anything on or after the commit that added
+# the `examples/` directories), then drop this `[[package]]` block.
+[[package]]
+name = "tsoracle"
+release = false


### PR DESCRIPTION
## Summary

- Fixes the `release-plz PR` workflow failure on `main` (run [26249229179](https://github.com/prisma-risk/tsoracle/actions/runs/26249229179/job/77255642403)) caused by `tsoracle` v0.1.0 having been published to crates.io from a commit where the workspace `Cargo.toml` declared `examples/embedded-server`, `examples/failover-demo`, and `examples/openraft-cluster` as members **before** those directories existed in the tree.
- release-plz reads the crates.io \`.cargo_vcs_info.json\` for the published version, checks that commit out into a temp dir, and runs \`cargo package\` to do file-equality diffing against current main. That step aborts the entire \`release-plz PR\` job for the whole workspace whenever the historical commit's \`cargo metadata\` fails — so no other crate gets its release PR opened either.
- Sets \`release = false\` on the \`tsoracle\` bin so release-plz skips it entirely. The other workspace crates continue through the normal release-pr / release pipeline.

## How to undo this once the bin is republishable

1. From any commit on or after the one that added \`examples/\` (i.e. current \`main\` is fine), manually \`cargo publish -p tsoracle\` a new version (e.g. \`0.1.1\`). Bump \`crates/tsoracle-bin/Cargo.toml\` if needed first.
2. release-plz's compare base for \`tsoracle\` then becomes the new version's commit, which has a valid workspace.
3. Drop the \`[[package]]\` block from \`release-plz.toml\`.

## Test plan

- [x] \`release-plz.toml\` parses as valid TOML (verified via \`python3 -c 'tomllib.loads(...)'\`).
- [x] Pre-commit hooks (\`cargo fmt --check\`, \`cargo clippy\`) clean.
- [ ] After merge: confirm the next \`release-plz PR\` run on \`main\` completes successfully (opens a release PR for the other crates, skips \`tsoracle\`).