### PR TITLE
docs(readme): refresh feature highlights for current capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ A standalone timestamp oracle for Rust — strictly monotonic, gap-free integer 
 
 - 🔢 **Monotonic & gap-free** — every issued timestamp is strictly greater than the last; no skipped or repeated values, ever.
 - 🛡️ **Crash-safe** — window state is fsync'd before any timestamp in that window is handed out, so a restart never rewinds.
-- 🔌 **Pluggable consensus** — implement one trait (`ConsensusDriver`) to plug in openraft, raft-rs, etcd, or your own replicated log.
+- 🔌 **Pluggable consensus, openraft included** — `tsoracle-driver-openraft` ships a production-ready replicated driver; implement one trait (`ConsensusDriver`) to back tsoracle with raft-rs, etcd, or your own replicated log instead.
 - 📦 **gRPC client included** — `tsoracle-client` handles leader discovery, request coalescing, and reconnection for you.
+- 📈 **Operational metrics** — enable the `metrics` feature on `tsoracle-server` to emit allocator, leader, and request metrics through the `metrics` facade.
+- 🧪 **Hardened** — coverage-guided fuzzing on the postcard decoders, failpoint-driven crash tests, and a stress harness covering single-process and multi-process raft topologies.
 - 🧩 **Embeddable** — host the server inside your own binary with a few lines of Rust, or run the standalone CLI.
 
 ## Quickstart


### PR DESCRIPTION
## Summary

The Features section was last touched before the openraft driver, the metrics facade, and the fuzz/failpoints/stress investments landed, so it understates what tsoracle actually ships today.

- Reframe the consensus bullet so `tsoracle-driver-openraft` is presented as shipped rather than DIY.
- Add an **Operational metrics** bullet for the `metrics` feature on `tsoracle-server` (#41).
- Add a **Hardened** bullet covering coverage-guided fuzzing, failpoint crash tests, and the stress harness (single-process and multi-process raft topologies).

No other sections changed. The stale `cargo install tsoracle` situation in the Quickstart (see notes in `release-plz.toml`) is intentionally left for a separate decision.

## Test plan

- [ ] Render the updated README on GitHub and confirm the emoji + bold + em-dash layout still flows.
- [ ] Spot-check each new/changed claim against the tree:
  - `crates/tsoracle-driver-openraft/` exists and is the openraft-backed `ConsensusDriver`.
  - `crates/tsoracle-server/Cargo.toml` has the `metrics = ["dep:metrics"]` feature; emit sites in `crates/tsoracle-server/src/{fence,leader_hint,service}.rs` cover allocator (`window.*`), leader (`leader_transition.*`, `not_leader.*`), and request (`get_ts.*`) categories.
  - `fuzz/fuzz_targets/` contains the 8 coverage-guided targets.
  - `benchmarks/stress/` covers mem, in-process, and process raft topologies.