### PR TITLE
ci(release-plz): use a dedicated app token so PRs trigger CI

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,9 +18,30 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Mint a short-lived installation token from a tsoracle-dedicated
+      # GitHub App. Using a non-`GITHUB_TOKEN` credential is what makes the
+      # pushes, tags, and PR created by release-plz visible to other
+      # workflows: GitHub deliberately does not cascade workflows triggered
+      # by the default `GITHUB_TOKEN`, so without this step ci.yml would
+      # never run against release-plz's commits.
+      #
+      # The App is scoped to only this repository so the credential cannot
+      # touch the org's private repos. Prerequisites (one-time setup):
+      #   1. Create a GitHub App with Contents: Read+Write and Pull
+      #      requests: Read+Write permissions; install it on
+      #      `prisma-risk/tsoracle` only.
+      #   2. Add repo-level secrets `RELEASE_PLZ_APP_ID` (the App's numeric
+      #      ID) and `RELEASE_PLZ_APP_PRIVATE_KEY` (the full PEM, including
+      #      the `-----BEGIN/END-----` lines).
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: system deps
@@ -29,7 +50,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Opens or updates the release PR whenever main moves. The PR contains the
@@ -45,9 +66,17 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      # See `release` job above for the prerequisites the App token needs
+      # to mint successfully.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: system deps
@@ -56,5 +85,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,21 +18,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      # Mint a short-lived installation token from a tsoracle-dedicated
-      # GitHub App. Using a non-`GITHUB_TOKEN` credential is what makes the
-      # pushes, tags, and PR created by release-plz visible to other
-      # workflows: GitHub deliberately does not cascade workflows triggered
-      # by the default `GITHUB_TOKEN`, so without this step ci.yml would
-      # never run against release-plz's commits.
-      #
-      # The App is scoped to only this repository so the credential cannot
-      # touch the org's private repos. Prerequisites (one-time setup):
-      #   1. Create a GitHub App with Contents: Read+Write and Pull
-      #      requests: Read+Write permissions; install it on
-      #      `prisma-risk/tsoracle` only.
-      #   2. Add repo-level secrets `RELEASE_PLZ_APP_ID` (the App's numeric
-      #      ID) and `RELEASE_PLZ_APP_PRIVATE_KEY` (the full PEM, including
-      #      the `-----BEGIN/END-----` lines).
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
@@ -66,8 +51,6 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      # See `release` job above for the prerequisites the App token needs
-      # to mint successfully.
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:


### PR DESCRIPTION
## Summary

- Replaces \`secrets.GITHUB_TOKEN\` with a short-lived installation token minted from a tsoracle-dedicated GitHub App, so release-plz's PRs and pushes propagate as user-style events. Today GitHub deliberately does not cascade workflows triggered by the default \`GITHUB_TOKEN\` — that's why every release-plz PR opens with no CI, and we've been close+reopen'ing each one to kick off ci.yml.
- The App is scoped to **this repo only**, isolated from the org's private repos.
- Also passes the token to \`actions/checkout\` so any direct git operations in the workflow run under the same identity.

## DO NOT MERGE until prerequisites are set up

This PR will fail at the \`actions/create-github-app-token@v1\` step until the dedicated app exists and its credentials are in the repo's secrets. Sequence:

1. **Create a dedicated GitHub App** (https://github.com/settings/apps/new or https://github.com/organizations/prisma-risk/settings/apps if you want it owned by the org).
   - Name: anything (e.g. \`tsoracle-release-bot\`).
   - Homepage URL: this repo.
   - Webhook: **disable**.
   - Repository permissions: \`Contents: Read and write\`, \`Pull requests: Read and write\`. Leave everything else "No access".
   - "Where can this GitHub App be installed?": **Only on this account**.
2. **Generate a private key** on the App's settings page (downloads a \`.pem\`). Note the **App ID** (numeric, shown at the top of the App's page).
3. **Install the App** on \`prisma-risk/tsoracle\` (and only this repo).
4. **Add two repo secrets** at https://github.com/prisma-risk/tsoracle/settings/secrets/actions:
   - \`RELEASE_PLZ_APP_ID\` — the numeric App ID from step 2.
   - \`RELEASE_PLZ_APP_PRIVATE_KEY\` — the full PEM from the \`.pem\` file, including the \`-----BEGIN/END-----\` lines.

Once those exist, the next push to \`main\` after merging this PR will mint a token cleanly and release-plz's PRs will start triggering ci.yml automatically.

## Test plan

- [x] Prerequisites above are completed.
- [ ] After merge, watch the next \`release-plz PR\` workflow run on \`main\`. Expect the \`actions/create-github-app-token\` step to succeed (or fail loudly with an obvious "app not installed / wrong permissions" error if a prereq was missed).
- [ ] The next release-plz PR opened should show \`ci.yml\` checks running automatically — no manual close+reopen.
- [ ] Confirm the resulting release PR's commits appear authored by the App's bot identity (e.g. \`tsoracle-release-bot[bot]\`), not \`github-actions[bot]\`.