### PR TITLE
chore: gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /.worktrees/
+/.claude/
 **/*.rs.bk
 Cargo.lock.bak
 *.swp


### PR DESCRIPTION
Tooling under \`.claude/\` (worktree dirs, runtime artifacts) was showing up as
untracked in repo-level \`git status\`, which made \`cargo publish\`'s dirty-tree
check refuse to run from the repo root. Ignore the whole directory.