### PR TITLE
fix(stress): meaningful --ci-smoke output (counter, params, precision)

### DIFF
--- a/benchmarks/stress/README.md
+++ b/benchmarks/stress/README.md
@@ -63,7 +63,7 @@ The text report ends with:
 - `outcome=Ok | InvariantViolation | ...` — the headline result. Maps to the exit code below.
 - `violations: N` — how many invariant breaks the supervisor recorded.
 - `chaos events: N` — how many nemesis ops were applied.
-- `latency per client call` — percentiles aggregated across all client tasks. (Latency stats currently read as zeros; per-client histogram recording is a known follow-up — see "Known gaps" below.)
+- `latency per client call` — percentiles aggregated across all client tasks, sourced from the supervisor's hdrhistogram (one sample per successful batch, recorded on `batch_idx == 0` so each RPC contributes once regardless of `--batch-size`). Reads as zeros when no batches completed — typically because chaos kept the system down for the entire run (e.g. continuous kills against a 1-node topology, where every kill takes the whole service down).
 
 `--json` produces a one-line JSON report on stdout. Use this for CI parsing. `outcome` is the only field a workflow needs to key off; the rest is supporting evidence.
 

--- a/benchmarks/stress/src/bin/stress.rs
+++ b/benchmarks/stress/src/bin/stress.rs
@@ -144,10 +144,16 @@ fn build_config(a: &RunArgs) -> StressConfig {
         ci_smoke: a.ci_smoke,
     };
     if cfg.ci_smoke {
+        // Tuned so the smoke completes its warmup and measurement phase
+        // even on the worst-case topology (process + 1 node + killer-loop),
+        // where the single child is killed every 2s and healthy windows
+        // are only hundreds of milliseconds. The previous warmup of 1000
+        // RPCs across 16 clients was unachievable in those windows, so the
+        // smoke reported `outcome=Ok` with zero timestamps — a useless gate.
         cfg.duration = Some(Duration::from_secs(20));
-        cfg.clients = 16;
+        cfg.clients = 8;
         cfg.batch_size = 4;
-        cfg.warmup = 1_000;
+        cfg.warmup = 100;
         cfg.scenario = ScenarioKind::Named("killer-loop".into());
     }
     cfg

--- a/benchmarks/stress/src/lib.rs
+++ b/benchmarks/stress/src/lib.rs
@@ -315,7 +315,7 @@ pub fn run(cfg: StressConfig) -> Result<Report, anyhow::Error> {
         .map_err(|err| anyhow::anyhow!("supervisor join: {err:?}"))?;
 
     // Build report.
-    let timestamps = supervisor_outcome.events_observed;
+    let timestamps = supervisor_outcome.issued_observed;
     let batch_size = cfg.batch_size.max(1) as u64;
     let client_calls = timestamps / batch_size;
     let elapsed_secs = elapsed.as_secs_f64().max(1e-9);

--- a/benchmarks/stress/src/report.rs
+++ b/benchmarks/stress/src/report.rs
@@ -111,7 +111,7 @@ impl Report {
              outcome={outcome_str}\n\
              elapsed:       {:.3} s\n\
              recorded:      client_calls={} timestamps={}\n\
-             throughput:    client_calls/s: {:.0}        timestamps/s: {:.0}\n\
+             throughput:    client_calls/s: {:.2}        timestamps/s: {:.2}\n\
              latency per client call:\n  \
              p50: {} µs          p90: {} µs           p99: {} µs           p999: {} µs\n  \
              min: {} µs           max: {} µs          mean: {} µs\n\

--- a/benchmarks/stress/src/supervisor.rs
+++ b/benchmarks/stress/src/supervisor.rs
@@ -19,7 +19,10 @@ use crate::{HISTO_MAX_US, new_histogram};
 pub struct SupervisorOutcome {
     pub violations: Vec<Violation>,
     pub high_water: Timestamp,
-    pub events_observed: u64,
+    /// Count of `SupervisorEvent::Issued` events received — i.e. real
+    /// timestamps returned to clients. Excludes `Chaos`, `Liveness`, and
+    /// `End` events, which would otherwise inflate the count under chaos.
+    pub issued_observed: u64,
     /// Per-RPC latency in microseconds. One sample per batch (recorded on the
     /// first `IssuedSample` of each batch, since all samples in a batch share
     /// the same `issued_at`/`recv_time`). Values clamped to
@@ -57,7 +60,7 @@ struct SupervisorState {
     /// grace and fence-checked, so it can't be relied on after the fact.
     chaos_history: Vec<ChaosWindow>,
     violations: Vec<Violation>,
-    events_observed: u64,
+    issued_observed: u64,
     latency: Histogram<u64>,
 }
 
@@ -71,7 +74,7 @@ impl Default for SupervisorState {
             open_windows: Vec::new(),
             chaos_history: Vec::new(),
             violations: Vec::new(),
-            events_observed: 0,
+            issued_observed: 0,
             latency: new_histogram(),
         }
     }
@@ -107,9 +110,11 @@ impl Supervisor {
 
     pub async fn run(mut self, mut rx: mpsc::Receiver<SupervisorEvent>) -> SupervisorOutcome {
         while let Some(event) = rx.recv().await {
-            self.state.events_observed += 1;
             match event {
-                SupervisorEvent::Issued(sample) => self.on_issued(sample),
+                SupervisorEvent::Issued(sample) => {
+                    self.state.issued_observed += 1;
+                    self.on_issued(sample);
+                }
                 SupervisorEvent::Chaos(ev) => self.on_chaos(ev),
                 SupervisorEvent::Liveness(incident) => self.on_liveness(incident),
                 SupervisorEvent::End => break,
@@ -119,7 +124,7 @@ impl Supervisor {
         SupervisorOutcome {
             violations: self.state.violations,
             high_water: self.state.high_water,
-            events_observed: self.state.events_observed,
+            issued_observed: self.state.issued_observed,
             latency: self.state.latency,
         }
     }
@@ -376,6 +381,57 @@ mod tests {
         drop(tx);
         let outcome = handle.await.unwrap();
         assert!(outcome.violations.is_empty(), "no violations expected");
+        assert_eq!(outcome.issued_observed, 3);
+    }
+
+    #[tokio::test]
+    async fn issued_observed_excludes_non_issued_events() {
+        use crate::chaos::{ChaosEvent, ChaosKind, ChaosOutcome, ChaosWindow};
+        use crate::sample::{LivenessIncident, LivenessIncidentKind};
+        use std::time::Duration;
+        // Mix 2 Issued with 1 Chaos + 1 Liveness; the supervisor must count
+        // only the 2 Issued events as `issued_observed`. Pre-fix, the
+        // counter incremented for every mpsc event variant, inflating the
+        // user-visible "timestamps" by every chaos and liveness signal.
+        let (tx, rx) = mpsc::channel::<SupervisorEvent>(16);
+        let supervisor = Supervisor::new();
+        let handle = tokio::spawn(supervisor.run(rx));
+        tx.send(SupervisorEvent::Issued(sample(0, 1)))
+            .await
+            .unwrap();
+        let now = Instant::now();
+        tx.send(SupervisorEvent::Chaos(ChaosEvent {
+            window: ChaosWindow {
+                kind: ChaosKind::LeaderKill,
+                started_at: now,
+                ended_at: now + Duration::from_millis(10),
+                grace: Duration::from_millis(50),
+            },
+            outcome: ChaosOutcome::Applied,
+        }))
+        .await
+        .unwrap();
+        tx.send(SupervisorEvent::Issued(sample(0, 2)))
+            .await
+            .unwrap();
+        tx.send(SupervisorEvent::Liveness(LivenessIncident {
+            kind: LivenessIncidentKind::DeadlineExceeded {
+                client_id: ClientId(0),
+                attempts: 3,
+                last_error: "transient".into(),
+                started_at: now,
+            },
+            at: Instant::now(),
+        }))
+        .await
+        .unwrap();
+        tx.send(SupervisorEvent::End).await.unwrap();
+        drop(tx);
+        let outcome = handle.await.unwrap();
+        assert_eq!(
+            outcome.issued_observed, 2,
+            "must count only Issued events, not Chaos/Liveness"
+        );
     }
 
     #[tokio::test]

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -68,7 +68,7 @@ The text report ends with:
 - `outcome=Ok | InvariantViolation | ProgrammerError | HarnessError | Interrupted` — the headline. Maps to the exit code; see below.
 - `violations: N` — how many invariant breaks the supervisor recorded. `0` for a clean run.
 - `chaos events: N` — how many nemesis ops were applied during the run.
-- `latency per client call` — percentiles aggregated across all client tasks. (Currently reads zero; per-client histogram recording is a tracked follow-up. See `benchmarks/stress/README.md` § "Known gaps".)
+- `latency per client call` — percentiles aggregated across all client tasks, sourced from the supervisor's hdrhistogram (one sample per successful batch, recorded on `batch_idx == 0` so each RPC contributes once regardless of `--batch-size`). Reads as zeros when no batches completed — typically because chaos kept the system down for the entire run (e.g. continuous kills against a 1-node topology, where every kill takes the whole service down).
 
 `--json` produces a one-line JSON report; use this for CI parsing. `outcome` is the only field a workflow needs to key off; the rest is supporting evidence. (`--json-stream` is plumbed as a CLI flag for a future dashboard consumer but not yet honored by the report path.)
 


### PR DESCRIPTION
## Summary

Follow-up to #50.  That PR's stress-smoke job reported `outcome=Ok, timestamps=10, latency 0` on the `--topology process --ci-smoke --nodes 1` row — a misleading pass that didn't actually exercise the system.  Diagnosis surfaced four distinct defects, all fixed here:

1. **`events_observed` was mislabeled as `timestamps`**.  The supervisor incremented `events_observed` for every SupervisorEvent variant (Issued, Chaos, Liveness, End), but `lib.rs:318` reported it as the user-visible "timestamps" field.  Under killer-loop, chaos events inflated the count while masking that zero real batches completed.  Renamed to `issued_observed`, moved the increment into the `Issued` arm only.  New unit test `issued_observed_excludes_non_issued_events` proves a mix of 2 Issued + 1 Chaos + 1 Liveness yields `issued_observed == 2`.
2. **`--ci-smoke`'s warmup was unachievable on process+1-node**.  16 clients × 1000 warmup RPCs requires sustained healthy windows that don't exist when the single child is killed every 2s.  Reduced to clients=8 + warmup=100, matching the known-good unit-test smoke shape in `tests/smoke.rs`.
3. **Throughput format `{:.0}` truncated sub-1.0 rates**.  `0.1 → "0"` hid the symptom from item 2.  Switched to `{:.2}`.
4. **Stale README/docs note**.  Both `benchmarks/stress/README.md` and `docs/stress-testing.md` claimed latency "currently reads as zeros" with a follow-up note — but the per-RPC histogram recording path has existed in `supervisor.rs` since the first stress crate.  Rewrote both notes to describe the real failure mode (empty histogram from no completed batches, e.g. continuous kills against an undersized topology).

## Verification (local, on this branch)

Same command the user ran on the merged PR, before vs after:

| | Before (#50 merged) | After (this PR) |
|---|---|---|
| `client_calls` | 2 | **12,216** |
| `timestamps` | 10 | **48,864** |
| `timestamps/s` | `0` | **`2443.05`** |
| `latency p50` | `0 µs` | **`2409 µs`** |
| `latency p99` | `0 µs` | **`2749 µs`** |
| `transient retries` | 0 | **216** (proves kills landed) |
| `violations` | 0 | 0 (still clean) |

`client_calls × batch_size = 12216 × 4 = 48864 = timestamps` — exact, no integer truncation, confirming the counter fix.

mem and raft smokes also re-verified:
- `mem --ci-smoke`: 265,120 timestamps, 13,254/s, p50=2.4ms.
- `raft --ci-smoke --nodes 3`: 206,272 timestamps, 10,313/s, p50=2.4ms.

## Test plan

- [x] `stress-smoke` CI job (added in #50) passes on this PR with non-zero throughput + non-zero latency percentiles across all three topology rows.
- [x] Existing unit tests + new `issued_observed_excludes_non_issued_events` pass.