### PR TITLE
chore(release-plz): restore tsoracle bin to managed releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,19 +30,3 @@ publish_no_verify = false
 # Off for now; flip to `true` (and `cargo install cargo-semver-checks`) once we
 # want automated semver-compat guarding on the release PR.
 semver_check = false
-
-# tsoracle (the bin) was published to crates.io as 0.1.0 from a commit whose
-# workspace `Cargo.toml` listed `examples/embedded-server` (et al.) as members
-# before those directories existed in the tree. `cargo package` fails at that
-# historical commit, which means release-plz cannot run its file-equality
-# comparison against the published version — and that error aborts the entire
-# release-pr step for the whole workspace, not just this one crate.
-#
-# Excluding the bin from release-plz management lets the other crates ride the
-# release-pr / release pipeline normally. To re-enable: manually
-# `cargo publish` a new `tsoracle` version from a commit where the workspace
-# `cargo metadata` succeeds (i.e. anything on or after the commit that added
-# the `examples/` directories), then drop this `[[package]]` block.
-[[package]]
-name = "tsoracle"
-release = false


### PR DESCRIPTION
## Summary

- PR #47 set `release = false` for the `tsoracle` bin because its v0.1.0 on crates.io had been published from a commit (`7f189ce`) whose workspace `Cargo.toml` referenced `examples/embedded-server` (and friends) before those directories existed. release-plz's file-equality check against that historical state aborted the entire workspace release pipeline.
- `tsoracle 0.1.1` was just manually published from current main (a commit where the workspace is well-formed). Future release-plz cycles will now use 0.1.1 as the compare base, which resolves cleanly.
- Drop the `[[package]]` override so the bin rides the normal release-pr / release pipeline alongside the libs.

## Verification

- `tsoracle 0.1.1` exists on crates.io: https://crates.io/crates/tsoracle/0.1.1
- The 8 lib crates are also at 0.1.1 — the whole workspace is aligned.

## Test plan

- [ ] After merge, the next release-plz cycle should include `tsoracle` in its bullet list of crates being released, without aborting on package-equality.