### PR TITLE
chore(release-plz): only bump versions for user-visible commit types

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,3 +30,11 @@ publish_no_verify = false
 # Off for now; flip to `true` (and `cargo install cargo-semver-checks`) once we
 # want automated semver-compat guarding on the release PR.
 semver_check = false
+
+# Only open a release PR when the commits since the last release include at
+# least one user-visible change (`feat:`, `fix:`, `perf:` — with or without
+# scope or `!` breaking marker). Commits prefixed `chore:`, `ci:`, `docs:`,
+# `refactor:`, `style:`, `test:`, or `build:` don't trigger a release on
+# their own, but they still appear in the changelog under "Other" when a
+# real release does happen.
+release_commits = "^(feat|fix|perf)"


### PR DESCRIPTION
## Summary

release-plz's default opens a release PR for any new commit on `main`, regardless of conventional-commit prefix. That made it open a 0.1.2 release PR (#58, closed) immediately after the 0.1.1 sequence finished — the only commits since 0.1.1 were CI/release-plz housekeeping (#52, #53, #54, #56) with no user-visible source changes, so a 0.1.2 release would have been pure churn.

Set \`release_commits = `^(feat|fix|perf)` so the release PR only opens when at least one commit since the last release has a user-visible prefix:

- ✓ `feat:`, `feat(scope):`, `feat!:` — new features (minor bump)
- ✓ `fix:`, `fix(scope):`, `fix!:` — bug fixes (patch bump)
- ✓ `perf:` — performance improvements (patch bump)
- ✗ `chore:`, `ci:`, `docs:`, `refactor:`, `style:`, `test:`, `build:` — no release triggered by these alone

Non-matching commits still appear in the changelog under "Other" when a real release does happen — they just don't open a release PR on their own.

## Test plan

- [ ] After merge, a follow-up `ci:` or `chore:`-only push to `main` should NOT open a new release PR.
- [ ] The next `feat:` or `fix:` push should open a release PR including the chore/ci commits in the "Other" section of the changelog.