### PR TITLE
ci(release-plz): serialize the release job per-ref

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Queue serial — never cancel a publish in flight (a half-done publish
+    # could leave the repo with some crates released and others not).
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
The `release-pr` job already has a `concurrency:` block, but the `release` job didn't. Every push to `main` spawned a new release job in parallel — during the 0.1.1 sequence we ended up with four release jobs running at once, racing each other on the `cargo publish` steps. Today they happened to converge cleanly because publish on an already-published version no-ops, but it's wasted CI minutes and a real race waiting to happen (e.g., two jobs both deciding to publish the same not-yet-published crate concurrently — only one succeeds, the other errors and fails the job for spurious reasons).

This PR adds a `release-plz-release-${{ github.ref }}` concurrency group with `cancel-in-progress: false`:

- At most one release job runs per ref.
- Subsequent runs queue rather than cancel — never interrupt a publish in flight (could leave the repo with some crates released and others not).
- The `release-pr` job uses a different group (`release-plz-${{ github.ref }}`) so the two job kinds can still run in parallel with each other.