### PR TITLE
fix(make): use the tsoracle bin's package name, not its directory name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ RELEASE_CRATES := \
     tsoracle-driver-openraft \
     tsoracle-server \
     tsoracle-client \
-    tsoracle-bin
+    tsoracle
 
 .PHONY: all ci check fmt fmt-check lint fix build test test-failpoints doc \
         proto proto-lint proto-fmt proto-fmt-check proto-breaking \


### PR DESCRIPTION
`RELEASE_CRATES` passed each entry to `cargo publish -p <name>`, which expects the cargo package name (`[package].name`), not the crate's directory name. `crates/tsoracle-bin/Cargo.toml` sets `name = "tsoracle"` (the bin is the user-visible CLI command — its directory is just named `tsoracle-bin` to disambiguate from the workspace root). So `cargo publish -p tsoracle-bin` errored with \"package ID specification \\`tsoracle-bin\\` did not match any packages\" and `make release-dry-run` aborted before reaching the bin.

Verified locally: `make release-dry-run` now walks all nine entries and reports "All crates packaged cleanly".