### PR TITLE
ci(leak): add nightly LeakSanitizer workspace test job

### DIFF
--- a/.github/workflows/leak-nightly.yml
+++ b/.github/workflows/leak-nightly.yml
@@ -1,0 +1,73 @@
+name: leak (nightly)
+
+on:
+  schedule:
+    # 04:00 UTC daily -- staggered after fuzz (02:00) and stress (03:00) so
+    # the three nightlies don't fight for runners.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  lsan:
+    name: workspace tests under LeakSanitizer
+    runs-on: ubuntu-latest
+    # Hard ceiling: -Zsanitizer=leak slows tests ~2-3x and -Zbuild-std
+    # rebuilds libstd with instrumentation, which dominates the cold-cache
+    # run. Warm runs should comfortably finish well under this.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pinned nightly toolchain
+        # Match the pin used by fuzz/rust-toolchain.toml so the two nightly
+        # jobs share a known-good revision. Bump them together.
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-03-31
+          components: rust-src, llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Sanitizer builds compile a separate copy of libstd into a custom
+          # target dir; isolate the cache key so it does not collide with
+          # the stable CI cache.
+          key: lsan
+          cache-targets: true
+
+      - name: System deps
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+
+      - name: Run workspace tests under LeakSanitizer
+        env:
+          # -Zsanitizer=leak swaps in the standalone LSan runtime (no ASan,
+          # so the slowdown is much smaller than -Zsanitizer=address).
+          RUSTFLAGS: "-Zsanitizer=leak"
+          RUSTDOCFLAGS: "-Zsanitizer=leak"
+          CARGO_TERM_COLOR: always
+        run: |
+          # LSAN_OPTIONS:
+          #   suppressions= points at the in-repo allowlist.
+          #   exitcode=23 distinguishes "leaks detected" from a test panic
+          #     (which exits 101); either still fails the job.
+          #   print_suppressions=0 keeps the log clean on successful matches.
+          # GITHUB_WORKSPACE is set by the runner and contains the checkout
+          # path -- safer to read here than to template github.workspace
+          # into env (which an actionlint reviewer would flag).
+          export LSAN_OPTIONS="suppressions=${GITHUB_WORKSPACE}/ci/lsan_suppressions.txt,exitcode=23,print_suppressions=0"
+
+          # -Zbuild-std rebuilds libstd with the leak-sanitizer runtime so
+          # stdlib allocations get accounted for instead of being reported
+          # as leaks. It requires an explicit --target, hence the spelled-
+          # out triple (also matches the convention in fuzz-nightly.yml).
+          # --no-fail-fast collects leak reports from every test binary in
+          # one run; cheaper to triage than re-running per-crate.
+          cargo +nightly-2026-03-31 \
+            -Zbuild-std \
+            test \
+            --workspace \
+            --all-features \
+            --locked \
+            --no-fail-fast \
+            --target x86_64-unknown-linux-gnu

--- a/ci/lsan_suppressions.txt
+++ b/ci/lsan_suppressions.txt
@@ -1,0 +1,26 @@
+# LeakSanitizer suppressions for the nightly leak-check job.
+#
+# Format: one rule per line.
+#   leak:<symbol-substring>   -- match by function/symbol in the backtrace
+#   leak:<library-substring>  -- match by shared library or object filename
+# See https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions
+#
+# Principles:
+#   * Keep this file as small as possible. Every entry hides real
+#     allocations from the leak gate.
+#   * Add a comment before each rule explaining *why* the allocation is
+#     acceptable at process exit, and link an issue/PR if relevant.
+#   * Prefer fixing the leak over adding a suppression.
+#
+# The first nightly run is expected to surface additional process-lifetime
+# allocations from dependencies (commonly: tokio thread-pool teardown,
+# tonic/hyper connection pools, tracing-subscriber registries, openraft
+# background tasks). Triage each one, then either fix it or add a narrowly
+# scoped rule here with a justification.
+
+# --- RocksDB (C++ FFI) ----------------------------------------------------
+# RocksDB owns background flush/compaction threads and global block-cache
+# state. Even after Db::close(), some allocations stay attached to static
+# tables that the OS reclaims on exit. These are not real leaks but LSan
+# (rightly) cannot tell.
+leak:rocksdb::


### PR DESCRIPTION
## Summary
- New `leak (nightly)` workflow runs `cargo test --workspace --all-features` under standalone LeakSanitizer (`-Zsanitizer=leak` + `-Zbuild-std`) on the same pinned nightly (`nightly-2026-03-31`) that `fuzz-nightly.yml` already uses — bump them together.
- Detects allocations that outlive the test process at exit, **including C/C++ FFI allocations** (RocksDB), which `dhat-rs` and Miri cannot see because they only wrap Rust's `#[global_allocator]`.
- Scheduled at 04:00 UTC to stagger after the existing fuzz (02:00) and stress (03:00) nightlies so the three jobs do not contend for runners. `workflow_dispatch` is enabled for ad-hoc manual runs.
- `ci/lsan_suppressions.txt` ships with a minimal `leak:rocksdb::` baseline. Additional suppressions should be added per-finding with a justifying comment as the first dispatches surface noise.

## Why standalone LSan over ASan
`-Zsanitizer=leak` enables LeakSanitizer **without** AddressSanitizer's shadow-memory and red-zone instrumentation, so the slowdown is closer to a normal `cargo test` than ASan's typical 2–3×. UAF / heap-overflow coverage is already provided by the `fuzz-nightly` ASan run on the decode targets, so this job intentionally focuses on the one thing fuzz doesn't measure: process-exit leak reachability across the whole workspace test suite.

## Test plan
- [ ] Manually dispatch the workflow on this branch (`gh workflow run 'leak (nightly)' --ref ci/lsan-nightly-leak-check`) and confirm the run completes.
- [ ] Triage any LSan reports the first run surfaces. For each finding: either fix the underlying leak, or add a narrowly scoped entry to `ci/lsan_suppressions.txt` with a comment explaining why the allocation is acceptable at process exit.
- [ ] Re-dispatch and confirm a clean baseline before allowing the schedule trigger to fire blindly.
- [ ] (Optional follow-up) wire an issue auto-filer similar to `.github/actions/fuzz-auto-issue` so leak regressions create deduplicated issues instead of relying on someone watching the Actions tab.