### PR TITLE
docs(examples): add prometheus metrics example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Cargo.lock.bak
 .DS_Store
 /examples/openraft-cluster/.data/
 /examples/embedded-server/tsoracle-embedded-data/
+/examples/metrics-prometheus/tsoracle-prometheus-data/
 /lcov.info
 
 # bench-minimal flamegraph artifacts (written to CWD by the bench binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
+
+[[package]]
 name = "example-embedded-server"
 version = "0.1.1"
 dependencies = [
@@ -757,6 +768,20 @@ dependencies = [
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-proto",
+ "tsoracle-server",
+]
+
+[[package]]
+name = "example-metrics-prometheus"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "metrics-exporter-prometheus",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tsoracle-client",
+ "tsoracle-driver-file",
  "tsoracle-server",
 ]
 
@@ -862,6 +887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +993,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,7 +1090,16 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1232,6 +1293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1426,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1486,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
+dependencies = [
+ "base64 0.22.1",
+ "evmap",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util 0.20.4",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "metrics-util"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1523,23 @@ dependencies = [
  "radix_trie",
  "rand 0.9.4",
  "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -2311,6 +2440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,7 +3161,7 @@ dependencies = [
  "fail",
  "futures",
  "metrics",
- "metrics-util",
+ "metrics-util 0.19.1",
  "parking_lot",
  "prost",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members  = [
     "crates/tsoracle-tests",
     "examples/embedded-server",
     "examples/failover-demo",
+    "examples/metrics-prometheus",
     "examples/openraft-piggyback",
     "examples/openraft-standalone",
     "benchmarks/minimal",
@@ -58,6 +59,7 @@ humantime          = "2"
 humantime-serde    = "1"
 husky-rs           = "0.3"
 metrics            = "0.24"
+metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }
 metrics-util       = "0.19"
 nix                = { version = "0.30", default-features = false, features = ["signal", "process"] }
 parking_lot        = "0.12"

--- a/examples/metrics-prometheus/Cargo.toml
+++ b/examples/metrics-prometheus/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name                   = "example-metrics-prometheus"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+description            = "tsoracle example: embed the server with the metrics feature and expose a Prometheus /metrics endpoint"
+publish                = false
+
+[dependencies]
+tsoracle-server      = { path = "../../crates/tsoracle-server", version = "0.1.1", features = ["metrics"] }
+tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "0.1.1" }
+tsoracle-client      = { path = "../../crates/tsoracle-client", version = "0.1.1" }
+metrics-exporter-prometheus = { workspace = true }
+tokio                = { workspace = true, features = ["signal"] }
+tracing              = { workspace = true }
+tracing-subscriber   = { workspace = true }
+anyhow               = { workspace = true }

--- a/examples/metrics-prometheus/README.md
+++ b/examples/metrics-prometheus/README.md
@@ -1,0 +1,51 @@
+# Prometheus metrics from an embedded tsoracle
+
+How to use the [`metrics`](https://docs.rs/metrics) feature on [`tsoracle-server`](https://docs.rs/tsoracle-server) from your own binary: install [`metrics-exporter-prometheus`](https://docs.rs/metrics-exporter-prometheus) before the server starts, then expose `/metrics` on a separate HTTP port for Prometheus to scrape. A background loop calls `GetTs` continuously so a fresh scrape immediately shows non-zero counters.
+
+If you just want metrics from the stock `tsoracle serve` binary, you don't need this example — the bin already installs a Prometheus exporter on `127.0.0.1:9551` by default. See [Operations → Monitoring hooks](../../docs/operations.md#monitoring-hooks). This example is for when you are *embedding* `tsoracle_server::Server` in your own binary and want to control the recorder yourself.
+
+## Run
+
+```bash
+cargo run -p example-metrics-prometheus
+```
+
+The example binds the gRPC server on `127.0.0.1:50552` and the Prometheus scrape endpoint on `127.0.0.1:9552` (one above the stock bin's default `9551`, so the two can run side-by-side). Ctrl-C drains in-flight RPCs and exits cleanly.
+
+Scrape it from another terminal:
+
+```bash
+curl -s http://127.0.0.1:9552/metrics | grep ^tsoracle_
+```
+
+After a few seconds the scrape body looks roughly like this (exact values move with load):
+
+```
+# TYPE tsoracle_get_ts_total counter
+tsoracle_get_ts_total 47
+# TYPE tsoracle_get_ts_timestamps_issued counter
+tsoracle_get_ts_timestamps_issued 235
+# TYPE tsoracle_leader_transition_total counter
+tsoracle_leader_transition_total 1
+# TYPE tsoracle_window_extensions_total counter
+tsoracle_window_extensions_total 1
+# TYPE tsoracle_window_extension_latency summary
+tsoracle_window_extension_latency{quantile="0.5"} 0.00031
+tsoracle_window_extension_latency_sum 0.00031
+tsoracle_window_extension_latency_count 1
+```
+
+The `metrics` crate translates `.` to `_` in the exposition output, so the documented `tsoracle.get_ts.total` is scraped as `tsoracle_get_ts_total`. Counters whose names end in `.total` keep that suffix (Prometheus tooling expects it). The full signal catalog lives in [`docs/operations.md`](../../docs/operations.md#monitoring-hooks).
+
+## What to look at in `src/main.rs`
+
+- **`PrometheusBuilder::new().with_http_listener(...).install()` runs before anything else.** The `metrics` crate caches the global recorder per call site on first emission, so any tsoracle code path that emits before `install()` pins that call site to the noop recorder for the rest of the process — it will be silently absent from scrapes forever. Install the exporter first, then build `FileDriver` and `Server`.
+- **`drive_load` is just there to make the demo visible.** It loops `get_ts_batch(5)` every 100 ms, retrying the initial `Client::connect` until the server is accepting. In a real embedding you would not synthesize load — your real workload is the load.
+- **Shutdown is one `broadcast::channel`.** Ctrl-C fires the channel; the `serve_with_shutdown` future returns (draining the server) and the load loop's `select!` arm wakes and exits. Both stop cleanly before `main` returns.
+- **Swapping exporters is a one-line change.** Replace the `metrics-exporter-prometheus` block with whichever recorder you want (`metrics-exporter-influx`, `metrics-exporter-statsd`, a custom `metrics::Recorder` impl). The `tsoracle-server` `metrics` feature only emits — it does not pick the sink.
+
+## When this example is *not* the right shape
+
+- **You are using the stock `tsoracle serve` binary.** It already installs a Prometheus exporter on `127.0.0.1:9551` and exposes `--metrics-listen` / `--no-metrics` flags. Just point your scraper at it.
+- **You want HA.** This example uses [`FileDriver`](https://docs.rs/tsoracle-driver-file), which is single-node by design. The metrics wiring is independent of the driver — swap in a `ConsensusDriver` (see [`examples/openraft-standalone`](../openraft-standalone/) or [`examples/openraft-piggyback`](../openraft-piggyback/)) and keep the recorder install exactly as written here.
+- **You want to expose metrics on the same listener as your gRPC traffic.** `PrometheusBuilder::with_http_listener` opens its own port. If you need a single port, use `PrometheusBuilder::build_recorder()` and serve the exposition payload from your own HTTP stack (the recorder's `handle()` returns a renderer).

--- a/examples/metrics-prometheus/src/main.rs
+++ b/examples/metrics-prometheus/src/main.rs
@@ -1,0 +1,92 @@
+//! Embed the tsoracle server with the metrics feature enabled, install a
+//! Prometheus recorder, and expose `/metrics` for scraping.
+//!
+//! Run: `cargo run -p example-metrics-prometheus`
+//! Then in another terminal: `curl http://127.0.0.1:9552/metrics`.
+//! Ctrl-C drains in-flight RPCs and exits cleanly.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tokio::sync::broadcast;
+use tsoracle_client::Client;
+use tsoracle_driver_file::FileDriver;
+use tsoracle_server::Server;
+
+const GRPC_ADDR: &str = "127.0.0.1:50552";
+const METRICS_ADDR: &str = "127.0.0.1:9552";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let metrics_addr: SocketAddr = METRICS_ADDR.parse()?;
+    let grpc_addr: SocketAddr = GRPC_ADDR.parse()?;
+
+    // The `metrics` crate resolves the global recorder lazily per call site
+    // and caches the result on first emission. An emission that lands before
+    // install pins that call site to the noop recorder for the rest of the
+    // process, so the exporter MUST be installed before any tsoracle code
+    // runs.
+    PrometheusBuilder::new()
+        .with_http_listener(metrics_addr)
+        .install()?;
+
+    let driver = FileDriver::open_or_init(PathBuf::from("./tsoracle-prometheus-data"))?;
+    let server = Server::builder().consensus_driver(driver).build()?;
+
+    let (shutdown_tx, _) = broadcast::channel::<()>(1);
+    let load_handle = tokio::spawn(drive_load(grpc_addr, shutdown_tx.subscribe()));
+
+    let shutdown_signal = {
+        let shutdown_tx = shutdown_tx.clone();
+        async move {
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!("ctrl-c received, draining");
+            let _ = shutdown_tx.send(());
+        }
+    };
+
+    println!(
+        "gRPC on http://{grpc_addr} \u{2014} scrape http://{metrics_addr}/metrics \u{2014} Ctrl-C to exit"
+    );
+
+    server
+        .serve_with_shutdown(grpc_addr, shutdown_signal)
+        .await?;
+    let _ = load_handle.await;
+    Ok(())
+}
+
+/// Calls `get_ts_batch` on a loop so a fresh scrape shows non-zero counters
+/// and at least one histogram sample, instead of an empty exposition body.
+async fn drive_load(addr: SocketAddr, mut shutdown: broadcast::Receiver<()>) {
+    let client = loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => return,
+            attempt = Client::connect(vec![addr.to_string()]) => match attempt {
+                Ok(client) => break client,
+                Err(err) => {
+                    tracing::debug!(%err, "client connect failed, retrying");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    };
+
+    let mut interval = tokio::time::interval(Duration::from_millis(100));
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => return,
+            _ = interval.tick() => {
+                if let Err(err) = client.get_ts_batch(5).await {
+                    tracing::debug!(%err, "get_ts_batch failed");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `examples/metrics-prometheus` crate: embeds tsoracle with the `metrics` feature on `tsoracle-server` and installs `metrics-exporter-prometheus` on `127.0.0.1:9552` **before** any tsoracle code runs (the `metrics` facade caches the recorder per call site on first emission, so install order matters).
- A background load loop calls `get_ts_batch(5)` every 100 ms so a fresh scrape of `/metrics` shows non-zero counters and at least one histogram sample, instead of an empty exposition body.
- Adds `metrics-exporter-prometheus = "0.18"` (default-features off, `http-listener` feature) to `[workspace.dependencies]` and the new crate to `[workspace] members`. Picks port 9552 so this example can run alongside the stock `tsoracle serve` bin (which defaults to 9551 on the `feat/metrics` branch).

Covers the **embedder** path — bring your own recorder. Users who just run the stock bin don't need this; they want the docs in `docs/operations.md` (currently in flight on `feat/metrics`).

## Test plan

- [ ] `cargo build -p example-metrics-prometheus` cleanly compiles.
- [ ] `cargo run -p example-metrics-prometheus` in one terminal; `curl -s http://127.0.0.1:9552/metrics | grep ^tsoracle_` in another shows all seven documented signals with non-zero values within a couple of seconds.
- [ ] Ctrl-C drains and exits cleanly. State dir `tsoracle-prometheus-data/` is gitignored.
- [ ] `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` both pass (verified locally; same checks the pre-commit hook runs).

## Follow-up (separate PR)

`metrics-exporter-prometheus` 0.18 renders metric names by `HashMap::drain()` order — randomized between scrapes even within one process run. A separate PR will wrap the exporter with a small custom HTTP handler that emits metric blocks in a hardcoded canonical order, so scrape output is stable and diffable across runs.