### PR TITLE
docs(contract): clarify monotonicity guarantee, drop "gap-free" overclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
         <img alt="tsoracle" src="assets/tsoracle-light.svg" width="360">
     </picture>
     <h4>
-        Strictly monotonic, gap-free timestamps in 🦀 Rust. Please ⭐ on <a href="https://github.com/prisma-risk/tsoracle">GitHub</a>!
+        Strictly monotonic timestamps in 🦀 Rust. Please ⭐ on <a href="https://github.com/prisma-risk/tsoracle">GitHub</a>!
     </h4>
 
 
@@ -18,11 +18,11 @@
 
 </div>
 
-A distributed timestamp oracle for Rust — highly available and fault-tolerant, issuing strictly monotonic, gap-free integer timestamps over gRPC, Raft-replicated via openraft with pluggable consensus.
+A distributed timestamp oracle for Rust — highly available and fault-tolerant, issuing strictly monotonic integer timestamps over gRPC, Raft-replicated via openraft with pluggable consensus.
 
 ## Features
 
-- 🔢 **Monotonic & gap-free** — every issued timestamp is strictly greater than the last; no skipped or repeated values, ever.
+- 🔢 **Strictly monotonic** — every issued timestamp is strictly greater than every previously issued one; no duplicates and no regression, ever. The packed integer space is not dense (logical resets when `physical_ms` advances, so some integer values are unused), but the issued sequence is total-ordered and unique.
 - 🛡️ **Crash-safe** — window state is fsync'd before any timestamp in that window is handed out, so a restart never rewinds.
 - 🔌 **Pluggable consensus, openraft included** — `tsoracle-driver-openraft` ships a production-ready replicated driver; implement one trait (`ConsensusDriver`) to back tsoracle with raft-rs, etcd, or your own replicated log instead.
 - 📦 **gRPC client included** — `tsoracle-client` handles leader discovery, request coalescing, and reconnection for you.

--- a/crates/tsoracle-server/src/docs/docs.md
+++ b/crates/tsoracle-server/src/docs/docs.md
@@ -1,6 +1,6 @@
 # tsoracle guide
 
-Long-form reference for [tsoracle][repo] — a distributed, highly available timestamp oracle issuing strictly monotonic, gap-free integer timestamps over gRPC.
+Long-form reference for [tsoracle][repo] — a distributed, highly available timestamp oracle issuing strictly monotonic integer timestamps over gRPC.
 
 This guide complements the crate-level API documentation. For auto-indexed, "ask the wiki" style lookups, see [DeepWiki](https://deepwiki.com/prisma-risk/tsoracle).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # tsoracle documentation
 
-The long-form prose guide to tsoracle — strictly monotonic, gap-free timestamps over gRPC.
+The long-form prose guide to tsoracle — strictly monotonic timestamps over gRPC.
 
 This directory is the **deep dive** covering everything from getting started through the allocator's monotonicity proof, consensus integration patterns, deployment topologies, and per-example walkthroughs. Browsable on GitHub and indexed by [DeepWiki](https://deepwiki.com/prisma-risk/tsoracle).
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-tsoracle is a distributed timestamp oracle (TSO) for Rust — a highly available, fault-tolerant service that hands out 64-bit strictly-monotonic, gap-free integer timestamps over gRPC. It is layered: a sync algorithm core (`tsoracle-core`), an async server (`tsoracle-server`) that wires the core to the network, and a pluggable consensus surface (`ConsensusDriver`) that lets you run it single-node behind one fsync or replicated on top of a consensus library of your choice.
+tsoracle is a distributed timestamp oracle (TSO) for Rust — a highly available, fault-tolerant service that hands out 64-bit strictly-monotonic integer timestamps over gRPC. Each issued timestamp is strictly greater than every previously issued one — no duplicates and no regression, even across failover. The packed integer space is not dense: the logical counter resets each time `physical_ms` advances (see [The Allocator](the-allocator.md)), so some integer values in the 64-bit space are skipped; the issued sequence itself is still total-ordered and unique. The crate is layered: a sync algorithm core (`tsoracle-core`), an async server (`tsoracle-server`) that wires the core to the network, and a pluggable consensus surface (`ConsensusDriver`) that lets you run it single-node behind one fsync or replicated on top of a consensus library of your choice.
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
## Summary

The README and overview prose described tsoracle as issuing "gap-free" timestamps with "no skipped values, ever." That overstates the actual contract:

- Timestamps are packed as `physical_ms << 18 | logical`.
- The logical counter resets each time `physical_ms` advances (see `docs/the-allocator.md:7`), so the packed 64-bit integer space is **not dense** — integer values inside an unused logical tail are skipped whenever wall-clock advance or a logical-boundary-straddling request rolls `physical_ms` forward.
- `monotonicity.rs` asserts only `first > prev`, not `first == prev + 1`.
- `try_grant_above_committed_is_window_exhausted` (in `crates/tsoracle-core/src/allocator.rs::tests`) is written *expecting* the wall-clock-advance branch to abandon unused logical slots and roll physical forward — i.e. the non-density is by design, not an oversight.

The real guarantee is: **strictly monotonic, never regressing, never duplicate** — but not dense. That matches every comparable TSO (TiDB PD, CockroachDB HLC, Spanner) and is the property downstream MVCC, snapshot-isolation, and audit-ordering consumers actually need.

This PR reconciles the docs with the code by removing "gap-free" from the four overclaiming sites and adding an explicit note in the README feature bullet and in `docs/overview.md` so readers know the packed integer space is not dense and don't build code that depends on density.

## Changes

- `README.md`: drop "gap-free" from the banner tagline (L7) and intro paragraph (L21); rewrite the feature bullet (L25) to "Strictly monotonic" with an inline note explaining non-density.
- `docs/README.md`: drop "gap-free" from the chapter-index intro.
- `docs/overview.md`: drop "gap-free", expand the intro paragraph with the strict-monotonic / not-dense distinction and a link to `the-allocator.md`.
- `crates/tsoracle-server/src/docs/docs.md`: drop "gap-free" from the crate-docs intro.

No code changes; allocator behavior is unchanged.

## Test plan

- [x] `grep -rn "gap-free\|no skipped" --include="*.md" --include="*.rs"` returns no matches after the edit.
- [x] `cargo fmt --check` and `cargo clippy` pre-commit hooks pass.
- [x] Existing tests untouched; allocator semantics unchanged.