### PR TITLE
ci(critical-path): widen marker scan to clear canonical header

### DIFF
--- a/docs/performance-critical-path.md
+++ b/docs/performance-critical-path.md
@@ -1,6 +1,6 @@
 # Performance-critical-path rules
 
-A handful of files in this workspace sit on the request-handling hot path: every `GetTs` / `GetTsBatch` RPC, every window extension, every Raft propose/apply touches them. Regressions in these files surface as elevated end-to-end latency or reduced batch throughput, not as test failures, so we enforce a small set of source-level rules on top of the regular clippy/build checks. Files on the critical path carry this marker as the first line of the file:
+A handful of files in this workspace sit on the request-handling hot path: every `GetTs` / `GetTsBatch` RPC, every window extension, every Raft propose/apply touches them. Regressions in these files surface as elevated end-to-end latency or reduced batch throughput, not as test failures, so we enforce a small set of source-level rules on top of the regular clippy/build checks. Files on the critical path carry this marker on the first non-blank line below the [canonical copyright header](../scripts/check-ts-header.py) — above any module-level doc, inner attribute, or `use`:
 
     // #[PerformanceCriticalPath]
 
@@ -22,7 +22,7 @@ Two related rules are intentionally not enforced by this guard — they live in 
 
 [`scripts/check-critical-path.sh`](../scripts/check-critical-path.sh) runs in CI as the `critical-path` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). It:
 
-- Finds every `crates/**/*.rs` whose first 10 lines contain `#[PerformanceCriticalPath]`.
+- Finds every `crates/**/*.rs` whose first 25 lines contain `#[PerformanceCriticalPath]` — wide enough to clear the 11-line canonical copyright header plus a separator, narrow enough that a marker buried under a long `//!` module doc still falls out of enforcement.
 - For each, greps for the banned patterns listed in the script (the `BANNED` array).
 - Prints violations with line numbers.
 
@@ -34,7 +34,7 @@ To adjust the list of banned patterns or the strict-mode toggle, edit the script
 
 ## Marker placement
 
-Place the marker on line 1, above any module-level doc comment (`//!`), any inner attribute (`#![...]`), and any `use` statement. The guard only scans the first 10 lines, so the marker must sit at the top — pushing it below a long module doc silently disables enforcement. The marker is a plain `//` line comment, not Rust syntax; it does not interfere with the file's `//!` module doc (which still attaches to the module) or with any `#![cfg_attr(...)]` inner attribute (such as the [panic-policy attribute](../CONTRIBUTING.md#panic-policy-unwrap-and-expect) in each library crate's `lib.rs`).
+Place the marker on the first non-blank line below the 11-line canonical copyright header — typically line 13, with one blank line separating header and marker — and above any module-level doc comment (`//!`), any inner attribute (`#![...]`), and any `use` statement. The guard scans the first 25 lines, so the marker must sit at the top — pushing it below a long module doc silently disables enforcement. The marker is a plain `//` line comment, not Rust syntax; it does not interfere with the file's `//!` module doc (which still attaches to the module) or with any `#![cfg_attr(...)]` inner attribute (such as the [panic-policy attribute](../CONTRIBUTING.md#panic-policy-unwrap-and-expect) in each library crate's `lib.rs`).
 
 The marker is per-file. If you split a marked module into child files, mark every child file that remains on the hot path — the guard does not inherit markers through `mod`.
 

--- a/scripts/check-critical-path.sh
+++ b/scripts/check-critical-path.sh
@@ -44,7 +44,13 @@ declare -a BANNED=(
 # The scan window for the marker. Files where the marker sits below this many
 # lines silently fall out of enforcement — see docs/performance-critical-path.md
 # for the placement rule.
-SCAN_WINDOW=10
+#
+# Sized to accommodate the 11-line canonical copyright header (enforced by
+# scripts/check-ts-header.py) plus a blank separator line plus the marker
+# itself, with slack for a short `#![cfg_attr(...)]` inner attribute. Bumping
+# this too high would let the marker hide under a long `//!` module doc; the
+# whole point is that the marker must sit *above* the module's own contents.
+SCAN_WINDOW=25
 
 # Locate repo root so the guard works from CI and from subdirectories.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)


### PR DESCRIPTION
## Summary

- `scripts/check-critical-path.sh` was silently passing the entire repo: the 11-line canonical copyright header (added in #70) pushed every `// #[PerformanceCriticalPath]` marker to line 13, outside the `SCAN_WINDOW=10` the guard read. The script then printed "No files carry the marker" and exited 0, never running the banned-pattern check on the four marked critical-path files.
- Bumps `SCAN_WINDOW` to `25` — enough headroom for the canonical header + blank separator + marker + a short `#![cfg_attr(...)]` inner attribute, but still narrow enough that a marker buried below a long `//!` module doc falls out of enforcement (the original guardrail in the script's comment).
- Updates `docs/performance-critical-path.md` so the placement rule matches reality: "first non-blank line below the canonical copyright header" instead of "line 1", and "first 25 lines" instead of "first 10".

## Test plan

- [x] Reproduce on `main`: `bash scripts/check-critical-path.sh` prints `No files carry the #[PerformanceCriticalPath] marker.` and exits 0 (the bug).
- [x] After fix: `CRITICAL_PATH_STRICT=1 bash scripts/check-critical-path.sh` prints `Critical-path guard: all 4 marked files clean.` and exits 0.
- [x] Confirm the four marked files (`crates/tsoracle-core/src/allocator.rs`, `crates/tsoracle-driver-file/src/lib.rs`, `crates/tsoracle-driver-openraft/src/lib.rs`, `crates/tsoracle-client/src/driver.rs`) are still detected and clean under strict mode.
- [x] CI: `critical-path` job runs in strict mode and stays green.