### PR TITLE
tests(stress): remove root and sanitizer fragility from three tests

### DIFF
--- a/benchmarks/stress/src/loadgen.rs
+++ b/benchmarks/stress/src/loadgen.rs
@@ -213,8 +213,27 @@ mod tests {
         let endpoint = format!("http://{addr}");
         let client = Arc::new(Client::connect(vec![endpoint]).await.unwrap());
 
-        let (tx, rx) = mpsc::channel::<SupervisorEvent>(64);
-        let supervisor_handle = tokio::spawn(Supervisor::new().run(rx));
+        // Insert a counting forwarder between the loadgen task and the
+        // Supervisor so the test can observe progress by polling instead of
+        // sleeping a fixed wall-clock budget — the latter is brittle under
+        // sanitizer or emulation slowdown where first-request latency can
+        // exceed any reasonable hand-picked duration.
+        let (tx_from_task, mut rx_from_task) = mpsc::channel::<SupervisorEvent>(64);
+        let (tx_to_supervisor, rx_to_supervisor) = mpsc::channel::<SupervisorEvent>(64);
+        let supervisor_handle = tokio::spawn(Supervisor::new().run(rx_to_supervisor));
+
+        let issued_seen = Arc::new(AtomicU64::new(0));
+        let issued_seen_for_forwarder = issued_seen.clone();
+        let forwarder_handle = tokio::spawn(async move {
+            while let Some(event) = rx_from_task.recv().await {
+                if matches!(event, SupervisorEvent::Issued(_)) {
+                    issued_seen_for_forwarder.fetch_add(1, Ordering::Relaxed);
+                }
+                if tx_to_supervisor.send(event).await.is_err() {
+                    break;
+                }
+            }
+        });
 
         let stop = Arc::new(AtomicBool::new(false));
         let cfg = ClientTaskCfg {
@@ -224,17 +243,28 @@ mod tests {
             warmup_iters: 4,
             liveness_deadline: Duration::from_secs(5),
             stop: stop.clone(),
-            tx: tx.clone(),
+            tx: tx_from_task.clone(),
             transient_retries: Arc::new(AtomicU64::new(0)),
         };
         let task = tokio::spawn(client_task(cfg));
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Poll for the first issued sample. The 30s ceiling is well above
+        // any realistic worst case; the loop exits as soon as progress
+        // shows, so fast machines pay nothing extra.
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            if issued_seen.load(Ordering::Relaxed) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
         stop.store(true, Ordering::Relaxed);
         let issued = task.await.unwrap().unwrap();
 
-        let _ = tx.send(SupervisorEvent::End).await;
-        drop(tx);
+        let _ = tx_from_task.send(SupervisorEvent::End).await;
+        drop(tx_from_task);
+        let _ = forwarder_handle.await;
         let outcome = supervisor_handle.await.unwrap();
         assert!(issued > 0, "expected some timestamps issued, got 0");
         assert!(

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -463,11 +463,13 @@ mod tests {
             event.outcome
         );
 
-        // Poll for a different leader; election timeout is 300-600ms, so up
-        // to 2s of polling is comfortably above the worst case while still
-        // failing fast if no re-election occurs.
+        // Poll for a different leader; election timeout is 300-600ms. The
+        // wall-clock cap is generous to tolerate sanitizer or emulation
+        // slowdown — the loop exits as soon as a new leader is observed, so
+        // fast machines pay nothing extra.
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
         let mut new_leader = None;
-        for _ in 0..40 {
+        while std::time::Instant::now() < deadline {
             if let Some(candidate) = topology.controller.current_leader() {
                 if candidate != original_leader {
                     new_leader = Some(candidate);
@@ -713,13 +715,16 @@ mod tests {
 
     #[test]
     fn open_log_store_errors_on_bad_path() {
-        // Pointing rocksdb at a path it cannot create (parent doesn't exist
-        // and we don't have permission to create it) exercises the error
-        // propagation from `DB::open_cf_descriptors`.
-        let bad = std::path::PathBuf::from("/nonexistent-root/stress-raft-test/log");
+        // Place a regular file in the ancestor chain so directory creation
+        // beneath it fails with ENOTDIR for any uid (including root inside
+        // a container, where DAC permission checks are bypassed).
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, b"").expect("create blocker file");
+        let bad = blocker.join("stress-raft-test").join("log");
         match open_log_store(&bad) {
             Err(_) => {}
-            Ok(_) => panic!("open_log_store should fail on unreadable path"),
+            Ok(_) => panic!("open_log_store should fail when an ancestor is not a directory"),
         }
     }
 


### PR DESCRIPTION
## Summary

Three tests in the `stress` crate fail when the workspace suite is run as root inside Docker, or under nightly LeakSanitizer with QEMU emulation. None are bugs in product code — each made an environmental assumption that breaks outside the GitHub `ubuntu-latest` x86_64 sandbox CI is tuned against.

- **`topology::raft::open_log_store_errors_on_bad_path`** asserted that opening a RocksDB log at `/nonexistent-root/...` would fail. Root inside a container bypasses DAC permission checks and `mkdir -p /nonexistent-root` succeeds, so the store opens cleanly and the test panics on the `Ok(_)` branch. Replaced with a path whose ancestor is a regular file — `mkdir -p` then fails with `ENOTDIR` for any uid.
- **`loadgen::client_task_round_trip_against_real_server`** granted the loadgen task a fixed 200 ms wall-clock budget (`sleep(200ms)` then signal stop) before checking `issued > 0`. Under LSan + emulation, first-RPC latency for the tonic/h2 handshake easily exceeds 200 ms and the test sees zero samples. Inserted a counting forwarder between the task and the supervisor so the test can poll on a real observable, with a 30 s ceiling. Exits as soon as the first issued sample arrives — fast machines pay nothing extra.
- **`topology::raft::kill_leader_triggers_reelection`** polled 2 s for a new leader after killing the original (election timeout 300–600 ms). The same compound slowdown can stretch openraft worker task scheduling past that window. Widened to a 30 s deadline; still exits early on success.

## Test plan

- [x] `cargo test -p stress --lib` — 105/105 pass in ~1.7 s locally (previously: 3 failures under LSan-in-Docker-as-root)
- [x] `cargo clippy -p stress --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `python3 scripts/check-ts-header.py` — all 138 files OK
- [ ] Nightly `leak` workflow on this branch: `gh workflow run leak-nightly.yml --ref fix/stress-tests-env-robustness`