### PR TITLE
feat(client,server): TLS and mTLS transport configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-tls-mtls"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "futures",
+ "rcgen",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "tsoracle-client",
+ "tsoracle-driver-file",
+ "tsoracle-server",
+]
+
+[[package]]
 name = "fail"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1779,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3420ea4424090cbd75a688996f696a807c68d6744b4863591b86435dc3078e9"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,6 +1892,12 @@ dependencies = [
  "embedded-io 0.6.1",
  "serde",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2185,6 +2216,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -2720,6 +2764,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3245,7 @@ version = "0.1.1"
 dependencies = [
  "fail",
  "futures",
+ "rcgen",
  "tokio",
  "tonic",
  "tsoracle-client",
@@ -3679,6 +3743,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ parking_lot        = "0.12"
 proptest           = "1"
 prost              = "0.14"
 rand               = { version = "0.9", default-features = false, features = ["std", "std_rng"] }
+rcgen              = "0.13"
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
 tempfile           = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members  = [
     "examples/metrics-prometheus",
     "examples/openraft-piggyback",
     "examples/openraft-standalone",
+    "examples/tls-mtls",
     "benchmarks/minimal",
     "benchmarks/stress",
 ]

--- a/benchmarks/minimal/src/harness.rs
+++ b/benchmarks/minimal/src/harness.rs
@@ -54,7 +54,8 @@ pub fn is_transient(err: &ClientError) -> bool {
         ),
         ClientError::NoReachableEndpoints
         | ClientError::InvalidEndpoint(_)
-        | ClientError::InvalidCount(_) => false,
+        | ClientError::InvalidCount(_)
+        | ClientError::Connector(_) => false,
     }
 }
 

--- a/benchmarks/stress/src/loadgen.rs
+++ b/benchmarks/stress/src/loadgen.rs
@@ -32,7 +32,8 @@ pub fn is_transient(err: &ClientError) -> bool {
         ),
         ClientError::NoReachableEndpoints
         | ClientError::InvalidEndpoint(_)
-        | ClientError::InvalidCount(_) => false,
+        | ClientError::InvalidCount(_)
+        | ClientError::Connector(_) => false,
     }
 }
 

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -288,6 +288,7 @@ fn clone_client_error(error: &ClientError) -> ClientError {
         ClientError::NoReachableEndpoints => ClientError::NoReachableEndpoints,
         ClientError::InvalidEndpoint(endpoint) => ClientError::InvalidEndpoint(endpoint.clone()),
         ClientError::InvalidCount(count) => ClientError::InvalidCount(*count),
+        ClientError::Connector(source) => ClientError::Connector(source.to_string().into()),
     }
 }
 

--- a/crates/tsoracle-client/src/error.rs
+++ b/crates/tsoracle-client/src/error.rs
@@ -22,4 +22,31 @@ pub enum ClientError {
     InvalidEndpoint(String),
     #[error("invalid count: {0}")]
     InvalidCount(u32),
+    #[error("custom channel connector failed: {0}")]
+    Connector(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connector_variant_renders_source_in_display() {
+        let inner: Box<dyn std::error::Error + Send + Sync + 'static> = "boom".into();
+        let err = ClientError::Connector(inner);
+        assert_eq!(
+            err.to_string(),
+            "custom channel connector failed: boom",
+            "Display should embed the boxed source's message"
+        );
+    }
+
+    #[test]
+    fn connector_variant_exposes_source() {
+        use std::error::Error;
+        let inner: Box<dyn std::error::Error + Send + Sync + 'static> =
+            std::io::Error::other("io-err").into();
+        let err = ClientError::Connector(inner);
+        assert!(err.source().is_some(), "Connector must propagate source()");
+    }
 }

--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -36,14 +36,19 @@ pub struct ChannelPool {
     configured: Vec<String>,
     channels: Mutex<HashMap<String, Channel>>,
     leader: Mutex<Option<String>>,
+    connector: Option<std::sync::Arc<crate::transport::ChannelConnector>>,
 }
 
 impl ChannelPool {
-    pub fn new(endpoints: Vec<String>) -> Self {
+    pub fn new(
+        endpoints: Vec<String>,
+        connector: Option<std::sync::Arc<crate::transport::ChannelConnector>>,
+    ) -> Self {
         ChannelPool {
             configured: endpoints,
             channels: Mutex::new(HashMap::new()),
             leader: Mutex::new(None),
+            connector,
         }
     }
 
@@ -64,15 +69,16 @@ impl ChannelPool {
         if let Some(channel) = self.channels.lock().get(endpoint).cloned() {
             return Ok(TsoServiceClient::new(channel));
         }
-        let uri = if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
-            endpoint.to_string()
-        } else {
-            format!("http://{endpoint}")
+        let channel = match &self.connector {
+            Some(connector) => connector(endpoint).await?,
+            None => {
+                let uri = crate::transport::normalize_uri(endpoint, false);
+                let transport_endpoint: Endpoint = uri
+                    .parse()
+                    .map_err(|_| ClientError::InvalidEndpoint(endpoint.into()))?;
+                transport_endpoint.connect().await?
+            }
         };
-        let transport_endpoint: Endpoint = uri
-            .parse()
-            .map_err(|_| ClientError::InvalidEndpoint(endpoint.into()))?;
-        let channel = transport_endpoint.connect().await?;
         self.channels
             .lock()
             .insert(endpoint.to_string(), channel.clone());
@@ -97,10 +103,12 @@ impl ChannelPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn iter_starts_with_cached_leader() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()]);
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None);
         pool.set_leader("b:1".into());
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["b:1", "a:1", "c:1"]);
@@ -108,20 +116,76 @@ mod tests {
 
     #[test]
     fn iter_without_cache_is_configured_order() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()]);
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None);
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["a:1", "b:1", "c:1"]);
     }
 
     #[test]
     fn clear_leader_drops_cached_leader() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()]);
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], None);
         pool.set_leader("b:1".into());
         assert_eq!(pool.cached_leader().as_deref(), Some("b:1"));
         pool.clear_leader();
-        assert!(pool.cached_leader().is_none());
         // With the cache cleared, round-robin order falls back to the
         // configured order — the cleared leader is not re-prepended.
+        assert!(pool.cached_leader().is_none());
         assert_eq!(pool.iter_round_robin(), vec!["a:1", "b:1"]);
+    }
+
+    #[tokio::test]
+    async fn pool_with_custom_connector_invokes_closure_per_endpoint() {
+        let captured = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+        let captured_for_closure = captured.clone();
+        let connector: Arc<crate::transport::ChannelConnector> = Arc::new(move |endpoint: &str| {
+            captured_for_closure.lock().push(endpoint.to_string());
+            let endpoint_owned = endpoint.to_string();
+            Box::pin(async move { Err(crate::error::ClientError::InvalidEndpoint(endpoint_owned)) })
+        });
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], Some(connector));
+        let _ = pool.client("a:1").await;
+        let _ = pool.client("b:1").await;
+        let seen = captured.lock().clone();
+        assert_eq!(seen, vec!["a:1".to_string(), "b:1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn pool_caches_channel_from_custom_connector() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_for_closure = call_count.clone();
+        let connector: Arc<crate::transport::ChannelConnector> =
+            Arc::new(move |_endpoint: &str| {
+                let n = call_count_for_closure.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(n, 0, "connector must only be invoked once per endpoint");
+                Box::pin(async {
+                    let channel = tonic::transport::Endpoint::from_static("http://127.0.0.1:1")
+                        .connect_lazy();
+                    Ok(channel)
+                })
+            });
+        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector));
+        let _ = pool
+            .client("a:1")
+            .await
+            .expect("first client() must succeed");
+        let _ = pool
+            .client("a:1")
+            .await
+            .expect("second client() must hit cache");
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn leader_hint_endpoint_goes_through_same_connector() {
+        let captured = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+        let captured_for_closure = captured.clone();
+        let connector: Arc<crate::transport::ChannelConnector> = Arc::new(move |endpoint: &str| {
+            captured_for_closure.lock().push(endpoint.to_string());
+            Box::pin(async { Err(crate::error::ClientError::InvalidEndpoint("x".into())) })
+        });
+        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector));
+        let _ = pool.client("hinted:1").await;
+        let seen = captured.lock().clone();
+        assert_eq!(seen, vec!["hinted:1".to_string()]);
     }
 }

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -26,6 +26,7 @@ mod error;
 mod leader_resolved;
 mod response;
 mod retry;
+mod transport;
 
 pub use error::ClientError;
 

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -16,6 +16,9 @@
 //! to a caller was allocated by the server after that caller's request entered
 //! the client driver. RPC efficiency comes from request coalescing (multiple
 //! concurrent waiters batch into one outgoing GetTs), not pre-fetching.
+//!
+//! TLS is configured via `ClientBuilder::tls_config(ClientTlsConfig)`;
+//! see `docs/client-api-and-usage.md` for the scheme rule and examples.
 
 // Panic policy (see CONTRIBUTING.md). `cfg_attr(not(test), ...)` skips the lint
 // for the lib's own unit tests; integration tests are separate compilation units.

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -29,6 +29,7 @@ mod retry;
 mod transport;
 
 pub use error::ClientError;
+pub use transport::BoxError;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -64,7 +65,7 @@ impl ClientBuilder {
         if self.endpoints.is_empty() {
             return Err(ClientError::NoReachableEndpoints);
         }
-        let pool = Arc::new(ChannelPool::new(self.endpoints));
+        let pool = Arc::new(ChannelPool::new(self.endpoints, None));
         let pool_for_rpc = pool.clone();
         let driver = driver::Driver::spawn(
             move |count| {

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -46,6 +46,7 @@ use crate::leader_resolved::ChannelPool;
 pub struct ClientBuilder {
     endpoints: Vec<String>,
     flush_interval: Duration,
+    connector: Option<Arc<crate::transport::ChannelConnector>>,
 }
 
 impl ClientBuilder {
@@ -53,6 +54,7 @@ impl ClientBuilder {
         ClientBuilder {
             endpoints,
             flush_interval: Duration::from_millis(1),
+            connector: None,
         }
     }
 
@@ -61,11 +63,33 @@ impl ClientBuilder {
         self
     }
 
+    /// Replace the default plaintext channel construction with a caller-owned
+    /// closure. The closure is invoked on first use of each endpoint —
+    /// configured endpoints and leader-hint redirects alike. Errors returned
+    /// from the closure surface as [`ClientError::Connector`].
+    ///
+    /// See module docs for the interaction with [`Self::tls_config`]
+    /// (last-wins) and the scheme matrix.
+    pub fn channel_connector<F, Fut>(mut self, connector: F) -> Self
+    where
+        F: Fn(&str) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<tonic::transport::Channel, crate::BoxError>>
+            + Send
+            + 'static,
+    {
+        let wrapped: Arc<crate::transport::ChannelConnector> = Arc::new(move |endpoint: &str| {
+            let fut = connector(endpoint);
+            Box::pin(async move { fut.await.map_err(ClientError::Connector) })
+        });
+        self.connector = Some(wrapped);
+        self
+    }
+
     pub async fn build(self) -> Result<Client, ClientError> {
         if self.endpoints.is_empty() {
             return Err(ClientError::NoReachableEndpoints);
         }
-        let pool = Arc::new(ChannelPool::new(self.endpoints, None));
+        let pool = Arc::new(ChannelPool::new(self.endpoints, self.connector));
         let pool_for_rpc = pool.clone();
         let driver = driver::Driver::spawn(
             move |count| {
@@ -114,6 +138,25 @@ mod tests {
             Err(ClientError::NoReachableEndpoints) => {}
             Err(other) => panic!("expected NoReachableEndpoints, got {other:?}"),
             Ok(_) => panic!("expected Err, got Ok(Client)"),
+        }
+    }
+
+    #[tokio::test]
+    async fn channel_connector_error_surfaces_as_connector_variant() {
+        let builder = ClientBuilder::endpoints(vec!["a:1".into()]).channel_connector(
+            |_endpoint: &str| async move {
+                Err::<tonic::transport::Channel, crate::BoxError>(
+                    std::io::Error::other("boom").into(),
+                )
+            },
+        );
+        let client = builder.build().await.expect("build must not fail");
+        let result = client.get_ts().await;
+        match result {
+            Err(ClientError::Connector(inner)) => {
+                assert!(inner.to_string().contains("boom"));
+            }
+            other => panic!("expected ClientError::Connector, got {other:?}"),
         }
     }
 

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -63,6 +63,19 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure the client to dial bare endpoints with TLS. Bare `host:port`
+    /// becomes `https://host:port`; explicit `http://...` endpoints remain
+    /// plaintext; explicit `https://...` endpoints use the provided TLS
+    /// config.
+    ///
+    /// Setting both [`Self::channel_connector`] and `tls_config` is allowed;
+    /// the last call wins (standard builder semantics).
+    #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+    pub fn tls_config(mut self, cfg: tonic::transport::ClientTlsConfig) -> Self {
+        self.connector = Some(crate::transport::tls_connector(cfg));
+        self
+    }
+
     /// Replace the default plaintext channel construction with a caller-owned
     /// closure. The closure is invoked on first use of each endpoint —
     /// configured endpoints and leader-hint redirects alike. Errors returned
@@ -158,6 +171,58 @@ mod tests {
             }
             other => panic!("expected ClientError::Connector, got {other:?}"),
         }
+    }
+
+    #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+    #[tokio::test]
+    async fn tls_config_then_channel_connector_last_wins() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let invoked = Arc::new(AtomicBool::new(false));
+        let invoked_for_closure = invoked.clone();
+        let builder = ClientBuilder::endpoints(vec!["a:1".into()])
+            .tls_config(tonic::transport::ClientTlsConfig::new())
+            .channel_connector(move |_endpoint: &str| {
+                let invoked = invoked_for_closure.clone();
+                async move {
+                    invoked.store(true, Ordering::SeqCst);
+                    Err::<tonic::transport::Channel, crate::BoxError>(
+                        std::io::Error::other("from-closure").into(),
+                    )
+                }
+            });
+        let client = builder.build().await.expect("build must not fail");
+        let _ = client.get_ts().await;
+        assert!(
+            invoked.load(Ordering::SeqCst),
+            "channel_connector closure must be the path taken when set last"
+        );
+    }
+
+    #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+    #[tokio::test]
+    async fn channel_connector_then_tls_config_last_wins() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let invoked = Arc::new(AtomicBool::new(false));
+        let invoked_for_closure = invoked.clone();
+        let builder = ClientBuilder::endpoints(vec!["a:1".into()])
+            .channel_connector(move |_endpoint: &str| {
+                let invoked = invoked_for_closure.clone();
+                async move {
+                    invoked.store(true, Ordering::SeqCst);
+                    Err::<tonic::transport::Channel, crate::BoxError>(
+                        std::io::Error::other("from-closure").into(),
+                    )
+                }
+            })
+            .tls_config(tonic::transport::ClientTlsConfig::new());
+        let client = builder.build().await.expect("build must not fail");
+        let _ = client.get_ts().await;
+        assert!(
+            !invoked.load(Ordering::SeqCst),
+            "tls_config set last must overwrite the prior channel_connector"
+        );
     }
 
     #[tokio::test]

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -93,10 +93,10 @@ mod tests {
     /// `visited` set being effective is the property under test here.
     #[tokio::test]
     async fn duplicate_endpoints_are_visited_once() {
-        let pool = ChannelPool::new(vec![
-            "http://127.0.0.1:1".into(),
-            "http://127.0.0.1:1".into(),
-        ]);
+        let pool = ChannelPool::new(
+            vec!["http://127.0.0.1:1".into(), "http://127.0.0.1:1".into()],
+            None,
+        );
         let result = issue_rpc(&pool, 1).await;
         assert!(result.is_err(), "no live endpoint must surface as Err");
     }
@@ -107,7 +107,7 @@ mod tests {
     /// continue path that's not reached by the happy-path integration tests.
     #[tokio::test]
     async fn unreachable_endpoints_surface_last_error() {
-        let pool = ChannelPool::new(vec!["http://127.0.0.1:1".into()]);
+        let pool = ChannelPool::new(vec!["http://127.0.0.1:1".into()], None);
         let result = issue_rpc(&pool, 1).await;
         assert!(result.is_err(), "expected Err from unreachable pool");
     }

--- a/crates/tsoracle-client/src/transport.rs
+++ b/crates/tsoracle-client/src/transport.rs
@@ -16,6 +16,22 @@
 //! `http://host:port` or `https://host:port` depending on whether a TLS
 //! transport is configured; explicit schemes are always preserved.
 
+use std::future::Future;
+use std::pin::Pin;
+use tonic::transport::Channel;
+
+use crate::error::ClientError;
+
+/// Boxed error returned by user-supplied connector closures.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Stored channel-construction strategy, shared by the built-in TLS path
+/// and any user-supplied closure. Errors are normalized to `ClientError`
+/// before storage so the pool's execution path is a single `await?`.
+pub(crate) type ChannelConnector = dyn Fn(&str) -> Pin<Box<dyn Future<Output = Result<Channel, ClientError>> + Send>>
+    + Send
+    + Sync;
+
 /// Apply the scheme rule to an endpoint string.
 ///
 /// - Explicit `http://...` and `https://...` are returned verbatim.
@@ -25,7 +41,6 @@
 /// "Explicit beats configured" is universal: callers wanting plaintext on a
 /// per-endpoint basis even when a TLS transport is configured can pass
 /// `http://host:port` and the rule returns it untouched.
-#[allow(dead_code)]
 pub(crate) fn normalize_uri(endpoint: &str, tls: bool) -> String {
     if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
         endpoint.to_string()

--- a/crates/tsoracle-client/src/transport.rs
+++ b/crates/tsoracle-client/src/transport.rs
@@ -1,0 +1,62 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Transport plumbing for the channel pool.
+//!
+//! `normalize_uri` enforces the scheme rule: bare `host:port` becomes
+//! `http://host:port` or `https://host:port` depending on whether a TLS
+//! transport is configured; explicit schemes are always preserved.
+
+/// Apply the scheme rule to an endpoint string.
+///
+/// - Explicit `http://...` and `https://...` are returned verbatim.
+/// - Bare `host:port` becomes `http://host:port` when `tls` is false,
+///   `https://host:port` when `tls` is true.
+///
+/// "Explicit beats configured" is universal: callers wanting plaintext on a
+/// per-endpoint basis even when a TLS transport is configured can pass
+/// `http://host:port` and the rule returns it untouched.
+#[allow(dead_code)]
+pub(crate) fn normalize_uri(endpoint: &str, tls: bool) -> String {
+    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.to_string()
+    } else if tls {
+        format!("https://{endpoint}")
+    } else {
+        format!("http://{endpoint}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_endpoint_without_tls_yields_http() {
+        assert_eq!(normalize_uri("host:1", false), "http://host:1");
+    }
+
+    #[test]
+    fn bare_endpoint_with_tls_yields_https() {
+        assert_eq!(normalize_uri("host:1", true), "https://host:1");
+    }
+
+    #[test]
+    fn explicit_http_preserved_under_tls() {
+        assert_eq!(normalize_uri("http://host:1", true), "http://host:1");
+    }
+
+    #[test]
+    fn explicit_https_preserved_without_tls() {
+        assert_eq!(normalize_uri("https://host:1", false), "https://host:1");
+    }
+}

--- a/crates/tsoracle-client/src/transport.rs
+++ b/crates/tsoracle-client/src/transport.rs
@@ -51,6 +51,36 @@ pub(crate) fn normalize_uri(endpoint: &str, tls: bool) -> String {
     }
 }
 
+/// Construct the built-in TLS-aware channel connector.
+///
+/// Bare endpoints are rewritten to `https://` via [`normalize_uri`].
+/// Explicit `http://...` endpoints are honored as plaintext even when this
+/// connector is in use ("explicit beats configured"). The TLS config is
+/// attached only when the resolved URI uses the `https` scheme.
+#[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+pub(crate) fn tls_connector(
+    cfg: tonic::transport::ClientTlsConfig,
+) -> std::sync::Arc<ChannelConnector> {
+    use tonic::transport::Endpoint;
+    std::sync::Arc::new(move |endpoint: &str| {
+        let uri = normalize_uri(endpoint, true);
+        let cfg = cfg.clone();
+        let endpoint_owned = endpoint.to_string();
+        Box::pin(async move {
+            let ep: Endpoint = uri
+                .parse()
+                .map_err(|_| ClientError::InvalidEndpoint(endpoint_owned))?;
+            let ep = if ep.uri().scheme_str() == Some("https") {
+                ep.tls_config(cfg).map_err(ClientError::from)?
+            } else {
+                ep
+            };
+            let channel = ep.connect().await.map_err(ClientError::from)?;
+            Ok(channel)
+        })
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -33,6 +33,10 @@
 //! `tsoracle` CLI from `tsoracle-bin` for a standalone process. The
 //! [`docs`] module contains the docs.rs-rendered operations chapter; the
 //! repo's `docs/key-subsystems.md` covers the same internals in depth.
+//!
+//! TLS termination is configured via
+//! `ServerBuilder::tls_config(ServerTlsConfig)`; see
+//! `docs/operations.md` for deployment guidance.
 
 #[macro_use]
 mod failpoint;

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -65,6 +65,8 @@ pub struct ServerBuilder {
     clock: Option<Arc<dyn Clock>>,
     window_ahead: Duration,
     failover_advance: Duration,
+    #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+    tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
 
 impl Default for ServerBuilder {
@@ -74,6 +76,8 @@ impl Default for ServerBuilder {
             clock: None,
             window_ahead: Duration::from_secs(3),
             failover_advance: Duration::from_secs(1),
+            #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+            tls_config: None,
         }
     }
 }
@@ -95,6 +99,18 @@ impl ServerBuilder {
         self.failover_advance = failover_advance;
         self
     }
+
+    /// Configure TLS termination for this server. Applied inside
+    /// [`Server::serve`], [`Server::serve_with_shutdown`], and
+    /// [`Server::serve_with_listener`]. Not applied to [`Server::into_router`] —
+    /// embedders mounting tsoracle alongside their own services control TLS
+    /// on their own tonic builder.
+    #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+    pub fn tls_config(mut self, cfg: tonic::transport::ServerTlsConfig) -> Self {
+        self.tls_config = Some(cfg);
+        self
+    }
+
     pub fn build(self) -> Result<Server, BuildError> {
         crate::leader_hint::validate_key()?;
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
@@ -112,6 +128,8 @@ impl ServerBuilder {
             state_rx,
             extension_lock: Arc::new(tokio::sync::Mutex::new(())),
             extension_gate: Arc::new(tokio::sync::RwLock::new(())),
+            #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+            tls_config: self.tls_config,
         })
     }
 }
@@ -136,6 +154,8 @@ pub struct Server {
     /// which drains all in-flight extensions started under the prior epoch
     /// before the fence proceeds.
     pub(crate) extension_gate: Arc<tokio::sync::RwLock<()>>,
+    #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+    pub(crate) tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
 
 impl Server {
@@ -264,6 +284,9 @@ impl Server {
         addr: SocketAddr,
         shutdown: impl Future<Output = ()> + Send + 'static,
     ) -> Result<(), ServerError> {
+        #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+        let tls_config = self.tls_config.clone();
+
         let (routes, mut watch_handle) = self.into_router();
         let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
 
@@ -276,7 +299,12 @@ impl Server {
             }
         };
 
-        let serve = TonicServer::builder()
+        let mut tonic = TonicServer::builder();
+        #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+        if let Some(cfg) = tls_config {
+            tonic = tonic.tls_config(cfg).map_err(ServerError::Transport)?;
+        }
+        let serve = tonic
             .add_routes(routes)
             .serve_with_shutdown(addr, combined_shutdown);
         tokio::pin!(serve);
@@ -334,6 +362,9 @@ impl Server {
         listener: tokio::net::TcpListener,
         shutdown: impl Future<Output = ()> + Send + 'static,
     ) -> Result<(), ServerError> {
+        #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+        let tls_config = self.tls_config.clone();
+
         let (routes, mut watch_handle) = self.into_router();
         let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
 
@@ -346,7 +377,12 @@ impl Server {
 
         let incoming = tonic::transport::server::TcpIncoming::from(listener);
 
-        let serve = TonicServer::builder()
+        let mut tonic = TonicServer::builder();
+        #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+        if let Some(cfg) = tls_config {
+            tonic = tonic.tls_config(cfg).map_err(ServerError::Transport)?;
+        }
+        let serve = tonic
             .add_routes(routes)
             .serve_with_incoming_shutdown(incoming, combined_shutdown);
         tokio::pin!(serve);
@@ -445,6 +481,24 @@ mod tests {
         assert_eq!(
             panic_payload_to_string(payload),
             "watch task panicked with non-string payload",
+        );
+    }
+
+    #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+    #[test]
+    fn builder_stores_tls_config() {
+        use crate::test_fakes::InMemoryDriver;
+
+        let driver = Arc::new(InMemoryDriver::new());
+        let cfg = tonic::transport::ServerTlsConfig::new();
+        let server = Server::builder()
+            .consensus_driver(driver)
+            .tls_config(cfg)
+            .build()
+            .expect("build with tls_config must succeed");
+        assert!(
+            server.tls_config.is_some(),
+            "tls_config must be stored on Server"
         );
     }
 

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -222,3 +222,35 @@ pub async fn wait_for_grpc_handshake(
         }
     }
 }
+
+/// TLS-aware counterpart to [`wait_for_grpc_handshake`]. Probes the server
+/// by dialing `https://{addr}` with the provided `ClientTlsConfig` so the
+/// readiness check actually completes a TLS handshake.
+#[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+pub async fn wait_for_grpc_handshake_tls(
+    addr: SocketAddr,
+    tls_config: tonic::transport::ClientTlsConfig,
+    budget: Duration,
+) -> Result<(), tonic::transport::Error> {
+    let deadline = Instant::now() + budget;
+    let endpoint: Endpoint = format!("https://{addr}")
+        .parse()
+        .expect("constructed endpoint URI must parse");
+    let endpoint = endpoint.tls_config(tls_config)?;
+    let mut last_err: Option<tonic::transport::Error> = None;
+    loop {
+        match endpoint.connect().await {
+            Ok(channel) => {
+                drop(channel);
+                return Ok(());
+            }
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    return Err(last_err.unwrap_or(err));
+                }
+                last_err = Some(err);
+                sleep(Duration::from_millis(25)).await;
+            }
+        }
+    }
+}

--- a/crates/tsoracle-tests/Cargo.toml
+++ b/crates/tsoracle-tests/Cargo.toml
@@ -9,7 +9,9 @@ publish      = false
 description  = "Private integration-test crate. Hosts the end-to-end tests that exercise tsoracle-client against tsoracle-server (and vice versa) so neither lib needs a dev-dep on the other — releasing one no longer requires the other to already be on crates.io."
 
 [features]
-default = []
+default    = ["tls-rustls"]
+tls-rustls = ["tsoracle-server/tls-rustls", "tsoracle-client/tls-rustls"]
+tls-native = ["tsoracle-server/tls-native", "tsoracle-client/tls-native"]
 # Mirror tsoracle-server's `failpoints` feature so the failpoint-driven
 # integration tests can be opted in. `cargo test -p tsoracle-tests --features failpoints`.
 failpoints = ["tsoracle-server/failpoints", "dep:fail"]
@@ -37,3 +39,6 @@ required-features = ["failpoints"]
 
 [[test]]
 name = "server_serve_with_listener"
+
+[[test]]
+name = "client_tls"

--- a/crates/tsoracle-tests/Cargo.toml
+++ b/crates/tsoracle-tests/Cargo.toml
@@ -17,6 +17,7 @@ failpoints = ["tsoracle-server/failpoints", "dep:fail"]
 [dependencies]
 fail            = { workspace = true, optional = true }
 futures         = { workspace = true }
+rcgen           = { workspace = true }
 tokio           = { workspace = true, features = ["test-util"] }
 tonic           = { workspace = true }
 tsoracle-client = { path = "../tsoracle-client" }

--- a/crates/tsoracle-tests/tests/client_tls.rs
+++ b/crates/tsoracle-tests/tests/client_tls.rs
@@ -1,0 +1,388 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! End-to-end TLS and mTLS tests. Each test boots a real
+//! `tsoracle_server::Server` with a self-signed CA minted in-process,
+//! then exercises the client side `tls_config` / `channel_connector`
+//! plumbing against it.
+
+#![cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+
+use std::sync::Arc;
+use std::time::Duration;
+use tonic::transport::{Certificate, ClientTlsConfig, Identity, ServerTlsConfig};
+use tsoracle_core::Epoch;
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{
+    boot_server, wait_for_grpc_handshake, wait_for_grpc_handshake_tls, wait_until_serving,
+};
+
+struct CertBundle {
+    ca_pem: String,
+    server_cert_pem: String,
+    server_key_pem: String,
+    client_cert_pem: String,
+    client_key_pem: String,
+}
+
+fn mint_certs() -> CertBundle {
+    use rcgen::{
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+        KeyUsagePurpose,
+    };
+
+    let ca_key = KeyPair::generate().expect("ca keypair");
+    let mut ca_params = CertificateParams::new(vec!["tsoracle-test-ca".into()]).expect("ca params");
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let ca_cert = ca_params.self_signed(&ca_key).expect("ca self-sign");
+
+    let server_key = KeyPair::generate().expect("server keypair");
+    let mut server_params = CertificateParams::new(vec!["localhost".into(), "127.0.0.1".into()])
+        .expect("server params");
+    server_params
+        .distinguished_name
+        .push(DnType::CommonName, "localhost");
+    server_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let server_cert = server_params
+        .signed_by(&server_key, &ca_cert, &ca_key)
+        .expect("server sign");
+
+    let client_key = KeyPair::generate().expect("client keypair");
+    let mut client_params = CertificateParams::new(Vec::<String>::new()).expect("client params");
+    client_params
+        .distinguished_name
+        .push(DnType::CommonName, "tsoracle-test-client");
+    client_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+    let client_cert = client_params
+        .signed_by(&client_key, &ca_cert, &ca_key)
+        .expect("client sign");
+
+    CertBundle {
+        ca_pem: ca_cert.pem(),
+        server_cert_pem: server_cert.pem(),
+        server_key_pem: server_key.serialize_pem(),
+        client_cert_pem: client_cert.pem(),
+        client_key_pem: client_key.serialize_pem(),
+    }
+}
+
+fn server_tls_config(bundle: &CertBundle) -> ServerTlsConfig {
+    let identity = Identity::from_pem(&bundle.server_cert_pem, &bundle.server_key_pem);
+    ServerTlsConfig::new().identity(identity)
+}
+
+fn mtls_server_tls_config(bundle: &CertBundle) -> ServerTlsConfig {
+    let identity = Identity::from_pem(&bundle.server_cert_pem, &bundle.server_key_pem);
+    let ca = Certificate::from_pem(&bundle.ca_pem);
+    ServerTlsConfig::new().identity(identity).client_ca_root(ca)
+}
+
+fn client_tls_config_with_ca(bundle: &CertBundle) -> ClientTlsConfig {
+    ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(&bundle.ca_pem))
+        .domain_name("localhost")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tls_handshake_succeeds_with_self_signed_ca() {
+    let bundle = mint_certs();
+    let driver = Arc::new(InMemoryDriver::new());
+    driver.become_leader(Epoch(1));
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .tls_config(server_tls_config(&bundle))
+        .build()
+        .expect("server build");
+
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake_tls(
+        booted.addr,
+        client_tls_config_with_ca(&bundle),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("tonic must accept TLS handshake");
+
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "127.0.0.1:{}",
+        booted.addr.port()
+    )])
+    .tls_config(client_tls_config_with_ca(&bundle))
+    .build()
+    .await
+    .expect("client connect");
+
+    let ts = client.get_ts().await.expect("get_ts");
+    assert!(ts.physical_ms() > 1_700_000_000_000);
+
+    drop(client);
+    booted.shutdown().await.expect("server exit");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tls_handshake_fails_without_ca() {
+    let bundle = mint_certs();
+    let driver = Arc::new(InMemoryDriver::new());
+    driver.become_leader(Epoch(1));
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .tls_config(server_tls_config(&bundle))
+        .build()
+        .expect("server build");
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    let result = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "127.0.0.1:{}",
+        booted.addr.port()
+    )])
+    .tls_config(ClientTlsConfig::new().domain_name("localhost"))
+    .build()
+    .await
+    .expect("build does not connect")
+    .get_ts()
+    .await;
+    match result {
+        Err(tsoracle_client::ClientError::Transport(_))
+        | Err(tsoracle_client::ClientError::NoReachableEndpoints) => {}
+        other => panic!("expected Transport/NoReachableEndpoints, got {other:?}"),
+    }
+    booted.shutdown().await.expect("server exit");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn channel_connector_parity_with_tls_config() {
+    let bundle = mint_certs();
+    let driver = Arc::new(InMemoryDriver::new());
+    driver.become_leader(Epoch(1));
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .tls_config(server_tls_config(&bundle))
+        .build()
+        .expect("server build");
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake_tls(
+        booted.addr,
+        client_tls_config_with_ca(&bundle),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("tls ready");
+
+    let tls = client_tls_config_with_ca(&bundle);
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "127.0.0.1:{}",
+        booted.addr.port()
+    )])
+    .channel_connector(move |endpoint: &str| {
+        let tls = tls.clone();
+        let uri = format!("https://{endpoint}");
+        async move {
+            let ep = tonic::transport::Endpoint::from_shared(uri)?.tls_config(tls)?;
+            Ok(ep.connect().await?)
+        }
+    })
+    .build()
+    .await
+    .expect("client connect");
+    let ts = client.get_ts().await.expect("get_ts");
+    assert!(ts.physical_ms() > 1_700_000_000_000);
+    booted.shutdown().await.expect("server exit");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_http_endpoint_stays_plaintext_under_tls_config() {
+    let bundle = mint_certs();
+    let driver = Arc::new(InMemoryDriver::new());
+    driver.become_leader(Epoch(1));
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .expect("server build");
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("plaintext ready");
+
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "http://127.0.0.1:{}",
+        booted.addr.port()
+    )])
+    .tls_config(client_tls_config_with_ca(&bundle))
+    .build()
+    .await
+    .expect("client connect");
+    let ts = client.get_ts().await.expect("get_ts");
+    assert!(ts.physical_ms() > 1_700_000_000_000);
+    booted.shutdown().await.expect("server exit");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bare_endpoint_becomes_tls_under_tls_config() {
+    let bundle = mint_certs();
+    let driver = Arc::new(InMemoryDriver::new());
+    driver.become_leader(Epoch(1));
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .tls_config(server_tls_config(&bundle))
+        .build()
+        .expect("server build");
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake_tls(
+        booted.addr,
+        client_tls_config_with_ca(&bundle),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("tls ready");
+
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "127.0.0.1:{}",
+        booted.addr.port()
+    )])
+    .tls_config(client_tls_config_with_ca(&bundle))
+    .build()
+    .await
+    .expect("client connect");
+    let ts = client.get_ts().await.expect("get_ts");
+    assert!(ts.physical_ms() > 1_700_000_000_000);
+    booted.shutdown().await.expect("server exit");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn leader_hint_redirect_under_tls() {
+    let bundle = mint_certs();
+
+    let leader_driver = Arc::new(InMemoryDriver::new());
+    leader_driver.become_leader(Epoch(1));
+    let leader = Server::builder()
+        .consensus_driver(leader_driver.clone())
+        .tls_config(server_tls_config(&bundle))
+        .build()
+        .expect("leader build");
+    let mut booted_leader = boot_server(leader).await;
+    wait_until_serving(&mut booted_leader.state_rx).await;
+    wait_for_grpc_handshake_tls(
+        booted_leader.addr,
+        client_tls_config_with_ca(&bundle),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("leader ready");
+
+    let leader_endpoint = format!("127.0.0.1:{}", booted_leader.addr.port());
+    let follower_driver = Arc::new(InMemoryDriver::new());
+    follower_driver.become_follower(Some(leader_endpoint.clone()));
+    let follower = Server::builder()
+        .consensus_driver(follower_driver.clone())
+        .tls_config(server_tls_config(&bundle))
+        .build()
+        .expect("follower build");
+    let booted_follower = boot_server(follower).await;
+    // The follower stays NotServing until it transitions to leader, which
+    // it never does — so wait_until_serving would block. Wait for the TLS
+    // port to be open instead.
+    wait_for_grpc_handshake_tls(
+        booted_follower.addr,
+        client_tls_config_with_ca(&bundle),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("follower port ready");
+
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![
+        format!("127.0.0.1:{}", booted_follower.addr.port()),
+        format!("127.0.0.1:{}", booted_leader.addr.port()),
+    ])
+    .tls_config(client_tls_config_with_ca(&bundle))
+    .build()
+    .await
+    .expect("client connect");
+
+    let ts = client.get_ts().await.expect("get_ts");
+    assert!(ts.physical_ms() > 1_700_000_000_000);
+
+    booted_leader.shutdown().await.expect("leader exit");
+    booted_follower.shutdown().await.expect("follower exit");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mtls_handshake_succeeds_with_client_identity() {
+    let bundle = mint_certs();
+    let driver = Arc::new(InMemoryDriver::new());
+    driver.become_leader(Epoch(1));
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .tls_config(mtls_server_tls_config(&bundle))
+        .build()
+        .expect("server build");
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+
+    let client_identity = Identity::from_pem(&bundle.client_cert_pem, &bundle.client_key_pem);
+    let tls = client_tls_config_with_ca(&bundle).identity(client_identity);
+    // Skip the readiness probe — it would need the same client identity.
+    // The first real client call exercises that.
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "127.0.0.1:{}",
+        booted.addr.port()
+    )])
+    .tls_config(tls)
+    .build()
+    .await
+    .expect("client connect");
+    let ts = client.get_ts().await.expect("get_ts");
+    assert!(ts.physical_ms() > 1_700_000_000_000);
+    booted.shutdown().await.expect("server exit");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mtls_handshake_fails_without_client_identity() {
+    let bundle = mint_certs();
+    let driver = Arc::new(InMemoryDriver::new());
+    driver.become_leader(Epoch(1));
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .tls_config(mtls_server_tls_config(&bundle))
+        .build()
+        .expect("server build");
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    let result = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "127.0.0.1:{}",
+        booted.addr.port()
+    )])
+    .tls_config(client_tls_config_with_ca(&bundle))
+    .build()
+    .await
+    .expect("build does not connect")
+    .get_ts()
+    .await;
+    // The mTLS failure mode is tonic-version dependent: the channel may open
+    // lazily and the handshake error surface during the RPC as `Rpc` with
+    // code `Unknown` ("transport error"), or the retry loop may exhaust to
+    // `NoReachableEndpoints`, or the eager handshake may fail with `Transport`.
+    // All three are valid signals of "server rejected the connection."
+    match result {
+        Err(tsoracle_client::ClientError::Transport(_))
+        | Err(tsoracle_client::ClientError::NoReachableEndpoints)
+        | Err(tsoracle_client::ClientError::Rpc(_)) => {}
+        other => panic!("expected Transport/NoReachableEndpoints/Rpc, got {other:?}"),
+    }
+    booted.shutdown().await.expect("server exit");
+}

--- a/docs/client-api-and-usage.md
+++ b/docs/client-api-and-usage.md
@@ -47,6 +47,7 @@ The trailer's wire format is described in [The leader-hint trailer](key-subsyste
 - `Rpc(Status)` — the last attempt returned a tonic `Status` we couldn't recover from.
 - `InvalidEndpoint(String)` — an endpoint string failed to parse as a URI.
 - `InvalidCount(u32)` — `count == 0` or `count > LOGICAL_MAX + 1` was passed to `get_ts_batch`.
+- `Connector(_)` — a user-supplied `channel_connector` closure returned an error. Built-in TLS failures continue to surface as `Transport(_)`.
 
 ## Configuration
 
@@ -67,3 +68,62 @@ ClientBuilder::endpoints(vec![
 **`batch_flush_interval`** is the *cold-start* coalescing window — the time the background driver waits, after the first buffered call arrives into an idle driver, before issuing the outgoing `GetTs` (default: 1 ms). It does *not* set the steady-state batch size: once any RPC is in flight, every waiter arriving during its round-trip is automatically coalesced into the next batch regardless of this knob, so steady-state batch size is set by `arrival_rate × rpc_round_trip` instead. Lowering `batch_flush_interval` (down to `Duration::ZERO`) reduces the per-call latency floor for cold-start callers but loses the first-burst coalescing window; raising it widens that window at the cost of a fixed latency tax on every first-after-idle request. For workloads that already batch explicitly, or that sustain enough concurrency to keep at least one RPC in flight at all times, the value is largely irrelevant. The full discussion — including why steady-state low batch size is a caller-concurrency problem and not a flushing problem — is in [The Client Driver](the-client-driver.md).
 
 There is no per-call timeout knob — wrap your call in `tokio::time::timeout` if you need one. The background coalescing task uses a bounded waiter queue (4096 entries); once full, callers await queue capacity, which applies backpressure before memory can grow without bound.
+
+## Custom transport (TLS, mTLS, connectors)
+
+The default `Client` dials each endpoint over plaintext HTTP/2. Two builder methods change that. `.tls_config(ClientTlsConfig)` (feature `tls-rustls` or `tls-native`; the former is on by default) attaches a `tonic::transport::ClientTlsConfig` to every endpoint the client opens, including leader-hint redirects to endpoints that were not in the configured list. `.channel_connector(|endpoint| async { ... })` is the generic escape hatch: the caller's closure builds and returns a `tonic::transport::Channel` for any endpoint string the client needs to dial. Use `tls_config` when a `ClientTlsConfig` is enough; reach for `channel_connector` when you also need to configure keepalive, custom connectors, service-mesh interposers, or proxies.
+
+Setting both `.tls_config(...)` and `.channel_connector(...)` is allowed; the last call wins (standard builder semantics).
+
+### Scheme rule
+
+| Configured state | Bare `host:port` becomes | `http://...` | `https://...` |
+| --- | --- | --- | --- |
+| No transport config (default) | `http://host:port` | plaintext | TLS (requires a `tls-*` feature to actually connect) |
+| `.tls_config(cfg)` set | `https://host:port` | plaintext (explicit beats configured) | TLS using `cfg` |
+| `.channel_connector(closure)` set | passed verbatim to the closure | passed verbatim | passed verbatim |
+
+"Explicit beats configured" is universal — including for leader-hint trailers. If the server emits a bare-host hint like `node-b:50551`, the client's rewrite rule applies (bare → https when `tls_config` is set; bare → http otherwise). If the server emits a fully-qualified scheme, that scheme is honored.
+
+### Minimal TLS example
+
+```rust
+use tonic::transport::{Certificate, ClientTlsConfig};
+
+let tls = ClientTlsConfig::new()
+    .ca_certificate(Certificate::from_pem(&ca_pem))
+    .domain_name("oracle.internal");
+
+let client = tsoracle_client::ClientBuilder::endpoints(vec![
+    "oracle-1.internal:50551".into(),
+    "oracle-2.internal:50551".into(),
+])
+    .tls_config(tls)
+    .build()
+    .await?;
+```
+
+### Minimal `channel_connector` example
+
+```rust
+let tls = ClientTlsConfig::new()
+    .ca_certificate(Certificate::from_pem(&ca_pem))
+    .identity(Identity::from_pem(&client_cert_pem, &client_key_pem))
+    .domain_name("oracle.internal");
+
+let client = tsoracle_client::ClientBuilder::endpoints(endpoints)
+    .channel_connector(move |endpoint: &str| {
+        let tls = tls.clone();
+        let uri = format!("https://{endpoint}");
+        async move {
+            let ep = tonic::transport::Endpoint::from_shared(uri)?
+                .tls_config(tls)?
+                .keep_alive_while_idle(true);
+            Ok(ep.connect().await?)
+        }
+    })
+    .build()
+    .await?;
+```
+
+See [`examples/tls-mtls`](../examples/tls-mtls/) for a runnable demo covering plain TLS, mTLS, the connector escape hatch, and a misconfigured mTLS negative path.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,3 +61,13 @@ The consensus driver owns the mapping from consensus leader identity to tsoracle
 ## Client retry behavior
 
 The client gives `FAILED_PRECONDITION` special handling: it parses the `tsoracle-leader-hint-bin` trailer (see [The leader-hint trailer](key-subsystems.md#the-leader-hint-trailer)) and moves the hinted leader to the front of the current retry worklist. Other gRPC errors, including `UNAVAILABLE` and `INTERNAL`, are recorded and the client continues through the configured endpoints once for that call. Configure `endpoints` with all known servers so cold-start works even when the cached leader is unreachable.
+
+## TLS termination
+
+`tsoracle-server` terminates TLS via `ServerBuilder::tls_config(tonic::transport::ServerTlsConfig)`. The configuration is applied inside `Server::serve`, `Server::serve_with_shutdown`, and `Server::serve_with_listener` — all three paths pass through tonic's server builder, and the TLS config is attached before `.add_routes(routes)`. The default feature `tls-rustls` (using `tonic/tls-aws-lc`) is on by default; opt into `tls-native` instead if you prefer the platform root store.
+
+`Server::into_router` does **not** take a TLS config. It returns a `Routes` value for embedders mounting tsoracle alongside their own services on a shared tonic server; in that case the embedder configures TLS on their own `TonicServer::builder()` and we stay out of the way.
+
+Cert and key shapes follow tonic: `ServerTlsConfig::new().identity(Identity::from_pem(cert, key))` for plain TLS; add `.client_ca_root(Certificate::from_pem(ca))` for mTLS.
+
+The stock `tsoracle` CLI does not currently expose TLS flags. If you need TLS today, embed the library — see [`examples/tls-mtls`](../examples/tls-mtls/) for a runnable starting point.

--- a/examples/tls-mtls/Cargo.toml
+++ b/examples/tls-mtls/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name                   = "example-tls-mtls"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+description            = "tsoracle example: TLS and mTLS configuration end-to-end (client + server, in-memory certs)"
+publish                = false
+
+[dependencies]
+tsoracle-server      = { path = "../../crates/tsoracle-server", version = "0.1.1" }
+tsoracle-client      = { path = "../../crates/tsoracle-client", version = "0.1.1" }
+tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "0.1.1" }
+tonic                = { workspace = true }
+tokio                = { workspace = true, features = ["signal"] }
+futures              = { workspace = true }
+rcgen                = { workspace = true }
+anyhow               = { workspace = true }
+tracing              = { workspace = true }
+tracing-subscriber   = { workspace = true }

--- a/examples/tls-mtls/README.md
+++ b/examples/tls-mtls/README.md
@@ -1,0 +1,33 @@
+# TLS and mTLS configuration end-to-end
+
+A single binary that demonstrates the four common shapes of TLS configuration on [`tsoracle-server`](https://docs.rs/tsoracle-server) and [`tsoracle-client`](https://docs.rs/tsoracle-client):
+
+1. **Plain TLS** — server presents a leaf cert, client verifies the chain.
+2. **mTLS** — server *also* verifies the client's cert against its configured CA root.
+3. **Custom connector** — same mTLS server, but the client uses `.channel_connector(...)` to add transport knobs (keepalive in this example) not exposed on `.tls_config(...)`.
+4. **mTLS misconfiguration** — same mTLS server, client *without* a client identity. The handshake fails and the error variant is printed so readers can recognize the pattern.
+
+All certificates are minted in memory via [`rcgen`](https://docs.rs/rcgen). Nothing is read from disk; nothing is shipped in the repo. Production callers would replace `certs::mint()` with `Identity::from_pem(std::fs::read_to_string(path)?, ...)` and load PEM material from their configured cert store.
+
+## Run
+
+```bash
+cargo run -p example-tls-mtls
+```
+
+Each step boots a fresh `tsoracle_server::Server` on `127.0.0.1:0`, captures the OS-picked port, runs three `get_ts()` calls, and tears down before the next step. Total runtime is a few hundred milliseconds.
+
+## What to look at in `src/main.rs`
+
+- **`ServerBuilder::tls_config(ServerTlsConfig::new().identity(...))`** is the server-side surface for plain TLS. Adding `.client_ca_root(...)` turns it into mTLS.
+- **`ClientBuilder::tls_config(ClientTlsConfig::new().ca_certificate(...).domain_name(...))`** is the client-side one-liner for the common case. Adding `.identity(...)` upgrades it to mTLS.
+- **`ClientBuilder::channel_connector(|endpoint| async { ... })`** is the escape hatch for transport behaviour beyond `ClientTlsConfig` — keepalive, proxies, service-mesh integrations. Errors returned from the closure surface as `ClientError::Connector`.
+- **The scheme rule** matters: bare `host:port` endpoints become `https://host:port` when `.tls_config(...)` is set; explicit `http://...` and `https://...` schemes are honored as-is. See `docs/client-api-and-usage.md` for the full table.
+- **Step 4** intentionally fails. `ClientError::Transport(_)` and `ClientError::Rpc(_)` are both possible failure surfaces for an mTLS handshake error depending on whether the handshake fails eagerly during `connect()` or lazily during the first RPC.
+
+## When this example is *not* the right shape
+
+- **Production cert management** (file watching, ACME, hot rotation, key rotation, cert reload on SIGHUP) is out of scope. Plug your own PEM-loading code into `Identity::from_pem` and `Certificate::from_pem`.
+- **Authentication policy** beyond "is the cert signed by the configured CA" is out of scope — that includes SPIFFE / SVID validation, subject DN matching, OCSP, and audit logging. Use a tonic interceptor or a service-mesh sidecar for those.
+- **CLI flags for TLS on the stock `tsoracle` binary** are not currently exposed. If you need TLS today, embed the library as this example does.
+- **HA / openraft.** This example uses [`FileDriver`](https://docs.rs/tsoracle-driver-file), a single-node driver. The TLS wiring is independent of consensus — swap in a `ConsensusDriver` from [`tsoracle-driver-openraft`](https://docs.rs/tsoracle-driver-openraft) and keep the `.tls_config(...)` calls exactly as written here.

--- a/examples/tls-mtls/src/certs.rs
+++ b/examples/tls-mtls/src/certs.rs
@@ -1,0 +1,62 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! In-memory cert minting for the TLS / mTLS example. Production callers
+//! load PEM-encoded material from disk via `std::fs::read_to_string` and
+//! `tonic::transport::Identity::from_pem(...)` — this helper is here so
+//! the example does not ship cert files.
+
+use anyhow::Result;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+    KeyUsagePurpose,
+};
+
+pub struct CertBundle {
+    pub ca_pem: String,
+    pub server_cert_pem: String,
+    pub server_key_pem: String,
+    pub client_cert_pem: String,
+    pub client_key_pem: String,
+}
+
+pub fn mint() -> Result<CertBundle> {
+    let ca_key = KeyPair::generate()?;
+    let mut ca_params = CertificateParams::new(vec!["tsoracle-example-ca".into()])?;
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let ca_cert = ca_params.self_signed(&ca_key)?;
+
+    let server_key = KeyPair::generate()?;
+    let mut server_params = CertificateParams::new(vec!["localhost".into(), "127.0.0.1".into()])?;
+    server_params
+        .distinguished_name
+        .push(DnType::CommonName, "localhost");
+    server_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let server_cert = server_params.signed_by(&server_key, &ca_cert, &ca_key)?;
+
+    let client_key = KeyPair::generate()?;
+    let mut client_params = CertificateParams::new(Vec::<String>::new())?;
+    client_params
+        .distinguished_name
+        .push(DnType::CommonName, "tsoracle-example-client");
+    client_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+    let client_cert = client_params.signed_by(&client_key, &ca_cert, &ca_key)?;
+
+    Ok(CertBundle {
+        ca_pem: ca_cert.pem(),
+        server_cert_pem: server_cert.pem(),
+        server_key_pem: server_key.serialize_pem(),
+        client_cert_pem: client_cert.pem(),
+        client_key_pem: client_key.serialize_pem(),
+    })
+}

--- a/examples/tls-mtls/src/main.rs
+++ b/examples/tls-mtls/src/main.rs
@@ -1,0 +1,277 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Four-step TLS / mTLS demo:
+//!   1. Plain TLS (server identity, client verifies)
+//!   2. mTLS (server also verifies client identity)
+//!   3. Custom connector against the mTLS server (transport escape hatch)
+//!   4. mTLS misconfiguration (no client identity) — expected to fail
+//!
+//! Each step boots a fresh server, runs three GetTs calls, and prints the
+//! results. All certs are minted in process via `rcgen`; nothing is read
+//! from disk.
+
+mod certs;
+
+use anyhow::Result;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+use tonic::transport::{Certificate, ClientTlsConfig, Identity, ServerTlsConfig};
+use tsoracle_client::{ClientBuilder, ClientError};
+use tsoracle_driver_file::FileDriver;
+use tsoracle_server::{Server, ServingState};
+
+async fn wait_until_serving(rx: &mut watch::Receiver<ServingState>) {
+    loop {
+        if matches!(*rx.borrow_and_update(), ServingState::Serving) {
+            return;
+        }
+        if rx.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let bundle = certs::mint()?;
+
+    step_plain_tls(&bundle).await?;
+    step_mtls(&bundle).await?;
+    step_custom_connector_against_mtls(&bundle).await?;
+    step_mtls_misconfigured(&bundle).await?;
+
+    Ok(())
+}
+
+async fn step_plain_tls(bundle: &certs::CertBundle) -> Result<()> {
+    println!("\n=== Step 1: plain TLS ===");
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let driver = boot_file_driver("tls")?;
+
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .tls_config(ServerTlsConfig::new().identity(server_identity(bundle)))
+        .build()?;
+
+    let mut state_rx = server.state_rx.clone();
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve_with_listener(listener, futures::future::pending())
+            .await
+    });
+    wait_until_serving(&mut state_rx).await;
+
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(&bundle.ca_pem))
+        .domain_name("localhost");
+    let client = ClientBuilder::endpoints(vec![format!("127.0.0.1:{}", addr.port())])
+        .tls_config(tls)
+        .build()
+        .await?;
+
+    for i in 0..3 {
+        let ts = client.get_ts().await?;
+        println!(
+            "  [tls] call {i} -> physical_ms={} logical={}",
+            ts.physical_ms(),
+            ts.logical()
+        );
+    }
+
+    drop(client);
+    server_handle.abort();
+    Ok(())
+}
+
+async fn step_mtls(bundle: &certs::CertBundle) -> Result<()> {
+    println!("\n=== Step 2: mTLS ===");
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let driver = boot_file_driver("mtls")?;
+
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .tls_config(
+            ServerTlsConfig::new()
+                .identity(server_identity(bundle))
+                .client_ca_root(Certificate::from_pem(&bundle.ca_pem)),
+        )
+        .build()?;
+
+    let mut state_rx = server.state_rx.clone();
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve_with_listener(listener, futures::future::pending())
+            .await
+    });
+    wait_until_serving(&mut state_rx).await;
+
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(&bundle.ca_pem))
+        .identity(Identity::from_pem(
+            &bundle.client_cert_pem,
+            &bundle.client_key_pem,
+        ))
+        .domain_name("localhost");
+    let client = ClientBuilder::endpoints(vec![format!("127.0.0.1:{}", addr.port())])
+        .tls_config(tls)
+        .build()
+        .await?;
+
+    for i in 0..3 {
+        let ts = client.get_ts().await?;
+        println!(
+            "  [mtls] call {i} -> physical_ms={} logical={}",
+            ts.physical_ms(),
+            ts.logical()
+        );
+    }
+
+    drop(client);
+    server_handle.abort();
+    Ok(())
+}
+
+async fn step_custom_connector_against_mtls(bundle: &certs::CertBundle) -> Result<()> {
+    println!("\n=== Step 3: custom connector against mTLS server ===");
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let driver = boot_file_driver("connector")?;
+
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .tls_config(
+            ServerTlsConfig::new()
+                .identity(server_identity(bundle))
+                .client_ca_root(Certificate::from_pem(&bundle.ca_pem)),
+        )
+        .build()?;
+
+    let mut state_rx = server.state_rx.clone();
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve_with_listener(listener, futures::future::pending())
+            .await
+    });
+    wait_until_serving(&mut state_rx).await;
+
+    // `.channel_connector(...)` is the escape hatch when you need transport
+    // knobs not exposed on the builder (keepalive here; concurrency,
+    // proxies, service-mesh integrations elsewhere).
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(&bundle.ca_pem))
+        .identity(Identity::from_pem(
+            &bundle.client_cert_pem,
+            &bundle.client_key_pem,
+        ))
+        .domain_name("localhost");
+    let client = ClientBuilder::endpoints(vec![format!("127.0.0.1:{}", addr.port())])
+        .channel_connector(move |endpoint: &str| {
+            let tls = tls.clone();
+            let uri = format!("https://{endpoint}");
+            async move {
+                let ep = tonic::transport::Endpoint::from_shared(uri)?
+                    .tls_config(tls)?
+                    .keep_alive_while_idle(true);
+                Ok(ep.connect().await?)
+            }
+        })
+        .build()
+        .await?;
+
+    for i in 0..3 {
+        let ts = client.get_ts().await?;
+        println!(
+            "  [connector] call {i} -> physical_ms={} logical={}",
+            ts.physical_ms(),
+            ts.logical()
+        );
+    }
+
+    drop(client);
+    server_handle.abort();
+    Ok(())
+}
+
+async fn step_mtls_misconfigured(bundle: &certs::CertBundle) -> Result<()> {
+    println!("\n=== Step 4: mTLS misconfigured (no client identity, expected failure) ===");
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let driver = boot_file_driver("misconfigured")?;
+
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .tls_config(
+            ServerTlsConfig::new()
+                .identity(server_identity(bundle))
+                .client_ca_root(Certificate::from_pem(&bundle.ca_pem)),
+        )
+        .build()?;
+
+    let mut state_rx = server.state_rx.clone();
+    let server_handle = tokio::spawn(async move {
+        server
+            .serve_with_listener(listener, futures::future::pending())
+            .await
+    });
+    wait_until_serving(&mut state_rx).await;
+
+    // No `.identity(...)` on the client TLS config.
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(&bundle.ca_pem))
+        .domain_name("localhost");
+    let client = ClientBuilder::endpoints(vec![format!("127.0.0.1:{}", addr.port())])
+        .tls_config(tls)
+        .build()
+        .await?;
+
+    match client.get_ts().await {
+        Err(ClientError::Transport(err)) => {
+            println!("  [expected] mTLS without identity -> ClientError::Transport: {err}");
+        }
+        Err(ClientError::NoReachableEndpoints) => {
+            println!("  [expected] mTLS without identity -> NoReachableEndpoints");
+        }
+        Err(ClientError::Rpc(status)) => {
+            println!(
+                "  [expected] mTLS without identity -> ClientError::Rpc: code={:?} message={}",
+                status.code(),
+                status.message()
+            );
+        }
+        other => println!("  [unexpected] {other:?}"),
+    }
+
+    drop(client);
+    server_handle.abort();
+    Ok(())
+}
+
+fn server_identity(bundle: &certs::CertBundle) -> Identity {
+    Identity::from_pem(&bundle.server_cert_pem, &bundle.server_key_pem)
+}
+
+fn boot_file_driver(tag: &str) -> Result<Arc<FileDriver>> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!("tsoracle-example-tls-{tag}-{nanos}"));
+    std::fs::create_dir_all(&dir)?;
+    Ok(FileDriver::open_or_init(&dir)?)
+}


### PR DESCRIPTION
## Summary

Adds first-class TLS configuration on both `tsoracle-client` and `tsoracle-server`, plus a transport escape hatch on the client. Closes issue #76.

**Client (`tsoracle-client`)** gains two new `ClientBuilder` methods:
- `.tls_config(ClientTlsConfig)` — attaches a tonic TLS config to every channel the client opens, including leader-hint redirects to endpoints not in the configured list. Feature-gated on `tls-rustls` (default) or `tls-native`.
- `.channel_connector(|endpoint| async { ... })` — the generic escape hatch for transport behaviour beyond `ClientTlsConfig` (keepalive, proxies, service-mesh interposers). Errors returned from the closure surface as a new `ClientError::Connector(BoxError)` variant; built-in TLS failures continue to surface as `ClientError::Transport(_)`.

Setting both is allowed; last call wins (standard builder semantics). Internally both methods set a single `Option<Arc<ChannelConnector>>` on `ChannelPool`, so there is exactly one execution path for channel construction at the call site.

**Scheme rule** — bare `host:port` becomes `https://host:port` when `.tls_config(...)` is set, `http://host:port` otherwise; explicit schemes (`http://` / `https://`) are always honored verbatim (`explicit beats configured`). The rule is universal — it applies to configured endpoints, leader-hint redirects, and trailers alike.

**Server (`tsoracle-server`)** gains a symmetric `ServerBuilder::tls_config(ServerTlsConfig)` method, applied inside `Server::serve`, `Server::serve_with_shutdown`, and `Server::serve_with_listener` before `.add_routes(...)`. `Server::into_router` is deliberately untouched — embedders mounting tsoracle alongside their own services keep control of TLS on their own tonic builder.

**Coverage** — 8 end-to-end tests in `crates/tsoracle-tests/tests/client_tls.rs` cover: TLS happy path with self-signed CA, handshake failure without CA, channel_connector parity, explicit-http override under tls_config, bare-host rewrite to https, leader-hint redirect under TLS, mTLS success with client identity, mTLS failure without client identity. Certs are minted in-process via `rcgen` (new workspace dep).

**Example** — `examples/tls-mtls/` is a single binary that boots a fresh server per step and walks through plain TLS → mTLS → custom connector → mTLS misconfigured (expected failure). Runs in a few hundred milliseconds.

**Docs** — `docs/client-api-and-usage.md` gains a Custom Transport section with the scheme rule table and minimal examples for both methods; `docs/operations.md` gains a TLS termination section. Both `lib.rs` files get two-line doc-pointer notes.

## Test plan

- [x] `cargo test --workspace` — green
- [x] `cargo test -p tsoracle-client --no-default-features` — green (33 tests; TLS-gated tests are correctly skipped)
- [x] `cargo test -p tsoracle-server --no-default-features` — green (14 tests; TLS-gated test correctly skipped)
- [x] `cargo test -p tsoracle-tests --test client_tls` — 8/8 pass
- [x] `cargo build --workspace --examples` — clean
- [x] `cargo run -p example-tls-mtls` — all four steps print expected output; step 4 surfaces the expected handshake failure
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Canonical copyright header verified on all new `.rs` files

## Notes for reviewers

- The mTLS-without-identity negative test accepts `Rpc(_)` in addition to `Transport(_)`/`NoReachableEndpoints` — under tonic 0.14 the lazy handshake failure most often surfaces as `Rpc(Status { code: Unknown, message: "transport error" })` during the first RPC rather than as a transport error during `connect()`.
- `clone_client_error` in `driver.rs` reconstructs the `Connector` variant via stringified message (the `Box<dyn Error>` is not `Clone`). Collapsing to `NoReachableEndpoints` like `Transport` does would be misleading — a connector-closure failure is not endpoint exhaustion.
- `tsoracle-tests` Cargo.toml gained `tls-rustls`/`tls-native` features mirroring the client/server crates. Without these the `#![cfg(...)]` gate in the test file silently compiled to zero tests.
- The benchmark crates (`bench-minimal`, `bench-stress`) had non-exhaustive `match`es on `ClientError`; both got `Connector(_)` arms in the first commit so pre-commit clippy stayed green.