### PR TITLE
fix: replace #[allow(dead_code)] with explanatory comment on leader_tx

### DIFF
--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -44,7 +44,8 @@ pub struct FileDriver {
     // without holding any state lock and then publish via a Release store.
     state: Arc<AtomicU64>,
     write_lock: tokio::sync::Mutex<()>,
-    #[allow(dead_code)]
+    // Held to keep the watch channel open; FileDriver never sends after the
+    // initial Leader { epoch: 0 } published at construction.
     leader_tx: watch::Sender<LeaderState>,
     leader_rx: watch::Receiver<LeaderState>,
 }


### PR DESCRIPTION
## What
Replaced #[allow(dead_code)] on leader_tx with an explanatory comment.

## Why
Closes #101. The allow(dead_code) annotation misleads maintainers into thinking the field is unused and deletable, but it's held to keep the watch channel open.

## How
- Removed #[allow(dead_code)]
- Added a comment explaining why leader_tx is stored

## Testing
- Compiles cleanly