### PR TITLE
fix: deduplicate MAX_TIMESTAMPS_PER_RPC between lib.rs and driver.rs

### DIFF
--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -26,6 +26,7 @@ use tokio::time::{Instant, sleep_until};
 use tsoracle_core::{LOGICAL_MAX, Timestamp};
 
 use crate::error::ClientError;
+use crate::MAX_TIMESTAMPS_PER_RPC;
 
 /// Bound on the waiter queue. A slow server combined with a fast caller
 /// must not grow this without limit; once full, `Driver::request` awaits
@@ -34,11 +35,6 @@ use crate::error::ClientError;
 /// Each `Waiter` is small (~32 bytes), so 4096 caps the queue at ~128 KB
 /// regardless of how aggressive the producers are.
 const QUEUE_CAPACITY: usize = 4096;
-
-/// The server's per-call cap, fixed by the 18-bit logical width. Any single
-/// outgoing `GetTs` RPC must respect this; coalesced batches that exceed it
-/// are split into multiple chunks of this size or less.
-const MAX_TIMESTAMPS_PER_RPC: u32 = LOGICAL_MAX + 1;
 
 pub(crate) struct Waiter {
     pub count: u32,


### PR DESCRIPTION
## What
Deduplicated MAX_TIMESTAMPS_PER_RPC constant - now declared once in lib.rs and imported by driver.rs.

## Why
Closes #104. Having the same constant in two modules risks drift where one gets updated but the other doesn't, causing silent bugs.

## How
- Removed duplicate const from driver.rs
- Added use crate::MAX_TIMESTAMPS_PER_RPC import

## Testing
- Compiles cleanly