### PR TITLE
fix(client): reject plaintext leader-hint under tls_config

### DIFF
--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -37,19 +37,34 @@ pub struct ChannelPool {
     channels: Mutex<HashMap<String, Channel>>,
     leader: Mutex<Option<String>>,
     connector: Option<std::sync::Arc<crate::transport::ChannelConnector>>,
+    /// Set by `ClientBuilder::tls_config`; cleared by `channel_connector`.
+    /// Tells the retry loop to drop wire-supplied `http://` leader hints so
+    /// a contacted peer cannot downgrade the transport. Has no effect on
+    /// operator-supplied endpoints; those use the documented scheme rule
+    /// ("explicit beats configured") unchanged.
+    tls_required: bool,
 }
 
 impl ChannelPool {
     pub fn new(
         endpoints: Vec<String>,
         connector: Option<std::sync::Arc<crate::transport::ChannelConnector>>,
+        tls_required: bool,
     ) -> Self {
         ChannelPool {
             configured: endpoints,
             channels: Mutex::new(HashMap::new()),
             leader: Mutex::new(None),
             connector,
+            tls_required,
         }
+    }
+
+    /// True when the built-in TLS connector is in use. The retry loop uses
+    /// this to refuse wire-supplied `http://` leader hints; see
+    /// `crate::retry::issue_rpc`.
+    pub fn tls_required(&self) -> bool {
+        self.tls_required
     }
 
     pub fn cached_leader(&self) -> Option<String> {
@@ -108,7 +123,7 @@ mod tests {
 
     #[test]
     fn iter_starts_with_cached_leader() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None);
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None, false);
         pool.set_leader("b:1".into());
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["b:1", "a:1", "c:1"]);
@@ -116,14 +131,14 @@ mod tests {
 
     #[test]
     fn iter_without_cache_is_configured_order() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None);
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None, false);
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["a:1", "b:1", "c:1"]);
     }
 
     #[test]
     fn clear_leader_drops_cached_leader() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], None);
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], None, false);
         pool.set_leader("b:1".into());
         assert_eq!(pool.cached_leader().as_deref(), Some("b:1"));
         pool.clear_leader();
@@ -142,7 +157,7 @@ mod tests {
             let endpoint_owned = endpoint.to_string();
             Box::pin(async move { Err(crate::error::ClientError::InvalidEndpoint(endpoint_owned)) })
         });
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], Some(connector));
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], Some(connector), false);
         let _ = pool.client("a:1").await;
         let _ = pool.client("b:1").await;
         let seen = captured.lock().clone();
@@ -163,7 +178,7 @@ mod tests {
                     Ok(channel)
                 })
             });
-        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector));
+        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector), false);
         let _ = pool
             .client("a:1")
             .await
@@ -183,7 +198,7 @@ mod tests {
             captured_for_closure.lock().push(endpoint.to_string());
             Box::pin(async { Err(crate::error::ClientError::InvalidEndpoint("x".into())) })
         });
-        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector));
+        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector), false);
         let _ = pool.client("hinted:1").await;
         let seen = captured.lock().clone();
         assert_eq!(seen, vec!["hinted:1".to_string()]);

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -50,6 +50,7 @@ pub struct ClientBuilder {
     endpoints: Vec<String>,
     flush_interval: Duration,
     connector: Option<Arc<crate::transport::ChannelConnector>>,
+    tls_required: bool,
 }
 
 impl ClientBuilder {
@@ -58,6 +59,7 @@ impl ClientBuilder {
             endpoints,
             flush_interval: Duration::from_millis(1),
             connector: None,
+            tls_required: false,
         }
     }
 
@@ -67,15 +69,24 @@ impl ClientBuilder {
     }
 
     /// Configure the client to dial bare endpoints with TLS. Bare `host:port`
-    /// becomes `https://host:port`; explicit `http://...` endpoints remain
-    /// plaintext; explicit `https://...` endpoints use the provided TLS
-    /// config.
+    /// becomes `https://host:port`; explicit `http://...` endpoints supplied
+    /// in [`Self::endpoints`] remain plaintext; explicit `https://...`
+    /// endpoints use the provided TLS config.
+    ///
+    /// Wire-supplied `http://...` leader-hint trailers are NOT honored under
+    /// `tls_config` — they are dropped to prevent a contacted peer from
+    /// downgrading the transport. Operator-supplied configuration still wins;
+    /// untrusted wire input does not.
     ///
     /// Setting both [`Self::channel_connector`] and `tls_config` is allowed;
-    /// the last call wins (standard builder semantics).
+    /// the last call wins (standard builder semantics). Calling
+    /// `channel_connector` after `tls_config` also clears the
+    /// reject-plaintext-hint policy, since the caller-owned connector owns
+    /// its own scheme policy.
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     pub fn tls_config(mut self, cfg: tonic::transport::ClientTlsConfig) -> Self {
         self.connector = Some(crate::transport::tls_connector(cfg));
+        self.tls_required = true;
         self
     }
 
@@ -85,7 +96,10 @@ impl ClientBuilder {
     /// from the closure surface as [`ClientError::Connector`].
     ///
     /// See module docs for the interaction with [`Self::tls_config`]
-    /// (last-wins) and the scheme matrix.
+    /// (last-wins) and the scheme matrix. A caller-owned connector replaces
+    /// the built-in TLS plumbing entirely, including the
+    /// reject-plaintext-leader-hint policy — the closure is responsible for
+    /// whatever scheme policy it wants to enforce.
     pub fn channel_connector<F, Fut>(mut self, connector: F) -> Self
     where
         F: Fn(&str) -> Fut + Send + Sync + 'static,
@@ -98,6 +112,7 @@ impl ClientBuilder {
             Box::pin(async move { fut.await.map_err(ClientError::Connector) })
         });
         self.connector = Some(wrapped);
+        self.tls_required = false;
         self
     }
 
@@ -105,7 +120,11 @@ impl ClientBuilder {
         if self.endpoints.is_empty() {
             return Err(ClientError::NoReachableEndpoints);
         }
-        let pool = Arc::new(ChannelPool::new(self.endpoints, self.connector));
+        let pool = Arc::new(ChannelPool::new(
+            self.endpoints,
+            self.connector,
+            self.tls_required,
+        ));
         let pool_for_rpc = pool.clone();
         let driver = driver::Driver::spawn(
             move |count| {

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -61,10 +61,11 @@ pub(crate) async fn issue_rpc(
                 }
             }
             Err(status) if status.code() == tonic::Code::FailedPrecondition => {
-                if let Some(hint) = decode_leader_hint(&status)
-                    && let Some(hinted_endpoint) = hint.leader_endpoint
-                    && !visited.contains(&hinted_endpoint)
-                {
+                let usable_hint = decode_leader_hint(&status)
+                    .and_then(|hint| hint.leader_endpoint)
+                    .filter(|hinted_endpoint| !visited.contains(hinted_endpoint))
+                    .filter(|hinted_endpoint| !rejects_plaintext_hint(pool, hinted_endpoint));
+                if let Some(hinted_endpoint) = usable_hint {
                     pool.set_leader(hinted_endpoint.clone());
                     worklist.push_front(hinted_endpoint);
                     continue;
@@ -82,6 +83,31 @@ pub(crate) async fn issue_rpc(
     Err(last_err.unwrap_or(ClientError::NoReachableEndpoints))
 }
 
+/// Refuse a wire-supplied leader hint that would downgrade the transport.
+///
+/// Under `ClientBuilder::tls_config`, a malicious or misconfigured peer
+/// could otherwise feed the client an `http://...` leader endpoint via the
+/// `tsoracle-leader-hint-bin` trailer and route the next RPC over plaintext.
+/// The check is scoped to wire input: operator-supplied `endpoints` carrying
+/// an explicit `http://` scheme are still honored ("explicit beats configured"
+/// remains true for caller-controlled config).
+///
+/// Match shape mirrors `normalize_uri`: ASCII lowercase `http://` prefix.
+/// Uppercase variants would already fail to parse after the bare→https
+/// rewrite, so checking the lowercase form is sufficient.
+fn rejects_plaintext_hint(pool: &ChannelPool, hint: &str) -> bool {
+    let reject = pool.tls_required() && hint.starts_with("http://");
+    #[cfg(feature = "tracing")]
+    if reject {
+        tracing::warn!(
+            hinted_endpoint = %hint,
+            "tsoracle-client: dropping plaintext leader-hint under tls_config; \
+             refusing to downgrade transport"
+        );
+    }
+    reject
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,6 +122,7 @@ mod tests {
         let pool = ChannelPool::new(
             vec!["http://127.0.0.1:1".into(), "http://127.0.0.1:1".into()],
             None,
+            false,
         );
         let result = issue_rpc(&pool, 1).await;
         assert!(result.is_err(), "no live endpoint must surface as Err");
@@ -107,8 +134,36 @@ mod tests {
     /// continue path that's not reached by the happy-path integration tests.
     #[tokio::test]
     async fn unreachable_endpoints_surface_last_error() {
-        let pool = ChannelPool::new(vec!["http://127.0.0.1:1".into()], None);
+        let pool = ChannelPool::new(vec!["http://127.0.0.1:1".into()], None, false);
         let result = issue_rpc(&pool, 1).await;
         assert!(result.is_err(), "expected Err from unreachable pool");
+    }
+
+    /// Direct table-test for the wire-hint policy. The integration test in
+    /// `crates/tsoracle-tests/tests/client_tls.rs` exercises the full
+    /// FAILED_PRECONDITION→trailer→retry path end-to-end; this unit test
+    /// pins down the predicate itself so a refactor cannot quietly flip
+    /// the policy.
+    #[test]
+    fn plaintext_hint_policy_matches_scheme_and_tls_state() {
+        let tls = ChannelPool::new(vec!["a:1".into()], None, true);
+        let plain = ChannelPool::new(vec!["a:1".into()], None, false);
+
+        assert!(
+            rejects_plaintext_hint(&tls, "http://attacker:1"),
+            "http:// hint must be rejected under tls_required"
+        );
+        assert!(
+            !rejects_plaintext_hint(&tls, "https://peer:1"),
+            "https:// hint must be allowed under tls_required"
+        );
+        assert!(
+            !rejects_plaintext_hint(&tls, "peer:1"),
+            "bare host:port hint must be allowed under tls_required (gets rewritten to https)"
+        );
+        assert!(
+            !rejects_plaintext_hint(&plain, "http://peer:1"),
+            "http:// hint must be allowed when tls is not required"
+        );
     }
 }

--- a/crates/tsoracle-client/src/transport.rs
+++ b/crates/tsoracle-client/src/transport.rs
@@ -15,6 +15,13 @@
 //! `normalize_uri` enforces the scheme rule: bare `host:port` becomes
 //! `http://host:port` or `https://host:port` depending on whether a TLS
 //! transport is configured; explicit schemes are always preserved.
+//!
+//! "Explicit beats configured" governs *operator-supplied* endpoint
+//! strings — those passed to `ClientBuilder::endpoints`. The
+//! `crate::retry::issue_rpc` loop applies a tighter rule to *wire-supplied*
+//! `tsoracle-leader-hint-bin` trailers under `tls_config`: explicit
+//! `http://...` hints are dropped so a contacted peer cannot downgrade the
+//! transport. See `crate::retry::rejects_plaintext_hint`.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -54,9 +61,15 @@ pub(crate) fn normalize_uri(endpoint: &str, tls: bool) -> String {
 /// Construct the built-in TLS-aware channel connector.
 ///
 /// Bare endpoints are rewritten to `https://` via [`normalize_uri`].
-/// Explicit `http://...` endpoints are honored as plaintext even when this
+/// Explicit `http://...` endpoints supplied via
+/// `ClientBuilder::endpoints` are honored as plaintext even when this
 /// connector is in use ("explicit beats configured"). The TLS config is
 /// attached only when the resolved URI uses the `https` scheme.
+///
+/// Explicit `http://...` endpoints arriving via the
+/// `tsoracle-leader-hint-bin` trailer are filtered out one layer up in
+/// `crate::retry::issue_rpc` and never reach this connector — they would
+/// otherwise dial plaintext here, downgrading a TLS-configured client.
 #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
 pub(crate) fn tls_connector(
     cfg: tonic::transport::ClientTlsConfig,

--- a/crates/tsoracle-tests/tests/client_tls.rs
+++ b/crates/tsoracle-tests/tests/client_tls.rs
@@ -321,6 +321,74 @@ async fn leader_hint_redirect_under_tls() {
     booted_follower.shutdown().await.expect("follower exit");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn leader_hint_rejects_plaintext_under_tls_config() {
+    // A TLS-configured client must not be redirected onto a plaintext
+    // `http://` endpoint by a leader-hint trailer from the wire. Setup:
+    // a fully functional plaintext leader, plus a TLS follower whose
+    // FAILED_PRECONDITION trailer hints at `http://<plaintext-leader>`.
+    // The client trusts ONLY the TLS follower's address; if the http://
+    // hint were honored, the client would dial the plaintext leader
+    // (not in its configured list) and accept the timestamp. The fix
+    // drops the hint, so the call surfaces the follower's
+    // FAILED_PRECONDITION instead.
+    let bundle = mint_certs();
+
+    let plaintext_leader_driver = Arc::new(InMemoryDriver::new());
+    plaintext_leader_driver.become_leader(Epoch(1));
+    let plaintext_leader = Server::builder()
+        .consensus_driver(plaintext_leader_driver.clone())
+        .build()
+        .expect("plaintext leader build");
+    let mut booted_plaintext = boot_server(plaintext_leader).await;
+    wait_until_serving(&mut booted_plaintext.state_rx).await;
+    wait_for_grpc_handshake(booted_plaintext.addr, Duration::from_secs(5))
+        .await
+        .expect("plaintext leader ready");
+
+    let plaintext_endpoint = format!("http://127.0.0.1:{}", booted_plaintext.addr.port());
+    let follower_driver = Arc::new(InMemoryDriver::new());
+    follower_driver.become_follower(Some(plaintext_endpoint.clone()));
+    let follower = Server::builder()
+        .consensus_driver(follower_driver.clone())
+        .tls_config(server_tls_config(&bundle))
+        .build()
+        .expect("follower build");
+    let booted_follower = boot_server(follower).await;
+    wait_for_grpc_handshake_tls(
+        booted_follower.addr,
+        client_tls_config_with_ca(&bundle),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("follower port ready");
+
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "127.0.0.1:{}",
+        booted_follower.addr.port()
+    )])
+    .tls_config(client_tls_config_with_ca(&bundle))
+    .build()
+    .await
+    .expect("client connect");
+
+    let result = client.get_ts().await;
+    match result {
+        Err(tsoracle_client::ClientError::Rpc(status))
+            if status.code() == tonic::Code::FailedPrecondition => {}
+        Err(tsoracle_client::ClientError::NoReachableEndpoints) => {}
+        Ok(ts) => panic!(
+            "TLS-configured client accepted plaintext leader hint and got timestamp {ts:?} \
+             — leader-hint downgrade defense is missing"
+        ),
+        Err(other) => panic!("expected FailedPrecondition or NoReachableEndpoints, got {other:?}"),
+    }
+
+    drop(client);
+    booted_plaintext.shutdown().await.expect("plaintext exit");
+    booted_follower.shutdown().await.expect("follower exit");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mtls_handshake_succeeds_with_client_identity() {
     let bundle = mint_certs();

--- a/docs/client-api-and-usage.md
+++ b/docs/client-api-and-usage.md
@@ -77,13 +77,27 @@ Setting both `.tls_config(...)` and `.channel_connector(...)` is allowed; the la
 
 ### Scheme rule
 
+The matrix below applies to *operator-supplied* endpoint strings — the entries passed to `ClientBuilder::endpoints`. The wire-input case (leader-hint trailers) is covered immediately after.
+
 | Configured state | Bare `host:port` becomes | `http://...` | `https://...` |
 | --- | --- | --- | --- |
 | No transport config (default) | `http://host:port` | plaintext | TLS (requires a `tls-*` feature to actually connect) |
 | `.tls_config(cfg)` set | `https://host:port` | plaintext (explicit beats configured) | TLS using `cfg` |
 | `.channel_connector(closure)` set | passed verbatim to the closure | passed verbatim | passed verbatim |
 
-"Explicit beats configured" is universal — including for leader-hint trailers. If the server emits a bare-host hint like `node-b:50551`, the client's rewrite rule applies (bare → https when `tls_config` is set; bare → http otherwise). If the server emits a fully-qualified scheme, that scheme is honored.
+"Explicit beats configured" applies to operator-supplied entries above: passing `http://host:port` to `endpoints` deliberately dials that one endpoint as plaintext even when `tls_config` is otherwise set, which is useful for mixed deployments (e.g., a loopback sidecar over plaintext alongside TLS-terminated peers).
+
+### Leader-hint trailers (wire input)
+
+`FAILED_PRECONDITION` responses can carry a `tsoracle-leader-hint-bin` trailer with a `leader_endpoint` string the client uses to redirect. That string is wire input from a contacted peer, not operator configuration, and the rule is tighter:
+
+| Configured state | Bare `host:port` hint | `http://...` hint | `https://...` hint |
+| --- | --- | --- | --- |
+| No transport config (default) | rewritten to `http://host:port` and dialed | dialed as plaintext | dialed as TLS (requires a `tls-*` feature) |
+| `.tls_config(cfg)` set | rewritten to `https://host:port` and dialed with `cfg` | **dropped** — logged at `warn` level (with the `tracing` feature); retry continues without redirecting | dialed as TLS with `cfg` |
+| `.channel_connector(closure)` set | passed verbatim to the closure | passed verbatim to the closure | passed verbatim to the closure |
+
+Under `tls_config`, an explicit `http://` hint from the wire is refused so a contacted peer cannot downgrade the transport. The `channel_connector` escape hatch owns its own scheme policy — the closure receives every endpoint string the retry loop produces and is responsible for whatever filtering it wants. If a caller wants TLS plus a custom connector with leader-hint-downgrade protection, set `.tls_config(...)` first, then build the connector inside the closure.
 
 ### Minimal TLS example
 

--- a/docs/key-subsystems.md
+++ b/docs/key-subsystems.md
@@ -73,6 +73,8 @@ Encoding and decoding live in `crates/tsoracle-server/src/leader_hint.rs` and `c
 
 When the trailer is present, the client moves the hinted endpoint to the front of its retry worklist and immediately tries it. When absent (e.g., the server itself only knows `LeaderState::Unknown`), the client falls back to round-robin across its configured endpoints. The full client-side algorithm is in [Leader discovery and retries](client-api-and-usage.md#leader-discovery-and-retries).
 
+The hinted endpoint is wire input from a contacted peer, so it is treated with less trust than operator-supplied configuration. When the client was built with `ClientBuilder::tls_config(...)`, an explicit `http://...` hint is dropped (and logged at `warn` level under the `tracing` feature); the retry surfaces the underlying `FAILED_PRECONDITION` instead. This prevents a malicious or misconfigured peer from downgrading a TLS-configured client onto a plaintext leader. Bare-host hints (`host:port`) are still rewritten under the configured scheme rule and dialed; explicit `https://...` hints are honored. See [Leader-hint trailers (wire input)](client-api-and-usage.md#leader-hint-trailers-wire-input) for the full matrix.
+
 ## Steady-state window extension
 
 During steady-state serving, a `get_ts` call that finds the allocator's `physical_ms` window exhausted joins a single-flight extension path before retrying. Concurrent callers serialize on `extension_lock`; the first caller persists a new high-water, and later callers recheck the allocator before touching consensus so a stampede normally produces one extension, not one extension per waiter. The path in `tsoracle-server/src/service.rs`:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,7 +60,7 @@ The consensus driver owns the mapping from consensus leader identity to tsoracle
 
 ## Client retry behavior
 
-The client gives `FAILED_PRECONDITION` special handling: it parses the `tsoracle-leader-hint-bin` trailer (see [The leader-hint trailer](key-subsystems.md#the-leader-hint-trailer)) and moves the hinted leader to the front of the current retry worklist. Other gRPC errors, including `UNAVAILABLE` and `INTERNAL`, are recorded and the client continues through the configured endpoints once for that call. Configure `endpoints` with all known servers so cold-start works even when the cached leader is unreachable.
+The client gives `FAILED_PRECONDITION` special handling: it parses the `tsoracle-leader-hint-bin` trailer (see [The leader-hint trailer](key-subsystems.md#the-leader-hint-trailer)) and moves the hinted leader to the front of the current retry worklist. Other gRPC errors, including `UNAVAILABLE` and `INTERNAL`, are recorded and the client continues through the configured endpoints once for that call. Configure `endpoints` with all known servers so cold-start works even when the cached leader is unreachable. Under `ClientBuilder::tls_config`, explicit `http://` leader-hint endpoints are dropped to prevent a contacted peer from downgrading the transport — emit hints with bare-host `host:port` (which the client rewrites to `https://` under TLS) or explicit `https://` only.
 
 ## TLS termination
 


### PR DESCRIPTION
## Summary

Closes a transport-downgrade gap in `tsoracle-client`. When `ClientBuilder::tls_config(...)` is set, a contacted peer can return `FAILED_PRECONDITION` with a `tsoracle-leader-hint-bin` trailer pointing at `http://<other-host>`; the retry loop then caches that endpoint as leader and dials it over plaintext through the same connector, bypassing the operator's TLS/mTLS expectation. A malicious or misconfigured peer can use this to feed the client unauthenticated timestamp responses.

The fix scopes \"explicit beats configured\" to *operator-supplied* config and refuses wire-supplied `http://` hints under TLS:

- `ClientBuilder` gains a `tls_required` flag — set by `tls_config()`, cleared by `channel_connector()` (last-wins, matching the existing connector semantics). Plumbed through `ChannelPool::new`.
- `retry::issue_rpc` runs each decoded hint through `rejects_plaintext_hint(pool, hint)` before pushing it onto the worklist. Rejected hints are logged at `warn` (under the `tracing` feature) and fall through to the existing FAILED_PRECONDITION path, so the call surfaces the underlying status instead of silently downgrading.
- Operator-supplied `http://` entries in `endpoints` keep working — mixed deployments (e.g., plaintext loopback sidecar + TLS-terminated peers) are unaffected.
- `channel_connector` closures own their own scheme policy; the built-in filter does not run when a caller-supplied connector is installed.

Scheme matrix in `docs/client-api-and-usage.md` is split into operator-supplied and wire-supplied tables. Leader-hint trailer doc in `docs/key-subsystems.md` and the client-retry section of `docs/operations.md` updated to describe the new rule.

## Test plan

- [x] New integration test `leader_hint_rejects_plaintext_under_tls_config` in `crates/tsoracle-tests/tests/client_tls.rs`: boots a fully functional plaintext leader plus a TLS follower whose driver emits `http://<plaintext-leader>` as its leader hint; the client is configured with only the TLS follower's address and `tls_config(...)`. The test was confirmed to **fail before the fix** (client erroneously got a timestamp from the plaintext leader) and **pass after** (call surfaces `FAILED_PRECONDITION` or `NoReachableEndpoints`).
- [x] New unit test `plaintext_hint_policy_matches_scheme_and_tls_state` in `crates/tsoracle-client/src/retry.rs` table-tests the predicate for `http://` / `https://` / bare hints × tls-required / not.
- [x] Existing `leader_hint_redirect_under_tls` (bare-host hint, two TLS servers) still passes — the rewrite path is unaffected.
- [x] Existing `explicit_http_endpoint_stays_plaintext_under_tls_config` still passes — operator-supplied `http://` endpoints continue to dial plaintext.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (all suites green, including `client_tls` 10/10 and `tsoracle-client` 36/36)