### PR TITLE
fix(driver-openraft): map RaftError::Fatal to PermanentDriver

### DIFF
--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -69,17 +69,8 @@ impl OpenraftHighWaterHost for StandaloneHost {
         // `tsoracle-server/src/fence.rs` is the load-bearing reader; a stale
         // value there would let a new leader's `serving_floor + 1` land below
         // a timestamp the prior leader could have served.
-        //
-        // `ForwardToLeader` maps to `NotLeader` so the server's step-down
-        // path triggers cleanly (same shape as `submit_advance` below); any
-        // other RaftError is transient (quorum loss, leadership churn).
         if let Err(e) = self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await {
-            return match e {
-                RaftError::APIError(LinearizableReadError::ForwardToLeader(_)) => {
-                    Err(ConsensusError::NotLeader { observed: None })
-                }
-                _ => Err(ConsensusError::TransientDriver(Box::new(e))),
-            };
+            return Err(classify_read_error(e));
         }
         Ok(self.state_machine.current_value().await)
     }
@@ -91,10 +82,62 @@ impl OpenraftHighWaterHost for StandaloneHost {
             .await
         {
             Ok(resp) => Ok(resp.data.value),
-            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(_))) => {
-                Err(ConsensusError::NotLeader { observed: None })
-            }
-            Err(e) => Err(ConsensusError::TransientDriver(Box::new(e))),
+            Err(e) => Err(classify_client_write_error(e)),
         }
+    }
+}
+
+// `ForwardToLeader` maps to `NotLeader` so the server's step-down path
+// triggers cleanly. `RaftError::Fatal` is the unrecoverable case — storage
+// failure, raft-task panic, explicit shutdown — and must surface as
+// `PermanentDriver` so the service layer returns `INTERNAL` rather than the
+// retryable `UNAVAILABLE` (see the classification table on `ConsensusError`).
+// Everything else (quorum loss, leadership churn) is transient.
+fn classify_read_error(
+    err: RaftError<TypeConfig, LinearizableReadError<TypeConfig>>,
+) -> ConsensusError {
+    match err {
+        RaftError::APIError(LinearizableReadError::ForwardToLeader(_)) => {
+            ConsensusError::NotLeader { observed: None }
+        }
+        RaftError::Fatal(_) => ConsensusError::PermanentDriver(Box::new(err)),
+        _ => ConsensusError::TransientDriver(Box::new(err)),
+    }
+}
+
+fn classify_client_write_error(
+    err: RaftError<TypeConfig, ClientWriteError<TypeConfig>>,
+) -> ConsensusError {
+    match err {
+        RaftError::APIError(ClientWriteError::ForwardToLeader(_)) => {
+            ConsensusError::NotLeader { observed: None }
+        }
+        RaftError::Fatal(_) => ConsensusError::PermanentDriver(Box::new(err)),
+        _ => ConsensusError::TransientDriver(Box::new(err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openraft::error::Fatal;
+
+    #[test]
+    fn fatal_read_error_classifies_as_permanent_driver() {
+        let err =
+            RaftError::<TypeConfig, LinearizableReadError<TypeConfig>>::Fatal(Fatal::Panicked);
+        assert!(matches!(
+            classify_read_error(err),
+            ConsensusError::PermanentDriver(_)
+        ));
+    }
+
+    #[test]
+    fn fatal_client_write_error_classifies_as_permanent_driver() {
+        let err = RaftError::<TypeConfig, ClientWriteError<TypeConfig>>::Fatal(Fatal::Stopped);
+        assert!(matches!(
+            classify_client_write_error(err),
+            ConsensusError::PermanentDriver(_)
+        ));
     }
 }

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -119,8 +119,13 @@ fn classify_client_write_error(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
+    use openraft::error::{
+        ChangeMembershipError, EmptyMembership, Fatal, ForwardToLeader, QuorumNotEnough,
+    };
+
     use super::*;
-    use openraft::error::Fatal;
 
     #[test]
     fn fatal_read_error_classifies_as_permanent_driver() {
@@ -138,6 +143,44 @@ mod tests {
         assert!(matches!(
             classify_client_write_error(err),
             ConsensusError::PermanentDriver(_)
+        ));
+    }
+
+    #[test]
+    fn forward_to_leader_read_error_classifies_as_not_leader() {
+        let err = RaftError::<TypeConfig, LinearizableReadError<TypeConfig>>::APIError(
+            LinearizableReadError::ForwardToLeader(ForwardToLeader::empty()),
+        );
+        assert!(matches!(
+            classify_read_error(err),
+            ConsensusError::NotLeader { observed: None }
+        ));
+    }
+
+    #[test]
+    fn quorum_not_enough_read_error_classifies_as_transient_driver() {
+        let err = RaftError::<TypeConfig, LinearizableReadError<TypeConfig>>::APIError(
+            LinearizableReadError::QuorumNotEnough(QuorumNotEnough {
+                cluster: String::new(),
+                got: BTreeSet::new(),
+            }),
+        );
+        assert!(matches!(
+            classify_read_error(err),
+            ConsensusError::TransientDriver(_)
+        ));
+    }
+
+    #[test]
+    fn change_membership_client_write_error_classifies_as_transient_driver() {
+        let err = RaftError::<TypeConfig, ClientWriteError<TypeConfig>>::APIError(
+            ClientWriteError::ChangeMembershipError(ChangeMembershipError::EmptyMembership(
+                EmptyMembership {},
+            )),
+        );
+        assert!(matches!(
+            classify_client_write_error(err),
+            ConsensusError::TransientDriver(_)
         ));
     }
 }


### PR DESCRIPTION
## Summary

- Closes #84.
- `StandaloneHost::current_high_water` and `submit_advance` matched `RaftError::ForwardToLeader` explicitly and folded every other variant — including `RaftError::Fatal` — into `ConsensusError::TransientDriver`. The service layer (`tsoracle-server/src/service.rs:206-209`) maps that to gRPC `UNAVAILABLE`, so a fatal raft state (storage failure, raft-task panic, explicit shutdown) currently surfaces to clients as a retryable error and turns into a tarpit.
- Extracted the classification into two private free functions (`classify_read_error`, `classify_client_write_error`) and routed `RaftError::Fatal(_)` through `ConsensusError::PermanentDriver`, which the service layer maps to `INTERNAL` ("do NOT silently retry"). `ForwardToLeader` still becomes `NotLeader`; quorum loss / leadership churn still becomes `TransientDriver`. The free-function shape lets the unit tests construct a `RaftError::Fatal` directly without standing up a raft cluster.

## Audit

`grep` for `TransientDriver` / `RaftError` across `crates/tsoracle-driver-openraft/src/` shows the only two production call sites that produced `TransientDriver` from a `RaftError` were the two in `standalone.rs`. No other call sites in the crate convert a fatal raft state to `TransientDriver`.

## Test plan

- [x] `cargo test -p tsoracle-driver-openraft --lib` — 48 passed, including two new tests:
  - `standalone::tests::fatal_read_error_classifies_as_permanent_driver` (constructs `RaftError::<_, LinearizableReadError<_>>::Fatal(Fatal::Panicked)`)
  - `standalone::tests::fatal_client_write_error_classifies_as_permanent_driver` (constructs `RaftError::<_, ClientWriteError<_>>::Fatal(Fatal::Stopped)`)
- [x] `cargo clippy -p tsoracle-driver-openraft --all-targets` — clean
- [x] `cargo fmt -p tsoracle-driver-openraft -- --check` — clean