### PR TITLE
chore(critical-path): reconcile marker set with current crate layout

### DIFF
--- a/crates/tsoracle-core/src/clock.rs
+++ b/crates/tsoracle-core/src/clock.rs
@@ -10,6 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+// #[PerformanceCriticalPath]
 //! Source of physical-time milliseconds for the TSO algorithm.
 //!
 //! The Allocator's monotonicity is independent of clock correctness — a clock

--- a/crates/tsoracle-core/src/timestamp.rs
+++ b/crates/tsoracle-core/src/timestamp.rs
@@ -10,6 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+// #[PerformanceCriticalPath]
 //! 64-bit packed timestamp: 46 high bits for `physical_ms`, 18 low bits for `logical`.
 
 const LOGICAL_BITS: u32 = 18;

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -10,6 +10,8 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+// #[PerformanceCriticalPath]
+
 use core::pin::Pin;
 use futures::{Stream, StreamExt};
 use std::fs;

--- a/crates/tsoracle-driver-file/src/lib.rs
+++ b/crates/tsoracle-driver-file/src/lib.rs
@@ -10,7 +10,6 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-// #[PerformanceCriticalPath]
 //! Single-node, fsync-durable [`ConsensusDriver`] implementation for tsoracle.
 //!
 //! Persists the committed high-water as a 17-byte CRC-checked record

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -10,6 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+// #[PerformanceCriticalPath]
 //! `ConsensusDriver` impl on top of any [`OpenraftHighWaterHost`].
 //!
 //! [`OpenraftDriver`] is a thin bridge: it owns the trait-surface boilerplate

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -10,7 +10,6 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-// #[PerformanceCriticalPath]
 //! openraft-backed `ConsensusDriver` for tsoracle.
 //!
 //! This crate replicates the TSO high-water mark across an openraft cluster

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -10,6 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+// #[PerformanceCriticalPath]
 //! Log entries replicated by the openraft cluster.
 //!
 //! The driver replicates a single command: advance the high-water mark to at

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -10,6 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+// #[PerformanceCriticalPath]
 //! `RaftStateMachine` for the high-water counter with pluggable snapshot
 //! persistence.
 //!

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -10,6 +10,8 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+// #[PerformanceCriticalPath]
+
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use tsoracle_consensus::ConsensusError;

--- a/docs/performance-critical-path.md
+++ b/docs/performance-critical-path.md
@@ -42,13 +42,28 @@ After placing the marker, verify `CRITICAL_PATH_STRICT=1 ./scripts/check-critica
 
 ## Current critical-path files
 
-Files in this list are compliant with the rules above — the guard is green against them today.
+Files in this list are compliant with the rules above — the guard is green against them today. Grouped by subsystem; within each group, files are ordered roughly by call frequency along the per-request path.
 
+**Per-request RPC path**
+
+- [`crates/tsoracle-server/src/service.rs`](../crates/tsoracle-server/src/service.rs) — `TsoServiceImpl::get_ts`, the per-request RPC handler. Every gRPC `GetTs` enters here and dispatches into the allocator and (when a window extension is needed) the consensus driver.
 - [`crates/tsoracle-core/src/allocator.rs`](../crates/tsoracle-core/src/allocator.rs) — the window allocator state machine. Every `try_grant` and `would_grant` call goes through here.
-- [`crates/tsoracle-driver-file/src/lib.rs`](../crates/tsoracle-driver-file/src/lib.rs) — single-node fsync-durable driver. The fsync on window extension is the durability boundary for non-replicated deployments.
-- [`crates/tsoracle-driver-openraft/src/lib.rs`](../crates/tsoracle-driver-openraft/src/lib.rs) — openraft-backed driver. The propose/apply path for replicated deployments.
+- [`crates/tsoracle-core/src/clock.rs`](../crates/tsoracle-core/src/clock.rs) — the `Clock` trait and `SystemClock`. `now_ms` is read on every grant attempt and on every window-extension prepare.
+- [`crates/tsoracle-core/src/timestamp.rs`](../crates/tsoracle-core/src/timestamp.rs) — the packed `Timestamp(u64)` type. `Timestamp::pack` constructs the returned value for every issued grant.
+
+**Window-extension / consensus path**
+
+- [`crates/tsoracle-driver-file/src/driver.rs`](../crates/tsoracle-driver-file/src/driver.rs) — `FileDriver`. The fsync on window extension is the durability boundary for non-replicated deployments.
+- [`crates/tsoracle-driver-openraft/src/driver.rs`](../crates/tsoracle-driver-openraft/src/driver.rs) — `OpenraftDriver`, the bridge implementing `ConsensusDriver::persist_high_water` on top of any `OpenraftHighWaterHost`.
+- [`crates/tsoracle-driver-openraft/src/log_entry.rs`](../crates/tsoracle-driver-openraft/src/log_entry.rs) — the single command type replicated through the openraft log; encoded on every propose, decoded on every apply.
+- [`crates/tsoracle-driver-openraft/src/state_machine.rs`](../crates/tsoracle-driver-openraft/src/state_machine.rs) — `HighWaterStateMachine::apply`, which runs on every committed entry.
+
+**Client path**
+
 - [`crates/tsoracle-client/src/driver.rs`](../crates/tsoracle-client/src/driver.rs) — client-side coalescing driver. Every concurrent waiter passes through `driver_task`'s select loop.
+
+The two driver crates' `lib.rs` files are intentionally NOT marked: each has been refactored into a thin module-declaration shell, and the hot-path code now lives in the sibling files listed above. The marker is per-file, so placing it on a shell `lib.rs` would scan the wrong file — the guard does not inherit through `mod`.
 
 ## Files considered but intentionally unmarked
 
-- [`crates/tsoracle-server/src/server.rs`](../crates/tsoracle-server/src/server.rs) — contains a one-shot `tracing::error!` on the leader-watch death path (line 177 at the time of this writing). The call fires at most once per process lifetime and is not on the per-request path, but the grep-based guard cannot distinguish it from per-request logging. Mark this file in a follow-up after splitting the request handlers into their own module or after deciding to downgrade the death-rattle log.
+- [`crates/tsoracle-server/src/server.rs`](../crates/tsoracle-server/src/server.rs) — owns the leader-watch supervisor task. The task emits one-shot `tracing::error!` death-rattle messages when the watch loop returns an error or panics, so operators get a visible signal that serving has stopped. Those calls fire at most once per process lifetime and are not on the per-request path, but the grep-based guard cannot distinguish a one-shot supervisory log from per-request logging. The per-request handlers themselves live in [`service.rs`](../crates/tsoracle-server/src/service.rs), which IS marked.


### PR DESCRIPTION
## Summary

- The `// #[PerformanceCriticalPath]` marker is per-file and does not inherit through `mod`. Earlier refactors split `tsoracle-driver-file` and `tsoracle-driver-openraft` into module-declaration shells, but the markers stayed on the shell `lib.rs` files while the hot-path implementation moved into sibling files — CI stayed green because the shells could not violate the rules, but the guard was no longer scanning the code that actually matters.
- Adds markers to the 7 files that actually carry the per-request RPC, window-extension, and consensus apply paths (clean of banned patterns at marking time):
  - `tsoracle-server/src/service.rs` (per-request `get_ts` handler)
  - `tsoracle-core/src/{clock,timestamp}.rs` (`now_ms` and `Timestamp::pack` per grant)
  - `tsoracle-driver-file/src/driver.rs` (`FileDriver` fsync durability boundary)
  - `tsoracle-driver-openraft/src/{driver,log_entry,state_machine}.rs` (bridge + propose/apply payload + apply hook)
- Removes the markers from `tsoracle-driver-{file,openraft}/src/lib.rs` (now module-declaration shells).
- Updates `docs/performance-critical-path.md`: regroups the file list by subsystem, rewrites the `server.rs` exception entry, and drops the stale line-number reference (line numbers drift with commits) — the `service.rs` split it anticipated as a follow-up has already shipped.

Marker count goes from 4 to 9; the `server.rs` intentional-exception entry is preserved with an updated rationale.

## Test plan

- [x] `CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh` reports "all 9 marked files clean"
- [x] `cargo check --workspace --all-features` succeeds
- [x] pre-commit `cargo fmt --check` + `cargo clippy` pass
- [x] CI `critical-path` job passes on the PR
- [x] CI full test matrix passes on the PR