### PR TITLE
feat(client): add RetryPolicy with deadlines, keepalive, and jittered backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,6 +3130,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "prost",
+ "rand 0.9.4",
  "thiserror",
  "tokio",
  "tonic",

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -27,6 +27,7 @@ async-trait    = { workspace = true }
 futures        = { workspace = true }
 parking_lot    = { workspace = true }
 prost          = { workspace = true }
+rand           = { workspace = true, features = ["thread_rng"] }
 thiserror      = { workspace = true }
 tokio          = { workspace = true }
 tonic          = { workspace = true }

--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -21,7 +21,9 @@ use tonic::transport::{Channel, Endpoint};
 use tsoracle_proto::v1::LeaderHint;
 use tsoracle_proto::v1::tso_service_client::TsoServiceClient;
 
+use crate::RetryPolicy;
 use crate::error::ClientError;
+use crate::transport::apply_endpoint_config;
 
 const LEADER_HINT_KEY: &str = "tsoracle-leader-hint-bin";
 
@@ -43,6 +45,11 @@ pub struct ChannelPool {
     /// operator-supplied endpoints; those use the documented scheme rule
     /// ("explicit beats configured") unchanged.
     tls_required: bool,
+    /// Frozen at builder time. The pool uses `per_attempt_deadline` plus
+    /// the keepalive constants to build each `Endpoint`; the retry loop
+    /// reads the same policy via [`Self::retry_policy`] to drive its
+    /// per-attempt and overall deadlines.
+    retry_policy: RetryPolicy,
 }
 
 impl ChannelPool {
@@ -50,6 +57,7 @@ impl ChannelPool {
         endpoints: Vec<String>,
         connector: Option<std::sync::Arc<crate::transport::ChannelConnector>>,
         tls_required: bool,
+        retry_policy: RetryPolicy,
     ) -> Self {
         ChannelPool {
             configured: endpoints,
@@ -57,6 +65,7 @@ impl ChannelPool {
             leader: Mutex::new(None),
             connector,
             tls_required,
+            retry_policy,
         }
     }
 
@@ -65,6 +74,10 @@ impl ChannelPool {
     /// `crate::retry::issue_rpc`.
     pub fn tls_required(&self) -> bool {
         self.tls_required
+    }
+
+    pub fn retry_policy(&self) -> &RetryPolicy {
+        &self.retry_policy
     }
 
     pub fn cached_leader(&self) -> Option<String> {
@@ -91,6 +104,8 @@ impl ChannelPool {
                 let transport_endpoint: Endpoint = uri
                     .parse()
                     .map_err(|_| ClientError::InvalidEndpoint(endpoint.into()))?;
+                let transport_endpoint =
+                    apply_endpoint_config(transport_endpoint, &self.retry_policy);
                 transport_endpoint.connect().await?
             }
         };
@@ -118,12 +133,18 @@ impl ChannelPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RetryPolicy;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn iter_starts_with_cached_leader() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None, false);
+        let pool = ChannelPool::new(
+            vec!["a:1".into(), "b:1".into(), "c:1".into()],
+            None,
+            false,
+            RetryPolicy::default(),
+        );
         pool.set_leader("b:1".into());
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["b:1", "a:1", "c:1"]);
@@ -131,14 +152,24 @@ mod tests {
 
     #[test]
     fn iter_without_cache_is_configured_order() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into(), "c:1".into()], None, false);
+        let pool = ChannelPool::new(
+            vec!["a:1".into(), "b:1".into(), "c:1".into()],
+            None,
+            false,
+            RetryPolicy::default(),
+        );
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["a:1", "b:1", "c:1"]);
     }
 
     #[test]
     fn clear_leader_drops_cached_leader() {
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], None, false);
+        let pool = ChannelPool::new(
+            vec!["a:1".into(), "b:1".into()],
+            None,
+            false,
+            RetryPolicy::default(),
+        );
         pool.set_leader("b:1".into());
         assert_eq!(pool.cached_leader().as_deref(), Some("b:1"));
         pool.clear_leader();
@@ -157,7 +188,12 @@ mod tests {
             let endpoint_owned = endpoint.to_string();
             Box::pin(async move { Err(crate::error::ClientError::InvalidEndpoint(endpoint_owned)) })
         });
-        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], Some(connector), false);
+        let pool = ChannelPool::new(
+            vec!["a:1".into(), "b:1".into()],
+            Some(connector),
+            false,
+            RetryPolicy::default(),
+        );
         let _ = pool.client("a:1").await;
         let _ = pool.client("b:1").await;
         let seen = captured.lock().clone();
@@ -178,7 +214,12 @@ mod tests {
                     Ok(channel)
                 })
             });
-        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector), false);
+        let pool = ChannelPool::new(
+            vec!["a:1".into()],
+            Some(connector),
+            false,
+            RetryPolicy::default(),
+        );
         let _ = pool
             .client("a:1")
             .await
@@ -198,7 +239,12 @@ mod tests {
             captured_for_closure.lock().push(endpoint.to_string());
             Box::pin(async { Err(crate::error::ClientError::InvalidEndpoint("x".into())) })
         });
-        let pool = ChannelPool::new(vec!["a:1".into()], Some(connector), false);
+        let pool = ChannelPool::new(
+            vec!["a:1".into()],
+            Some(connector),
+            false,
+            RetryPolicy::default(),
+        );
         let _ = pool.client("hinted:1").await;
         let seen = captured.lock().clone();
         assert_eq!(seen, vec!["hinted:1".to_string()]);

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -29,9 +29,11 @@ mod error;
 mod leader_resolved;
 mod response;
 mod retry;
+mod retry_policy;
 mod transport;
 
 pub use error::ClientError;
+pub use retry_policy::RetryPolicy;
 pub use transport::BoxError;
 
 use std::sync::Arc;
@@ -51,6 +53,7 @@ pub struct ClientBuilder {
     flush_interval: Duration,
     connector: Option<Arc<crate::transport::ChannelConnector>>,
     tls_required: bool,
+    retry_policy: RetryPolicy,
 }
 
 impl ClientBuilder {
@@ -60,11 +63,28 @@ impl ClientBuilder {
             flush_interval: Duration::from_millis(1),
             connector: None,
             tls_required: false,
+            retry_policy: RetryPolicy::default(),
         }
     }
 
     pub fn batch_flush_interval(mut self, flush_interval: Duration) -> Self {
         self.flush_interval = flush_interval;
+        self
+    }
+
+    /// Override the default [`RetryPolicy`].
+    ///
+    /// The policy controls per-attempt deadlines, the overall deadline
+    /// across all candidate endpoints, the cap on attempts, and the
+    /// jittered backoff base. The per-attempt deadline is also pushed
+    /// down to `tonic::transport::Endpoint::connect_timeout` and
+    /// `Endpoint::timeout` for the built-in default and TLS transport
+    /// paths so a blackholed peer fails fast at the transport layer.
+    /// User-supplied [`Self::channel_connector`] closures own their
+    /// own Endpoint config; the policy still bounds the retry loop's
+    /// outer `tokio::time::timeout` around them.
+    pub fn retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
         self
     }
 
@@ -85,7 +105,10 @@ impl ClientBuilder {
     /// its own scheme policy.
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     pub fn tls_config(mut self, cfg: tonic::transport::ClientTlsConfig) -> Self {
-        self.connector = Some(crate::transport::tls_connector(cfg));
+        self.connector = Some(crate::transport::tls_connector(
+            cfg,
+            self.retry_policy.clone(),
+        ));
         self.tls_required = true;
         self
     }
@@ -124,6 +147,7 @@ impl ClientBuilder {
             self.endpoints,
             self.connector,
             self.tls_required,
+            self.retry_policy,
         ));
         let pool_for_rpc = pool.clone();
         let driver = driver::Driver::spawn(
@@ -250,5 +274,64 @@ mod tests {
         let builder = ClientBuilder::endpoints(vec!["http://127.0.0.1:1".into()])
             .batch_flush_interval(custom);
         assert_eq!(builder.flush_interval, custom);
+    }
+
+    #[tokio::test]
+    async fn retry_policy_override_propagates_to_builder() {
+        // The builder field is what `build` hands to the pool and retry
+        // loop. If `retry_policy()` ever silently stops storing the
+        // override, the loop reverts to defaults; this test pins the
+        // override path against that.
+        let policy = RetryPolicy {
+            max_attempts: 7,
+            per_attempt_deadline: Duration::from_millis(11),
+            overall_deadline: Duration::from_millis(13),
+            base_backoff: Duration::from_millis(17),
+        };
+        let builder = ClientBuilder::endpoints(vec!["http://127.0.0.1:1".into()])
+            .retry_policy(policy.clone());
+        assert_eq!(builder.retry_policy.max_attempts, policy.max_attempts);
+        assert_eq!(
+            builder.retry_policy.per_attempt_deadline,
+            policy.per_attempt_deadline
+        );
+        assert_eq!(
+            builder.retry_policy.overall_deadline,
+            policy.overall_deadline
+        );
+        assert_eq!(builder.retry_policy.base_backoff, policy.base_backoff);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_ts_returns_within_overall_deadline_when_all_endpoints_unreachable() {
+        // End-to-end test of the issue's acceptance criterion: with no
+        // listener bound at the configured endpoints, a `get_ts` call
+        // must return well before the OS-default TCP timeout (~75 s on
+        // Linux). The bound here is generous enough to absorb CI
+        // scheduler jitter — the assertion is "fast", not "exactly the
+        // configured deadline".
+        let policy = RetryPolicy {
+            max_attempts: 3,
+            per_attempt_deadline: Duration::from_millis(100),
+            overall_deadline: Duration::from_millis(300),
+            base_backoff: Duration::ZERO,
+        };
+        let client = ClientBuilder::endpoints(vec![
+            "http://127.0.0.1:1".into(),
+            "http://127.0.0.1:2".into(),
+            "http://127.0.0.1:3".into(),
+        ])
+        .retry_policy(policy)
+        .build()
+        .await
+        .expect("builder must accept the policy");
+        let start = std::time::Instant::now();
+        let result = client.get_ts().await;
+        let elapsed = start.elapsed();
+        assert!(result.is_err(), "no listener can reply: {result:?}");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "deadline must short-circuit; took {elapsed:?}"
+        );
     }
 }

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -18,69 +18,149 @@
 //! so we retry the hinted leader immediately — not at the end of the
 //! round-robin pass, which would leave the current call to fail if the
 //! hinted endpoint wasn't otherwise in the queue.
+//!
+//! Three deadlines bound the loop, governed by [`crate::RetryPolicy`]:
+//!
+//! - `per_attempt_deadline`: each `(pool.client, client.get_ts)` pair is
+//!   wrapped in `tokio::time::timeout`. Same value is pushed to the
+//!   tonic `Endpoint::connect_timeout` / `Endpoint::timeout` for the
+//!   built-in transport paths so the transport layer also fails fast.
+//! - `overall_deadline`: hard wall-clock cap on the whole call. The
+//!   loop exits before starting any attempt that would push past it,
+//!   even when `max_attempts` and the worklist still have headroom.
+//! - `max_attempts`: tighter cap than the visited-set (which already
+//!   prevents revisiting an endpoint). Bites only when leader-hint
+//!   redirects expand the effective worklist.
+//!
+//! Between attempts whose last error is `Unavailable`,
+//! `DeadlineExceeded`, or a transport-layer failure, the loop sleeps a
+//! jittered exponential backoff. FAILED_PRECONDITION-with-hint redirects
+//! do not back off — the next endpoint is known and the redirect is
+//! part of normal discovery.
 
 use std::collections::{HashSet, VecDeque};
+use std::time::Duration;
 
+use tokio::time::Instant;
 use tsoracle_core::Timestamp;
 
 use crate::error::ClientError;
 use crate::leader_resolved::{ChannelPool, decode_leader_hint};
 use crate::response::decode_get_ts_response;
+use crate::retry_policy::{jittered_backoff, should_backoff};
 
 pub(crate) async fn issue_rpc(
     pool: &ChannelPool,
     count: u32,
 ) -> Result<Vec<Timestamp>, ClientError> {
+    let policy = pool.retry_policy().clone();
+    let start = Instant::now();
+    let deadline = start + policy.overall_deadline;
     let mut worklist: VecDeque<String> = pool.iter_round_robin().into();
     let mut visited: HashSet<String> = HashSet::new();
     let mut last_err: Option<ClientError> = None;
+    let mut attempt_index: u32 = 0;
 
     while let Some(endpoint) = worklist.pop_front() {
         if !visited.insert(endpoint.clone()) {
             continue;
         }
-        let mut client = match pool.client(&endpoint).await {
-            Ok(c) => c,
-            Err(e) => {
-                last_err = Some(e);
+        if attempt_index as usize >= policy.max_attempts {
+            break;
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+        let attempt_budget = (deadline - now).min(policy.per_attempt_deadline);
+
+        match attempt(pool, &endpoint, count, attempt_budget).await {
+            AttemptOutcome::Ok(timestamps) => {
+                pool.set_leader(endpoint);
+                return Ok(timestamps);
+            }
+            AttemptOutcome::LeaderHint(hinted_endpoint) => {
+                pool.set_leader(hinted_endpoint.clone());
+                worklist.push_front(hinted_endpoint);
+                // No backoff: a leader hint is known progress, not a
+                // failure to throttle.
+                attempt_index = attempt_index.saturating_add(1);
                 continue;
             }
-        };
-        match client
-            .get_ts(tsoracle_proto::v1::GetTsRequest { count })
-            .await
-        {
-            Ok(resp) => {
-                pool.set_leader(endpoint);
-                match decode_get_ts_response(resp.into_inner(), count) {
-                    Ok(timestamps) => return Ok(timestamps),
-                    Err(e) => {
-                        last_err = Some(e);
-                        continue;
-                    }
-                }
-            }
-            Err(status) if status.code() == tonic::Code::FailedPrecondition => {
-                let usable_hint = decode_leader_hint(&status)
-                    .and_then(|hint| hint.leader_endpoint)
-                    .filter(|hinted_endpoint| !visited.contains(hinted_endpoint))
-                    .filter(|hinted_endpoint| !rejects_plaintext_hint(pool, hinted_endpoint));
-                if let Some(hinted_endpoint) = usable_hint {
-                    pool.set_leader(hinted_endpoint.clone());
-                    worklist.push_front(hinted_endpoint);
-                    continue;
-                }
+            AttemptOutcome::HintRejected(status) => {
                 pool.clear_leader();
                 last_err = Some(ClientError::Rpc(status));
+                attempt_index = attempt_index.saturating_add(1);
                 continue;
             }
-            Err(status) => {
-                last_err = Some(ClientError::Rpc(status));
+            AttemptOutcome::Err(err) => {
+                let should_sleep = should_backoff(&err);
+                last_err = Some(err);
+                attempt_index = attempt_index.saturating_add(1);
+                if should_sleep {
+                    let backoff = jittered_backoff(policy.base_backoff, attempt_index - 1);
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let sleep_for = backoff.min(remaining);
+                    if sleep_for > Duration::ZERO {
+                        tokio::time::sleep(sleep_for).await;
+                    }
+                }
                 continue;
             }
         }
     }
     Err(last_err.unwrap_or(ClientError::NoReachableEndpoints))
+}
+
+/// Per-attempt outcome. Surfaces FAILED_PRECONDITION redirects as
+/// their own variant so the caller can preserve the existing "no
+/// backoff on hint" behaviour while still applying backoff to other
+/// retriable failures.
+enum AttemptOutcome {
+    Ok(Vec<Timestamp>),
+    LeaderHint(String),
+    HintRejected(tonic::Status),
+    Err(ClientError),
+}
+
+async fn attempt(
+    pool: &ChannelPool,
+    endpoint: &str,
+    count: u32,
+    budget: Duration,
+) -> AttemptOutcome {
+    let mut client = match tokio::time::timeout(budget, pool.client(endpoint)).await {
+        Ok(Ok(client)) => client,
+        Ok(Err(err)) => return AttemptOutcome::Err(err),
+        Err(_) => {
+            return AttemptOutcome::Err(ClientError::Rpc(tonic::Status::deadline_exceeded(
+                format!("connect exceeded per_attempt_deadline of {budget:?}"),
+            )));
+        }
+    };
+    let rpc = client.get_ts(tsoracle_proto::v1::GetTsRequest { count });
+    let response = match tokio::time::timeout(budget, rpc).await {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(status)) if status.code() == tonic::Code::FailedPrecondition => {
+            let usable_hint = decode_leader_hint(&status)
+                .and_then(|hint| hint.leader_endpoint)
+                .filter(|hinted| !rejects_plaintext_hint(pool, hinted));
+            return match usable_hint {
+                Some(hinted) => AttemptOutcome::LeaderHint(hinted),
+                None => AttemptOutcome::HintRejected(status),
+            };
+        }
+        Ok(Err(status)) => return AttemptOutcome::Err(ClientError::Rpc(status)),
+        Err(_) => {
+            return AttemptOutcome::Err(ClientError::Rpc(tonic::Status::deadline_exceeded(
+                format!("rpc exceeded per_attempt_deadline of {budget:?}"),
+            )));
+        }
+    };
+    match decode_get_ts_response(response.into_inner(), count) {
+        Ok(timestamps) => AttemptOutcome::Ok(timestamps),
+        Err(err) => AttemptOutcome::Err(err),
+    }
 }
 
 /// Refuse a wire-supplied leader hint that would downgrade the transport.
@@ -111,6 +191,20 @@ fn rejects_plaintext_hint(pool: &ChannelPool, hint: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RetryPolicy;
+
+    /// Aggressive policy used by the unit tests to keep them fast.
+    /// `per_attempt_deadline` is the dominant cost — the integration
+    /// tests cover wall-clock behaviour against real (unreachable)
+    /// sockets, but the unit tests just want the loop to terminate.
+    fn short_policy() -> RetryPolicy {
+        RetryPolicy {
+            max_attempts: 2,
+            per_attempt_deadline: Duration::from_millis(100),
+            overall_deadline: Duration::from_millis(300),
+            base_backoff: Duration::from_millis(1),
+        }
+    }
 
     /// A pool seeded with duplicate endpoints must visit each once; the
     /// second visit hits the `!visited.insert` short-circuit and continues
@@ -123,6 +217,7 @@ mod tests {
             vec!["http://127.0.0.1:1".into(), "http://127.0.0.1:1".into()],
             None,
             false,
+            short_policy(),
         );
         let result = issue_rpc(&pool, 1).await;
         assert!(result.is_err(), "no live endpoint must surface as Err");
@@ -134,7 +229,12 @@ mod tests {
     /// continue path that's not reached by the happy-path integration tests.
     #[tokio::test]
     async fn unreachable_endpoints_surface_last_error() {
-        let pool = ChannelPool::new(vec!["http://127.0.0.1:1".into()], None, false);
+        let pool = ChannelPool::new(
+            vec!["http://127.0.0.1:1".into()],
+            None,
+            false,
+            short_policy(),
+        );
         let result = issue_rpc(&pool, 1).await;
         assert!(result.is_err(), "expected Err from unreachable pool");
     }
@@ -146,8 +246,8 @@ mod tests {
     /// the policy.
     #[test]
     fn plaintext_hint_policy_matches_scheme_and_tls_state() {
-        let tls = ChannelPool::new(vec!["a:1".into()], None, true);
-        let plain = ChannelPool::new(vec!["a:1".into()], None, false);
+        let tls = ChannelPool::new(vec!["a:1".into()], None, true, RetryPolicy::default());
+        let plain = ChannelPool::new(vec!["a:1".into()], None, false, RetryPolicy::default());
 
         assert!(
             rejects_plaintext_hint(&tls, "http://attacker:1"),
@@ -164,6 +264,83 @@ mod tests {
         assert!(
             !rejects_plaintext_hint(&plain, "http://peer:1"),
             "http:// hint must be allowed when tls is not required"
+        );
+    }
+
+    /// A pool full of unreachable endpoints must surface its failure within
+    /// the `overall_deadline`, not the OS-default TCP timeout (`~75 s` on
+    /// Linux). The per-attempt deadline ensures each closed-port dial
+    /// returns quickly; the overall deadline ensures the loop terminates
+    /// even if a large pool would otherwise blow past it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn overall_deadline_caps_total_wall_clock() {
+        // 5 endpoints, each closed. With max_attempts=5 and per_attempt
+        // budget=100ms, naive iteration could spend up to ~500ms; the
+        // overall_deadline=200ms must cut the loop short. Choose
+        // base_backoff=0 so backoff sleeps are not a factor here — this
+        // test pins the overall_deadline branch, not the backoff.
+        let policy = RetryPolicy {
+            max_attempts: 5,
+            per_attempt_deadline: Duration::from_millis(100),
+            overall_deadline: Duration::from_millis(200),
+            base_backoff: Duration::ZERO,
+        };
+        let pool = ChannelPool::new(
+            vec![
+                "http://127.0.0.1:1".into(),
+                "http://127.0.0.1:2".into(),
+                "http://127.0.0.1:3".into(),
+                "http://127.0.0.1:4".into(),
+                "http://127.0.0.1:5".into(),
+            ],
+            None,
+            false,
+            policy,
+        );
+        let start = std::time::Instant::now();
+        let result = issue_rpc(&pool, 1).await;
+        let elapsed = start.elapsed();
+        assert!(result.is_err(), "expected Err from all-unreachable pool");
+        // Grace allowance covers tokio runtime jitter on slow CI runners.
+        // The point is "≪ OS TCP timeout", not a microbenchmark.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "must return within ~overall_deadline; took {elapsed:?}"
+        );
+    }
+
+    /// `max_attempts` must cap the attempt count below the worklist size.
+    /// Configuring 4 unreachable endpoints with `max_attempts=2` and a
+    /// generous per-attempt budget proves the loop exits after two
+    /// attempts rather than burning through the whole worklist.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn max_attempts_caps_iteration() {
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            per_attempt_deadline: Duration::from_millis(50),
+            overall_deadline: Duration::from_secs(10),
+            base_backoff: Duration::ZERO,
+        };
+        let pool = ChannelPool::new(
+            vec![
+                "http://127.0.0.1:1".into(),
+                "http://127.0.0.1:2".into(),
+                "http://127.0.0.1:3".into(),
+                "http://127.0.0.1:4".into(),
+            ],
+            None,
+            false,
+            policy,
+        );
+        let start = std::time::Instant::now();
+        let result = issue_rpc(&pool, 1).await;
+        let elapsed = start.elapsed();
+        assert!(result.is_err());
+        // Two attempts at ~50ms each + scheduler slack. Capping at 1s is
+        // enough to detect "loop kept iterating past max_attempts".
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "max_attempts=2 must cap iteration; took {elapsed:?}"
         );
     }
 }

--- a/crates/tsoracle-client/src/retry_policy.rs
+++ b/crates/tsoracle-client/src/retry_policy.rs
@@ -1,0 +1,240 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Retry and deadline policy for client RPCs.
+//!
+//! `per_attempt_deadline` bounds a single endpoint dial + RPC; the same
+//! value is pushed down to `tonic::transport::Endpoint::connect_timeout`
+//! and `Endpoint::timeout` so the transport layer also surfaces
+//! `DeadlineExceeded` rather than parking on an OS-default TCP timeout.
+//! `overall_deadline` bounds the whole `issue_rpc` call across all
+//! candidate endpoints — the retry loop short-circuits once it elapses,
+//! so a flapping leader cannot stretch a single caller's `request.await`
+//! across many RTTs. `max_attempts` is a tighter cap than the worklist's
+//! visited-set (the loop already visits each endpoint at most once), used
+//! to limit pathological leader-hint redirect chains. `base_backoff` is
+//! the unit for the jittered exponential backoff applied between
+//! attempts when the previous attempt returned `Unavailable` or
+//! `DeadlineExceeded` — see `crate::retry::issue_rpc`.
+
+use std::time::Duration;
+
+/// Retry and deadline knobs for client RPCs.
+///
+/// Every field has a default chosen for steady-state availability; see
+/// [`RetryPolicy::default`] for the values. Pass a customised policy via
+/// [`crate::ClientBuilder::retry_policy`] when the defaults don't match
+/// your deployment (for example, longer `per_attempt_deadline` for
+/// cross-region servers, or tighter `overall_deadline` for
+/// latency-sensitive paths).
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    /// Maximum number of endpoints `issue_rpc` will attempt before
+    /// returning the last error. Caps leader-hint redirect chains; the
+    /// existing per-endpoint visited-set means the loop already visits
+    /// each endpoint at most once, so this only bites when leader hints
+    /// expand the worklist beyond the configured list.
+    pub max_attempts: usize,
+    /// Wall-clock deadline applied to each `(connect, get_ts)` pair.
+    /// Pushed down to `Endpoint::connect_timeout` / `Endpoint::timeout`
+    /// for the built-in transport paths, and enforced by an outer
+    /// `tokio::time::timeout` for user-supplied
+    /// [`crate::ClientBuilder::channel_connector`] closures.
+    pub per_attempt_deadline: Duration,
+    /// Wall-clock deadline for the entire `issue_rpc` call. Once
+    /// elapsed, the retry loop returns the last observed error rather
+    /// than starting another attempt — even if `max_attempts` and the
+    /// worklist still have headroom.
+    pub overall_deadline: Duration,
+    /// Base unit for the jittered exponential backoff applied between
+    /// attempts whose last error was `Unavailable` or `DeadlineExceeded`.
+    /// The actual sleep is `rand_uniform(0, base_backoff * 2^attempt)`,
+    /// capped internally at [`RetryPolicy::MAX_BACKOFF`] so a long
+    /// `base_backoff` plus a high attempt count cannot consume the
+    /// overall deadline in a single sleep.
+    pub base_backoff: Duration,
+}
+
+impl RetryPolicy {
+    /// Upper bound on a single backoff sleep, regardless of
+    /// `base_backoff` and attempt count. Prevents the jittered
+    /// exponential from sleeping past the overall deadline in one step.
+    pub const MAX_BACKOFF: Duration = Duration::from_secs(5);
+}
+
+impl Default for RetryPolicy {
+    /// `max_attempts = 5`, `per_attempt_deadline = 2s`,
+    /// `overall_deadline = 10s`, `base_backoff = 50ms`. Five attempts at
+    /// the per-attempt cap plus modest backoff fit inside the overall
+    /// deadline for the common case; the loop returns
+    /// `NoReachableEndpoints` (or the last status) once exhausted.
+    fn default() -> Self {
+        RetryPolicy {
+            max_attempts: 5,
+            per_attempt_deadline: Duration::from_secs(2),
+            overall_deadline: Duration::from_secs(10),
+            base_backoff: Duration::from_millis(50),
+        }
+    }
+}
+
+/// Decide whether to back off before the next attempt based on the
+/// last error. Returns `true` for `Unavailable` / `DeadlineExceeded`
+/// gRPC statuses, and for transport-layer errors (which are inherently
+/// "service unavailable" class — the connect itself never reached the
+/// peer). Other failures (e.g. `Internal`, `Unauthenticated`, or a
+/// user-supplied connector's own error) are treated as deterministic:
+/// the next endpoint is tried immediately without sleep.
+pub(crate) fn should_backoff(error: &crate::error::ClientError) -> bool {
+    use crate::error::ClientError;
+    match error {
+        ClientError::Rpc(status) => matches!(
+            status.code(),
+            tonic::Code::Unavailable | tonic::Code::DeadlineExceeded
+        ),
+        ClientError::Transport(_) => true,
+        ClientError::NoReachableEndpoints
+        | ClientError::InvalidEndpoint(_)
+        | ClientError::InvalidCount(_)
+        | ClientError::Connector(_) => false,
+    }
+}
+
+/// Jittered exponential backoff. The returned duration is uniformly
+/// distributed in `[0, base * 2^attempt]`, capped at
+/// [`RetryPolicy::MAX_BACKOFF`]. Attempt 0 gives `[0, base]`; attempt 1
+/// gives `[0, 2*base]`; and so on. Full-jitter (AWS-style) is used
+/// because it minimises thundering-herd retries — every client picks
+/// an independent point in the window rather than clustering at the
+/// upper bound.
+pub(crate) fn jittered_backoff(base: Duration, attempt: u32) -> Duration {
+    if base.is_zero() {
+        return Duration::ZERO;
+    }
+    let shift = attempt.min(20);
+    let upper = base
+        .saturating_mul(1u32.checked_shl(shift).unwrap_or(u32::MAX))
+        .min(RetryPolicy::MAX_BACKOFF);
+    let upper_micros = upper.as_micros().min(u64::MAX as u128) as u64;
+    if upper_micros == 0 {
+        return Duration::ZERO;
+    }
+    let picked = rand::random_range(0..=upper_micros);
+    Duration::from_micros(picked)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_documented_values() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.max_attempts, 5);
+        assert_eq!(policy.per_attempt_deadline, Duration::from_secs(2));
+        assert_eq!(policy.overall_deadline, Duration::from_secs(10));
+        assert_eq!(policy.base_backoff, Duration::from_millis(50));
+    }
+
+    #[test]
+    fn jittered_backoff_zero_base_returns_zero() {
+        for attempt in 0..5 {
+            assert_eq!(jittered_backoff(Duration::ZERO, attempt), Duration::ZERO);
+        }
+    }
+
+    #[test]
+    fn jittered_backoff_respects_window_at_attempt_zero() {
+        let base = Duration::from_millis(10);
+        for _ in 0..200 {
+            let picked = jittered_backoff(base, 0);
+            assert!(
+                picked <= base,
+                "attempt 0 must be in [0, base]; got {picked:?} > {base:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn jittered_backoff_respects_window_at_higher_attempts() {
+        let base = Duration::from_millis(10);
+        for attempt in 1..6u32 {
+            let upper = base
+                .saturating_mul(1u32 << attempt)
+                .min(RetryPolicy::MAX_BACKOFF);
+            for _ in 0..200 {
+                let picked = jittered_backoff(base, attempt);
+                assert!(
+                    picked <= upper,
+                    "attempt {attempt} must be in [0, {upper:?}]; got {picked:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn jittered_backoff_caps_at_max_backoff() {
+        let base = Duration::from_secs(10);
+        for _ in 0..200 {
+            let picked = jittered_backoff(base, 5);
+            assert!(
+                picked <= RetryPolicy::MAX_BACKOFF,
+                "saturating cap must hold; got {picked:?} > {:?}",
+                RetryPolicy::MAX_BACKOFF
+            );
+        }
+    }
+
+    #[test]
+    fn jittered_backoff_produces_a_distribution_not_a_constant() {
+        // Full-jitter: across many draws at the same attempt count, the
+        // picked duration must vary. If it were a constant (e.g. always
+        // upper bound, never sampled), the property test above would
+        // pass but the de-correlation goal would be defeated.
+        let base = Duration::from_millis(100);
+        let mut min = Duration::MAX;
+        let mut max = Duration::ZERO;
+        for _ in 0..200 {
+            let picked = jittered_backoff(base, 3);
+            if picked < min {
+                min = picked;
+            }
+            if picked > max {
+                max = picked;
+            }
+        }
+        assert!(
+            max > min,
+            "jittered_backoff must produce a distribution; min={min:?}, max={max:?}"
+        );
+    }
+
+    #[test]
+    fn should_backoff_matches_documented_status_codes() {
+        use crate::error::ClientError;
+        assert!(should_backoff(&ClientError::Rpc(
+            tonic::Status::unavailable("u")
+        )));
+        assert!(should_backoff(&ClientError::Rpc(
+            tonic::Status::deadline_exceeded("d")
+        )));
+        assert!(!should_backoff(&ClientError::Rpc(tonic::Status::internal(
+            "i"
+        ))));
+        assert!(!should_backoff(&ClientError::Rpc(
+            tonic::Status::failed_precondition("fp")
+        )));
+        assert!(!should_backoff(&ClientError::NoReachableEndpoints));
+        assert!(!should_backoff(&ClientError::InvalidEndpoint("e".into())));
+        assert!(!should_backoff(&ClientError::InvalidCount(0)));
+    }
+}

--- a/crates/tsoracle-client/src/transport.rs
+++ b/crates/tsoracle-client/src/transport.rs
@@ -25,12 +25,44 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 use tonic::transport::Channel;
 
+use crate::RetryPolicy;
 use crate::error::ClientError;
 
 /// Boxed error returned by user-supplied connector closures.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// HTTP/2 keepalive ping interval. Hardcoded rather than exposed on
+/// [`RetryPolicy`] because no realistic deployment needs to tune it
+/// independently of the per-attempt deadline — 30 s is well below the
+/// idle-connection cull window of common L4 load balancers and NATs
+/// (AWS NLB: 350 s, AWS ALB: 60 s default, GCP: 600 s, conntrack:
+/// 432 000 s but earlier eviction under pressure). Callers needing a
+/// different value can use [`crate::ClientBuilder::channel_connector`]
+/// and build the `Endpoint` themselves.
+pub(crate) const HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Apply the four `Endpoint` knobs the [`RetryPolicy`] dictates:
+/// `connect_timeout`, `timeout` (both seeded from
+/// `per_attempt_deadline`), `keep_alive_while_idle(true)`, and
+/// `http2_keep_alive_interval`. Called from the built-in default and
+/// built-in TLS paths so a blackholed peer surfaces a tonic transport
+/// error within `per_attempt_deadline` instead of parking on the
+/// OS-default TCP timeout. User-supplied
+/// [`crate::ClientBuilder::channel_connector`] closures own their own
+/// `Endpoint` config and do not go through this helper.
+pub(crate) fn apply_endpoint_config(
+    endpoint: tonic::transport::Endpoint,
+    policy: &RetryPolicy,
+) -> tonic::transport::Endpoint {
+    endpoint
+        .connect_timeout(policy.per_attempt_deadline)
+        .timeout(policy.per_attempt_deadline)
+        .keep_alive_while_idle(true)
+        .http2_keep_alive_interval(HTTP2_KEEPALIVE_INTERVAL)
+}
 
 /// Stored channel-construction strategy, shared by the built-in TLS path
 /// and any user-supplied closure. Errors are normalized to `ClientError`
@@ -73,11 +105,13 @@ pub(crate) fn normalize_uri(endpoint: &str, tls: bool) -> String {
 #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
 pub(crate) fn tls_connector(
     cfg: tonic::transport::ClientTlsConfig,
+    policy: RetryPolicy,
 ) -> std::sync::Arc<ChannelConnector> {
     use tonic::transport::Endpoint;
     std::sync::Arc::new(move |endpoint: &str| {
         let uri = normalize_uri(endpoint, true);
         let cfg = cfg.clone();
+        let policy = policy.clone();
         let endpoint_owned = endpoint.to_string();
         Box::pin(async move {
             let ep: Endpoint = uri
@@ -88,6 +122,7 @@ pub(crate) fn tls_connector(
             } else {
                 ep
             };
+            let ep = apply_endpoint_config(ep, &policy);
             let channel = ep.connect().await.map_err(ClientError::from)?;
             Ok(channel)
         })

--- a/docs/client-api-and-usage.md
+++ b/docs/client-api-and-usage.md
@@ -51,7 +51,7 @@ The trailer's wire format is described in [The leader-hint trailer](key-subsyste
 
 ## Configuration
 
-The builder exposes two knobs:
+The builder exposes three knobs:
 
 ```rust
 ClientBuilder::endpoints(vec![
@@ -59,6 +59,7 @@ ClientBuilder::endpoints(vec![
     "http://host2:50551".into(),
 ])
     .batch_flush_interval(Duration::from_millis(1))
+    .retry_policy(tsoracle_client::RetryPolicy::default())
     .build()
     .await?;
 ```
@@ -67,7 +68,7 @@ ClientBuilder::endpoints(vec![
 
 **`batch_flush_interval`** is the *cold-start* coalescing window — the time the background driver waits, after the first buffered call arrives into an idle driver, before issuing the outgoing `GetTs` (default: 1 ms). It does *not* set the steady-state batch size: once any RPC is in flight, every waiter arriving during its round-trip is automatically coalesced into the next batch regardless of this knob, so steady-state batch size is set by `arrival_rate × rpc_round_trip` instead. Lowering `batch_flush_interval` (down to `Duration::ZERO`) reduces the per-call latency floor for cold-start callers but loses the first-burst coalescing window; raising it widens that window at the cost of a fixed latency tax on every first-after-idle request. For workloads that already batch explicitly, or that sustain enough concurrency to keep at least one RPC in flight at all times, the value is largely irrelevant. The full discussion — including why steady-state low batch size is a caller-concurrency problem and not a flushing problem — is in [The Client Driver](the-client-driver.md).
 
-There is no per-call timeout knob — wrap your call in `tokio::time::timeout` if you need one. The background coalescing task uses a bounded waiter queue (4096 entries); once full, callers await queue capacity, which applies backpressure before memory can grow without bound.
+**`retry_policy`** bounds the per-attempt and overall wall-clock cost of one `get_ts`/`get_ts_batch` call, and governs the backoff applied between retries. The struct is `RetryPolicy { max_attempts, per_attempt_deadline, overall_deadline, base_backoff }`; defaults are `5`, `2 s`, `10 s`, and `50 ms` respectively. `per_attempt_deadline` is pushed down to `tonic::transport::Endpoint::connect_timeout` and `Endpoint::timeout` for the built-in default and TLS transport paths (along with `keep_alive_while_idle(true)` and a 30-second HTTP/2 keepalive interval), so a blackholed peer fails fast at the transport layer instead of parking on the OS-default TCP timeout. The retry loop also wraps each `(connect, get_ts)` pair in `tokio::time::timeout(per_attempt_deadline, ...)`, which is the only deadline that applies when a user-supplied [`channel_connector`](#custom-transport-tls-mtls-connectors) replaces the built-in path. `overall_deadline` short-circuits the loop across the full worklist; `max_attempts` caps iteration when leader-hint redirects expand the worklist beyond the configured list. Between attempts whose last error was `Unavailable`, `DeadlineExceeded`, or a transport-layer failure, the loop sleeps a jittered exponential backoff (full-jitter in `[0, base_backoff × 2^attempt]`, capped internally at 5 seconds). FAILED_PRECONDITION-with-hint redirects do not back off — the next endpoint is known and the redirect is part of normal discovery. Callers wanting a per-call cap tighter than the policy can still wrap their `get_ts` call in `tokio::time::timeout`; the background coalescing task uses a bounded waiter queue (4096 entries), so callers also see backpressure once it is full.
 
 ## Custom transport (TLS, mTLS, connectors)
 


### PR DESCRIPTION
Closes #85.

## Summary

A blackholed peer (network partition with no RST) could park `connect()` indefinitely. Because the driver task funnels every coalesced batch through one in-flight RPC at a time (by design, to preserve the freshness invariant documented at `crates/tsoracle-client/src/lib.rs:15-18`), every queued waiter was blocked behind that one hung connect. The retry loop also had no wall-clock deadline, so a flapping leader could stretch one caller's `request.await` across many RTTs.

This PR adds `RetryPolicy` exposed on `ClientBuilder` and wires its `per_attempt_deadline` down to both the retry loop's `tokio::time::timeout` wrappers and to `tonic::transport::Endpoint::connect_timeout`/`Endpoint::timeout`. Endpoints also get `keep_alive_while_idle(true)` and a 30 s HTTP/2 keepalive interval so an idle leader connection survives a follower-side load balancer.

- New `RetryPolicy { max_attempts, per_attempt_deadline, overall_deadline, base_backoff }` exposed via `ClientBuilder::retry_policy`. Defaults: `5`, `2 s`, `10 s`, `50 ms`.
- `issue_rpc` wraps each `(pool.client, client.get_ts)` pair in `tokio::time::timeout(per_attempt_deadline, ...)`, tracks an overall deadline, and short-circuits when it elapses. `max_attempts` caps iteration tighter than the visited-set (which already prevents revisiting an endpoint).
- Full-jitter exponential backoff (`rand_uniform(0, base_backoff × 2^attempt)`, capped at 5 s) between attempts whose last error was `Unavailable`, `DeadlineExceeded`, or a transport-layer failure. `FailedPrecondition`-with-hint redirects do not back off — the next endpoint is known progress.
- The four `Endpoint` knobs (`connect_timeout`, `timeout`, `keep_alive_while_idle(true)`, `http2_keep_alive_interval(30 s)`) are applied on both the built-in plaintext path and the built-in TLS connector via a new `apply_endpoint_config` helper. User-supplied `channel_connector` closures still own their own `Endpoint` config; the retry loop's `tokio::time::timeout` still bounds them.

## Test plan

- [x] `cargo test -p tsoracle-client --all-features` — 47 unit tests pass, including 6 new tests covering the backoff distribution and per-status retry policy, 2 new retry-loop tests (`overall_deadline_caps_total_wall_clock`, `max_attempts_caps_iteration`), and 2 new public-API tests covering builder propagation and end-to-end unreachable-endpoint behaviour.
- [x] `cargo test -p tsoracle-tests` — 16 cross-crate integration tests still pass (including all 10 TLS tests, since the TLS connector now also threads the policy through `apply_endpoint_config`).
- [x] `cargo clippy -p tsoracle-client --tests --all-features` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Acceptance: a `Client` built against `127.0.0.1:1`/`:2`/`:3` with `overall_deadline = 300 ms` returns an error within `< 2 s` instead of parking on the OS-default TCP timeout (`get_ts_returns_within_overall_deadline_when_all_endpoints_unreachable`).