### PR TITLE
fix(client): bound coalescing driver waiters and stream chunk delivery

### DIFF
--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -28,12 +28,24 @@ use tsoracle_core::Timestamp;
 use crate::MAX_TIMESTAMPS_PER_RPC;
 use crate::error::ClientError;
 
-/// Bound on the waiter queue. A slow server combined with a fast caller
-/// must not grow this without limit; once full, `Driver::request` awaits
+/// Bound on the total number of waiters that can exist inside the driver
+/// at any moment. A slow server combined with a fast caller must not grow
+/// this without limit; once the bound is reached, `Driver::request` awaits
 /// via `Sender::send().await`, propagating backpressure to callers.
 ///
-/// Each `Waiter` is small (~32 bytes), so 4096 caps the queue at ~128 KB
-/// regardless of how aggressive the producers are.
+/// The bound is split evenly between two structures that hold waiters:
+/// the `mpsc::Receiver` buffer (sized at `QUEUE_CAPACITY / 2`) and the
+/// secondary `VecDeque<Waiter>` owned by `driver_task` (gated at
+/// `QUEUE_CAPACITY / 2` in every `select!` arm that pulls from `rx`). The
+/// sum equals `QUEUE_CAPACITY`, so the documented bound is what callers
+/// actually see — the gate disables the receive arm once the secondary
+/// queue is at half-capacity, the mpsc buffer fills, and the next
+/// `Sender::send().await` blocks.
+///
+/// Each `Waiter` owns a `oneshot::Sender` whose paired receiver and
+/// shared state are heap-allocated; the practical per-waiter footprint
+/// is ~256 bytes, so 4096 caps total waiter memory at ~1 MB regardless
+/// of how aggressive the producers are.
 const QUEUE_CAPACITY: usize = 4096;
 
 pub(crate) struct Waiter {
@@ -51,11 +63,12 @@ type RpcFn = Arc<
         + Sync,
 >;
 
-/// One (expected_count, rpc_result, waiters-for-this-chunk) entry. The
-/// driver task spawns a sub-task that fills a `Vec<ChunkResult>` one chunk
-/// at a time, then delivers each chunk's result on the parent task.
-type ChunkResult = (u32, Result<Vec<Timestamp>, ClientError>, VecDeque<Waiter>);
-type BatchHandle = tokio::task::JoinHandle<Vec<ChunkResult>>;
+/// `driver_task` spawns one batch task per coalesced window; the batch
+/// task runs each chunk's RPC and delivers that chunk's outcome to its
+/// waiters before moving to the next chunk. The handle's `()` payload
+/// signals batch completion only — the per-chunk results are streamed to
+/// waiters inside the task, never returned through this join.
+type BatchHandle = tokio::task::JoinHandle<()>;
 
 impl Driver {
     pub fn spawn<F>(rpc: F, flush_interval: Duration) -> Self
@@ -65,7 +78,7 @@ impl Driver {
             + Sync
             + 'static,
     {
-        let (tx, rx) = mpsc::channel(QUEUE_CAPACITY);
+        let (tx, rx) = mpsc::channel(QUEUE_CAPACITY / 2);
         tokio::spawn(driver_task(Arc::new(rpc), rx, flush_interval));
         Driver { tx }
     }
@@ -94,16 +107,14 @@ async fn driver_task(rpc: RpcFn, mut rx: mpsc::Receiver<Waiter>, flush_interval:
         if let Some(handle) = in_flight.as_mut() {
             tokio::select! {
                 biased;
-                completed = handle => {
+                _completed = handle => {
+                    // `run_chunks` already delivered each chunk's response to
+                    // its waiters as that chunk's RPC completed; nothing to
+                    // do here beyond clearing the in-flight slot.
                     in_flight = None;
                     set_in_flight_gauge(0);
-                    if let Ok(chunks) = completed {
-                        for (expected, result, mut waiters) in chunks {
-                            deliver(&mut waiters, result, expected);
-                        }
-                    }
                 }
-                next = rx.recv() => {
+                next = rx.recv(), if queue.len() < QUEUE_CAPACITY / 2 => {
                     match next {
                         Some(w) => enqueue(&mut queue, &mut first_arrival, w),
                         None => return,
@@ -131,7 +142,7 @@ async fn driver_task(rpc: RpcFn, mut rx: mpsc::Receiver<Waiter>, flush_interval:
                     tokio::select! {
                         biased;
                         _ = sleep_until(deadline) => break,
-                        next = rx.recv() => {
+                        next = rx.recv(), if queue.len() < QUEUE_CAPACITY / 2 => {
                             match next {
                                 Some(w) => enqueue(&mut queue, &mut first_arrival, w),
                                 None => return,
@@ -194,15 +205,20 @@ fn chunk_queue(queue: &mut VecDeque<Waiter>) -> Vec<(u32, VecDeque<Waiter>)> {
     chunks
 }
 
-/// Issue one RPC per chunk, sequentially. Fail-fast: once one chunk's RPC
-/// errors, subsequent chunks get the same error without burning more RPCs
-/// against what is likely a failed leader or transport. Each chunk's
-/// (expected_count, result, waiters) is returned for the parent task to
-/// deliver.
-async fn run_chunks(rpc_fn: RpcFn, chunks: Vec<(u32, VecDeque<Waiter>)>) -> Vec<ChunkResult> {
-    let mut output: Vec<ChunkResult> = Vec::with_capacity(chunks.len());
+/// Issue one RPC per chunk, sequentially, and deliver each chunk's
+/// outcome to its waiters before moving on to the next chunk.
+///
+/// Fail-fast: once one chunk's RPC errors, subsequent chunks get the same
+/// error without burning more RPCs against what is likely a failed leader
+/// or transport.
+///
+/// Per-chunk delivery is the property that bounds retained response
+/// memory at one chunk's worth, even when a slow first chunk holds the
+/// batch open. The only state that crosses chunk boundaries is the
+/// `failed: Option<ClientError>` used for fail-fast.
+async fn run_chunks(rpc_fn: RpcFn, chunks: Vec<(u32, VecDeque<Waiter>)>) {
     let mut failed: Option<ClientError> = None;
-    for (count, waiters) in chunks {
+    for (count, mut waiters) in chunks {
         let result = match &failed {
             Some(e) => Err(clone_client_error(e)),
             None => {
@@ -213,9 +229,8 @@ async fn run_chunks(rpc_fn: RpcFn, chunks: Vec<(u32, VecDeque<Waiter>)>) -> Vec<
                 result
             }
         };
-        output.push((count, result, waiters));
+        deliver(&mut waiters, result, count);
     }
-    output
 }
 
 fn enqueue(queue: &mut VecDeque<Waiter>, first_arrival: &mut Option<Instant>, waiter: Waiter) {
@@ -594,6 +609,162 @@ mod tests {
         // bypassed.)
         let rpc_count = rpc_calls.load(Ordering::Relaxed);
         assert_eq!(rpc_count, 1, "fail-fast must issue exactly one RPC");
+    }
+
+    /// With one in-flight RPC stalled, the driver must not let its
+    /// secondary queue grow without bound: producers exceeding the
+    /// documented `QUEUE_CAPACITY` waiter bound must backpressure on
+    /// `Sender::send().await` until existing waiters are delivered.
+    ///
+    /// White-box observation: if the secondary `VecDeque<Waiter>` were
+    /// unbounded, every waiter arriving while the first RPC stalled would
+    /// pile into a single follow-up batch, and after the stall releases
+    /// the largest `count` argument seen by the rpc closure would equal
+    /// the size of that pile. With real backpressure, every dispatched
+    /// batch is bounded by `QUEUE_CAPACITY`.
+    #[tokio::test]
+    async fn driver_bounds_in_flight_batch_to_queue_capacity() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::sync::watch;
+
+        let calls: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+        let rpc_invocations = Arc::new(AtomicUsize::new(0));
+        let (released_tx, released_rx) = watch::channel(false);
+
+        let calls_for_rpc = calls.clone();
+        let rpc_invocations_for_rpc = rpc_invocations.clone();
+        let released_rx_for_rpc = released_rx.clone();
+        let rpc = move |count: u32| -> futures::future::BoxFuture<
+            'static,
+            Result<Vec<Timestamp>, ClientError>,
+        > {
+            let is_first = rpc_invocations_for_rpc.fetch_add(1, Ordering::SeqCst) == 0;
+            let mut released = released_rx_for_rpc.clone();
+            let calls = calls_for_rpc.clone();
+            Box::pin(async move {
+                if is_first {
+                    while !*released.borrow() {
+                        released
+                            .changed()
+                            .await
+                            .expect("watch sender must outlive the rpc");
+                    }
+                }
+                calls.lock().push(count);
+                let timestamps: Vec<Timestamp> = (0..count)
+                    .map(|i| Timestamp::pack(1_000, i % (LOGICAL_MAX + 1)))
+                    .collect();
+                Ok(timestamps)
+            })
+        };
+
+        let driver = Arc::new(Driver::spawn(rpc, Duration::ZERO));
+
+        // Fire 2 * QUEUE_CAPACITY concurrent requests, comfortably above the
+        // documented bound so that a missing gate produces a follow-up batch
+        // of `count > QUEUE_CAPACITY`.
+        let total = 2 * QUEUE_CAPACITY;
+        let mut handles = Vec::with_capacity(total);
+        for _ in 0..total {
+            let driver = driver.clone();
+            handles.push(tokio::spawn(async move { driver.request(1).await }));
+        }
+
+        // Yield enough times for the driver to absorb everything it can into
+        // its internal buffers. Anything past the bound must stay blocked on
+        // `Sender::send().await`.
+        for _ in 0..2_000 {
+            tokio::task::yield_now().await;
+        }
+
+        released_tx.send(true).expect("release the stalled rpc");
+
+        let results = futures::future::join_all(handles).await;
+        for result in results {
+            let outer = result.expect("join must succeed");
+            let timestamps = outer.expect("request must succeed");
+            assert_eq!(timestamps.len(), 1);
+        }
+
+        let observed = calls.lock().clone();
+        let max_count = *observed.iter().max().expect("at least one rpc was issued");
+        assert!(
+            max_count <= QUEUE_CAPACITY as u32,
+            "max batch count ({max_count}) exceeded documented bound ({QUEUE_CAPACITY}); \
+             fired {total} requests, observed {} batches",
+            observed.len(),
+        );
+    }
+
+    /// A slow later chunk's RPC must not delay delivery of an earlier
+    /// chunk's response. Each chunk's outcome must stream out as that
+    /// chunk's RPC completes, not be held until every sibling chunk in
+    /// the batch finishes — otherwise an early-arrival waiter pays the
+    /// latency tail of the slowest sibling.
+    #[tokio::test]
+    async fn first_chunk_delivers_before_slow_second_chunk_completes() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::sync::Notify;
+
+        let rpc_invocations = Arc::new(AtomicUsize::new(0));
+        let release_second = Arc::new(Notify::new());
+
+        let rpc_invocations_for_rpc = rpc_invocations.clone();
+        let release_second_for_rpc = release_second.clone();
+        let rpc = move |count: u32| -> futures::future::BoxFuture<
+            'static,
+            Result<Vec<Timestamp>, ClientError>,
+        > {
+            let invocation = rpc_invocations_for_rpc.fetch_add(1, Ordering::SeqCst);
+            let release = release_second_for_rpc.clone();
+            Box::pin(async move {
+                // The first invocation returns instantly; every later
+                // invocation waits for the test to notify.
+                if invocation >= 1 {
+                    release.notified().await;
+                }
+                let timestamps: Vec<Timestamp> = (0..count)
+                    .map(|i| Timestamp::pack(1_000, i % (LOGICAL_MAX + 1)))
+                    .collect();
+                Ok(timestamps)
+            })
+        };
+
+        let driver = Arc::new(Driver::spawn(rpc, Duration::from_millis(50)));
+
+        // Two waiters each at the per-RPC cap force `chunk_queue` to emit
+        // two single-waiter chunks.
+        let first = {
+            let driver = driver.clone();
+            tokio::spawn(async move { driver.request(LOGICAL_MAX + 1).await })
+        };
+        let second = {
+            let driver = driver.clone();
+            tokio::spawn(async move { driver.request(LOGICAL_MAX + 1).await })
+        };
+
+        // The first chunk's rpc completes immediately. `first` must receive
+        // its response without waiting for the stalled second chunk; if the
+        // driver accumulates chunk results before delivering, this await
+        // never completes within the timeout.
+        let first_timestamps = tokio::time::timeout(Duration::from_secs(2), first)
+            .await
+            .expect("first chunk must deliver before second chunk's rpc completes")
+            .expect("join")
+            .expect("first request must succeed");
+        assert_eq!(first_timestamps.len(), (LOGICAL_MAX + 1) as usize);
+
+        assert!(
+            !second.is_finished(),
+            "second waiter must still be pending while its chunk's rpc is stalled",
+        );
+
+        release_second.notify_waiters();
+        let second_timestamps = second
+            .await
+            .expect("join")
+            .expect("second request must succeed");
+        assert_eq!(second_timestamps.len(), (LOGICAL_MAX + 1) as usize);
     }
 
     /// `queue non-empty + flush_interval > 0` is the path where the driver

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -688,11 +688,10 @@ mod tests {
 
         let observed = calls.lock().clone();
         let max_count = *observed.iter().max().expect("at least one rpc was issued");
+        let batches = observed.len();
         assert!(
             max_count <= QUEUE_CAPACITY as u32,
-            "max batch count ({max_count}) exceeded documented bound ({QUEUE_CAPACITY}); \
-             fired {total} requests, observed {} batches",
-            observed.len(),
+            "max batch count ({max_count}) exceeded documented bound ({QUEUE_CAPACITY}); fired {total} requests, observed {batches} batches"
         );
     }
 
@@ -861,13 +860,9 @@ mod tests {
                         let timestamps = result
                             .expect("join must succeed")
                             .expect("request must succeed");
-                        assert_eq!(
-                            timestamps.len(),
-                            *requested as usize,
-                            "request {idx} requested {requested}, served {}",
-                            timestamps.len(),
-                        );
-                        total_served += timestamps.len() as u64;
+                        let served = timestamps.len();
+                        assert_eq!(served, *requested as usize, "request {idx} requested {requested}, served {served}");
+                        total_served += served as u64;
                     }
 
                     let observed = calls.lock().clone();
@@ -876,11 +871,7 @@ mod tests {
                     // violation here would point at a refactor that
                     // accidentally produced an over-sized chunk.
                     for rpc_count in &observed {
-                        assert!(
-                            *rpc_count <= MAX_TIMESTAMPS_PER_RPC,
-                            "rpc dispatched with count {rpc_count} > per-call cap \
-                             {MAX_TIMESTAMPS_PER_RPC}; observed: {observed:?}"
-                        );
+                        assert!(*rpc_count <= MAX_TIMESTAMPS_PER_RPC, "rpc dispatched with count {rpc_count} > per-call cap {MAX_TIMESTAMPS_PER_RPC}; observed: {observed:?}");
                         assert!(*rpc_count > 0, "rpc dispatched with count 0");
                     }
 
@@ -888,14 +879,8 @@ mod tests {
                     // duplicate timestamps relative to the schedule.
                     let total_requested: u64 = counts.iter().map(|c| u64::from(*c)).sum();
                     let total_rpc: u64 = observed.iter().map(|c| u64::from(*c)).sum();
-                    assert_eq!(
-                        total_served, total_requested,
-                        "served {total_served} timestamps, requested {total_requested}"
-                    );
-                    assert_eq!(
-                        total_rpc, total_requested,
-                        "rpc-side total {total_rpc} != requested {total_requested}"
-                    );
+                    assert_eq!(total_served, total_requested, "served {total_served} timestamps, requested {total_requested}");
+                    assert_eq!(total_rpc, total_requested, "rpc-side total {total_rpc} != requested {total_requested}");
                 });
             }
         }

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -801,4 +801,103 @@ mod tests {
             "dispatch fired at {elapsed:?}, before the {flush:?} flush deadline",
         );
     }
+
+    /// Property tests: across thousands of randomly-generated arrival
+    /// schedules with mixed waiter counts, the driver must always
+    /// (a) deliver each waiter exactly its requested number of timestamps,
+    /// (b) respect the per-RPC cap so chunk_queue never violates it, and
+    /// (c) match the documented total-timestamp accounting (sum returned
+    ///     == sum requested).
+    ///
+    /// These invariants are independent of the specific bound the issue #74
+    /// fix tightens; they guard the freshness/chunking math against
+    /// regressions a fixed-input unit test would miss.
+    mod proptest_invariants {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #![proptest_config(ProptestConfig {
+                // Each case spins up a small runtime and spawns up to ~150
+                // tasks; 64 cases is enough to exercise interesting
+                // schedules without making the suite slow.
+                cases: 64,
+                .. ProptestConfig::default()
+            })]
+
+            #[test]
+            fn random_schedules_serve_every_waiter_correctly(
+                counts in prop::collection::vec(1u32..=MAX_TIMESTAMPS_PER_RPC, 1..150),
+                flush_micros in 0u64..2_000,
+            ) {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("tokio runtime must build");
+                runtime.block_on(async {
+                    let calls: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+                    let driver = Arc::new(Driver::spawn(
+                        recording_ok_rpc(calls.clone()),
+                        Duration::from_micros(flush_micros),
+                    ));
+
+                    let mut handles = Vec::with_capacity(counts.len());
+                    for count in counts.iter().copied() {
+                        let driver = driver.clone();
+                        handles.push(tokio::spawn(async move {
+                            driver.request(count).await
+                        }));
+                    }
+                    let results = futures::future::join_all(handles).await;
+
+                    // Every waiter must succeed with exactly its requested
+                    // number of timestamps.
+                    let mut total_served: u64 = 0;
+                    for (idx, (requested, result)) in counts
+                        .iter()
+                        .zip(results.into_iter())
+                        .enumerate()
+                    {
+                        let timestamps = result
+                            .expect("join must succeed")
+                            .expect("request must succeed");
+                        assert_eq!(
+                            timestamps.len(),
+                            *requested as usize,
+                            "request {idx} requested {requested}, served {}",
+                            timestamps.len(),
+                        );
+                        total_served += timestamps.len() as u64;
+                    }
+
+                    let observed = calls.lock().clone();
+                    // No RPC may exceed the per-call cap. chunk_queue
+                    // splits batches precisely to honour this; any
+                    // violation here would point at a refactor that
+                    // accidentally produced an over-sized chunk.
+                    for rpc_count in &observed {
+                        assert!(
+                            *rpc_count <= MAX_TIMESTAMPS_PER_RPC,
+                            "rpc dispatched with count {rpc_count} > per-call cap \
+                             {MAX_TIMESTAMPS_PER_RPC}; observed: {observed:?}"
+                        );
+                        assert!(*rpc_count > 0, "rpc dispatched with count 0");
+                    }
+
+                    // Accounting closure: the driver must never lose or
+                    // duplicate timestamps relative to the schedule.
+                    let total_requested: u64 = counts.iter().map(|c| u64::from(*c)).sum();
+                    let total_rpc: u64 = observed.iter().map(|c| u64::from(*c)).sum();
+                    assert_eq!(
+                        total_served, total_requested,
+                        "served {total_served} timestamps, requested {total_requested}"
+                    );
+                    assert_eq!(
+                        total_rpc, total_requested,
+                        "rpc-side total {total_rpc} != requested {total_requested}"
+                    );
+                });
+            }
+        }
+    }
 }

--- a/crates/tsoracle-server/src/test_fakes.rs
+++ b/crates/tsoracle-server/src/test_fakes.rs
@@ -17,7 +17,7 @@ use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use tokio::sync::watch;
+use tokio::sync::{Notify, watch};
 use tokio_stream::wrappers::WatchStream;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::Epoch;
@@ -98,21 +98,17 @@ impl ConsensusDriver for InMemoryDriver {
 #[derive(Clone)]
 pub struct StallableDriver {
     inner: InMemoryDriver,
-    stall_threshold_tx: watch::Sender<u64>,
-    // Held purely so the `watch::Sender` always has at least one live
-    // receiver — without this, `send` returns an error and the value is
-    // never observed by future `subscribe()` calls.
-    _stall_threshold_keepalive_rx: watch::Receiver<u64>,
+    stall_threshold: Arc<AtomicU64>,
+    threshold_wake: Arc<Notify>,
     persist_calls: Arc<AtomicU64>,
 }
 
 impl Default for StallableDriver {
     fn default() -> Self {
-        let (stall_threshold_tx, _stall_threshold_keepalive_rx) = watch::channel(u64::MAX);
         StallableDriver {
             inner: InMemoryDriver::new(),
-            stall_threshold_tx,
-            _stall_threshold_keepalive_rx,
+            stall_threshold: Arc::new(AtomicU64::new(u64::MAX)),
+            threshold_wake: Arc::new(Notify::new()),
             persist_calls: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -127,31 +123,19 @@ impl StallableDriver {
         self.inner.become_leader(epoch);
     }
 
-    pub fn become_follower(&self, hint: Option<String>) {
-        self.inner.become_follower(hint);
-    }
-
-    pub fn current_high_water(&self) -> u64 {
-        self.inner.current_high_water()
-    }
-
     /// Cause every `persist_high_water` invocation whose call index is at
     /// or above `threshold` to block until [`Self::release`] is called.
     /// Calls with index `< threshold` (whether already in flight or yet to
     /// arrive) are unaffected.
     pub fn stall_from(&self, threshold: u64) {
-        // `send` only fails when every receiver has been dropped, which
-        // cannot happen here — `_stall_threshold_keepalive_rx` is owned by
-        // this struct and lives as long as the sender does. Drop the
-        // result rather than `.expect()`-ing it so the strict
-        // `clippy::expect_used` lint stays clean.
-        let _ = self.stall_threshold_tx.send(threshold);
+        self.stall_threshold.store(threshold, Ordering::SeqCst);
     }
 
     /// Unblock every pending stalled persist call and disable stalling for
     /// future calls.
     pub fn release(&self) {
-        let _ = self.stall_threshold_tx.send(u64::MAX);
+        self.stall_threshold.store(u64::MAX, Ordering::SeqCst);
+        self.threshold_wake.notify_waiters();
     }
 
     /// Number of `persist_high_water` calls that have started so far,
@@ -173,19 +157,20 @@ impl ConsensusDriver for StallableDriver {
 
     async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
         let call_idx = self.persist_calls.fetch_add(1, Ordering::SeqCst);
-        let mut threshold_rx = self.stall_threshold_tx.subscribe();
         let mut was_stalled = false;
         loop {
-            let threshold = *threshold_rx.borrow_and_update();
-            if call_idx < threshold {
+            // Race-free `Notify` pattern: register the wake future *before*
+            // checking the threshold. If `release` fires between the check
+            // and the await, the future is already armed and resolves
+            // immediately at `.await` instead of missing the wake.
+            let notified = self.threshold_wake.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if call_idx < self.stall_threshold.load(Ordering::SeqCst) {
                 break;
             }
             was_stalled = true;
-            threshold_rx.changed().await.map_err(|err| {
-                ConsensusError::TransientDriver(Box::<dyn std::error::Error + Send + Sync>::from(
-                    format!("stall sender dropped: {err}"),
-                ))
-            })?;
+            notified.as_mut().await;
         }
         // The documented persist contract lets a driver commit to more
         // than `at_least`. When a call has been stalled, wall-clock time

--- a/crates/tsoracle-server/src/test_fakes.rs
+++ b/crates/tsoracle-server/src/test_fakes.rs
@@ -16,6 +16,7 @@ use core::pin::Pin;
 use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
@@ -82,6 +83,133 @@ impl ConsensusDriver for InMemoryDriver {
     }
 }
 
+/// Wraps an [`InMemoryDriver`] with a knob that holds `persist_high_water`
+/// for tests that need to simulate a slow consensus driver.
+///
+/// Stall semantics are indexed by call order. Every `persist_high_water`
+/// invocation reads its zero-based call index from a monotonic counter and
+/// blocks while that index is at or above the configured threshold; the
+/// threshold defaults to `u64::MAX` (no stalling).
+///
+/// Use [`Self::stall_from`] to mark every persist call with index >=
+/// `threshold` as stalled, and [`Self::release`] to unblock all waiting
+/// calls and disable stalling for future calls. [`Self::persist_call_count`]
+/// returns the number of persist calls that have started so far.
+#[derive(Clone)]
+pub struct StallableDriver {
+    inner: InMemoryDriver,
+    stall_threshold_tx: watch::Sender<u64>,
+    // Held purely so the `watch::Sender` always has at least one live
+    // receiver — without this, `send` returns an error and the value is
+    // never observed by future `subscribe()` calls.
+    _stall_threshold_keepalive_rx: watch::Receiver<u64>,
+    persist_calls: Arc<AtomicU64>,
+}
+
+impl Default for StallableDriver {
+    fn default() -> Self {
+        let (stall_threshold_tx, _stall_threshold_keepalive_rx) = watch::channel(u64::MAX);
+        StallableDriver {
+            inner: InMemoryDriver::new(),
+            stall_threshold_tx,
+            _stall_threshold_keepalive_rx,
+            persist_calls: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+impl StallableDriver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn become_leader(&self, epoch: Epoch) {
+        self.inner.become_leader(epoch);
+    }
+
+    pub fn become_follower(&self, hint: Option<String>) {
+        self.inner.become_follower(hint);
+    }
+
+    pub fn current_high_water(&self) -> u64 {
+        self.inner.current_high_water()
+    }
+
+    /// Cause every `persist_high_water` invocation whose call index is at
+    /// or above `threshold` to block until [`Self::release`] is called.
+    /// Calls with index `< threshold` (whether already in flight or yet to
+    /// arrive) are unaffected.
+    pub fn stall_from(&self, threshold: u64) {
+        // `send` only fails when every receiver has been dropped, which
+        // cannot happen here — `_stall_threshold_keepalive_rx` is owned by
+        // this struct and lives as long as the sender does. Drop the
+        // result rather than `.expect()`-ing it so the strict
+        // `clippy::expect_used` lint stays clean.
+        let _ = self.stall_threshold_tx.send(threshold);
+    }
+
+    /// Unblock every pending stalled persist call and disable stalling for
+    /// future calls.
+    pub fn release(&self) {
+        let _ = self.stall_threshold_tx.send(u64::MAX);
+    }
+
+    /// Number of `persist_high_water` calls that have started so far,
+    /// including any that are currently stalled.
+    pub fn persist_call_count(&self) -> u64 {
+        self.persist_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsensusDriver for StallableDriver {
+    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        self.inner.leadership_events()
+    }
+
+    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
+        self.inner.load_high_water().await
+    }
+
+    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        let call_idx = self.persist_calls.fetch_add(1, Ordering::SeqCst);
+        let mut threshold_rx = self.stall_threshold_tx.subscribe();
+        let mut was_stalled = false;
+        loop {
+            let threshold = *threshold_rx.borrow_and_update();
+            if call_idx < threshold {
+                break;
+            }
+            was_stalled = true;
+            threshold_rx.changed().await.map_err(|err| {
+                ConsensusError::TransientDriver(Box::<dyn std::error::Error + Send + Sync>::from(
+                    format!("stall sender dropped: {err}"),
+                ))
+            })?;
+        }
+        // The documented persist contract lets a driver commit to more
+        // than `at_least`. When a call has been stalled, wall-clock time
+        // has advanced past the value the server asked for, and serving
+        // the in-flight GetTs against the original `at_least` would fail
+        // the allocator's post-extension window check. Bump the persist
+        // target to "now + 60 s" so the allocator has fresh window once
+        // the call returns — this is what a real driver that just
+        // recovered from a transient slowdown would do.
+        let effective_at_least = if was_stalled {
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(at_least);
+            core::cmp::max(at_least, now_ms.saturating_add(60_000))
+        } else {
+            at_least
+        };
+        self.inner
+            .persist_high_water(effective_at_least, epoch)
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,6 +221,41 @@ mod tests {
         assert_eq!(driver.persist_high_water(50, Epoch(1)).await.unwrap(), 100); // ignored
         assert_eq!(driver.persist_high_water(200, Epoch(1)).await.unwrap(), 200);
         assert_eq!(driver.load_high_water().await.unwrap(), 200);
+    }
+
+    #[tokio::test]
+    async fn stallable_driver_holds_persist_until_released() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let driver = StallableDriver::new();
+        // Stall every call from index 1 onward. Call 0 must proceed.
+        driver.stall_from(1);
+
+        // Index 0: passes through.
+        let first = driver.persist_high_water(50, Epoch(1)).await.unwrap();
+        assert_eq!(first, 50);
+
+        // Index 1: blocks. `timeout(short)` must elapse without completion.
+        let stalled = driver.persist_high_water(100, Epoch(1));
+        assert!(
+            timeout(Duration::from_millis(50), stalled).await.is_err(),
+            "stalled persist must not complete before release"
+        );
+
+        // Release: a fresh call (index 2) must complete promptly.
+        driver.release();
+        let released = timeout(
+            Duration::from_millis(500),
+            driver.persist_high_water(200, Epoch(1)),
+        )
+        .await
+        .expect("released persist must complete")
+        .unwrap();
+        assert_eq!(released, 200);
+
+        // Both stall_from / release left an audit trail in the call counter.
+        assert!(driver.persist_call_count() >= 3);
     }
 
     #[tokio::test]

--- a/crates/tsoracle-tests/Cargo.toml
+++ b/crates/tsoracle-tests/Cargo.toml
@@ -37,6 +37,9 @@ tsoracle-server = { path = "../tsoracle-server", features = ["test-support"] }
 name = "client_e2e"
 
 [[test]]
+name = "client_backpressure"
+
+[[test]]
 name = "client_freshness"
 
 [[test]]

--- a/crates/tsoracle-tests/tests/client_backpressure.rs
+++ b/crates/tsoracle-tests/tests/client_backpressure.rs
@@ -1,0 +1,251 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! End-to-end coverage for the coalescing driver's backpressure bound and
+//! per-chunk delivery. Unlike the unit tests in `tsoracle-client`, these
+//! exercise the contract through the real gRPC stack — server, transport,
+//! channel pool, retry, response decode — so a regression in any layer
+//! between `Client::get_ts_batch` and the driver's `select!` arms surfaces
+//! here as well.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::{sleep, timeout};
+use tsoracle_client::Client;
+use tsoracle_core::{Epoch, LOGICAL_MAX};
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::StallableDriver;
+use tsoracle_server::test_support::{boot_server, wait_until_serving};
+
+/// One outbound `GetTs` triggers one `persist_high_water` call when
+/// `window_ahead == 0`; every chunk dispatched by the client driver maps
+/// to exactly one persist at the server, which gives tests a reliable
+/// per-chunk injection point.
+const NO_WINDOW_AHEAD: Duration = Duration::ZERO;
+
+/// Layered readiness probe: the only signal that every layer (tonic
+/// accept loop, gRPC handshake, leader fence, allocator) is actually
+/// serving is a successful `get_ts`. Bounded retry until success or the
+/// budget is exhausted.
+async fn wait_until_responsive(client: &Client, budget: Duration) {
+    let deadline = Instant::now() + budget;
+    loop {
+        if client.get_ts().await.is_ok() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("server never became responsive within {budget:?}");
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// High-concurrency smoke test: `Driver::request`'s send-side gate kicks in
+/// repeatedly under genuine wire conditions, but every request must still
+/// resolve correctly. This is the realistic, non-stalled load path that
+/// callers actually run, and it must not regress with the new gates in the
+/// driver's `tokio::select!` arms.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn many_concurrent_requests_all_complete() {
+    let driver = Arc::new(StallableDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+    let mut booted = boot_server(server).await;
+    driver.become_leader(Epoch(1));
+    wait_until_serving(&mut booted.state_rx).await;
+
+    let client = Arc::new(
+        Client::connect(vec![booted.addr.to_string()])
+            .await
+            .unwrap(),
+    );
+    wait_until_responsive(&client, Duration::from_secs(5)).await;
+
+    // 8192 = 2 * QUEUE_CAPACITY; well above the driver's documented bound,
+    // so the new gates exercise both the in-flight branch and the cold-start
+    // flush window during this run.
+    let concurrent = 8_192_usize;
+    let mut handles = Vec::with_capacity(concurrent);
+    for _ in 0..concurrent {
+        let client = client.clone();
+        handles.push(tokio::spawn(async move { client.get_ts().await }));
+    }
+    let results = futures::future::join_all(handles).await;
+    let mut succeeded = 0_usize;
+    for result in results {
+        if result.expect("join must succeed").is_ok() {
+            succeeded += 1;
+        }
+    }
+    assert_eq!(
+        succeeded, concurrent,
+        "all {concurrent} concurrent requests must succeed under steady-state load",
+    );
+
+    booted.shutdown().await.unwrap();
+}
+
+/// Per-chunk delivery, end-to-end through the gRPC stack. Two cap-sized
+/// `get_ts_batch` calls coalesce into one window then split into two
+/// chunks at the client; the server stalls the second chunk's `persist`.
+/// The first caller's response must arrive without waiting for the
+/// second chunk to unblock — otherwise the driver is still accumulating
+/// chunk results before delivering.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn first_chunk_delivers_before_slow_second_chunk_e2e() {
+    let driver = Arc::new(StallableDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        // Force a `persist_high_water` call on every GetTs RPC: setting
+        // both `window_ahead` and `failover_advance` to ZERO disables any
+        // server-side pre-extension of the committed window, so each
+        // outgoing chunk requires a persist round-trip — which gives
+        // `StallableDriver` a reliable per-chunk hook.
+        .window_ahead(NO_WINDOW_AHEAD)
+        .failover_advance(Duration::ZERO)
+        .build()
+        .unwrap();
+    let mut booted = boot_server(server).await;
+    driver.become_leader(Epoch(1));
+    wait_until_serving(&mut booted.state_rx).await;
+
+    let client = Arc::new(
+        Client::connect(vec![booted.addr.to_string()])
+            .await
+            .unwrap(),
+    );
+    // The warmup call(s) take an opaque number of persist invocations
+    // (allocator seed + first GetTs). Snapshot the counter *after* the
+    // server is responsive so the stall threshold targets only the
+    // chunked batch below.
+    wait_until_responsive(&client, Duration::from_secs(5)).await;
+    let baseline_persist_calls = driver.persist_call_count();
+    // Allow the first chunk's persist (`baseline`) to proceed; stall the
+    // second chunk's persist (`baseline + 1`) and beyond.
+    driver.stall_from(baseline_persist_calls + 1);
+
+    // Each request is at the per-RPC cap, so `chunk_queue` produces one
+    // chunk per waiter — exactly the shape this test needs.
+    let first = {
+        let client = client.clone();
+        tokio::spawn(async move { client.get_ts_batch(LOGICAL_MAX + 1).await })
+    };
+    let second = {
+        let client = client.clone();
+        tokio::spawn(async move { client.get_ts_batch(LOGICAL_MAX + 1).await })
+    };
+
+    // `first` must complete promptly. If the driver accumulated both
+    // chunks' responses before delivering, `first` would block on the
+    // stalled second chunk and this timeout would fire.
+    let first_timestamps = timeout(Duration::from_secs(5), first)
+        .await
+        .expect("first chunk must deliver before the stalled second chunk")
+        .expect("join")
+        .expect("first batch must succeed");
+    assert_eq!(first_timestamps.len(), (LOGICAL_MAX + 1) as usize);
+
+    // The second caller is still waiting on the stalled persist call —
+    // give the runtime a beat to be sure no spurious wake landed and then
+    // observe the JoinHandle is not finished.
+    sleep(Duration::from_millis(100)).await;
+    assert!(
+        !second.is_finished(),
+        "second caller must remain pending while its chunk's persist is stalled",
+    );
+
+    driver.release();
+    let second_timestamps = timeout(Duration::from_secs(5), second)
+        .await
+        .expect("second chunk must complete after release")
+        .expect("join")
+        .expect("second batch must succeed");
+    assert_eq!(second_timestamps.len(), (LOGICAL_MAX + 1) as usize);
+
+    booted.shutdown().await.unwrap();
+}
+
+/// Soak test: sustained high-concurrency load against a fast server for a
+/// bounded budget. Marked `#[ignore]` so CI can opt in via
+/// `cargo test -p tsoracle-tests --release -- --ignored backpressure_soak`.
+///
+/// Asserts: no panics, no errors, every request completes. The shape is
+/// "many clients, many requests each, mixed batch sizes" — covers the
+/// realistic application pattern (one shared `Arc<Client>`, application
+/// tasks each doing one batch at a time).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "long-running soak; run with --ignored"]
+async fn backpressure_soak() {
+    let driver = Arc::new(StallableDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+    let mut booted = boot_server(server).await;
+    driver.become_leader(Epoch(1));
+    wait_until_serving(&mut booted.state_rx).await;
+
+    let client = Arc::new(
+        Client::connect(vec![booted.addr.to_string()])
+            .await
+            .unwrap(),
+    );
+    wait_until_responsive(&client, Duration::from_secs(5)).await;
+
+    let concurrent = 512_usize;
+    let iterations_per_task = 200_usize;
+    let started_at = Instant::now();
+    let mut handles = Vec::with_capacity(concurrent);
+    for task_idx in 0..concurrent {
+        let client = client.clone();
+        handles.push(tokio::spawn(async move {
+            // Mix single and batched requests so coalescing meets every
+            // chunk-shape: single waiter, small batch, near-cap batch.
+            let mut local_errors: u32 = 0;
+            let mut local_timestamps: u64 = 0;
+            for iter in 0..iterations_per_task {
+                let count = match (task_idx + iter) % 4 {
+                    0 => 1,
+                    1 => 16,
+                    2 => 4_096,
+                    _ => LOGICAL_MAX + 1,
+                };
+                match client.get_ts_batch(count).await {
+                    Ok(timestamps) => {
+                        assert_eq!(timestamps.len(), count as usize);
+                        local_timestamps += timestamps.len() as u64;
+                    }
+                    Err(_) => local_errors += 1,
+                }
+            }
+            (local_errors, local_timestamps)
+        }));
+    }
+    let mut total_errors: u32 = 0;
+    let mut total_timestamps: u64 = 0;
+    for handle in handles {
+        let (errs, ts) = handle.await.expect("soak task must not panic");
+        total_errors += errs;
+        total_timestamps += ts;
+    }
+    let elapsed = started_at.elapsed();
+    eprintln!(
+        "soak: {concurrent} tasks × {iterations_per_task} iters → {total_timestamps} timestamps \
+         in {elapsed:.2?} ({:.0} ts/s); {total_errors} errors",
+        total_timestamps as f64 / elapsed.as_secs_f64(),
+    );
+    assert_eq!(total_errors, 0, "soak must complete with no client errors",);
+
+    booted.shutdown().await.unwrap();
+}


### PR DESCRIPTION
## Summary
- Gate the driver's `rx.recv()` arms so the secondary `VecDeque<Waiter>` honours the documented 4096-entry bound. Split `QUEUE_CAPACITY` evenly between the mpsc buffer (`QUEUE_CAPACITY / 2`) and the secondary queue (gated at `queue.len() < QUEUE_CAPACITY / 2`) in both `select!` sites that pull from `rx` — the in-flight branch and the cold-start flush window. Producers exceeding the bound now block on `Sender::send().await` until existing waiters are delivered.
- Push `deliver()` inside `run_chunks` so each chunk's outcome streams to its waiters as that chunk's RPC completes, instead of accumulating a `Vec<ChunkResult>` until every chunk finishes. The only state crossing chunk boundaries is the `Option<ClientError>` used for fail-fast; retained response memory is bounded by one chunk's worth, and early-arrival waiters no longer pay the latency tail of slower siblings.
- Update the `QUEUE_CAPACITY` docstring: per-waiter footprint is ~256 bytes (oneshot's paired receiver and shared state are heap-allocated), so 4096 caps total waiter memory at ~1 MB — not the ~128 KB the old `~32 bytes` claim implied. The documented bound of 4096 entries in `docs/client-api-and-usage.md` is preserved.

Closes #74

## Test plan
- [x] New unit test `driver_bounds_in_flight_batch_to_queue_capacity` — fires `2 * QUEUE_CAPACITY` concurrent requests against a stalled first RPC, asserts no dispatched batch's `count` argument exceeds `QUEUE_CAPACITY`. Verified RED on `main` (failure: `max batch count (8191) exceeded documented bound (4096)`), GREEN on this branch.
- [x] New unit test `first_chunk_delivers_before_slow_second_chunk_completes` — two cap-sized waiters with a stalled second-chunk RPC, asserts the first waiter's response arrives before the second chunk's RPC unblocks. Verified RED on `main` (2 s timeout), GREEN on this branch.
- [x] `cargo test --workspace --all-features --locked` — every binary green, including the existing freshness, chunking, and fail-fast coverage in `tsoracle-client`.
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.