### PR TITLE
feat(client): instrument retry, driver, and connect signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,8 @@ version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
+ "metrics",
+ "metrics-util 0.19.1",
  "parking_lot",
  "proptest",
  "prost",
@@ -3262,8 +3264,11 @@ version = "0.1.2"
 dependencies = [
  "fail",
  "futures",
+ "metrics",
+ "metrics-util 0.19.1",
  "rcgen",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tsoracle-client",
  "tsoracle-core",

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -13,18 +13,20 @@ keywords      = ["tsoracle", "grpc", "client", "timestamp", "oracle"]
 categories    = ["network-programming", "database", "api-bindings"]
 
 [features]
-default    = ["tls-rustls"]
+default    = ["tls-rustls", "tracing"]
+metrics    = ["dep:metrics"]
 tls-rustls = ["tonic/tls-aws-lc"]
 tls-native = ["tonic/tls-native-roots"]
 tracing    = ["dep:tracing"]
 
 [package.metadata.docs.rs]
-features       = ["tls-rustls", "tracing"]
+features       = ["tls-rustls", "tracing", "metrics"]
 rustdoc-args   = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait    = { workspace = true }
 futures        = { workspace = true }
+metrics        = { workspace = true, optional = true }
 parking_lot    = { workspace = true }
 prost          = { workspace = true }
 rand           = { workspace = true, features = ["thread_rng"] }
@@ -36,5 +38,6 @@ tsoracle-core  = { path = "../tsoracle-core", version = "0.1.1" }
 tsoracle-proto = { path = "../tsoracle-proto", version = "0.1.1" }
 
 [dev-dependencies]
-tokio    = { workspace = true, features = ["test-util"] }
-proptest = { workspace = true }
+metrics-util = { workspace = true }
+proptest     = { workspace = true }
+tokio        = { workspace = true, features = ["test-util"] }

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -100,6 +100,7 @@ async fn driver_task(rpc: RpcFn, mut rx: mpsc::Receiver<Waiter>, flush_interval:
                 biased;
                 completed = handle => {
                     in_flight = None;
+                    set_in_flight_gauge(0);
                     if let Ok(chunks) = completed {
                         for (expected, result, mut waiters) in chunks {
                             deliver(&mut waiters, result, expected);
@@ -146,6 +147,7 @@ async fn driver_task(rpc: RpcFn, mut rx: mpsc::Receiver<Waiter>, flush_interval:
             first_arrival = None;
 
             let chunks = chunk_queue(&mut queue);
+            set_queue_depth_gauge(queue.len());
             if chunks.is_empty() {
                 // Every waiter was rejected inline (oversize/zero counts).
                 continue;
@@ -154,6 +156,7 @@ async fn driver_task(rpc: RpcFn, mut rx: mpsc::Receiver<Waiter>, flush_interval:
             in_flight = Some(tokio::spawn(
                 async move { run_chunks(rpc_fn, chunks).await },
             ));
+            set_in_flight_gauge(1);
         }
     }
 }
@@ -224,6 +227,29 @@ fn enqueue(queue: &mut VecDeque<Waiter>, first_arrival: &mut Option<Instant>, wa
         *first_arrival = Some(Instant::now());
     }
     queue.push_back(waiter);
+    set_queue_depth_gauge(queue.len());
+}
+
+/// Refresh the driver's waiter-queue gauge to the current size. Compiled away
+/// to a no-op without the `metrics` feature so the hot path stays free of
+/// branches when no recorder is installed.
+#[inline]
+fn set_queue_depth_gauge(depth: usize) {
+    #[cfg(feature = "metrics")]
+    metrics::gauge!("tsoracle.client.driver.queue_depth").set(depth as f64);
+    #[cfg(not(feature = "metrics"))]
+    let _ = depth;
+}
+
+/// 0 or 1: whether the driver currently has an outgoing batch in flight.
+/// A scalar gauge keeps the wire shape predictable and aligns with the
+/// "one batch at a time" invariant of the driver.
+#[inline]
+fn set_in_flight_gauge(state: u8) {
+    #[cfg(feature = "metrics")]
+    metrics::gauge!("tsoracle.client.driver.in_flight").set(f64::from(state));
+    #[cfg(not(feature = "metrics"))]
+    let _ = state;
 }
 
 /// Deliver one chunk's RPC outcome to its waiters.

--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -27,11 +27,32 @@ use crate::transport::apply_endpoint_config;
 
 const LEADER_HINT_KEY: &str = "tsoracle-leader-hint-bin";
 
-pub fn decode_leader_hint(status: &Status) -> Option<LeaderHint> {
-    let key = MetadataKey::from_bytes(LEADER_HINT_KEY.as_bytes()).ok()?;
-    let value = status.metadata().get_bin(key)?;
-    let bytes = value.to_bytes().ok()?;
-    LeaderHint::decode(bytes.as_ref()).ok()
+/// Outcome of inspecting a `Status`'s trailers for the leader-hint payload.
+///
+/// The retry loop treats the three cases differently: `Absent` is the normal
+/// "this peer doesn't know who the leader is" signal and stays silent;
+/// `Malformed` is a wire-protocol bug worth a warning + counter; `Decoded`
+/// is the followable redirect.
+pub enum LeaderHintLookup {
+    Absent,
+    Decoded(LeaderHint),
+    Malformed,
+}
+
+pub fn decode_leader_hint(status: &Status) -> LeaderHintLookup {
+    let Ok(key) = MetadataKey::from_bytes(LEADER_HINT_KEY.as_bytes()) else {
+        return LeaderHintLookup::Absent;
+    };
+    let Some(value) = status.metadata().get_bin(key) else {
+        return LeaderHintLookup::Absent;
+    };
+    let Ok(bytes) = value.to_bytes() else {
+        return LeaderHintLookup::Malformed;
+    };
+    match LeaderHint::decode(bytes.as_ref()) {
+        Ok(hint) => LeaderHintLookup::Decoded(hint),
+        Err(_) => LeaderHintLookup::Malformed,
+    }
 }
 
 pub struct ChannelPool {
@@ -97,22 +118,41 @@ impl ChannelPool {
         if let Some(channel) = self.channels.lock().get(endpoint).cloned() {
             return Ok(TsoServiceClient::new(channel));
         }
+        // Cache miss: we are about to actually dial. Time the dial so the
+        // `connect.duration` histogram only captures real connect work, not
+        // the cache-hit fast path.
+        #[cfg(feature = "metrics")]
+        let connect_started = std::time::Instant::now();
         let channel = match &self.connector {
-            Some(connector) => connector(endpoint).await?,
-            None => {
-                let uri = crate::transport::normalize_uri(endpoint, false);
-                let transport_endpoint: Endpoint = uri
-                    .parse()
-                    .map_err(|_| ClientError::InvalidEndpoint(endpoint.into()))?;
-                let transport_endpoint =
-                    apply_endpoint_config(transport_endpoint, &self.retry_policy);
-                transport_endpoint.connect().await?
-            }
+            Some(connector) => connector(endpoint).await,
+            None => match crate::transport::normalize_uri(endpoint, false).parse::<Endpoint>() {
+                Ok(transport_endpoint) => {
+                    let transport_endpoint =
+                        apply_endpoint_config(transport_endpoint, &self.retry_policy);
+                    transport_endpoint
+                        .connect()
+                        .await
+                        .map_err(ClientError::from)
+                }
+                Err(_) => Err(ClientError::InvalidEndpoint(endpoint.into())),
+            },
         };
-        self.channels
-            .lock()
-            .insert(endpoint.to_string(), channel.clone());
-        Ok(TsoServiceClient::new(channel))
+        match channel {
+            Ok(channel) => {
+                #[cfg(feature = "metrics")]
+                metrics::histogram!("tsoracle.client.connect.duration")
+                    .record(connect_started.elapsed().as_secs_f64());
+                self.channels
+                    .lock()
+                    .insert(endpoint.to_string(), channel.clone());
+                Ok(TsoServiceClient::new(channel))
+            }
+            Err(error) => {
+                #[cfg(feature = "metrics")]
+                metrics::counter!("tsoracle.client.connect.failures.total").increment(1);
+                Err(error)
+            }
+        }
     }
 
     pub fn iter_round_robin(&self) -> Vec<String> {

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -45,7 +45,7 @@ use tokio::time::Instant;
 use tsoracle_core::Timestamp;
 
 use crate::error::ClientError;
-use crate::leader_resolved::{ChannelPool, decode_leader_hint};
+use crate::leader_resolved::{ChannelPool, LeaderHintLookup, decode_leader_hint};
 use crate::response::decode_get_ts_response;
 use crate::retry_policy::{jittered_backoff, should_backoff};
 
@@ -74,12 +74,29 @@ pub(crate) async fn issue_rpc(
         }
         let attempt_budget = (deadline - now).min(policy.per_attempt_deadline);
 
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            endpoint = %endpoint,
+            count,
+            attempt_index,
+            budget_ms = attempt_budget.as_millis() as u64,
+            "tsoracle-client: dispatching GetTs to endpoint",
+        );
+
         match attempt(pool, &endpoint, count, attempt_budget).await {
             AttemptOutcome::Ok(timestamps) => {
                 pool.set_leader(endpoint);
                 return Ok(timestamps);
             }
             AttemptOutcome::LeaderHint(hinted_endpoint) => {
+                #[cfg(feature = "metrics")]
+                metrics::counter!("tsoracle.client.leader_pivots.total").increment(1);
+                #[cfg(feature = "tracing")]
+                tracing::debug!(
+                    from = %endpoint,
+                    to = %hinted_endpoint,
+                    "tsoracle-client: pivoting to hinted leader",
+                );
                 pool.set_leader(hinted_endpoint.clone());
                 worklist.push_front(hinted_endpoint);
                 // No backoff: a leader hint is known progress, not a
@@ -131,8 +148,34 @@ async fn attempt(
 ) -> AttemptOutcome {
     let mut client = match tokio::time::timeout(budget, pool.client(endpoint)).await {
         Ok(Ok(client)) => client,
-        Ok(Err(err)) => return AttemptOutcome::Err(err),
+        Ok(Err(err)) => {
+            #[cfg(feature = "metrics")]
+            metrics::counter!(
+                "tsoracle.client.retries.total",
+                "reason" => "connect_failure",
+            )
+            .increment(1);
+            #[cfg(feature = "tracing")]
+            tracing::debug!(
+                endpoint = %endpoint,
+                error = %err,
+                "tsoracle-client: connect failed; advancing worklist",
+            );
+            return AttemptOutcome::Err(err);
+        }
         Err(_) => {
+            #[cfg(feature = "metrics")]
+            metrics::counter!(
+                "tsoracle.client.retries.total",
+                "reason" => "deadline_exceeded",
+            )
+            .increment(1);
+            #[cfg(feature = "tracing")]
+            tracing::debug!(
+                endpoint = %endpoint,
+                budget_ms = budget.as_millis() as u64,
+                "tsoracle-client: connect exceeded per_attempt_deadline",
+            );
             return AttemptOutcome::Err(ClientError::Rpc(tonic::Status::deadline_exceeded(
                 format!("connect exceeded per_attempt_deadline of {budget:?}"),
             )));
@@ -142,16 +185,74 @@ async fn attempt(
     let response = match tokio::time::timeout(budget, rpc).await {
         Ok(Ok(resp)) => resp,
         Ok(Err(status)) if status.code() == tonic::Code::FailedPrecondition => {
-            let usable_hint = decode_leader_hint(&status)
-                .and_then(|hint| hint.leader_endpoint)
-                .filter(|hinted| !rejects_plaintext_hint(pool, hinted));
+            #[cfg(feature = "metrics")]
+            metrics::counter!("tsoracle.client.not_leader.total").increment(1);
+            #[cfg(feature = "metrics")]
+            metrics::counter!(
+                "tsoracle.client.retries.total",
+                "reason" => "not_leader",
+            )
+            .increment(1);
+
+            let hinted_endpoint = match decode_leader_hint(&status) {
+                LeaderHintLookup::Decoded(hint) => hint.leader_endpoint,
+                LeaderHintLookup::Absent => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        endpoint = %endpoint,
+                        "tsoracle-client: FAILED_PRECONDITION without leader-hint trailer; \
+                         contacted peer cannot redirect us",
+                    );
+                    None
+                }
+                LeaderHintLookup::Malformed => {
+                    #[cfg(feature = "metrics")]
+                    metrics::counter!("tsoracle.client.leader_hint.decode_failures.total")
+                        .increment(1);
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        endpoint = %endpoint,
+                        "tsoracle-client: FAILED_PRECONDITION carried a malformed \
+                         leader-hint trailer; treating as no hint",
+                    );
+                    None
+                }
+            };
+            let usable_hint =
+                hinted_endpoint.filter(|hinted| !rejects_plaintext_hint(pool, hinted));
             return match usable_hint {
                 Some(hinted) => AttemptOutcome::LeaderHint(hinted),
                 None => AttemptOutcome::HintRejected(status),
             };
         }
-        Ok(Err(status)) => return AttemptOutcome::Err(ClientError::Rpc(status)),
+        Ok(Err(status)) => {
+            #[cfg(feature = "metrics")]
+            metrics::counter!(
+                "tsoracle.client.retries.total",
+                "reason" => "transport",
+            )
+            .increment(1);
+            #[cfg(feature = "tracing")]
+            tracing::debug!(
+                endpoint = %endpoint,
+                code = ?status.code(),
+                "tsoracle-client: RPC failed; advancing worklist",
+            );
+            return AttemptOutcome::Err(ClientError::Rpc(status));
+        }
         Err(_) => {
+            #[cfg(feature = "metrics")]
+            metrics::counter!(
+                "tsoracle.client.retries.total",
+                "reason" => "deadline_exceeded",
+            )
+            .increment(1);
+            #[cfg(feature = "tracing")]
+            tracing::debug!(
+                endpoint = %endpoint,
+                budget_ms = budget.as_millis() as u64,
+                "tsoracle-client: RPC exceeded per_attempt_deadline",
+            );
             return AttemptOutcome::Err(ClientError::Rpc(tonic::Status::deadline_exceeded(
                 format!("rpc exceeded per_attempt_deadline of {budget:?}"),
             )));
@@ -159,7 +260,15 @@ async fn attempt(
     };
     match decode_get_ts_response(response.into_inner(), count) {
         Ok(timestamps) => AttemptOutcome::Ok(timestamps),
-        Err(err) => AttemptOutcome::Err(err),
+        Err(err) => {
+            #[cfg(feature = "metrics")]
+            metrics::counter!(
+                "tsoracle.client.retries.total",
+                "reason" => "decode_error",
+            )
+            .increment(1);
+            AttemptOutcome::Err(err)
+        }
     }
 }
 

--- a/crates/tsoracle-tests/Cargo.toml
+++ b/crates/tsoracle-tests/Cargo.toml
@@ -15,12 +15,18 @@ tls-native = ["tsoracle-server/tls-native", "tsoracle-client/tls-native"]
 # Mirror tsoracle-server's `failpoints` feature so the failpoint-driven
 # integration tests can be opted in. `cargo test -p tsoracle-tests --features failpoints`.
 failpoints = ["tsoracle-server/failpoints", "dep:fail"]
+# Opt-in mirror of `tsoracle-client`'s `metrics` feature so `client_metrics`
+# can drive the recorder-fake test that asserts the documented client signals.
+metrics = ["tsoracle-client/metrics", "dep:metrics", "dep:metrics-util", "dep:tokio-stream"]
 
 [dependencies]
 fail            = { workspace = true, optional = true }
 futures         = { workspace = true }
+metrics         = { workspace = true, optional = true }
+metrics-util    = { workspace = true, optional = true }
 rcgen           = { workspace = true }
 tokio           = { workspace = true, features = ["test-util"] }
+tokio-stream    = { workspace = true, optional = true, features = ["net"] }
 tonic           = { workspace = true }
 tsoracle-client = { path = "../tsoracle-client" }
 tsoracle-core   = { path = "../tsoracle-core" }
@@ -42,3 +48,7 @@ name = "server_serve_with_listener"
 
 [[test]]
 name = "client_tls"
+
+[[test]]
+name              = "client_metrics"
+required-features = ["metrics"]

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -1,0 +1,320 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Recorder-fake test for the documented `tsoracle.client.*` metrics catalog.
+//!
+//! Drives three back-to-back scenarios through a process-global
+//! `DebuggingRecorder` and asserts every documented client signal fires at
+//! least once. Scenarios are sequenced inside one test binary because the
+//! `metrics` recorder slot is process-global; running each scenario as its
+//! own `#[tokio::test]` would race on `install()`.
+
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use metrics_util::{
+    CompositeKey, MetricKind,
+    debugging::{DebugValue, DebuggingRecorder, Snapshotter},
+};
+use tokio::net::TcpListener;
+use tonic::{
+    Request, Response, Status,
+    metadata::{BinaryMetadataValue, MetadataKey},
+    transport::Server as TonicServer,
+};
+use tsoracle_client::Client;
+use tsoracle_core::Epoch;
+use tsoracle_proto::v1::{
+    GetTsRequest, GetTsResponse,
+    tso_service_server::{TsoService, TsoServiceServer},
+};
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{
+    boot_server, wait_for_grpc_handshake, wait_until, wait_until_serving,
+};
+use tsoracle_server::{Server, ServingState};
+
+const LEADER_HINT_TRAILER: &str = "tsoracle-leader-hint-bin";
+
+type RecordedMetric = (
+    CompositeKey,
+    Option<metrics::Unit>,
+    Option<metrics::SharedString>,
+    DebugValue,
+);
+
+fn install_recorder() -> Snapshotter {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    recorder.install().expect("install metrics recorder");
+    snapshotter
+}
+
+fn counter_value(snapshot: &[RecordedMetric], name: &str) -> u64 {
+    let mut total = 0u64;
+    for (composite, _unit, _desc, value) in snapshot {
+        if composite.kind() == MetricKind::Counter && composite.key().name() == name {
+            if let DebugValue::Counter(n) = value {
+                total = total.saturating_add(*n);
+            }
+        }
+    }
+    total
+}
+
+fn counter_value_with_label(
+    snapshot: &[RecordedMetric],
+    name: &str,
+    label_key: &str,
+    label_value: &str,
+) -> u64 {
+    for (composite, _unit, _desc, value) in snapshot {
+        if composite.kind() != MetricKind::Counter || composite.key().name() != name {
+            continue;
+        }
+        let matches_label = composite
+            .key()
+            .labels()
+            .any(|l| l.key() == label_key && l.value() == label_value);
+        if matches_label {
+            if let DebugValue::Counter(n) = value {
+                return *n;
+            }
+        }
+    }
+    0
+}
+
+fn histogram_sample_count(snapshot: &[RecordedMetric], name: &str) -> usize {
+    let mut total = 0usize;
+    for (composite, _unit, _desc, value) in snapshot {
+        if composite.kind() == MetricKind::Histogram && composite.key().name() == name {
+            if let DebugValue::Histogram(samples) = value {
+                total = total.saturating_add(samples.len());
+            }
+        }
+    }
+    total
+}
+
+fn gauge_registered(snapshot: &[RecordedMetric], name: &str) -> bool {
+    snapshot.iter().any(|(composite, _unit, _desc, value)| {
+        composite.kind() == MetricKind::Gauge
+            && composite.key().name() == name
+            && matches!(value, DebugValue::Gauge(_))
+    })
+}
+
+/// Bind a TCP listener, capture its assigned port, and drop the listener.
+/// The OS will not re-assign that port to another process within the same
+/// test run; subsequent connect attempts will fail with ECONNREFUSED, which
+/// is exactly the `connect.failures` signal we want to exercise.
+async fn closed_port_endpoint() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    drop(listener);
+    format!("http://{addr}")
+}
+
+/// Minimal `TsoService` that always returns FAILED_PRECONDITION with a
+/// deliberately-malformed `tsoracle-leader-hint-bin` trailer. Bytes are
+/// chosen to fail `LeaderHint::decode` (field tag 1 declares a 5-byte
+/// length-delimited string but only 2 bytes follow) — exercising the
+/// `LeaderHintLookup::Malformed` arm in `decode_leader_hint`.
+struct MalformedHintService;
+
+#[tonic::async_trait]
+impl TsoService for MalformedHintService {
+    async fn get_ts(
+        &self,
+        _request: Request<GetTsRequest>,
+    ) -> Result<Response<GetTsResponse>, Status> {
+        let mut status = Status::failed_precondition("not leader");
+        let key =
+            MetadataKey::from_bytes(LEADER_HINT_TRAILER.as_bytes()).expect("trailer key is ascii");
+        let garbage: &[u8] = &[0x0a, 0x05, b'h', b'i'];
+        status
+            .metadata_mut()
+            .insert_bin(key, BinaryMetadataValue::from_bytes(garbage));
+        Err(status)
+    }
+}
+
+/// Bind a malformed-hint fake server on a random port. Returns its socket
+/// address; the spawned task is detached and lives until the runtime shuts
+/// down at end of test.
+async fn boot_malformed_hint_server() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    let server = TonicServer::builder().add_service(TsoServiceServer::new(MalformedHintService));
+    tokio::spawn(async move {
+        let _ = server.serve_with_incoming(incoming).await;
+    });
+    wait_for_grpc_handshake(addr, Duration::from_secs(5))
+        .await
+        .expect("malformed-hint server never accepted gRPC handshake");
+    addr
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn emits_documented_client_signals_end_to_end() {
+    let snapshotter = install_recorder();
+
+    // ── Scenario 1: follower→leader pivot via in-band hint ──────────────
+    //
+    // Drives connect.duration (cache-miss on both A and B), not_leader.total,
+    // leader_pivots.total, retries.total{reason=not_leader}, and both driver
+    // gauges (queue_depth, in_flight).
+    let driver_a = Arc::new(InMemoryDriver::new());
+    let driver_b = Arc::new(InMemoryDriver::new());
+    let server_a = Server::builder()
+        .consensus_driver(driver_a.clone())
+        .build()
+        .unwrap();
+    let server_b = Server::builder()
+        .consensus_driver(driver_b.clone())
+        .build()
+        .unwrap();
+    let mut booted_a = boot_server(server_a).await;
+    let mut booted_b = boot_server(server_b).await;
+    driver_b.become_leader(Epoch(1));
+    driver_a.become_follower(Some(format!("http://{}", booted_b.addr)));
+    wait_until_serving(&mut booted_b.state_rx).await;
+    wait_until(&mut booted_a.state_rx, |s| {
+        matches!(
+            s,
+            ServingState::NotServing {
+                leader_endpoint: Some(_)
+            }
+        )
+    })
+    .await;
+    wait_for_grpc_handshake(booted_a.addr, Duration::from_secs(5))
+        .await
+        .expect("server A handshake");
+    wait_for_grpc_handshake(booted_b.addr, Duration::from_secs(5))
+        .await
+        .expect("server B handshake");
+
+    let client_pivot = Client::connect(vec![format!("http://{}", booted_a.addr)])
+        .await
+        .expect("pivot-scenario client connect");
+    client_pivot
+        .get_ts()
+        .await
+        .expect("scenario 1 must succeed via hint");
+
+    // ── Scenario 2: connect failure → retried against live endpoint ─────
+    //
+    // The dead endpoint is listed first so the round-robin queue tries it,
+    // hits ECONNREFUSED, increments connect.failures + retries{connect_failure},
+    // and falls through to B which serves the timestamp.
+    let dead_endpoint = closed_port_endpoint().await;
+    let client_dead_first =
+        Client::connect(vec![dead_endpoint, format!("http://{}", booted_b.addr)])
+            .await
+            .expect("dead-then-live client connect");
+    client_dead_first
+        .get_ts()
+        .await
+        .expect("scenario 2 must succeed via second endpoint");
+
+    // ── Scenario 3: FAILED_PRECONDITION carrying a malformed hint trailer
+    //
+    // The only peer returns a hint trailer whose bytes don't decode as
+    // `LeaderHint`. retry::issue_rpc reaches `LeaderHintLookup::Malformed`,
+    // counts a decode failure, and surfaces the FAILED_PRECONDITION up to
+    // the caller because there's no follow-up endpoint to pivot to.
+    let malformed_addr = boot_malformed_hint_server().await;
+    let client_malformed = Client::connect(vec![format!("http://{}", malformed_addr)])
+        .await
+        .expect("malformed-hint client connect");
+    let err = client_malformed
+        .get_ts()
+        .await
+        .expect_err("malformed-hint scenario must surface FAILED_PRECONDITION");
+    assert!(
+        matches!(
+            err,
+            tsoracle_client::ClientError::Rpc(ref status)
+                if status.code() == tonic::Code::FailedPrecondition,
+        ),
+        "expected ClientError::Rpc(FAILED_PRECONDITION), got {err:?}",
+    );
+
+    booted_a.shutdown().await.unwrap();
+    booted_b.shutdown().await.unwrap();
+
+    let snapshot: Vec<RecordedMetric> = snapshotter.snapshot().into_vec();
+
+    // Counters with shape we drove directly.
+    assert!(
+        counter_value(&snapshot, "tsoracle.client.not_leader.total") >= 1,
+        "tsoracle.client.not_leader.total never incremented despite a FAILED_PRECONDITION reply"
+    );
+    assert!(
+        counter_value(&snapshot, "tsoracle.client.leader_pivots.total") >= 1,
+        "tsoracle.client.leader_pivots.total never incremented despite a follower→leader hint"
+    );
+    assert!(
+        counter_value_with_label(
+            &snapshot,
+            "tsoracle.client.retries.total",
+            "reason",
+            "not_leader",
+        ) >= 1,
+        "retries.total{{reason=not_leader}} did not fire on the hint-pivot scenario"
+    );
+    assert!(
+        counter_value_with_label(
+            &snapshot,
+            "tsoracle.client.retries.total",
+            "reason",
+            "connect_failure",
+        ) >= 1,
+        "retries.total{{reason=connect_failure}} did not fire when an endpoint was unreachable"
+    );
+    assert!(
+        counter_value(&snapshot, "tsoracle.client.connect.failures.total") >= 1,
+        "tsoracle.client.connect.failures.total never incremented for the closed-port endpoint"
+    );
+    assert!(
+        counter_value(
+            &snapshot,
+            "tsoracle.client.leader_hint.decode_failures.total"
+        ) >= 1,
+        "tsoracle.client.leader_hint.decode_failures.total never incremented for the \
+         malformed-trailer scenario"
+    );
+
+    // Histogram: connect.duration must have at least one sample — across all
+    // three scenarios we performed multiple cache-miss connects.
+    assert!(
+        histogram_sample_count(&snapshot, "tsoracle.client.connect.duration") >= 1,
+        "tsoracle.client.connect.duration recorded no samples; histogram path never executed"
+    );
+
+    // Gauges: any get_ts call flows through driver_task and sets both
+    // queue_depth (≥0 on enqueue) and in_flight (1 on dispatch, 0 on
+    // completion). We assert registration rather than a specific level
+    // because both gauges land at 0 once the driver settles.
+    assert!(
+        gauge_registered(&snapshot, "tsoracle.client.driver.queue_depth"),
+        "tsoracle.client.driver.queue_depth was never registered with the recorder"
+    );
+    assert!(
+        gauge_registered(&snapshot, "tsoracle.client.driver.in_flight"),
+        "tsoracle.client.driver.in_flight was never registered with the recorder"
+    );
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,7 +14,9 @@ Default is 1 second. On leadership gain, the new leader first computes `serving_
 
 ## Monitoring hooks
 
-The server emits the following signals through the [`metrics`](https://docs.rs/metrics) crate facade. Emission is gated behind the `metrics` Cargo feature on `tsoracle-server` (off by default so the dependency stays opt-in for embedders who do not want it):
+Both `tsoracle-server` and `tsoracle-client` emit signals through the [`metrics`](https://docs.rs/metrics) crate facade. Emission is gated behind the `metrics` Cargo feature on each crate (off by default so the dependency stays opt-in for embedders who do not want it). The client additionally emits structured events through the [`tracing`](https://docs.rs/tracing) crate; `tracing` is on by default for `tsoracle-client` (matching `tsoracle-server`).
+
+**Server signals**
 
 - `tsoracle.get_ts.total` — total GetTs RPCs handled (counter)
 - `tsoracle.get_ts.timestamps_issued` — sum of `count` across all GetTs responses (counter)
@@ -24,11 +26,23 @@ The server emits the following signals through the [`metrics`](https://docs.rs/m
 - `tsoracle.leader_transition.fence_latency` — duration of the failover fence (histogram, seconds)
 - `tsoracle.not_leader.total` — RPCs rejected with `NOT_LEADER` (counter)
 
-The library is exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the [`Server`]. The example below wires Prometheus over an HTTP listener:
+**Client signals**
+
+- `tsoracle.client.not_leader.total` — `FAILED_PRECONDITION` responses observed by the client (counter)
+- `tsoracle.client.leader_pivots.total` — times the retry loop accepted a leader-hint redirect and immediately retried the hinted endpoint (counter)
+- `tsoracle.client.retries.total{reason}` — endpoints the retry loop advanced past without success (counter). `reason` is one of `connect_failure`, `not_leader`, `transport`, `decode_error`, `deadline_exceeded`.
+- `tsoracle.client.leader_hint.decode_failures.total` — `FAILED_PRECONDITION` responses whose `tsoracle-leader-hint-bin` trailer was present but failed to decode as `LeaderHint` (counter). A non-zero rate indicates a misbehaving peer; absent trailers do not increment this.
+- `tsoracle.client.connect.duration` — wall-clock duration of a fresh `Channel` dial on cache miss (histogram, seconds). Cache hits are not sampled.
+- `tsoracle.client.connect.failures.total` — connect attempts that returned an error (counter)
+- `tsoracle.client.driver.queue_depth` — waiter-queue size inside the coalescing driver task (gauge). Updated after every enqueue and after each dispatch drain.
+- `tsoracle.client.driver.in_flight` — 0 or 1 indicating whether the driver currently has an outgoing batch in flight (gauge)
+
+Both libraries are exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the [`Server`] or [`Client`]. The example below wires Prometheus over an HTTP listener for a process that hosts either side:
 
 ```toml
 [dependencies]
 tsoracle-server             = { version = "0.1", features = ["metrics"] }
+tsoracle-client             = { version = "0.1", features = ["metrics"] }
 metrics-exporter-prometheus = "0.16"
 ```
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `metrics` Cargo feature on `tsoracle-client` (mirrors `tsoracle-server`) and turns `tracing` on by default. Emits eight `tsoracle.client.*` signals: `not_leader.total`, `leader_pivots.total`, `retries.total{reason}`, `leader_hint.decode_failures.total`, `connect.duration` (histogram), `connect.failures.total`, `driver.queue_depth` (gauge), and `driver.in_flight` (gauge).
- Refactors `decode_leader_hint` from `Option<LeaderHint>` to a `LeaderHintLookup::{Absent, Decoded, Malformed}` enum so the new decode-failure counter and warning fire only on genuine wire-format errors, not on missing trailers.
- Adds tracing events at every retry decision (debug per attempt, debug per pivot, warn on FAILED_PRECONDITION without a usable hint, debug on connect/transport failure).
- Adds `crates/tsoracle-tests/tests/client_metrics.rs` — an end-to-end recorder-fake test that drives three scenarios (follower→leader pivot, closed-port retry, malformed-trailer fake service) and asserts every documented client signal fires via `metrics_util::DebuggingRecorder`.
- Documents the new client catalog in `docs/operations.md` alongside the existing server section.

Closes #86.

## Test plan

- [x] `cargo check -p tsoracle-client` under `--no-default-features`, `--features tracing`, `--features metrics`, `--features "tracing metrics"`, and `--all-features` (all four combinations from the acceptance criteria + the union)
- [x] `cargo test -p tsoracle-client --all-features` — 36 unit tests pass
- [x] `cargo test -p tsoracle-tests --features metrics` — the new `client_metrics` binary passes plus all existing integration suites (client_e2e, client_freshness, client_tls, server_serve_with_listener)
- [x] `cargo test --workspace --all-features` — full workspace green
- [x] `cargo clippy --workspace --all-features --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`