### PR TITLE
fix(openraft-toolkit): dedup leadership_events by full value

### DIFF
--- a/crates/tsoracle-openraft-toolkit/src/lifecycle/leader.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lifecycle/leader.rs
@@ -13,10 +13,17 @@
 //! Leader-state stream derived from `Raft::metrics()`.
 //!
 //! [`leadership_events`] converts openraft's metrics watch into a stream of
-//! [`LeadershipState`] transitions, emitting only when the role class changes
-//! (Leader → Follower, Follower → Candidate, etc.). Term updates and
-//! current-leader changes that don't change the role class are swallowed so
-//! consumers don't see one event per internal raft tick.
+//! [`LeadershipState`] transitions. Every change in role, term, or
+//! follower-leader identity is emitted; consecutive *identical* projections
+//! are suppressed so steady-state metric ticks don't produce a stream of
+//! duplicate events.
+//!
+//! Dedup is full-value (`LeadershipState<C>: PartialEq`), not role-class only.
+//! Class-only dedup is unsafe here: the underlying watch coalesces between
+//! polls, so a `Leader(N) → Follower(M) → Leader(K)` sequence that lands
+//! during a slow poll would be silently swallowed (both endpoints are
+//! "Leader"), and the downstream failover fence — which only runs on
+//! `Leader` events — would miss the new term. See issue #77.
 //!
 //! The metrics watch in alpha.20 is `WatchReceiverOf<C, RaftMetrics<C>>` — a
 //! runtime-abstracted receiver, not a plain `tokio::sync::watch::Receiver`. The
@@ -54,37 +61,15 @@ pub enum LeadershipState<C: RaftTypeConfig> {
     Shutdown,
 }
 
-/// Role-class discriminant used for dedup. Two consecutive projections compare
-/// equal when their classes match; the inner fields (term, leader hint) are
-/// allowed to drift without re-emitting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RoleClass {
-    Leader,
-    Follower,
-    Candidate,
-    Learner,
-    Shutdown,
-}
-
-impl<C: RaftTypeConfig> LeadershipState<C> {
-    fn class(&self) -> RoleClass {
-        match self {
-            LeadershipState::Leader { .. } => RoleClass::Leader,
-            LeadershipState::Follower { .. } => RoleClass::Follower,
-            LeadershipState::Candidate { .. } => RoleClass::Candidate,
-            LeadershipState::Learner => RoleClass::Learner,
-            LeadershipState::Shutdown => RoleClass::Shutdown,
-        }
-    }
-}
-
 /// Build a stream of `LeadershipState` transitions from a raft instance.
 ///
 /// The returned stream:
 ///
 /// 1. Emits one initial `LeadershipState` derived from the current metrics
 ///    value (always — even on first poll).
-/// 2. Emits subsequent values only when the role class changes.
+/// 2. Emits subsequent values whenever the projection differs from the last
+///    emitted one (any change in role, term, or follower-leader identity).
+///    Identical projections are suppressed.
 /// 3. Terminates when openraft drops its sender (i.e., the raft has shut
 ///    down).
 pub fn leadership_events<C, SM>(raft: &Raft<C, SM>) -> impl Stream<Item = LeadershipState<C>>
@@ -103,28 +88,32 @@ where
 pub fn stream_from_receiver<C: RaftTypeConfig>(
     rx: WatchReceiverOf<C, RaftMetrics<C>>,
 ) -> impl Stream<Item = LeadershipState<C>> {
-    // (receiver, last-emitted class) carried across unfold iterations.
+    // (receiver, last-emitted projection) carried across unfold iterations.
     // `last` = None means "haven't emitted yet"; the next state always emits.
-    let init: (WatchReceiverOf<C, RaftMetrics<C>>, Option<RoleClass>) = (rx, None);
+    let init: (
+        WatchReceiverOf<C, RaftMetrics<C>>,
+        Option<LeadershipState<C>>,
+    ) = (rx, None);
 
     futures::stream::unfold(init, |(mut rx, mut last)| async move {
         loop {
             // Read the current value first. On first iteration `last` is None
             // so the freshly-borrowed projection is emitted unconditionally.
-            // On later iterations we compare classes and skip duplicates.
+            // On later iterations we compare the full projection and skip
+            // duplicates — class-only dedup would silently swallow term
+            // changes coalesced through an intermediate Follower (see #77).
             let projected: LeadershipState<C> = {
                 let snap = rx.borrow_watched();
                 project_state::<C>(&snap)
                 // `snap` (the lock guard) is dropped here, before any `.await`.
             };
 
-            let class = projected.class();
-            if last.map(|l| l != class).unwrap_or(true) {
-                last = Some(class);
+            if last.as_ref().map(|l| l != &projected).unwrap_or(true) {
+                last = Some(projected.clone());
                 return Some((projected, (rx, last)));
             }
 
-            // Same class as last emit — wait for the next change.
+            // Same projection as last emit — wait for the next change.
             if rx.changed().await.is_err() {
                 // Sender dropped (raft shut down). Terminate the stream.
                 return None;

--- a/crates/tsoracle-openraft-toolkit/tests/lifecycle.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/lifecycle.rs
@@ -282,6 +282,130 @@ async fn leadership_events_resolves_follower_leader_when_in_membership() {
     }
 }
 
+// Regression test for the term-coalesce bug fixed in #77.
+//
+// Scenario: this node is Leader(term=N). Quorum churn causes a fast
+// Leader → Follower(term=M) → Leader(term=K) sequence on a higher term.
+// All three updates land on the watch channel before the stream's next
+// poll. The watch only stores the latest value, so the receiver sees
+// Leader(term=K) directly — the intermediate Follower(term=M) is gone.
+//
+// Under the previous `RoleClass`-keyed dedup the new `Leader(term=K)`
+// compared equal to the prior `Leader(term=N)` ("both are Leader") and
+// was silently suppressed. Downstream of `tsoracle-driver-openraft`'s
+// `leadership_events`, that means `tsoracle-server`'s failover fence
+// never runs for term K, and this node continues issuing timestamps
+// from the term-N allocator floor — a global ordering regression.
+//
+// Under full-value dedup, `Leader(term=K)` is not equal to
+// `Leader(term=N)`, so the next poll emits the new Leader and the
+// fence runs.
+#[tokio::test]
+async fn leadership_events_emits_leader_after_coalesced_term_change() {
+    use futures::StreamExt;
+    use openraft::RaftMetrics;
+    use openraft::ServerState;
+    use openraft::WatchSender;
+    use openraft::type_config::TypeConfigExt;
+    use tsoracle_openraft_toolkit::LeadershipState;
+
+    // Initial value is Leader(term=1) so the first poll establishes the
+    // last-emitted projection without any pre-roll transitions.
+    let mut initial: RaftMetrics<TestTypeConfig> = RaftMetrics::new_initial(1u64);
+    initial.state = ServerState::Leader;
+    initial.current_term = 1;
+    let (tx, rx) = <TestTypeConfig as TypeConfigExt>::watch_channel(initial);
+
+    let mut stream = std::pin::pin!(
+        tsoracle_openraft_toolkit::lifecycle::leader::stream_from_receiver::<TestTypeConfig>(rx)
+    );
+
+    let first = stream.next().await.expect("initial Leader");
+    assert!(
+        matches!(first, LeadershipState::Leader { term: 1 }),
+        "expected initial Leader {{ term: 1 }}; got {first:?}",
+    );
+
+    // Push Follower(term=2) and Leader(term=3) before the next poll.
+    // The watch coalesces: receiver's next borrow yields Leader(term=3).
+    let mut as_follower: RaftMetrics<TestTypeConfig> = RaftMetrics::new_initial(1u64);
+    as_follower.state = ServerState::Follower;
+    as_follower.current_term = 2;
+    tx.send(as_follower).unwrap();
+
+    let mut as_leader_again: RaftMetrics<TestTypeConfig> = RaftMetrics::new_initial(1u64);
+    as_leader_again.state = ServerState::Leader;
+    as_leader_again.current_term = 3;
+    tx.send(as_leader_again).unwrap();
+
+    // Drop the sender so a broken dedup that suppresses the term change
+    // falls through to `changed().await` → Err → `None`, instead of
+    // hanging the test forever.
+    drop(tx);
+
+    let next = stream.next().await;
+    assert!(
+        matches!(next, Some(LeadershipState::Leader { term: 3 })),
+        "expected Leader {{ term: 3 }} after coalesced Follower(2)/Leader(3); \
+         got {next:?} — a None here means the dedup suppressed the new term, \
+         which is the bug this test exists to prevent",
+    );
+
+    // Once the new leader is emitted, the stream terminates (sender dropped).
+    assert!(stream.next().await.is_none());
+}
+
+// Acceptance-criteria guard: same-shape projections (identical role, term,
+// and leader identity) must continue to be suppressed. Under the previous
+// `RoleClass`-keyed dedup this was trivially true; under full-value dedup
+// it still holds because `LeadershipState<C>` derives `PartialEq`.
+//
+// The send goes through the channel rather than being a no-op so the test
+// would also catch a (hypothetical) future change that emits on every
+// sender-side notification regardless of value equality.
+#[tokio::test]
+async fn leadership_events_suppresses_identical_projection() {
+    use futures::StreamExt;
+    use openraft::RaftMetrics;
+    use openraft::WatchSender;
+    use openraft::type_config::TypeConfigExt;
+    use tsoracle_openraft_toolkit::LeadershipState;
+
+    let initial: RaftMetrics<TestTypeConfig> = RaftMetrics::new_initial(1u64);
+    let (tx, rx) = <TestTypeConfig as TypeConfigExt>::watch_channel(initial);
+
+    let mut stream = std::pin::pin!(
+        tsoracle_openraft_toolkit::lifecycle::leader::stream_from_receiver::<TestTypeConfig>(rx)
+    );
+
+    let first = stream.next().await.expect("initial Follower");
+    assert!(
+        matches!(
+            first,
+            LeadershipState::Follower {
+                term: 0,
+                leader: None,
+            },
+        ),
+        "expected initial Follower {{ term: 0, leader: None }}; got {first:?}",
+    );
+
+    // Send an identical projection. Channel coalescing isn't the suppressor
+    // here — only one send happens — so any emission would come from the
+    // dedup logic letting an equal value through.
+    let identical: RaftMetrics<TestTypeConfig> = RaftMetrics::new_initial(1u64);
+    tx.send(identical).unwrap();
+    drop(tx);
+
+    // With identical-projection suppression the stream sees no new emit and
+    // terminates when the sender drops.
+    assert!(
+        stream.next().await.is_none(),
+        "identical projection must be suppressed; stream should terminate \
+         on sender drop without re-emitting",
+    );
+}
+
 // Counterpart to the test above: when `current_leader` is set but the node id
 // isn't present in `membership_config.nodes()` (e.g. the leader was just
 // removed from the config), `resolve_leader` returns `None` and the Follower


### PR DESCRIPTION
## Summary

- `tsoracle_openraft_toolkit::lifecycle::leader::stream_from_receiver` deduplicated emitted transitions by a `RoleClass` discriminant that stripped `term` and `leader` from the projected `LeadershipState`. When the underlying watch coalesced a `Leader(N) → Follower(M) → Leader(K)` sequence between polls, the receiver only ever saw `Leader(K)`; `RoleClass::Leader == RoleClass::Leader` then suppressed it, swallowing the new term entirely.
- Downstream, `tsoracle-driver-openraft`'s `leadership_events` maps `LeadershipState::Leader { term }` to `LeaderState::Leader { epoch: Epoch(term) }`, and `tsoracle-server::fence::run_leader_watch` only runs the failover fence on `LeaderState::Leader`. A suppressed term change therefore meant a missed fence: the allocator continued issuing timestamps from the prior epoch's seeded floor, producing a global ordering regression of the same class as #72.
- Replaces the `RoleClass`-keyed dedup with full-value dedup on `LeadershipState<C>` (which already derives `PartialEq`). Every change in role, term, or follower-leader identity is now emitted; identical projections still compare equal and remain suppressed, so steady-state metric ticks don't produce event storms. Removes the private `RoleClass` enum and the `class()` method that existed only to support the broken dedup.

Closes #77.

## Test plan

- [x] New regression test `leadership_events_emits_leader_after_coalesced_term_change` in `crates/tsoracle-openraft-toolkit/tests/lifecycle.rs` — drives `Leader(term=1)` → coalesced `Follower(term=2)` + `Leader(term=3)`, asserts `Leader(term=3)` is emitted on the next poll. Verified failing on the pre-fix code (`got None`) and passing after the fix.
- [x] New invariant test `leadership_events_suppresses_identical_projection` — sends an identical projection through the channel after the initial emit, asserts no re-emission. Pins the acceptance criterion that same-shape projections continue to be suppressed under the new key.
- [x] `cargo test --workspace --all-features --locked` (CI canonical) — green, 0 failures across all crates.
- [x] Acceptance-criteria driver tests: `cargo test -p tsoracle-driver-openraft --test single_node --test three_node --test partition_churn` — 1 + 4 + 2 tests, all green. The stricter dedup did not introduce false emits that confused the fence.
- [x] `cargo clippy -p tsoracle-openraft-toolkit --all-features --all-targets -- -D warnings` — clean.

## Notes

- No change to the `LeadershipState<C>` public type or its variants.
- The pre-existing test `leadership_events_dedups_repeated_class_until_transition` continues to pass under the new contract (its mid-sequence `Follower(term=1)` send is now hidden by watch-channel coalescing rather than by the dedup key). Left in place to keep this PR scoped; a follow-up rename could clarify what it actually pins under the new semantics.