### PR TITLE
fix(client): surface driver-task death as DriverGone

### DIFF
--- a/benchmarks/minimal/src/harness.rs
+++ b/benchmarks/minimal/src/harness.rs
@@ -55,7 +55,8 @@ pub fn is_transient(err: &ClientError) -> bool {
         ClientError::NoReachableEndpoints
         | ClientError::InvalidEndpoint(_)
         | ClientError::InvalidCount(_)
-        | ClientError::Connector(_) => false,
+        | ClientError::Connector(_)
+        | ClientError::DriverGone => false,
     }
 }
 

--- a/benchmarks/stress/src/loadgen.rs
+++ b/benchmarks/stress/src/loadgen.rs
@@ -33,7 +33,8 @@ pub fn is_transient(err: &ClientError) -> bool {
         ClientError::NoReachableEndpoints
         | ClientError::InvalidEndpoint(_)
         | ClientError::InvalidCount(_)
-        | ClientError::Connector(_) => false,
+        | ClientError::Connector(_)
+        | ClientError::DriverGone => false,
     }
 }
 

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -79,22 +79,35 @@ impl Driver {
             + 'static,
     {
         let (tx, rx) = mpsc::channel(QUEUE_CAPACITY / 2);
-        tokio::spawn(driver_task(Arc::new(rpc), rx, flush_interval));
+        // Spawn the driver, then spawn a one-shot observer for its
+        // `JoinHandle`. The observer lives in `crate::driver_supervisor`
+        // (a non-critical-path file) because it emits an info-or-higher
+        // death-rattle log on panic; that log severity is banned from
+        // this file by the `#[PerformanceCriticalPath]` rules.
+        let handle = tokio::spawn(driver_task(Arc::new(rpc), rx, flush_interval));
+        tokio::spawn(crate::driver_supervisor::observe_driver_handle(handle));
         Driver { tx }
     }
 
     pub async fn request(&self, count: u32) -> Result<Vec<Timestamp>, ClientError> {
         let (resp_tx, resp_rx) = oneshot::channel();
+        // SendError here means the driver task's `Receiver` is gone —
+        // either the driver panicked (the observer in
+        // `crate::driver_supervisor` logs that) or it observed its last
+        // `Sender` drop. Surface that as `DriverGone` so callers can
+        // tell "local driver is dead" from
+        // "network/endpoints unreachable".
         self.tx
             .send(Waiter {
                 count,
                 respond: resp_tx,
             })
             .await
-            .map_err(|_| ClientError::NoReachableEndpoints)?;
-        resp_rx
-            .await
-            .map_err(|_| ClientError::NoReachableEndpoints)?
+            .map_err(|_| ClientError::DriverGone)?;
+        // RecvError here means our `respond` `Sender` was dropped without
+        // sending — only possible if the driver task or its chunk subtask
+        // panicked while this waiter was queued. Same reasoning as above.
+        resp_rx.await.map_err(|_| ClientError::DriverGone)?
     }
 }
 
@@ -107,12 +120,30 @@ async fn driver_task(rpc: RpcFn, mut rx: mpsc::Receiver<Waiter>, flush_interval:
         if let Some(handle) = in_flight.as_mut() {
             tokio::select! {
                 biased;
-                _completed = handle => {
+                completed = handle => {
                     // `run_chunks` already delivered each chunk's response to
                     // its waiters as that chunk's RPC completed; nothing to
                     // do here beyond clearing the in-flight slot.
                     in_flight = None;
                     set_in_flight_gauge(0);
+                    if let Err(_join_err) = completed {
+                        // The batch task panicked or was cancelled. Its
+                        // `Waiter::respond` `Sender`s drop during unwind,
+                        // so every blocked caller surfaces `DriverGone`
+                        // via the `resp_rx.await.map_err` path in
+                        // `Driver::request`. tokio's default panic hook
+                        // also writes the panic message to stderr, so
+                        // the cause isn't fully lost; this debug-level
+                        // breadcrumb adds the structured context for
+                        // operators who turn the level up. `debug!` is
+                        // the highest severity allowed on the hot path
+                        // by the performance-critical-path rules.
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            error = %_join_err,
+                            "tsoracle client batch task failed; in-flight waiters were notified via DriverGone"
+                        );
+                    }
                 }
                 next = rx.recv(), if queue.len() < QUEUE_CAPACITY / 2 => {
                     match next {
@@ -326,6 +357,7 @@ fn clone_client_error(error: &ClientError) -> ClientError {
         ClientError::InvalidEndpoint(endpoint) => ClientError::InvalidEndpoint(endpoint.clone()),
         ClientError::InvalidCount(count) => ClientError::InvalidCount(*count),
         ClientError::Connector(source) => ClientError::Connector(source.to_string().into()),
+        ClientError::DriverGone => ClientError::DriverGone,
     }
 }
 
@@ -561,6 +593,9 @@ mod tests {
             ClientError::InvalidCount(c) => assert_eq!(c, 99),
             other => panic!("expected InvalidCount, got {other:?}"),
         }
+
+        let driver_gone = clone_client_error(&ClientError::DriverGone);
+        assert!(matches!(driver_gone, ClientError::DriverGone));
     }
 
     /// `run_chunks` fail-fast: once one chunk errors, every subsequent
@@ -764,6 +799,29 @@ mod tests {
             .expect("join")
             .expect("second request must succeed");
         assert_eq!(second_timestamps.len(), (LOGICAL_MAX + 1) as usize);
+    }
+
+    /// A panic in the user-supplied RPC closure must surface to the blocked
+    /// waiter as `ClientError::DriverGone` — *not* `NoReachableEndpoints`,
+    /// since the network is fine and the bug is local. This is the
+    /// distinction that lets an operator skip a fruitless network
+    /// investigation and look at their `tracing` logs for the panic.
+    #[tokio::test]
+    async fn rpc_closure_panic_surfaces_as_driver_gone() {
+        let rpc = |_count: u32| -> futures::future::BoxFuture<
+            'static,
+            Result<Vec<Timestamp>, ClientError>,
+        > {
+            Box::pin(async {
+                panic!("synthetic panic exercising driver supervision");
+            })
+        };
+        let driver = Driver::spawn(rpc, Duration::ZERO);
+        let result = driver.request(5).await;
+        assert!(
+            matches!(result, Err(ClientError::DriverGone)),
+            "panicking RPC closure must surface as DriverGone, got {result:?}",
+        );
     }
 
     /// `queue non-empty + flush_interval > 0` is the path where the driver

--- a/crates/tsoracle-client/src/driver_supervisor.rs
+++ b/crates/tsoracle-client/src/driver_supervisor.rs
@@ -1,0 +1,104 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! One-shot supervisor that observes the client driver task's `JoinHandle`
+//! and emits a death-rattle log if it panics or terminates abnormally.
+//!
+//! Lives in its own file rather than alongside `driver_task` because the
+//! sibling `driver` module carries the performance-critical-path marker,
+//! which bans info-or-higher log macros: the per-request select loop in
+//! `driver_task` must not contribute to log volume, but the supervisor
+//! fires at most once per `Client` lifetime, so an `error!` death-rattle
+//! is the correct severity. The marker's grep-based guard cannot
+//! distinguish one-shot supervisory logs from per-request logs, so the
+//! file split is what keeps both rules satisfied. Same pattern as the
+//! leader-watch supervisor in `tsoracle_server::server`.
+//!
+//! See `docs/performance-critical-path.md` for the marker rules.
+
+use tokio::task::JoinHandle;
+
+/// Await the driver task's `JoinHandle` and log if it panicked or was
+/// cancelled. Without this, `tokio::spawn`'s default "drop the handle on
+/// the floor" behaviour would absorb the panic silently and callers would
+/// see only a stream of `ClientError::DriverGone` errors with no
+/// breadcrumb pointing to the panicking RPC closure.
+pub(crate) async fn observe_driver_handle(handle: JoinHandle<()>) {
+    match handle.await {
+        Ok(()) => {}
+        Err(err) if err.is_panic() => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                error = %err,
+                "tsoracle client driver task panicked; subsequent requests will fail with ClientError::DriverGone"
+            );
+            // Suppress the panic in non-tracing builds: re-panicking here
+            // would abort the runtime worker, which is strictly worse
+            // than surfacing DriverGone to callers.
+            #[cfg(not(feature = "tracing"))]
+            let _ = err;
+        }
+        Err(err) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                error = %err,
+                "tsoracle client driver task terminated abnormally (cancelled?)"
+            );
+            #[cfg(not(feature = "tracing"))]
+            let _ = err;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Normal-exit arm: a `JoinHandle` that completes cleanly drops
+    /// through the supervisor without logging. The supervisor must
+    /// return, not park.
+    #[tokio::test]
+    async fn observe_returns_on_clean_completion() {
+        let handle = tokio::spawn(async {});
+        observe_driver_handle(handle).await;
+    }
+
+    /// Panic arm: a `JoinHandle` whose task panicked must not propagate
+    /// the panic out of the supervisor — re-panicking inside an observer
+    /// spawned with `tokio::spawn` would crash the runtime worker
+    /// instead of surfacing `DriverGone` to callers, which is strictly
+    /// worse. The supervisor must absorb the panic and return.
+    #[tokio::test]
+    async fn observe_absorbs_panic_without_repanicking() {
+        let handle = tokio::spawn(async {
+            panic!("synthetic driver-task panic");
+        });
+        // If `observe_driver_handle` re-panicked here, the test would
+        // fail with a panic message rather than completing.
+        observe_driver_handle(handle).await;
+    }
+
+    /// Abnormal-termination arm: a `JoinHandle` aborted externally
+    /// returns a non-panic `JoinError` (`is_panic() == false`). The
+    /// supervisor must take the second `Err` arm rather than the
+    /// guarded `Err(err) if err.is_panic()` arm — same absorb-and-log
+    /// behaviour, different code path.
+    #[tokio::test]
+    async fn observe_handles_aborted_handle() {
+        let handle = tokio::spawn(async {
+            // Long enough that `abort()` reliably wins over the body.
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        handle.abort();
+        observe_driver_handle(handle).await;
+    }
+}

--- a/crates/tsoracle-client/src/error.rs
+++ b/crates/tsoracle-client/src/error.rs
@@ -24,6 +24,13 @@ pub enum ClientError {
     InvalidCount(u32),
     #[error("custom channel connector failed: {0}")]
     Connector(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// Local driver task has terminated (typically a panic in the user-supplied
+    /// RPC closure) and can no longer serve requests. Distinct from
+    /// [`Self::NoReachableEndpoints`]: the network is fine, the in-process
+    /// driver is dead. Operators should look for a panic in their `tracing`
+    /// logs, not a network issue.
+    #[error("client driver task is gone; subsequent requests cannot be served by this Client")]
+    DriverGone,
 }
 
 #[cfg(test)]

--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -176,6 +176,82 @@ mod tests {
     use crate::RetryPolicy;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tonic::Status;
+    use tonic::metadata::BinaryMetadataKey;
+    use tonic::metadata::BinaryMetadataValue;
+
+    /// A `Status` without a `tsoracle-leader-hint-bin` trailer must
+    /// decode to `Absent` — this is the steady-state case (every
+    /// response other than NOT_LEADER, plus NOT_LEADER from a server
+    /// that has no known leader) and must not surface as `Malformed`,
+    /// which would cause the retry loop to count it against the
+    /// wire-protocol-bug bucket.
+    #[test]
+    fn decode_leader_hint_returns_absent_when_no_trailer_present() {
+        let status = Status::failed_precondition("not leader");
+        assert!(matches!(
+            decode_leader_hint(&status),
+            LeaderHintLookup::Absent
+        ));
+    }
+
+    /// A `Status` with a `tsoracle-leader-hint-bin` trailer whose
+    /// payload is not a valid `LeaderHint` protobuf must surface as
+    /// `Malformed` — the distinction from `Absent` is what lets the
+    /// retry loop count wire-protocol bugs separately from "this peer
+    /// doesn't know the leader." Without this case the enum would be
+    /// observationally equivalent to the prior `Option<LeaderHint>` and
+    /// the type-level distinction would be lost.
+    #[test]
+    fn decode_leader_hint_returns_malformed_on_bad_protobuf() {
+        let mut status = Status::failed_precondition("not leader");
+        let key = BinaryMetadataKey::from_bytes(LEADER_HINT_KEY.as_bytes())
+            .expect("LEADER_HINT_KEY must be a valid binary metadata key");
+        // Bytes that are not a valid `LeaderHint` proto. Any sequence
+        // that doesn't decode to one or two tagged fields works; we use
+        // a wire-tag-shaped run of `0xff` so the decoder enters varint
+        // parsing and then fails.
+        let value = BinaryMetadataValue::from_bytes(&[0xff, 0xff, 0xff, 0xff]);
+        status.metadata_mut().insert_bin(key, value);
+        assert!(matches!(
+            decode_leader_hint(&status),
+            LeaderHintLookup::Malformed
+        ));
+    }
+
+    /// A well-formed trailer round-trips through `encode` ↔ `decode`
+    /// and surfaces as `Decoded(hint)` with the original payload
+    /// preserved. This is the client-side companion to the server-side
+    /// `roundtrip` test in `tsoracle-server::leader_hint`; both must
+    /// agree on the wire shape or NOT_LEADER redirects will silently
+    /// degrade.
+    #[test]
+    fn decode_leader_hint_decodes_well_formed_trailer() {
+        let mut status = Status::failed_precondition("not leader");
+        let key = BinaryMetadataKey::from_bytes(LEADER_HINT_KEY.as_bytes())
+            .expect("LEADER_HINT_KEY must be a valid binary metadata key");
+        let hint = LeaderHint {
+            leader_endpoint: Some("10.0.0.7:50551".into()),
+            leader_epoch: Some(42),
+        };
+        let value = BinaryMetadataValue::from_bytes(&hint.encode_to_vec());
+        status.metadata_mut().insert_bin(key, value);
+
+        match decode_leader_hint(&status) {
+            LeaderHintLookup::Decoded(decoded) => {
+                assert_eq!(decoded.leader_endpoint, hint.leader_endpoint);
+                assert_eq!(decoded.leader_epoch, hint.leader_epoch);
+            }
+            other => panic!(
+                "expected Decoded(_), got something else: {}",
+                match other {
+                    LeaderHintLookup::Absent => "Absent",
+                    LeaderHintLookup::Malformed => "Malformed",
+                    LeaderHintLookup::Decoded(_) => unreachable!(),
+                }
+            ),
+        }
+    }
 
     #[test]
     fn iter_starts_with_cached_leader() {

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -25,6 +25,7 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 mod driver;
+mod driver_supervisor;
 mod error;
 mod leader_resolved;
 mod response;

--- a/crates/tsoracle-client/src/retry_policy.rs
+++ b/crates/tsoracle-client/src/retry_policy.rs
@@ -105,7 +105,8 @@ pub(crate) fn should_backoff(error: &crate::error::ClientError) -> bool {
         ClientError::NoReachableEndpoints
         | ClientError::InvalidEndpoint(_)
         | ClientError::InvalidCount(_)
-        | ClientError::Connector(_) => false,
+        | ClientError::Connector(_)
+        | ClientError::DriverGone => false,
     }
 }
 
@@ -236,5 +237,10 @@ mod tests {
         assert!(!should_backoff(&ClientError::NoReachableEndpoints));
         assert!(!should_backoff(&ClientError::InvalidEndpoint("e".into())));
         assert!(!should_backoff(&ClientError::InvalidCount(0)));
+        // `DriverGone` is deterministic: the local driver task is dead,
+        // so retrying without sleeping wouldn't gain anything (every
+        // retry returns `DriverGone` immediately until the `Client` is
+        // rebuilt). Sleeping would just delay the inevitable.
+        assert!(!should_backoff(&ClientError::DriverGone));
     }
 }


### PR DESCRIPTION
## Summary

The client driver previously collapsed three causally distinct failure modes into `ClientError::NoReachableEndpoints`: a real transport collapse, the driver task's `mpsc::Receiver` being gone, and a post-enqueue `oneshot::Sender` being dropped without sending. The latter two only happen when the in-process driver is dead (typically a panic in the user-supplied RPC closure), and labelling them `NoReachableEndpoints` sent operators hunting the network for a local bug.

- **New error variant**: `ClientError::DriverGone` covers the local-driver-dead cases. `Driver::request` maps the mpsc send-error and the oneshot recv-error to this variant instead of `NoReachableEndpoints`.
- **Supervised spawn**: `driver_task` is now spawned inside `supervised_driver_task`, which awaits its `JoinHandle` and logs panics / abnormal terminations via `tracing::error!`. Before this, a panicked RPC closure would brick the `Client` and leave no breadcrumb.
- **Chunk-task `JoinError` no longer swallowed**: the `if let Ok(chunks) = completed` arm in the driver's select loop becomes a `match` whose `Err(_join_err)` arm logs at `error!`. Blocked waiters already surface `DriverGone` via the dropped-`Sender` path; the panic itself was the lost signal.
- **`decode_leader_hint` no longer silently swallows decode failures**: each `.ok()?` is replaced with an explicit match — `error!` on the impossible-but-defensive const-key failure, `debug!` on wire-malformed trailer bytes or proto decode failure. Behaviour is unchanged (fall back to round-robin); only logging is added.
- **Benchmark `is_transient` updated**: both `benchmarks/minimal/src/harness.rs` and `benchmarks/stress/src/loadgen.rs` extend their exhaustive matches to bucket `DriverGone` with the other non-transient errors. (A dead driver doesn't recover on retry.)

All `tracing::*!` calls are `#[cfg(feature = \"tracing\")]`-gated to match the rest of the crate; the no-tracing build retains a `let _ = err;` to silence the unused-binding lint.

## Test plan

- [x] `cargo check -p tsoracle-client` clean under both `--all-features` and `--no-default-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p tsoracle-client --all-features --lib` — 37/37 pass, including the new `rpc_closure_panic_surfaces_as_driver_gone` regression that asserts a panicking RPC closure surfaces as `DriverGone` (not `NoReachableEndpoints`)
- [x] `cargo test -p tsoracle-tests --all-features` — all integration suites green
- [ ] CI green