### PR TITLE
ci: free runner disk before cargo build in test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      # The workspace's debug+test binaries for the openraft + rocksdb crates
+      # have grown past the ubuntu-latest runner's free disk budget — the
+      # final link step in `cargo test --workspace --all-features` hits
+      # ENOSPC inside `ld`. Stripping the pre-installed Android SDK / .NET /
+      # Haskell toolchains frees ~30 GB before any cargo work begins; the
+      # Rust toolchain installed below lives in ~/.cargo and is not touched
+      # by `tool-cache: false`.
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary

The `test` job in `.github/workflows/ci.yml` has started hitting `/usr/bin/ld: final link failed: No space left on device` during `cargo test --workspace --all-features --locked`. Most recent occurrence: run [26296774606](https://github.com/prisma-risk/tsoracle/actions/runs/26296774606/job/77411357313) on PR #114. The `fmt`, `clippy`, and `build` substeps in the same job pass — disk pressure only crests during the link step of the openraft/rocksdb test binaries.

Add `jlumbroso/free-disk-space` as the first step in the `test` job. The action removes the pre-installed Android SDK / .NET / Haskell toolchains and frees ~30 GB before any cargo work begins. `tool-cache: false` preserves `/opt/hostedtoolcache`; the Rust toolchain installed by `dtolnay/rust-toolchain` lives in `~/.cargo` / `~/.rustup` and is not touched.

The action itself takes ~20-30 s — a small fixed cost added to the job's wall-clock time, in exchange for build reliability.

## Scope

Only the `test` job. `coverage` (instrumented build, smaller artifacts) and `stress-smoke` (release profile, single binary) currently pass without it, so leaving them untouched keeps the change minimal. If they begin to fail in the same way later, the same step can be added then.

## Test plan

- [ ] CI green on this PR — the action runs at the top of the `test` job and reports freed disk before checkout.
- [ ] After merge, watch the next few `main` builds for a recurrence of the ENOSPC linker error.