### PR TITLE
feat: add opt-in bt cargo feature for error backtraces

### DIFF
--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -15,6 +15,10 @@ path = "src/main.rs"
 [features]
 default    = []
 reflection = ["tsoracle-server/reflection"]
+# Capture backtraces in instrumented error variants. Fans out to every
+# direct dependency that exposes a `bt` feature. Runtime capture is still
+# gated by `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE`.
+bt         = ["tsoracle-core/bt", "tsoracle-server/bt", "tsoracle-driver-file/bt"]
 
 [dependencies]
 anyhow                = "1"

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -17,6 +17,7 @@ default    = ["tls-rustls"]
 tls-rustls = ["tonic/tls-aws-lc"]
 tls-native = ["tonic/tls-native-roots"]
 tracing    = ["dep:tracing"]
+bt         = ["tsoracle-core/bt"]
 
 [package.metadata.docs.rs]
 features       = ["tls-rustls", "tracing"]

--- a/crates/tsoracle-consensus/Cargo.toml
+++ b/crates/tsoracle-consensus/Cargo.toml
@@ -15,6 +15,7 @@ categories    = ["network-programming", "concurrency", "rust-patterns"]
 [features]
 default = []
 serde   = ["dep:serde", "tsoracle-core/serde"]
+bt      = ["tsoracle-core/bt"]
 
 [package.metadata.docs.rs]
 features       = ["serde"]

--- a/crates/tsoracle-core/Cargo.toml
+++ b/crates/tsoracle-core/Cargo.toml
@@ -17,6 +17,10 @@ default    = ["std"]
 std        = []
 serde      = ["dep:serde"]
 test-clock = []
+# Capture a `std::backtrace::Backtrace` in instrumented error variants. With
+# this off, `Bt` is a ZST and `Bt::capture()` is a no-op. With it on, capture
+# is still gated at runtime by `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE`.
+bt = ["std"]
 
 [package.metadata.docs.rs]
 features       = ["std", "serde"]

--- a/crates/tsoracle-core/src/bt.rs
+++ b/crates/tsoracle-core/src/bt.rs
@@ -128,4 +128,21 @@ mod tests {
         // therefore must occupy some space.
         assert!(core::mem::size_of::<Bt>() > 0);
     }
+
+    #[cfg(feature = "bt")]
+    #[test]
+    fn display_renders_captured_backtrace() {
+        // Exercise the `BacktraceStatus::Captured` branch of `Display::fmt`
+        // without relying on `RUST_BACKTRACE` at test time (coverage runs
+        // don't set it). `force_capture` ignores the env var and always
+        // produces a `Captured` status, which is what gates the `write!`.
+        let bt = Bt(std::backtrace::Backtrace::force_capture());
+        let rendered = format!("{bt}");
+        assert!(
+            rendered.starts_with('\n'),
+            "captured backtrace must render with a leading newline so it sits \
+             beneath the error message; got {rendered:?}",
+        );
+        assert!(rendered.len() > 1, "captured backtrace must be non-empty");
+    }
 }

--- a/crates/tsoracle-core/src/bt.rs
+++ b/crates/tsoracle-core/src/bt.rs
@@ -1,0 +1,131 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Optional backtrace capture for error types.
+//!
+//! [`Bt`] is a zero-sized type unless the `bt` Cargo feature is enabled. With
+//! the feature off, [`Bt::capture`] is a no-op and the field adds nothing to
+//! the enclosing error's layout. With the feature on, [`Bt::capture`] delegates
+//! to [`std::backtrace::Backtrace::capture`], which itself honors the
+//! `RUST_BACKTRACE` / `RUST_LIB_BACKTRACE` environment variables — so symbol
+//! resolution stays opt-in at runtime even when the feature is compiled in.
+//!
+//! Embedding `Bt` in a `thiserror` enum variant:
+//!
+//! ```ignore
+//! use tsoracle_core::Bt;
+//!
+//! #[derive(Debug, thiserror::Error)]
+//! pub enum MyError {
+//!     #[error("something went wrong{bt}")]
+//!     SomethingWentWrong { bt: Bt },
+//! }
+//!
+//! let err = MyError::SomethingWentWrong { bt: Bt::capture() };
+//! ```
+
+use core::fmt;
+
+/// Optional captured backtrace.
+///
+/// See module docs for behavior under the `bt` feature.
+#[cfg(feature = "bt")]
+#[derive(Debug)]
+pub struct Bt(std::backtrace::Backtrace);
+
+#[cfg(not(feature = "bt"))]
+#[derive(Debug, Clone, Copy)]
+pub struct Bt;
+
+impl Bt {
+    /// Capture a backtrace at the call site.
+    ///
+    /// With the `bt` feature off this is a no-op that returns the unit-sized
+    /// [`Bt`]. With the feature on, capture is delegated to
+    /// [`std::backtrace::Backtrace::capture`] and is gated by the
+    /// `RUST_BACKTRACE` / `RUST_LIB_BACKTRACE` environment variables.
+    #[inline]
+    pub fn capture() -> Self {
+        #[cfg(feature = "bt")]
+        {
+            Self(std::backtrace::Backtrace::capture())
+        }
+        #[cfg(not(feature = "bt"))]
+        {
+            Self
+        }
+    }
+}
+
+impl fmt::Display for Bt {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "bt")]
+        {
+            use std::backtrace::BacktraceStatus;
+            if matches!(self.0.status(), BacktraceStatus::Captured) {
+                // Newline-prefix so the backtrace renders on its own line
+                // beneath the error message in default `Display` output.
+                write!(formatter, "\n{}", self.0)?;
+            }
+            Ok(())
+        }
+        #[cfg(not(feature = "bt"))]
+        {
+            let _ = formatter;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_does_not_panic() {
+        let _ = Bt::capture();
+    }
+
+    #[test]
+    fn display_is_format_safe() {
+        // Must format without panic in either feature mode. Whether content
+        // is present depends on `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE` and the
+        // feature flag; only absence-of-panic is asserted here.
+        let _ = format!("{}", Bt::capture());
+    }
+
+    #[cfg(not(feature = "bt"))]
+    #[test]
+    fn bt_is_zero_sized_without_feature() {
+        // Without the feature, embedding `Bt` in a struct must add no bytes.
+        // This is the load-bearing claim that makes opt-in instrumentation
+        // free for downstream crates that never enable `bt`.
+        assert_eq!(core::mem::size_of::<Bt>(), 0);
+    }
+
+    #[cfg(not(feature = "bt"))]
+    #[test]
+    fn display_is_empty_without_feature() {
+        // No trailing backtrace section under `Display` when the feature is
+        // off. Important so `#[error("...{bt}")]` formats identically to
+        // `#[error("...")]` in the off configuration.
+        assert_eq!(format!("{}", Bt::capture()), "");
+    }
+
+    #[cfg(feature = "bt")]
+    #[test]
+    fn bt_is_nonzero_sized_with_feature() {
+        // With the feature on, `Bt` holds a `std::backtrace::Backtrace` and
+        // therefore must occupy some space.
+        assert!(core::mem::size_of::<Bt>() > 0);
+    }
+}

--- a/crates/tsoracle-core/src/lib.rs
+++ b/crates/tsoracle-core/src/lib.rs
@@ -19,6 +19,7 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 mod allocator;
+mod bt;
 mod clock;
 mod epoch;
 mod timestamp;
@@ -26,6 +27,7 @@ mod timestamp;
 pub mod docs;
 
 pub use allocator::{Allocator, CoreError, WindowGrant};
+pub use bt::Bt;
 pub use clock::{Clock, SystemClock};
 pub use epoch::Epoch;
 pub use timestamp::{LOGICAL_MAX, PHYSICAL_MS_MAX, Timestamp, TimestampError};

--- a/crates/tsoracle-driver-file/Cargo.toml
+++ b/crates/tsoracle-driver-file/Cargo.toml
@@ -15,6 +15,7 @@ categories    = ["database-implementations", "filesystem"]
 [features]
 default    = []
 failpoints = ["dep:fail", "fail/failpoints"]
+bt         = ["tsoracle-core/bt", "tsoracle-consensus/bt"]
 
 [package.metadata.docs.rs]
 all-features = false

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -22,6 +22,7 @@ tracing    = ["dep:tracing"]
 test-fakes = []
 test-support = ["test-fakes"]
 reflection = ["dep:tonic-reflection", "tsoracle-proto/reflection"]
+bt         = ["tsoracle-core/bt", "tsoracle-consensus/bt"]
 
 [package.metadata.docs.rs]
 features       = ["tls-rustls", "tracing", "reflection", "metrics"]

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -19,7 +19,7 @@ use tokio::sync::watch;
 use tonic::service::Routes;
 use tonic::transport::Server as TonicServer;
 use tsoracle_consensus::ConsensusDriver;
-use tsoracle_core::{Allocator, Clock, SystemClock};
+use tsoracle_core::{Allocator, Bt, Clock, SystemClock};
 #[cfg(any(test, feature = "test-fakes"))]
 use tsoracle_core::{CoreError, WindowGrant};
 use tsoracle_proto::v1::tso_service_server::TsoServiceServer;
@@ -50,8 +50,8 @@ pub enum ServerError {
     /// The leader-watch task panicked. Distinct from a clean error return so
     /// operators can tell "driver returned Err" (recoverable design) from
     /// "task panicked" (programming bug).
-    #[error("leader-watch task panicked: {payload}")]
-    WatchPanic { payload: String },
+    #[error("leader-watch task panicked: {payload}{bt}")]
+    WatchPanic { payload: String, bt: Bt },
 }
 
 #[derive(Clone, Debug)]
@@ -418,7 +418,10 @@ fn join_to_server_result(
         Ok(inner) => inner,
         Err(join_err) if join_err.is_panic() => {
             let payload = panic_payload_to_string(join_err.into_panic());
-            Err(ServerError::WatchPanic { payload })
+            Err(ServerError::WatchPanic {
+                payload,
+                bt: Bt::capture(),
+            })
         }
         Err(_cancelled) => Ok(()),
     }
@@ -516,11 +519,12 @@ mod tests {
         let handle = tokio::spawn(async {
             Err::<(), ServerError>(ServerError::WatchPanic {
                 payload: "synthetic".into(),
+                bt: Bt::capture(),
             })
         });
         let join = handle.await;
         match join_to_server_result(join) {
-            Err(ServerError::WatchPanic { payload }) => assert_eq!(payload, "synthetic"),
+            Err(ServerError::WatchPanic { payload, .. }) => assert_eq!(payload, "synthetic"),
             other => panic!("expected forwarded WatchPanic, got {other:?}"),
         }
     }
@@ -536,7 +540,9 @@ mod tests {
         });
         let join = handle.await;
         match join_to_server_result(join) {
-            Err(ServerError::WatchPanic { payload }) => assert!(payload.contains("intentional")),
+            Err(ServerError::WatchPanic { payload, .. }) => {
+                assert!(payload.contains("intentional"))
+            }
             other => panic!("expected WatchPanic, got {other:?}"),
         }
     }

--- a/crates/tsoracle-server/tests/serve_shutdown.rs
+++ b/crates/tsoracle-server/tests/serve_shutdown.rs
@@ -134,7 +134,7 @@ async fn serve_with_shutdown_translates_watch_panic_to_server_error() {
     let _ = shutdown_tx; // unused; the watch arm exits first
 
     match outcome {
-        Err(ServerError::WatchPanic { payload }) => {
+        Err(ServerError::WatchPanic { payload, .. }) => {
             assert!(payload.contains("watch boom"), "got {payload}");
         }
         other => panic!("expected WatchPanic, got {other:?}"),


### PR DESCRIPTION
## Summary

- Adds a workspace-wide `bt` Cargo feature gating a `Bt` newtype around `std::backtrace::Backtrace`. With the feature off, `Bt` is a ZST and `Bt::capture()` is a no-op — embedding it in an error variant is free. With the feature on, capture still respects `RUST_BACKTRACE` / `RUST_LIB_BACKTRACE`, so symbol resolution stays opt-in at runtime.
- `tsoracle-client`, `tsoracle-consensus`, `tsoracle-server`, and `tsoracle-driver-file` each forward to `tsoracle-core/bt`. The `tsoracle` binary aggregates them, so `--features bt` on the bin lights up the whole stack.
- First instrumented variant: `ServerError::WatchPanic`. Its semantics ("watch task panicked — programming bug") match what backtrace capture is for. `tsoracle-openraft-toolkit` is deliberately skipped — no current variant wants `Bt`, and it has no direct edge to `tsoracle-core`, so opting it in would mean adding a fresh crate-edge for no current consumer.

## Test plan

- [x] `cargo check --workspace --all-targets` (default features)
- [x] `cargo check -p tsoracle --features bt --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (both with and without `--features bt`)
- [x] `cargo test -p tsoracle-core --lib` (with and without `--features bt`; cfg-gated tests assert ZST/non-ZST and empty/non-empty Display)
- [x] `cargo test -p tsoracle-server --lib` and `--test serve_shutdown --features 'test-fakes bt'`
- [x] `RUST_BACKTRACE=1 cargo test … --features bt`: panic backtrace renders through `WatchPanic` `Display`.