### PR TITLE
refactor(client): dedupe MAX_TIMESTAMPS_PER_RPC into lib.rs

### DIFF
--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -23,8 +23,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Instant, sleep_until};
-use tsoracle_core::{LOGICAL_MAX, Timestamp};
+use tsoracle_core::Timestamp;
 
+use crate::MAX_TIMESTAMPS_PER_RPC;
 use crate::error::ClientError;
 
 /// Bound on the waiter queue. A slow server combined with a fast caller
@@ -34,11 +35,6 @@ use crate::error::ClientError;
 /// Each `Waiter` is small (~32 bytes), so 4096 caps the queue at ~128 KB
 /// regardless of how aggressive the producers are.
 const QUEUE_CAPACITY: usize = 4096;
-
-/// The server's per-call cap, fixed by the 18-bit logical width. Any single
-/// outgoing `GetTs` RPC must respect this; coalesced batches that exceed it
-/// are split into multiple chunks of this size or less.
-const MAX_TIMESTAMPS_PER_RPC: u32 = LOGICAL_MAX + 1;
 
 pub(crate) struct Waiter {
     pub count: u32,


### PR DESCRIPTION
## Summary

- `MAX_TIMESTAMPS_PER_RPC` was declared in both `crates/tsoracle-client/src/lib.rs` (validation in `Client::get_ts_batch`) and `crates/tsoracle-client/src/driver.rs` (chunking in `Driver::chunk_queue`). Drift between the two would let oversize requests pass the public-API check and then get rejected or split incorrectly by the driver.
- Keep the single `pub(crate)` declaration in `lib.rs` (the public-API validation point) and `use crate::MAX_TIMESTAMPS_PER_RPC;` from `driver.rs`.
- Drop `LOGICAL_MAX` from the top-of-file import in `driver.rs` — only the removed const referenced it; the `#[cfg(test)]` module already imports it independently.

Closes #104.

## Test plan

- [x] `cargo build -p tsoracle-client`
- [x] `cargo test -p tsoracle-client` — 47/47 unit tests pass, including `coalesced_batch_above_per_rpc_cap_is_chunked`, `waiter_above_per_rpc_cap_gets_invalid_count`, and `oversize_waiter_does_not_poison_sibling_waiters`
- [x] `cargo clippy -p tsoracle-client --all-targets -- -D warnings`