### PR TITLE
fix(server): poison serving state on leader-watch stream EOF

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -128,5 +128,10 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
             }
         }
     }
-    Ok(())
+    // The leadership stream is contracted to live for the life of the server;
+    // reaching here means the driver dropped it (shutdown, lost session,
+    // partition recovery). Surface that as an explicit error so the watch-task
+    // termination always routes through the poisoning branch in `into_router`
+    // and is observable to callers of `serve_with_*`. See #72.
+    Err(ServerError::WatchStreamClosed)
 }

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -52,6 +52,15 @@ pub enum ServerError {
     /// "task panicked" (programming bug).
     #[error("leader-watch task panicked: {payload}{bt}")]
     WatchPanic { payload: String, bt: Bt },
+    /// The consensus driver's `leadership_events()` stream ended cleanly while
+    /// the leader-watch task was running. The stream is contracted to live for
+    /// the life of the server, so its end is anomalous (driver shutdown, lost
+    /// session, etc.) — distinct from a `Consensus` error returned mid-fence.
+    /// The watch task publishes `ServingState::NotServing` before returning
+    /// this variant so embedders who never observe the `JoinHandle` still get
+    /// the documented fail-safe behavior.
+    #[error("consensus driver leadership stream closed")]
+    WatchStreamClosed,
 }
 
 #[derive(Clone, Debug)]
@@ -196,10 +205,13 @@ impl Server {
     /// on a shared tonic listener instead of binding a dedicated port.
     ///
     /// The `JoinHandle` payload is `Result<(), ServerError>` so embedders
-    /// can observe leader-watch termination. Before returning an error, the
-    /// task publishes `ServingState::NotServing { leader_endpoint: None }`
-    /// so all subsequent RPCs fail fast with `FAILED_PRECONDITION` — even
-    /// embedders who never inspect the handle get fail-safe behavior.
+    /// can observe leader-watch termination. The task never returns
+    /// `Ok(())`: every termination — driver error, panic, or clean EOF on
+    /// the leadership stream (surfaced as `ServerError::WatchStreamClosed`)
+    /// — publishes `ServingState::NotServing { leader_endpoint: None }`
+    /// before returning, so all subsequent RPCs fail fast with
+    /// `FAILED_PRECONDITION`. Embedders who never inspect the handle still
+    /// get fail-safe behavior.
     ///
     /// The `Server::serve()` method is a thin wrapper over this — it calls
     /// `into_router`, builds a tonic `Server`, and binds a listener.
@@ -406,9 +418,12 @@ impl Server {
 
 /// Convert a `JoinHandle` result into a `ServerError`-typed result.
 ///
-/// - `Ok(Ok(()))` — task ended cleanly (driver stream closed). Caller decides
-///   whether this is normal (shutdown) or anomalous.
-/// - `Ok(Err(e))` — task returned an error. Forward verbatim.
+/// - `Ok(Ok(()))` — unreachable in production: `run_leader_watch` only
+///   returns from its loop via the `WatchStreamClosed` branch. Forwarded
+///   verbatim so the conversion remains total for test helpers that spawn
+///   no-op join futures.
+/// - `Ok(Err(e))` — task returned an error (including `WatchStreamClosed`
+///   from a clean EOF). Forward verbatim.
 /// - `Err(JoinError)` — task was cancelled or panicked. Cancellation maps to
 ///   Ok (we asked for it); panic maps to `WatchPanic` with payload.
 fn join_to_server_result(

--- a/crates/tsoracle-server/tests/embedded_router.rs
+++ b/crates/tsoracle-server/tests/embedded_router.rs
@@ -10,12 +10,18 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+use core::pin::Pin;
+use futures::{Stream, StreamExt, stream};
 use std::{sync::Arc, time::Duration};
+use tokio::sync::Notify;
+use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::Epoch;
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::InMemoryDriver;
-use tsoracle_server::test_support::{boot_router, wait_for_grpc_handshake, wait_until_serving};
+use tsoracle_server::test_support::{
+    boot_router, wait_for_grpc_handshake, wait_until_not_serving, wait_until_serving,
+};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn embedded_router_serves_via_caller_owned_listener() {
@@ -50,4 +56,108 @@ async fn embedded_router_serves_via_caller_owned_listener() {
     assert_eq!(resp.epoch, 1);
 
     booted.shutdown().await.unwrap();
+}
+
+/// Regression for #72: a clean EOF on the consensus driver's leadership
+/// stream must trigger the same fail-safe poisoning as an error return,
+/// even when the embedder has dropped the watch `JoinHandle`.
+///
+/// Embedders who mount `into_router` directly rely on the documented
+/// out-of-band guarantee that "any termination of the watch task publishes
+/// `ServingState::NotServing`". Before the fix, the stream-end branch of
+/// `run_leader_watch` returned `Ok(())`, the conditional poisoning in
+/// `into_router` was skipped, and `Serving` remained published — leaving
+/// the allocator able to issue timestamps from a stale epoch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn embedded_router_poisons_when_leadership_stream_closes() {
+    // EOF is held back by `eof_gate` so the test can deterministically
+    // observe the Serving → NotServing transition pair, instead of racing
+    // the watch task through both transitions and only catching the final
+    // state.
+    let eof_gate = Arc::new(Notify::new());
+    let driver: Arc<dyn ConsensusDriver> = Arc::new(LeaderThenGatedEofDriver {
+        epoch: Epoch(1),
+        eof_gate: eof_gate.clone(),
+    });
+
+    let tsoracle = Server::builder().consensus_driver(driver).build().unwrap();
+
+    let mut state_rx = tsoracle.state_rx.clone();
+    let (router, leader_watch) = tsoracle.into_router();
+
+    // Drop the JoinHandle so the test exercises the embedder shape that
+    // never observes watch-task termination directly.
+    drop(leader_watch);
+
+    let booted = boot_router(router).await;
+
+    // Phase 1: the driver emits Leader and the fence reaches Serving.
+    tokio::time::timeout(Duration::from_secs(5), wait_until_serving(&mut state_rx))
+        .await
+        .expect("fence never reached Serving after Leader event");
+
+    // Phase 2: release the gate; the leadership stream ends and the watch
+    // task must publish NotServing before terminating.
+    eof_gate.notify_one();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        wait_until_not_serving(&mut state_rx),
+    )
+    .await
+    .expect("watch task did not publish NotServing after leadership stream ended");
+
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
+
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
+        .await
+        .unwrap();
+    let status = client
+        .get_ts(GetTsRequest { count: 1 })
+        .await
+        .expect_err("GetTs must fail fast once the watch task has terminated");
+    assert_eq!(
+        status.code(),
+        tonic::Code::FailedPrecondition,
+        "post-EOF GetTs must surface FAILED_PRECONDITION; got {status:?}",
+    );
+
+    booted.shutdown().await.unwrap();
+}
+
+/// Driver whose `leadership_events()` stream yields one `Leader` event and
+/// then ends after the test signals `eof_gate`. The two-phase shape lets the
+/// test pin the Serving → NotServing transition deterministically; modelling
+/// a real consensus backend whose watch can terminate on driver shutdown,
+/// restart, or partition recovery.
+struct LeaderThenGatedEofDriver {
+    epoch: Epoch,
+    eof_gate: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl ConsensusDriver for LeaderThenGatedEofDriver {
+    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        let epoch = self.epoch;
+        let gate = self.eof_gate.clone();
+        let leader = stream::iter(vec![LeaderState::Leader { epoch }]);
+        // Yield once after the gate fires, then flat-map that unit to an
+        // empty stream so the overall stream ends without a spurious event.
+        let wait_then_end = stream::once(async move {
+            gate.notified().await;
+        })
+        .flat_map(|()| stream::empty::<LeaderState>());
+        Box::pin(leader.chain(wait_then_end))
+    }
+    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
+        Ok(0)
+    }
+    async fn persist_high_water(
+        &self,
+        at_least: u64,
+        _epoch: Epoch,
+    ) -> Result<u64, ConsensusError> {
+        Ok(at_least)
+    }
 }

--- a/crates/tsoracle-server/tests/serve_shutdown.rs
+++ b/crates/tsoracle-server/tests/serve_shutdown.rs
@@ -73,8 +73,9 @@ async fn serve_method_resolves_when_watch_task_terminates() {
     // watch task. Use a driver whose leadership stream closes immediately
     // (no leader ever published) to drive that exit deterministically.
     //
-    // The driver-leadership-stream-closed branch returns Ok per
-    // `run_leader_watch`'s contract, so the outer `serve` returns Ok.
+    // Per #72, an EOF on the leadership stream is anomalous: the watch task
+    // poisons serving state and returns `ServerError::WatchStreamClosed`.
+    // `serve` forwards that verbatim.
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
@@ -92,10 +93,10 @@ async fn serve_method_resolves_when_watch_task_terminates() {
         .await
         .expect("serve must return after watch stream closes")
         .expect("spawned task panicked");
-    // Either Ok (clean watch close) or Err(WatchPanic) depending on whether
-    // the closed-stream branch is interpreted as a clean exit. Both exercise
-    // `serve` itself; the more-specific watch-panic path has its own test.
-    let _ = outcome;
+    match outcome {
+        Err(ServerError::WatchStreamClosed) => {}
+        other => panic!("expected WatchStreamClosed, got {other:?}"),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
- Surfaces a clean EOF on `consensus.leadership_events()` as `ServerError::WatchStreamClosed` so the existing Err branch in `into_router` poisons via `step_down_due_to_consensus_rejection(None)`. Embedders that mount `into_router` on their own tonic listener and drop the watch `JoinHandle` now get the documented fail-safe behavior instead of silently keeping `ServingState::Serving` published after the watch task dies.
- Makes the embedded-router termination contract symmetric with the error and panic paths from #27 — every watch-task termination publishes `NotServing` before returning.
- Tightens `serve_method_resolves_when_watch_task_terminates` in `tests/serve_shutdown.rs` to assert `Err(ServerError::WatchStreamClosed)` instead of accepting either `Ok`/`Err`.

## Why this matters
Before the fix, the trailing `Ok(())` in `run_leader_watch` (`fence.rs:131`) skipped the conditional poisoning at `server.rs:226-232`. A node that had already observed `Leader` and published `Serving` would keep the allocator seeded with the prior leader's epoch and ceiling after EOF; the `GetTs` fast-gate only checks `NotServing`, so it continued granting timestamps. If a new leader subsequently elected, a client straddling both nodes could observe a monotonicity violation — the new leader issues a higher `physical_ms`, the stale node later issues a lower one. Closes #72.

## Test plan
- [x] New regression: `embedded_router_poisons_when_leadership_stream_closes` mounts `into_router`, drops the watch handle, uses a gated `LeaderThenGatedEofDriver` to deterministically pin the `Serving → NotServing` transition, then asserts the post-EOF `GetTs` returns `FAILED_PRECONDITION`.
- [x] Red-green verified: reverting only `fence.rs:131` causes the new test to fail at "watch task did not publish NotServing after leadership stream ended"; restoring the fix turns it green.
- [x] `cargo test -p tsoracle-server --features test-support,test-fakes` — 31 tests pass (was 30; +1 new).
- [x] `cargo test -p tsoracle-tests --features failpoints` — failpoints and TLS suites unchanged.
- [x] `cargo test -p tsoracle-client`, `tsoracle-driver-file`, `tsoracle-driver-openraft` — pass.
- [x] `cargo clippy -p tsoracle-server --features test-support,test-fakes --all-targets` — clean.
- [x] `cargo build --workspace --all-targets` — clean.