### PR TITLE
fix(bench): lower bench-latency warmup to avoid ~4min serial stall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ bench-throughput-sweep:
 
 bench-latency:
 	$(CARGO) run --release -p bench-minimal --bin bench -- \
-	  --clients 1 --ops 200k --batch-size 1
+	  --clients 1 --ops 200k --batch-size 1 --warmup 5_000
 
 # Help -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `make bench-latency` appears to hang for ~4 minutes before producing any output. It isn't hung — it's burning through the default 100,000-op warmup serially.
- Override the target with `--warmup 5_000` (≈12s on commodity hardware) while keeping `--ops 200k` so tail-percentile sample counts are preserved.
- The `bench-minimal` binary's CLI default for `--warmup` is unchanged; only this Makefile target is touched. Direct invocations with other flag combinations are unaffected.

## Why the stall happens

`warmup_per_task = cfg.warmup / cfg.batch_size / cfg.clients` (`benchmarks/minimal/src/harness.rs:148`).

| Target | `warmup` | `clients × batch_size` | `warmup_per_task` | Wall-clock warmup @ ~2.4ms/op |
|---|---:|---:|---:|---:|
| `make bench` | 100,000 | 64 × 4 = 256 | 391 | ~0.9 s (parallel × 64) |
| `make bench-latency` (before) | 100,000 (CLI default) | 1 × 1 = 1 | 100,000 | **~240 s** (serial) |
| `make bench-latency` (after) | 5,000 | 1 × 1 = 1 | 5,000 | ~12 s (serial) |

During warmup the progress printer prints `recorded=0 (+0 in last 1s, ≈0 calls/s)` every second because warmup iterations don't tick `recorded_count` (`harness.rs:109-111`, `harness.rs:127`). From the outside that's indistinguishable from a stuck process.

## Verification

Run on `fix/bench-latency-warmup` (MacBook Pro, 14-core):

```
config:        clients=1 ops=200000 batch=1 client_threads=1 server_threads=14 warmup=5000
recorded:      client_calls=195000 timestamps=195000
elapsed:       466.584 s
throughput:    client_calls/s: 418        timestamps/s: 418
latency per client call:
  p50: 2369 µs    p90: 2445 µs    p99: 2973 µs    p999: 7187 µs
  min: 1096 µs    max: 83135 µs   mean: 2392 µs
transient retries:    0
out-of-range samples: 0
```

Recording started a few seconds after the run began — no dead window.

## Test plan

- [x] `make bench-latency` produces progress output within ~15s of starting (vs. ~240s before)
- [x] Pre-commit hook (`cargo fmt --check` + `cargo clippy --workspace --all-targets --all-features -- -D warnings`) passes
- [x] `bench-minimal` direct invocations without `--warmup` retain their previous default behavior (binary unchanged)