### PR TITLE
fix(stress): unblock nightly under process and raft chaos

### DIFF
--- a/.github/actions/stress-auto-issue/action.yml
+++ b/.github/actions/stress-auto-issue/action.yml
@@ -26,6 +26,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Ensure labels exist
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        gh label create area:stress \
+          --repo "$REPO" \
+          --color BFD4F2 \
+          --description "Stress + chaos harness regressions" 2>/dev/null || true
+        gh label create priority:investigate \
+          --repo "$REPO" \
+          --color FBCA04 \
+          --description "Needs root-cause investigation" 2>/dev/null || true
+
     - name: Compute dedupe signature
       id: sig
       shell: bash

--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -99,11 +99,20 @@ jobs:
           ARGS: ${{ steps.args.outputs.args }}
         run: |
           set +e
-          # ARGS is intentionally word-split here.
+          # `tsoracle serve` is single-node; the process topology spawns one
+          # binary and exercises SIGKILL/respawn against the file driver's
+          # persisted high water. The shared --nodes default of 3 fits raft
+          # but would manufacture incoherent clock baselines under process.
+          case "$TOPOLOGY" in
+            process) NODES_ARG="--nodes 1" ;;
+            *)       NODES_ARG="" ;;
+          esac
+          # ARGS and NODES_ARG are intentionally word-split here.
           # shellcheck disable=SC2086
           cargo run --release -p stress --features stress-failpoints -- \
             run --topology "$TOPOLOGY" \
             $ARGS \
+            $NODES_ARG \
             --clients 32 --batch-size 4 \
             --json --schedule-out stress-schedule.json \
             > stress-report.json

--- a/benchmarks/stress/src/config.rs
+++ b/benchmarks/stress/src/config.rs
@@ -78,6 +78,18 @@ impl StressConfig {
         if matches!(self.topology, TopologyKind::Raft | TopologyKind::Process) && self.nodes < 1 {
             return Err("--nodes must be >= 1 for raft/process topology".into());
         }
+        // `tsoracle serve` is single-node (FileDriver, no cluster protocol).
+        // Spawning multiple of them under process topology gives independent
+        // oracles with independent physical-clock baselines; client failover
+        // between them under chaos would surface as per-client monotonicity
+        // regressions that are an artifact of the harness, not a real bug.
+        if matches!(self.topology, TopologyKind::Process) && self.nodes != 1 {
+            return Err(
+                "--nodes must be 1 for process topology (tsoracle serve is single-node; \
+                 multi-node coordination requires raft topology)"
+                    .into(),
+            );
+        }
         Ok(())
     }
 
@@ -177,5 +189,28 @@ mod tests {
         cfg.topology = TopologyKind::Raft;
         cfg.nodes = 0;
         assert!(cfg.validate().unwrap_err().contains("--nodes"));
+    }
+
+    #[test]
+    fn process_topology_rejects_multi_node() {
+        // Process topology spawns independent single-node oracles; >1 produces
+        // unrelated physical-clock baselines and surfaces as fake per-client
+        // monotonicity regressions under client failover.
+        let mut cfg = ok_config();
+        cfg.topology = TopologyKind::Process;
+        cfg.nodes = 3;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("--nodes must be 1 for process topology"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn process_topology_accepts_single_node() {
+        let mut cfg = ok_config();
+        cfg.topology = TopologyKind::Process;
+        cfg.nodes = 1;
+        cfg.validate().unwrap();
     }
 }

--- a/benchmarks/stress/src/lib.rs
+++ b/benchmarks/stress/src/lib.rs
@@ -368,7 +368,7 @@ pub fn run(cfg: StressConfig) -> Result<Report, anyhow::Error> {
         transient_retries: transient_retries.load(Ordering::Relaxed),
         out_of_range_samples: 0,
         violations: supervisor_outcome.violations,
-        chaos_events: Vec::new(),
+        chaos_events: supervisor_outcome.chaos_events,
         schedule,
         outcome,
     };

--- a/benchmarks/stress/src/loadgen.rs
+++ b/benchmarks/stress/src/loadgen.rs
@@ -69,9 +69,34 @@ pub struct ClientTaskCfg {
 /// exceeding the deadline budget emitting a `LivenessIncident` and the call
 /// being abandoned (loop continues with the next call).
 pub async fn client_task(cfg: ClientTaskCfg) -> Result<u64, tsoracle_client::ClientError> {
-    // Warmup: discard results.
+    // Warmup: discard results. Honors `stop` between iterations and inside
+    // each retry loop so the harness's `--duration` timer can always end
+    // the run promptly — even if the cluster is in a degraded state that
+    // makes warmup calls keep failing transient.
     for _ in 0..cfg.warmup_iters {
-        let _ = issue_one(&cfg.client, cfg.batch_size, &cfg.transient_retries).await?;
+        if cfg.stop.load(Ordering::Relaxed) {
+            break;
+        }
+        match issue_one(
+            &cfg.client,
+            cfg.batch_size,
+            &cfg.transient_retries,
+            &cfg.stop,
+        )
+        .await
+        {
+            Ok(_) => {}
+            // Stop-driven abort surfaces as `NoReachableEndpoints`. Treat it
+            // as a clean break from warmup rather than a task failure: the
+            // outer harness will call `for handle in handles { _ = h.await }`
+            // and ignore the result.
+            Err(tsoracle_client::ClientError::NoReachableEndpoints)
+                if cfg.stop.load(Ordering::Relaxed) =>
+            {
+                break;
+            }
+            Err(e) => return Err(e),
+        }
     }
 
     let mut batch_counter: BatchId = 0;
@@ -137,8 +162,18 @@ async fn issue_one(
     client: &Client,
     batch_size: u32,
     transient_retries: &AtomicU64,
+    stop: &AtomicBool,
 ) -> Result<u64, tsoracle_client::ClientError> {
     loop {
+        // Cooperative cancellation point. Without this, a persistently
+        // unavailable cluster (e.g. a chaos op that never healed) would
+        // spin in retries past the harness's `--duration` deadline and
+        // strand the job at its 30-minute hard timeout. The caller treats
+        // `NoReachableEndpoints` returned while `stop` is set as a clean
+        // warmup-abort signal.
+        if stop.load(Ordering::Relaxed) {
+            return Err(tsoracle_client::ClientError::NoReachableEndpoints);
+        }
         let result = if batch_size == 1 {
             client.get_ts().await.map(|_| 1u64)
         } else {
@@ -387,6 +422,45 @@ mod tests {
             saw_incident,
             "expected a DeadlineExceeded LivenessIncident from follower-state server",
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn warmup_aborts_on_stop_against_unavailable_cluster() {
+        // Follower-state driver returns FailedPrecondition forever (transient
+        // per the stress classifier). Before the stop-aware warmup, this
+        // would loop indefinitely and pin a 30-minute CI timeout. With the
+        // fix, flipping `stop` mid-flight breaks out of warmup promptly so
+        // the harness can drain client handles and finish on schedule.
+        let driver = Arc::new(InMemoryDriver::new());
+        driver.become_follower(None);
+        let (client, shutdown_tx, server_handle) = spawn_server_with(driver).await;
+        let (tx, _rx) = mpsc::channel::<SupervisorEvent>(8);
+        let stop = Arc::new(AtomicBool::new(false));
+        let cfg = ClientTaskCfg {
+            client_id: ClientId(0),
+            client: client.clone(),
+            batch_size: 1,
+            // Large enough that the loop would never naturally finish under
+            // a follower-state server within the test's wall-clock budget.
+            warmup_iters: 1_000_000,
+            liveness_deadline: Duration::from_secs(5),
+            stop: stop.clone(),
+            tx,
+            transient_retries: Arc::new(AtomicU64::new(0)),
+        };
+        let task = tokio::spawn(client_task(cfg));
+        // Give warmup a chance to enter the retry loop, then signal stop.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        stop.store(true, Ordering::Relaxed);
+        let result = tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("client_task must exit promptly after stop is set");
+        // `client_task` returns Ok with zero issued (warmup aborted, main
+        // loop saw stop immediately and skipped).
+        let issued = result.unwrap().unwrap();
+        assert_eq!(issued, 0, "expected no issued samples; got {issued}");
+        let _ = shutdown_tx.send(());
+        let _ = server_handle.await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/benchmarks/stress/src/report.rs
+++ b/benchmarks/stress/src/report.rs
@@ -185,7 +185,7 @@ impl Report {
             "transient_retries": self.transient_retries,
             "out_of_range_samples": self.out_of_range_samples,
             "violations": self.violations.iter().map(violation_summary).collect::<Vec<_>>(),
-            "chaos_events": self.chaos_events.len(),
+            "chaos_events": self.chaos_events.iter().map(chaos_event_summary).collect::<Vec<_>>(),
             "schedule_summary": {
                 "source": match &self.schedule.source {
                     crate::schedule::ScheduleSource::Named { scenario } => format!("named:{scenario}"),
@@ -196,6 +196,40 @@ impl Report {
         });
         value.to_string()
     }
+}
+
+fn chaos_event_summary(ev: &crate::chaos::ChaosEvent) -> serde_json::Value {
+    use crate::chaos::{ChaosKind, ChaosOutcome};
+    // `Instant` isn't serializable and ms-since-Unix-epoch isn't recoverable
+    // from `Instant`. We surface only what's useful for triage: the kind
+    // (KillLeader / PauseLeader / FailpointArm{name} / FailpointDisarm{name})
+    // and the outcome label. Window timing is implicit in the schedule.
+    let kind = match &ev.window.kind {
+        ChaosKind::LeaderKill => serde_json::json!({ "kind": "LeaderKill" }),
+        ChaosKind::LeaderPause => serde_json::json!({ "kind": "LeaderPause" }),
+        ChaosKind::FailpointArm { name } => {
+            serde_json::json!({ "kind": "FailpointArm", "name": name })
+        }
+        ChaosKind::FailpointDisarm { name } => {
+            serde_json::json!({ "kind": "FailpointDisarm", "name": name })
+        }
+    };
+    let outcome = match &ev.outcome {
+        ChaosOutcome::Applied => serde_json::json!({ "outcome": "Applied" }),
+        ChaosOutcome::Skipped { reason } => {
+            serde_json::json!({ "outcome": "Skipped", "reason": reason })
+        }
+        ChaosOutcome::Failed { reason } => {
+            serde_json::json!({ "outcome": "Failed", "reason": reason })
+        }
+    };
+    let mut out = kind;
+    if let (Some(out_obj), Some(outcome_obj)) = (out.as_object_mut(), outcome.as_object()) {
+        for (k, v) in outcome_obj {
+            out_obj.insert(k.clone(), v.clone());
+        }
+    }
+    out
 }
 
 fn violation_summary(v: &crate::violation::Violation) -> serde_json::Value {
@@ -434,6 +468,72 @@ mod tests {
         };
         let v: serde_json::Value = serde_json::from_str(&r.render_json()).unwrap();
         assert_eq!(v["schedule_summary"]["source"], "random:7");
+    }
+
+    #[test]
+    fn chaos_event_summary_covers_all_kinds_and_outcomes() {
+        // Before this PR, `render_json` emitted `chaos_events: <len>` —
+        // hiding everything that actually fired. The artifact in run
+        // 26268395168 showed `chaos_events: 0` despite an `op_count: 612`
+        // schedule, which made root-causing the failure harder. This test
+        // pins the typed-list shape and exercises every variant.
+        use crate::chaos::{ChaosEvent, ChaosKind, ChaosOutcome, ChaosWindow};
+        use std::time::Instant;
+
+        let now = Instant::now();
+        let make = |kind, outcome| ChaosEvent {
+            window: ChaosWindow {
+                kind,
+                started_at: now,
+                ended_at: now,
+                grace: Duration::from_millis(50),
+            },
+            outcome,
+        };
+
+        let mut r = sample_report();
+        r.chaos_events = vec![
+            make(ChaosKind::LeaderKill, ChaosOutcome::Applied),
+            make(
+                ChaosKind::LeaderPause,
+                ChaosOutcome::Skipped {
+                    reason: "no leader".into(),
+                },
+            ),
+            make(
+                ChaosKind::FailpointArm {
+                    name: "stress::fp_x".into(),
+                },
+                ChaosOutcome::Applied,
+            ),
+            make(
+                ChaosKind::FailpointDisarm {
+                    name: "stress::fp_x".into(),
+                },
+                ChaosOutcome::Failed {
+                    reason: "fail::remove failed".into(),
+                },
+            ),
+        ];
+
+        let v: serde_json::Value = serde_json::from_str(&r.render_json()).unwrap();
+        let arr = v["chaos_events"]
+            .as_array()
+            .expect("chaos_events is a list");
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0]["kind"], "LeaderKill");
+        assert_eq!(arr[0]["outcome"], "Applied");
+        assert_eq!(arr[1]["kind"], "LeaderPause");
+        assert_eq!(arr[1]["outcome"], "Skipped");
+        assert_eq!(arr[1]["reason"], "no leader");
+        assert_eq!(arr[2]["kind"], "FailpointArm");
+        assert_eq!(arr[2]["name"], "stress::fp_x");
+        assert_eq!(arr[3]["kind"], "FailpointDisarm");
+        assert_eq!(arr[3]["outcome"], "Failed");
+
+        // Text renderer keeps a count-only line; preserve it.
+        let text = r.render_text();
+        assert!(text.contains("chaos events: 4"), "{text}");
     }
 
     #[test]

--- a/benchmarks/stress/src/supervisor.rs
+++ b/benchmarks/stress/src/supervisor.rs
@@ -40,6 +40,14 @@ pub struct SupervisorOutcome {
     /// the same `issued_at`/`recv_time`). Values clamped to
     /// `[1, HISTO_MAX_US]` to stay within histogram bounds.
     pub latency: Histogram<u64>,
+    /// Every Applied chaos event the supervisor observed during the run, in
+    /// arrival order. Carried out of the supervisor so the final `Report`
+    /// can surface what chaos actually fired — the dedup/triage step in
+    /// `.github/actions/stress-auto-issue` and on-call repro both depend
+    /// on this. Skipped/Failed events never reach the supervisor (the
+    /// nemesis `play` loop drops them), so this matches the supervisor's
+    /// fence-freshness/liveness gating sets exactly.
+    pub chaos_events: Vec<ChaosEvent>,
 }
 
 pub struct Supervisor {
@@ -71,6 +79,12 @@ struct SupervisorState {
     /// `open_windows` gets pruned in `on_issued` once a window is past
     /// grace and fence-checked, so it can't be relied on after the fact.
     chaos_history: Vec<ChaosWindow>,
+    /// Full `ChaosEvent`s (window + outcome) for every Applied event the
+    /// supervisor observed, in arrival order. Distinct from
+    /// `chaos_history`: that one is `ChaosWindow`-only (the shape the
+    /// liveness attribution needs); this one carries the outcome too so
+    /// the final report can surface it.
+    chaos_events: Vec<ChaosEvent>,
     violations: Vec<Violation>,
     issued_observed: u64,
     latency: Histogram<u64>,
@@ -85,6 +99,7 @@ impl Default for SupervisorState {
             open_batches: HashMap::new(),
             open_windows: Vec::new(),
             chaos_history: Vec::new(),
+            chaos_events: Vec::new(),
             violations: Vec::new(),
             issued_observed: 0,
             latency: new_histogram(),
@@ -138,6 +153,7 @@ impl Supervisor {
             high_water: self.state.high_water,
             issued_observed: self.state.issued_observed,
             latency: self.state.latency,
+            chaos_events: self.state.chaos_events,
         }
     }
 
@@ -271,7 +287,8 @@ impl Supervisor {
 
     fn on_chaos(&mut self, ev: ChaosEvent) {
         // Only Applied windows participate in invariant checks. Skipped/Failed
-        // are recorded by the caller (in chaos_events vec); supervisor ignores.
+        // never reach the supervisor — `nemesis::play` only forwards Applied
+        // events — so this guard is defensive belt-and-braces.
         if !ev.outcome.is_applied() {
             return;
         }
@@ -283,6 +300,9 @@ impl Supervisor {
             ChaosKind::FailpointArm { .. } | ChaosKind::FailpointDisarm { .. } => true,
         };
         self.state.chaos_history.push(ev.window.clone());
+        // Retain the full event (window + outcome) for the final report so
+        // an operator triaging an artifact can see what actually fired.
+        self.state.chaos_events.push(ev.clone());
         self.state.open_windows.push(OpenChaosWindow {
             window: ev.window,
             pre_window_high_water,

--- a/benchmarks/stress/src/topology/process/mod.rs
+++ b/benchmarks/stress/src/topology/process/mod.rs
@@ -13,24 +13,20 @@
 //! Process topology: spawned `tsoracle` binaries, POSIX-signal chaos,
 //! `FAILPOINTS` env propagation. Unix-only.
 //!
+//! `tsoracle serve` is single-node, so this topology runs exactly one
+//! child: it exercises SIGKILL/respawn against the file driver's persisted
+//! high water (validated by `StressConfig::validate` rejecting `nodes != 1`).
+//! Multi-node coordination requires raft topology.
+//!
 //! Architecture:
-//! - Each child runs the production `tsoracle` binary bound to an
+//! - The child runs the production `tsoracle` binary bound to an
 //!   OS-assigned port. The binary prints `serving on 127.0.0.1:NNNN` on
 //!   stdout after binding; the harness scans for that line to learn the
-//!   actual port.
-//! - The harness owns a per-child reaper task (one tokio task per PID)
-//!   that calls `child.wait()` and either swallows the exit
-//!   (nemesis-initiated) or pushes a `LivenessIncident::UnexpectedServerExit`
-//!   to the supervisor.
-//! - Best-effort "current leader": round-robin over children. The harness
-//!   has no protocol handle to discover the actual Raft leader; the
-//!   supervisor's invariants stay correct because monotonicity is global
-//!   and fence freshness is keyed on chaos windows rather than which
-//!   specific PID was targeted.
-//!
-//! Chaos ops (`kill_leader`, `pause_leader`, `arm_failpoint`,
-//! `disarm_failpoint`) land in follow-up commits; this one wires the
-//! topology surface that doesn't need POSIX signals.
+//!   actual port. A respawned child rebinds to the same port so client
+//!   endpoint lists handed out before the first chaos op stay valid.
+//! - The harness owns a per-child reaper task that calls `child.wait()`
+//!   and either swallows the exit (nemesis-initiated) or pushes a
+//!   `LivenessIncident::UnexpectedServerExit` to the supervisor.
 
 mod child;
 mod failpoints_env;
@@ -100,8 +96,14 @@ pub struct ProcessController {
 
 impl ProcessTopology {
     pub async fn spawn(node_count: usize, grace: Duration) -> anyhow::Result<Self> {
-        if node_count < 1 {
-            anyhow::bail!("--nodes must be >= 1 for process topology");
+        // `StressConfig::validate` rejects this combination at the CLI, but
+        // the topology layer also asserts it so direct test callers cannot
+        // construct an incoherent multi-process oracle setup.
+        if node_count != 1 {
+            anyhow::bail!(
+                "process topology requires exactly 1 node (got {node_count}); \
+                 tsoracle serve is single-node, multi-node needs raft topology"
+            );
         }
         let binary = locate_tsoracle_binary()?;
         let tmp_root = tempfile::tempdir()?;

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -46,7 +46,7 @@ use tokio::time::{Instant, sleep};
 use tsoracle_driver_openraft::{
     HighWaterStateMachine, OpenraftDriver, OpenraftPeer, StandaloneHost, TypeConfig,
 };
-use tsoracle_openraft_toolkit::test_fakes::MemNetwork;
+use tsoracle_openraft_toolkit::test_fakes::{MemNetwork, PartitionController};
 use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
 use tsoracle_server::Server;
 
@@ -289,6 +289,23 @@ async fn wait_for_leader(nodes: &[RaftNode], timeout: Duration) -> anyhow::Resul
     }
 }
 
+/// RAII guard that heals a node-level partition on drop. Used to make
+/// `kill_leader` / `pause_leader` cancel-safe: if the harness's outer
+/// `select!` (e.g. the `--duration` timer) drops the chaos future while
+/// it is parked at the mid-window `sleep`, the guard's `Drop` still fires
+/// and restores reachability — without this, the cluster would remain
+/// partitioned for the rest of the run.
+struct HealOnDrop {
+    partitions: Arc<PartitionController<u64>>,
+    node: u64,
+}
+
+impl Drop for HealOnDrop {
+    fn drop(&mut self) {
+        self.partitions.heal(self.node);
+    }
+}
+
 #[async_trait]
 impl ChaosController for RaftController {
     async fn kill_leader(&self) -> ChaosEvent {
@@ -312,13 +329,20 @@ impl ChaosController for RaftController {
         let partitions = self.network.partitions();
         timed_event(ChaosKind::LeaderKill, self.grace, move || async move {
             partitions.isolate(leader_raft_id);
+            // Heal-on-drop guarantees reachability is restored even if the
+            // outer future is cancelled at the `sleep` below — see
+            // `HealOnDrop`'s doc.
+            let _guard = HealOnDrop {
+                partitions,
+                node: leader_raft_id,
+            };
             // Election timeout is 300-600ms; openraft can also need a few
             // heartbeat-interval ticks (100ms each) before followers escalate
             // to a candidate after losing the leader. 1500ms keeps the chaos
             // window short while reliably producing a re-election in CI; the
             // 750ms baseline from the sketch was tight enough to flake.
             tokio::time::sleep(Duration::from_millis(1500)).await;
-            partitions.heal(leader_raft_id);
+            // `_guard` drops here on the happy path too, performing the heal.
             ChaosOutcome::Applied
         })
         .await
@@ -343,8 +367,12 @@ impl ChaosController for RaftController {
         let partitions = self.network.partitions();
         timed_event(ChaosKind::LeaderPause, self.grace, move || async move {
             partitions.isolate(leader_raft_id);
+            // Cancel-safety guard; see `kill_leader` for the rationale.
+            let _guard = HealOnDrop {
+                partitions,
+                node: leader_raft_id,
+            };
             tokio::time::sleep(dur).await;
-            partitions.heal(leader_raft_id);
             ChaosOutcome::Applied
         })
         .await
@@ -505,6 +533,47 @@ mod tests {
         };
         assert_ne!(original_leader, new_leader);
 
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kill_leader_heals_on_cancel() {
+        // The outer `--duration` timer in the stress harness wins the
+        // top-level `select!` and drops the in-flight chaos future. Before
+        // the `HealOnDrop` guard, that cancellation parked at the
+        // mid-window `sleep` and `heal` never ran, stranding the cluster
+        // partitioned for the rest of the run. The guard's `Drop` impl is
+        // what makes this test pass: the partition is healed even though
+        // the chaos future never reached its end-of-window heal site.
+        let topology = RaftTopology::spawn(3, Duration::from_millis(750))
+            .await
+            .expect("spawn 3-node raft topology");
+        let leader_raft_id: u64 = topology
+            .controller
+            .nodes
+            .iter()
+            .find_map(|n| n.raft.metrics().borrow_watched().current_leader)
+            .expect("a leader at boot");
+        let partitions = topology.controller.network.partitions();
+        // The mid-window sleep in `kill_leader` is 1500ms; cancelling at
+        // 50ms reliably lands us inside it on any reasonable machine.
+        match tokio::time::timeout(Duration::from_millis(50), topology.controller.kill_leader())
+            .await
+        {
+            Err(_elapsed) => {} // expected — future was dropped mid-sleep
+            Ok(event) => panic!(
+                "kill_leader should not have finished within 50ms; got {:?}",
+                event.outcome,
+            ),
+        }
+        // `is_reachable(x, x)` returns true iff `x` is NOT isolated, so this
+        // probe directly reports the node-level partition state we care
+        // about without needing to pick a peer id.
+        assert!(
+            partitions.is_reachable(leader_raft_id, leader_raft_id),
+            "partition for node {leader_raft_id} must be healed after the \
+             chaos future is dropped; the node is still in the isolated set",
+        );
         Box::new(topology.controller).shutdown().await;
     }
 


### PR DESCRIPTION
## Summary

The first `stress-nightly` run (#26268395168) surfaced **two real failure modes** and **three adjacent issues** that masked or amplified them. This PR fixes all five so the next nightly is green and any future failure is diagnosable from its artifact.

### process/random-{1,2,3} — 83,456 Monotonicity violations (real)

`tsoracle serve` is single-node (file driver, no cluster protocol). The shared `--nodes` default of `3` spawned three independent oracles with three unrelated physical-clock baselines; under chaos the client failed over between them and the supervisor's per-client monotonicity check flagged the cross-oracle ts comparisons as regressions.

- `StressConfig::validate` rejects `nodes != 1` for process topology with a clear message
- `ProcessTopology::spawn` asserts the same so direct test callers can't construct the incoherent setup either
- `.github/workflows/stress-nightly.yml` passes `--nodes 1` for process rows
- Stale "monotonicity is global" docstring in `process/mod.rs` removed

### raft/random-{1,2,3} + raft/fence-stress — 30m job timeouts (real)

`RaftController::{kill_leader,pause_leader}` were `isolate → sleep → heal`. When the harness's `--duration` timer won the outer `select!`, the chaos future was dropped mid-sleep and the heal never ran, stranding the cluster partitioned for the rest of the run. With the cluster permanently down, `issue_one`'s warmup loop (which retried transient errors forever and never checked `stop`) hung the job until the workflow's 30-minute hard cap killed it.

- `HealOnDrop` RAII guard in `raft.rs` restores reachability whether the chaos future completes or is cancelled (sync `Drop` over `parking_lot`-backed `PartitionController` — safe and minimal)
- `issue_one` takes `&AtomicBool stop` and yields a clean `NoReachableEndpoints` when set; `client_task` treats that as a warmup-break (defense-in-depth so a degraded cluster can never again pin the job at its 30m cap)

### Auto-issue dedup step — `could not add label: 'area:stress' not found`

The action assumed `area:stress` / `priority:investigate` labels existed; on a fresh repo it errored at the "Open new issue" step, masking the real triage signal. A new idempotent `Ensure labels exist` step (`gh label create ... || true`) runs first.

### Diagnostic plumbing — `chaos_events: 0` in every artifact

`lib::run` overwrote the supervisor's accumulated chaos events with `Vec::new()`, so artifacts always rendered `chaos_events: 0` regardless of what actually fired. The failing run's artifact reported `0` despite an `op_count: 612` schedule, which made root-causing slower than it should have been. Supervisor now exposes the list via `SupervisorOutcome`, the report carries it through, and the JSON renderer emits a typed list (kind, outcome, reason) instead of a count.

## Test plan

- [x] `cargo test --release -p stress --features stress-failpoints` — 111 unit + 7 smoke, all green; including new tests:
  - `config::tests::process_topology_{rejects_multi_node,accepts_single_node}`
  - `topology::raft::tests::kill_leader_heals_on_cancel` (drops the chaos future mid-sleep, asserts the partition was healed by `Drop`)
  - `loadgen::tests::warmup_aborts_on_stop_against_unavailable_cluster` (proves the stop-aware warmup exits within 2s against a follower-state server that would otherwise loop forever)
  - `report::tests::chaos_event_summary_covers_all_kinds_and_outcomes`
- [x] `cargo clippy --release -p stress --features stress-failpoints -- -D warnings` — clean
- [x] Local repro `process/random --seed 2 --nodes 1` (90s, 32 clients) → `Ok`, 0 violations, 189 chaos events visible (was 5,504 Monotonicity violations)
- [x] Local repro `raft/random --seed 2` (60s, 32 clients) → `Ok`, 0 violations, 95 chaos events visible, finished in 60.2s (was 30-minute timeout)
- [ ] Tonight's `stress-nightly` cron run is the canonical full integration verification

## Files

| Path | Why |
|---|---|
| `benchmarks/stress/src/config.rs` | Validate process ⇒ `nodes == 1` |
| `benchmarks/stress/src/topology/process/mod.rs` | Mirror assertion in spawn; refresh docstring |
| `benchmarks/stress/src/topology/raft.rs` | `HealOnDrop` guard + cancel-safety test |
| `benchmarks/stress/src/loadgen.rs` | Stop-aware warmup + test |
| `benchmarks/stress/src/supervisor.rs` | Carry `chaos_events` out of `SupervisorOutcome` |
| `benchmarks/stress/src/lib.rs` | Plumb `chaos_events` into `Report` |
| `benchmarks/stress/src/report.rs` | Emit typed `chaos_events` list in JSON + test |
| `.github/workflows/stress-nightly.yml` | Pass `--nodes 1` for process topology |
| `.github/actions/stress-auto-issue/action.yml` | Idempotent label bootstrap |