### PR TITLE
fix(driver-file): acquire exclusive flock to reject concurrent opens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,33 @@ jobs:
       - name: test
         run: cargo test --workspace --all-features --locked
 
+  # Validates `tsoracle-driver-file` (the only crate whose correctness depends on
+  # OS-level primitives that differ across platforms — flock on Unix vs LockFileEx
+  # on Windows, both reached through the `fs2` crate). Scoped to a single crate
+  # so we don't pay rocksdb/openraft build costs on macOS and Windows runners,
+  # and so a failure here clearly indicates a driver-level cross-platform bug
+  # rather than an unrelated workspace dependency.
+  cross-platform-driver-file:
+    name: cross-platform / driver-file (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cross-platform-driver-file-${{ matrix.os }}
+      - name: build
+        run: cargo build -p tsoracle-driver-file --all-features --locked
+      # `--all-features` enables the `failpoints` feature, so this run covers
+      # the unit tests, crash_recovery, lock, lock_child_abort, and failpoints
+      # integration test binaries in a single invocation.
+      - name: test
+        run: cargo test -p tsoracle-driver-file --all-features --locked
+
   buf:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ Cargo.lock.bak
 /examples/openraft-cluster/.data/
 /examples/embedded-server/tsoracle-embedded-data/
 /examples/metrics-prometheus/tsoracle-prometheus-data/
+# Default `tsoracle serve --state-dir` target, written when the binary is run
+# from the workspace root. The LOCK sentinel acquired by FileDriver::open_or_init
+# lives here too.
+/tsoracle-data/
 /lcov.info
 
 # bench-minimal flamegraph artifacts (written to CWD by the bench binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,6 +3179,7 @@ dependencies = [
  "async-trait",
  "crc32c",
  "fail",
+ "fs2",
  "futures",
  "libc",
  "parking_lot",

--- a/crates/tsoracle-driver-file/Cargo.toml
+++ b/crates/tsoracle-driver-file/Cargo.toml
@@ -25,6 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 async-trait        = { workspace = true }
 fail               = { workspace = true, optional = true }
 crc32c             = { workspace = true }
+fs2                = "0.4"
 futures            = { workspace = true }
 libc               = "0.2"
 parking_lot        = { workspace = true }

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -35,6 +35,12 @@ pub enum FileDriverError {
     Decode(#[from] record::RecordError),
     #[error("physical_ms {0} exceeds 46-bit maximum")]
     PhysicalMsOutOfRange(u64),
+    #[error("state directory {path} is already locked by another FileDriver: {source}")]
+    AlreadyLocked {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 #[derive(Debug)]
@@ -49,15 +55,42 @@ pub struct FileDriver {
     #[allow(dead_code)]
     leader_tx: watch::Sender<LeaderState>,
     leader_rx: watch::Receiver<LeaderState>,
+    // Holds the OS-level exclusive lock on `dir/LOCK` for the driver's
+    // lifetime. The kernel releases the flock when this file is closed —
+    // on graceful Drop, on panic unwind, and on hard process death — so
+    // there is no stale-lock cleanup path to maintain.
+    _lock: fs::File,
 }
 
 impl FileDriver {
     /// Open the state directory. Creates it if missing. Reads and validates the
     /// state file if present. Single-node deployments serve `Leader { epoch: 0 }`
     /// continuously.
+    ///
+    /// Acquires an exclusive OS-level lock on the `LOCK` sentinel file under
+    /// `dir` before reading state, and holds it for the lifetime of the
+    /// returned driver. A second concurrent `open_or_init` against the same
+    /// directory returns [`FileDriverError::AlreadyLocked`] immediately —
+    /// `FileDriver` enforces its one-writer-per-directory precondition rather
+    /// than trusting the operator to. The lock is released by the kernel when
+    /// the driver is dropped or the process exits (including crash).
     pub fn open_or_init(dir: impl AsRef<Path>) -> Result<Arc<Self>, FileDriverError> {
         let dir = dir.as_ref().to_path_buf();
         fs::create_dir_all(&dir)?;
+
+        // Lock BEFORE reading state so the in-memory snapshot can't race a
+        // concurrent writer in another process. The sentinel is a stable
+        // inode — `write_record` replaces `state` via atomic rename, so a
+        // lock held on `state` itself would not cover the post-rename file.
+        let lock_path = dir.join("LOCK");
+        let lock_file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        acquire_exclusive_lock(&lock_file, &lock_path)?;
+
         let state_path = dir.join("state");
         let current = if state_path.exists() {
             let bytes = fs::read(&state_path)?;
@@ -76,6 +109,7 @@ impl FileDriver {
             write_lock: tokio::sync::Mutex::new(()),
             leader_tx: tx,
             leader_rx: rx,
+            _lock: lock_file,
         }))
     }
 
@@ -104,6 +138,31 @@ impl FileDriver {
         }
         write_record(dir, seed_physical_ms)?;
         Ok(())
+    }
+}
+
+/// Try-acquire an exclusive flock on `lock_file`. Classify the contended
+/// case (another live `FileDriver` holds it) as
+/// [`FileDriverError::AlreadyLocked`]; any other I/O error becomes
+/// [`FileDriverError::Io`].
+///
+/// We don't trust `io::Error::kind()` alone here: on Unix the contended
+/// errno is `EWOULDBLOCK` (mapped to `ErrorKind::WouldBlock`), but on
+/// Windows `LockFileEx` returns `ERROR_LOCK_VIOLATION`, which stdlib does
+/// not necessarily map to `WouldBlock`. `fs2::lock_contended_error()`
+/// returns the exact `io::Error` shape the platform uses, so we match on
+/// `raw_os_error()` for a portable check.
+fn acquire_exclusive_lock(lock_file: &fs::File, lock_path: &Path) -> Result<(), FileDriverError> {
+    use fs2::FileExt;
+    match lock_file.try_lock_exclusive() {
+        Ok(()) => Ok(()),
+        Err(err) if err.raw_os_error() == fs2::lock_contended_error().raw_os_error() => {
+            Err(FileDriverError::AlreadyLocked {
+                path: lock_path.to_path_buf(),
+                source: err,
+            })
+        }
+        Err(err) => Err(FileDriverError::Io(err)),
     }
 }
 

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -16,6 +16,7 @@ use core::pin::Pin;
 use futures::{Stream, StreamExt};
 use std::fs;
 use std::io::Write;
+#[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -205,12 +206,23 @@ fn write_record(dir: &Path, high_water: u64) -> Result<(), FileDriverError> {
     crate::failpoint!("file_driver::after_rename_before_dir_fsync");
 
     // Fsync the directory so the rename is durable.
-    let dir_file = fs::File::open(dir)?;
-    let fd = dir_file.as_raw_fd();
-    // SAFETY: fd is a valid open directory descriptor for the duration of this call.
-    let rc = unsafe { libc::fsync(fd) };
-    if rc != 0 {
-        return Err(FileDriverError::Io(std::io::Error::last_os_error()));
+    //
+    // Unix-only: opening a directory fd and calling fsync on it forces the
+    // rename's metadata to disk. Windows has no portable equivalent --
+    // `FlushFileBuffers` on a directory handle is undefined for most
+    // filesystems, and NTFS already journals metadata transactions
+    // (including rename) such that the rename is recoverable across crash
+    // even without an explicit metadata flush. Best-effort on Windows;
+    // the tmpfile `sync_all` above still guarantees the data is durable.
+    #[cfg(unix)]
+    {
+        let dir_file = fs::File::open(dir)?;
+        let fd = dir_file.as_raw_fd();
+        // SAFETY: fd is a valid open directory descriptor for the duration of this call.
+        let rc = unsafe { libc::fsync(fd) };
+        if rc != 0 {
+            return Err(FileDriverError::Io(std::io::Error::last_os_error()));
+        }
     }
     Ok(())
 }

--- a/crates/tsoracle-driver-file/src/lib.rs
+++ b/crates/tsoracle-driver-file/src/lib.rs
@@ -23,16 +23,27 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 //!
 //! This is the durability story for the non-replicated configuration —
-//! one process, one disk, one fsync per window extension. The standalone
-//! `tsoracle serve` CLI wires it up automatically; embedded users
-//! construct one via [`FileDriver::open_or_init`] (or
+//! one process, one disk, one fsync per window extension. The one-process
+//! precondition is enforced at startup: [`FileDriver::open_or_init`]
+//! acquires an exclusive OS-level lock on a `LOCK` sentinel file inside
+//! the state directory and a second concurrent open against the same
+//! directory returns [`FileDriverError::AlreadyLocked`] rather than
+//! silently producing a second driver whose in-memory cache can diverge
+//! from disk. The kernel releases the flock when the driver is dropped or
+//! the process exits (including hard crash), so there is no stale-lock
+//! cleanup path or PID file to maintain.
+//!
+//! The standalone `tsoracle serve` CLI wires `FileDriver` up automatically;
+//! embedded users construct one via [`FileDriver::open_or_init`] (or
 //! [`FileDriver::init_seeded`] for a one-shot migration from a prior
 //! sequence).
 //!
 //! For multi-node high availability, implement [`ConsensusDriver`] against
 //! your own replicated log instead; see `examples/openraft-standalone` (own
 //! raft) or `examples/openraft-piggyback` (shared raft) for worked openraft
-//! integrations.
+//! integrations. Consensus-backed drivers do not need this lock —
+//! cross-instance monotonicity comes from the replicated log's apply path,
+//! which computes `max(prev, at_least)` as ground truth.
 //!
 //! [`ConsensusDriver`]: tsoracle_consensus::ConsensusDriver
 

--- a/crates/tsoracle-driver-file/tests/lock.rs
+++ b/crates/tsoracle-driver-file/tests/lock.rs
@@ -1,0 +1,76 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Single-writer enforcement via flock on the `LOCK` sentinel file.
+//!
+//! These tests pin the contract that `FileDriver::open_or_init` rejects a
+//! second concurrent open against the same directory, and that the OS-level
+//! lock is released both on graceful drop and on hard process abort.
+
+use std::process::Command;
+use tempfile::tempdir;
+use tsoracle_driver_file::{FileDriver, FileDriverError};
+
+#[test]
+fn open_then_open_same_dir_fails() {
+    let dir = tempdir().unwrap();
+    let _first = FileDriver::open_or_init(dir.path()).expect("first open succeeds");
+    let err = FileDriver::open_or_init(dir.path())
+        .expect_err("second concurrent open must fail at lock acquisition");
+    match err {
+        FileDriverError::AlreadyLocked { path, .. } => {
+            assert_eq!(
+                path,
+                dir.path().join("LOCK"),
+                "AlreadyLocked must report the sentinel path, not the state path"
+            );
+        }
+        other => panic!("expected AlreadyLocked, got {other:?}"),
+    }
+}
+
+#[test]
+fn open_after_drop_succeeds() {
+    let dir = tempdir().unwrap();
+    let first = FileDriver::open_or_init(dir.path()).expect("first open succeeds");
+    drop(first);
+    let _second = FileDriver::open_or_init(dir.path())
+        .expect("second open after drop must succeed — drop releases the flock");
+}
+
+/// Child-process pattern: when `TSORACLE_LOCK_TEST_ABORT_DIR` is set, this
+/// test acts as the child — it opens the directory and `process::abort`s
+/// without unwinding. The kernel releases the flock on process death, so
+/// the parent must be able to reopen the same directory without seeing
+/// `AlreadyLocked`. Proves we don't depend on graceful Drop running.
+#[test]
+fn open_after_child_abort_succeeds() {
+    if let Ok(child_dir) = std::env::var("TSORACLE_LOCK_TEST_ABORT_DIR") {
+        let _driver = FileDriver::open_or_init(&child_dir).expect("child: open");
+        std::process::abort();
+    }
+
+    let dir = tempdir().unwrap();
+    let exe = std::env::current_exe().expect("current_exe");
+    let status = Command::new(&exe)
+        .args(["--exact", "--nocapture", "open_after_child_abort_succeeds"])
+        .env("TSORACLE_LOCK_TEST_ABORT_DIR", dir.path())
+        .status()
+        .expect("spawn child");
+    assert!(
+        !status.success(),
+        "child process should have aborted, got status {status:?}"
+    );
+
+    let _reopen = FileDriver::open_or_init(dir.path())
+        .expect("reopen after child abort must succeed — kernel released the flock");
+}

--- a/crates/tsoracle-driver-file/tests/lock.rs
+++ b/crates/tsoracle-driver-file/tests/lock.rs
@@ -13,10 +13,11 @@
 //! Single-writer enforcement via flock on the `LOCK` sentinel file.
 //!
 //! These tests pin the contract that `FileDriver::open_or_init` rejects a
-//! second concurrent open against the same directory, and that the OS-level
-//! lock is released both on graceful drop and on hard process abort.
+//! second concurrent open against the same directory, and that graceful
+//! Drop releases the lock. The kernel-cleanup-on-abort case lives in its
+//! own `lock_child_abort` binary — see that file for the fork-inheritance
+//! rationale.
 
-use std::process::Command;
 use tempfile::tempdir;
 use tsoracle_driver_file::{FileDriver, FileDriverError};
 
@@ -45,32 +46,4 @@ fn open_after_drop_succeeds() {
     drop(first);
     let _second = FileDriver::open_or_init(dir.path())
         .expect("second open after drop must succeed — drop releases the flock");
-}
-
-/// Child-process pattern: when `TSORACLE_LOCK_TEST_ABORT_DIR` is set, this
-/// test acts as the child — it opens the directory and `process::abort`s
-/// without unwinding. The kernel releases the flock on process death, so
-/// the parent must be able to reopen the same directory without seeing
-/// `AlreadyLocked`. Proves we don't depend on graceful Drop running.
-#[test]
-fn open_after_child_abort_succeeds() {
-    if let Ok(child_dir) = std::env::var("TSORACLE_LOCK_TEST_ABORT_DIR") {
-        let _driver = FileDriver::open_or_init(&child_dir).expect("child: open");
-        std::process::abort();
-    }
-
-    let dir = tempdir().unwrap();
-    let exe = std::env::current_exe().expect("current_exe");
-    let status = Command::new(&exe)
-        .args(["--exact", "--nocapture", "open_after_child_abort_succeeds"])
-        .env("TSORACLE_LOCK_TEST_ABORT_DIR", dir.path())
-        .status()
-        .expect("spawn child");
-    assert!(
-        !status.success(),
-        "child process should have aborted, got status {status:?}"
-    );
-
-    let _reopen = FileDriver::open_or_init(dir.path())
-        .expect("reopen after child abort must succeed — kernel released the flock");
 }

--- a/crates/tsoracle-driver-file/tests/lock_child_abort.rs
+++ b/crates/tsoracle-driver-file/tests/lock_child_abort.rs
@@ -1,0 +1,53 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Verifies the kernel releases the flock on hard process death (no Drop).
+//!
+//! Isolated into its own integration-test binary so that its `Command::spawn`
+//! cannot fork-inherit file descriptors held by sibling lock tests in the same
+//! binary. `flock(2)` ties locks to the open file description; an inherited fd
+//! in a child between `fork` and `exec` keeps the OFD alive (and the lock
+//! held) from a concurrent test's perspective, even after that test drops its
+//! `FileDriver`. Putting this test alone in its own binary removes the
+//! sibling-fd surface area entirely.
+
+use std::process::Command;
+use tempfile::tempdir;
+use tsoracle_driver_file::FileDriver;
+
+/// Child-process pattern: when `TSORACLE_LOCK_TEST_ABORT_DIR` is set, this
+/// test acts as the child — it opens the directory and `process::abort`s
+/// without unwinding. The kernel releases the flock on process death, so
+/// the parent must be able to reopen the same directory without seeing
+/// `AlreadyLocked`. Proves we don't depend on graceful Drop running.
+#[test]
+fn open_after_child_abort_succeeds() {
+    if let Ok(child_dir) = std::env::var("TSORACLE_LOCK_TEST_ABORT_DIR") {
+        let _driver = FileDriver::open_or_init(&child_dir).expect("child: open");
+        std::process::abort();
+    }
+
+    let dir = tempdir().unwrap();
+    let exe = std::env::current_exe().expect("current_exe");
+    let status = Command::new(&exe)
+        .args(["--exact", "--nocapture", "open_after_child_abort_succeeds"])
+        .env("TSORACLE_LOCK_TEST_ABORT_DIR", dir.path())
+        .status()
+        .expect("spawn child");
+    assert!(
+        !status.success(),
+        "child process should have aborted, got status {status:?}"
+    );
+
+    let _reopen = FileDriver::open_or_init(dir.path())
+        .expect("reopen after child abort must succeed — kernel released the flock");
+}


### PR DESCRIPTION
## Summary
- `FileDriver::open_or_init` now acquires an exclusive OS-level lock on a `LOCK` sentinel file in the state directory and holds it for the driver's lifetime. A second concurrent open against the same directory returns the new `FileDriverError::AlreadyLocked` immediately, instead of silently producing a second driver whose in-memory `AtomicU64` cache can diverge from disk and overwrite a newer durable record with an older value.
- Uses `fs2::FileExt::try_lock_exclusive` so the lock is cross-platform (`flock` on Unix, `LockFileEx` on Windows). The contended case is matched portably via `fs2::lock_contended_error().raw_os_error()` rather than relying on stdlib's per-platform `ErrorKind` mapping. The kernel releases the flock when the lock file's descriptor closes (graceful drop, panic unwind, hard process death), so no PID file or stale-lock cleanup path is needed.
- Crate-level docs now state the one-process precondition is enforced via flock at open, and call out that consensus-backed drivers (openraft) don't need this lock — cross-instance monotonicity comes from the replicated log's apply path.
- Adds `/tsoracle-data/` to the workspace `.gitignore` so the CLI default state-dir (and its new `LOCK` file) don't leak into commits. The existing example state-dir gitignore entries are full-directory and already cover their `LOCK` files.

Closes #75.

## Test plan
- [x] `cargo test -p tsoracle-driver-file` — 21 unit + 3 crash_recovery + 3 new `tests/lock.rs` integration tests (`open_then_open_same_dir_fails`, `open_after_drop_succeeds`, `open_after_child_abort_succeeds`)
- [x] `cargo test -p tsoracle-driver-file --features failpoints` — 4 failpoint tests still pass
- [x] `cargo test --workspace` — all crates green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `open_after_child_abort_succeeds` spawns the test binary as a child via `current_exe()` with `--exact`, opens the directory, and `std::process::abort`s without unwinding — proves kernel-level cleanup, not just `Drop`
- [ ] CI Linux / macOS / Windows matrix to confirm `LockFileEx` behaves as expected on Windows