### PR TITLE
fix(release-plz): stop exposing crates.io token to release-pr job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,6 +15,7 @@ jobs:
   release:
     name: release-plz release
     runs-on: ubuntu-latest
+    environment: crates-io
     permissions:
       contents: write
     # Queue serial — never cancel a publish in flight (a half-done publish
@@ -74,4 +75,3 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- The `release-pr` job runs `release-plz/action` with `command: release-pr`, which only opens/updates the version-bump PR and never runs `cargo publish` (per `release-plz.toml` lines 6–10). Passing `CARGO_REGISTRY_TOKEN` into that step's env exposed crates.io publish authority (`publish-new` + `publish-update`, per `CONTRIBUTING.md:168`) to action code that has no use for it — a clean blast-radius win if the third-party action is ever compromised.
- Opted the `release` job into the `crates-io` GitHub Environment so the publish token can live as an environment secret (gated by environment protection rules) instead of a repo-wide secret accessible to any workflow.

## Required GitHub-side changes for the full mitigation

The workflow diff alone is necessary but not sufficient. To realize the security benefit:

1. **Move `CARGO_REGISTRY_TOKEN` to the `crates-io` environment** and **delete the repo-level secret**. GitHub resolves secrets as env → repo → org, so the repo-level secret stays accessible to other workflows until it's deleted.
2. **Add protection rules to the `crates-io` environment** — required reviewers (a human clicks "Approve and deploy" before the publish runs) and/or deployment-branches restricted to `main`. Without rules, `environment:` is mostly audit metadata.

## What this PR deliberately does not do

- SHA-pin third-party actions (`release-plz/action@v0.5`, `actions/create-github-app-token@v1`, etc.). Worth doing separately for all actions in the workflow with Dependabot's `github-actions` ecosystem enabled, rather than cherry-picking one.

## Reference

Codex finding: https://chatgpt.com/codex/cloud/security/findings/819e88f6833481918edab07e3e83d4a0?repo=https%3A%2F%2Fgithub.com%2Fprisma-risk%2Ftsoracle&sev=medium%2Chigh%2Ccritical%2Clow%2Cinformational

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-plz.yml'))"` → `YAML OK`
- [x] Pre-commit `cargo fmt --check` + `cargo clippy` pass locally
- [ ] On next merge to `main`, confirm the `release-plz PR` job completes (it never needed the token)
- [ ] On the next merged release PR, confirm the `release-plz release` job successfully reads `CARGO_REGISTRY_TOKEN` from the `crates-io` environment and publishes