### PR TITLE
ci: pin actions to SHAs, restrict default token, enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
       # Rust toolchain installed below lives in ~/.cargo and is not touched
       # by `tool-cache: false`.
       - name: free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           tool-cache: false
           android: true
@@ -26,11 +29,12 @@ jobs:
           large-packages: false
           docker-images: true
           swap-storage: true
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
       - name: fmt
@@ -45,10 +49,10 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99  # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: buf lint
@@ -67,39 +71,40 @@ jobs:
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823  # v2
 
   critical-path:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: guard
         run: CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh
 
   header-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: guard
         run: python3 scripts/check-ts-header.py
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
+          toolchain: stable
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac  # v2
         with:
           tool: cargo-llvm-cov
       - name: system deps
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
       - name: coverage
         run: make coverage
-      - uses: coverallsapp/github-action@v2
+      - uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e  # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: lcov.info
@@ -110,9 +115,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
       - name: build

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,20 +23,22 @@ jobs:
       group: release-plz-release-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
-      - uses: release-plz/action@v0.5
+      - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db  # v0.5
         with:
           command: release
         env:
@@ -56,20 +58,22 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
-      - uses: release-plz/action@v0.5
+      - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db  # v0.5
         with:
           command: release-pr
         env:


### PR DESCRIPTION
Closes #129. Companion to #131 (token-scoping); this is the broader supply-chain hardening that review called out as a follow-up.

## Summary

Three changes, all in CI/release plumbing — no runtime code touched.

### 1. SHA-pin every third-party action

Every `uses:` reference in `.github/workflows/ci.yml` and `.github/workflows/release-plz.yml` now points to a 40-char commit SHA instead of a mutable ref (`@main`, `@stable`, `@v4`, etc.). A trailing comment carries the human-readable version so the target is still greppable and Dependabot can track it.

The most pressing case was `jlumbroso/free-disk-space@main` (a branch HEAD, so any new commit to that branch would run automatically in CI). It's now pinned to `54081f1` (v1.3.1).

### 2. Workflow-level `permissions: contents: read` on `ci.yml`

The default `GITHUB_TOKEN` had no explicit scope, so test/build jobs were inheriting whatever the org/repo defaults are (which `validated` security findings flagged as a write-capable default in some configurations). All jobs in `ci.yml` only need read access to the repo contents, so the workflow-level scope is now `contents: read`. `release-plz.yml` already had this and remains unchanged.

### 3. Dependabot config for the github-actions ecosystem

`.github/dependabot.yml` opts the github-actions ecosystem in, with:

- **Weekly grouped updates** — all action bumps for a given week land as a single PR rather than ~10 per week
- **`chore(ci)` commit prefix** — matches the repo's conventional-commits style so it doesn't break the changelog convention release-plz expects

Without this, SHA pins are a one-time hardening that go stale; with it, they get maintained automatically.

## Subtlety worth flagging in review

`dtolnay/rust-toolchain` picks the toolchain channel from the ref name (`@stable`, `@nightly`, `@1.79.0`). SHA pinning loses that signal, so each usage now also passes `toolchain: stable` explicitly as a `with:` input. Behavior is unchanged; the explicit input restores the implicit ref-based signal.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all three changed files
- [x] `grep -E 'uses: .+@(main|stable|nightly|v[0-9]+(\.[0-9]+)*)\s*$'` returns empty for both workflows (no mutable refs remaining)
- [x] Pre-commit `cargo fmt --check` + `cargo clippy` pass locally
- [ ] On merge, confirm all `ci.yml` jobs still execute successfully (action resolution + toolchain install)
- [ ] On next merged release PR, confirm `release-plz.yml` publish step still runs successfully
- [ ] Confirm Dependabot opens its first grouped PR on the next weekly cycle