### PR TITLE
chore: add PR template with post-merge follow-ups section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What changed and why. -->
+
+## Test plan
+
+<!-- Pre-merge checks. Tick each item before requesting review. -->
+
+- [ ]
+
+## Post-merge follow-ups
+
+<!--
+Items that can only be verified AFTER this PR is merged — e.g. the next nightly run, the next release-plz cycle, the first Dependabot PR, a workflow that only fires on `main`, a deferred operational check.
+
+Each unchecked item left in this section at merge time will be filed as a tracking issue with the `post-merge-followup` label, linked back to this PR.
+
+Tick an item before merge if you verified it yourself. Delete this entire section (heading included) if there are no post-merge items.
+-->
+
+- [ ]


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` introducing the `## Post-merge follow-ups` convention. The new section is for items that can only be verified after a PR is merged — next nightly run, next release-plz cycle, first Dependabot PR, deferred operational checks like an "Enforce HTTPS" toggle that depends on a deployed site.

The convention is the foundation for a follow-up PR that will add a `pull_request` (closed/merged) workflow to auto-file one tracking issue per unchecked item in the section, labeled `post-merge-followup`. Until that workflow lands, the section serves as a structured place for these items so they're greppable post-merge instead of buried in `## Test plan`.

A first backfill pass against existing PRs filed 5 tracking issues:
- #137 — release-plz publish step under SHA-pinned actions (from #136)
- #138 — `CARGO_REGISTRY_TOKEN` reads from `crates-io` env on next publish (from #131)
- #139 — first Dependabot grouped PR on next weekly cycle (from #136)
- #140 — Enable "Enforce HTTPS" for tsoracle.rs Pages (from #111) — currently `http://tsoracle.rs/` returns 200 instead of a 301
- #141 — DeepWiki regeneration with new structure + chapter (from #107 and #65)

~28 other post-merge items across PRs #16-#136 were resolved by current repo state (CI green on `main`, `tsoracle-v0.1.2` tagged, fuzz/leak/stress nightlies passing, release PR #121 authored by the app bot, etc.) and didn't need tracking issues.

The `post-merge-followup` label was created out-of-band (`gh label create`) and is already attached to all 5 backfill issues.

## Test plan

- [x] `.github/PULL_REQUEST_TEMPLATE.md` exists and contains the `## Post-merge follow-ups` heading exactly (the string the future parser will key on)
- [x] Label `post-merge-followup` exists: `gh label list --search post-merge` confirms
- [x] 5 backfill issues filed and visible: `gh issue list --label post-merge-followup` returns #137, #138, #139, #140, #141
- [x] Pre-commit hooks (`cargo fmt --check`, `cargo clippy`) pass

## Post-merge follow-ups

- [ ] Open the next PR after this one is merged and confirm GitHub auto-populates the body from `.github/PULL_REQUEST_TEMPLATE.md` (GitHub only reads the template from the default branch, so this cannot be verified pre-merge on this PR itself)