### PR TITLE
feat(ci): auto-file tracking issues from PR Post-merge follow-ups

### DIFF
--- a/.github/workflows/post-merge-followups.yml
+++ b/.github/workflows/post-merge-followups.yml
@@ -1,0 +1,155 @@
+name: post-merge follow-ups
+
+# On merge into the default branch, parse the merged PR body for a
+# `## Post-merge follow-ups` section and open one tracking issue per
+# unchecked item, labeled `post-merge-followup`. Items the author
+# ticked before merge are skipped (already verified by hand). The
+# section is optional — PRs without one are a no-op.
+#
+# Dedup: each issue body carries a stable marker
+# `<!-- post-merge-followup:pr-<N>:item-<i> -->`. If the workflow
+# re-runs for the same merged PR, the search-by-marker step finds
+# the existing issue and skips creation.
+#
+# Security note: all PR-supplied data (body, title, author) is read
+# inside the actions/github-script JS context via the typed event
+# payload. No `${{ github.event.* }}` expansion is interpolated into
+# shell `run:` commands, so workflow-injection vectors (CRLF, command
+# substitution, etc.) are not reachable here.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  file-issues:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71  # v9.0.0
+        with:
+          script: |
+            const SECTION_HEADER = '## Post-merge follow-ups';
+            const LABEL = 'post-merge-followup';
+            const MAX_TITLE_LEN = 200;
+
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            // Strip HTML comments so the section delimiter and item text
+            // are not contaminated by template guidance.
+            let body = (pr.body || '').replace(/<!--[\s\S]*?-->/g, '');
+
+            const headerIdx = body.indexOf(SECTION_HEADER);
+            if (headerIdx === -1) {
+              core.info(`PR #${pr.number}: no "${SECTION_HEADER}" section; nothing to file.`);
+              return;
+            }
+
+            // Section spans from after the header to the next H1/H2 heading
+            // or end of body, whichever comes first.
+            let sectionBody = body.slice(headerIdx + SECTION_HEADER.length);
+            const nextHeading = sectionBody.search(/^#{1,2} /m);
+            if (nextHeading !== -1) {
+              sectionBody = sectionBody.slice(0, nextHeading);
+            }
+
+            // Parse top-level checkbox items. Non-checkbox indented or
+            // contiguous non-blank lines after a checkbox are treated as
+            // continuation of the prior item.
+            const lines = sectionBody.split('\n');
+            const items = [];
+            let cur = null;
+            for (const raw of lines) {
+              const m = raw.match(/^- \[( |x|X)\] ?(.*)$/);
+              if (m) {
+                if (cur) items.push(cur);
+                cur = {
+                  checked: m[1].toLowerCase() === 'x',
+                  lines: [m[2]],
+                };
+              } else if (cur && raw.trim() !== '') {
+                cur.lines.push(raw);
+              } else if (cur) {
+                items.push(cur);
+                cur = null;
+              }
+            }
+            if (cur) items.push(cur);
+
+            const targets = items.filter(
+              (it) => !it.checked && it.lines.join(' ').trim() !== ''
+            );
+
+            if (targets.length === 0) {
+              core.info(`PR #${pr.number}: no unchecked, non-empty post-merge items.`);
+              return;
+            }
+
+            core.info(`PR #${pr.number}: filing ${targets.length} follow-up issue(s).`);
+
+            const filed = [];
+            for (let i = 0; i < targets.length; i++) {
+              const item = targets[i];
+              const itemIndex = i + 1;
+              const marker = `<!-- post-merge-followup:pr-${pr.number}:item-${itemIndex} -->`;
+
+              // Dedup: a re-fired workflow finds the prior marker and skips.
+              const existing = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${owner}/${repo} in:body "${marker}"`,
+              });
+              if (existing.data.total_count > 0) {
+                const num = existing.data.items[0].number;
+                core.info(`Item ${itemIndex}: matches existing #${num}, skipping.`);
+                filed.push({ index: itemIndex, number: num, existed: true });
+                continue;
+              }
+
+              let title = item.lines[0].trim().replace(/\s+/g, ' ');
+              if (title.length > MAX_TITLE_LEN) {
+                title = title.slice(0, MAX_TITLE_LEN - 1) + '…';
+              }
+              title = `${title} (PR #${pr.number})`;
+
+              const issueBody = [
+                `Post-merge follow-up auto-filed on merge of #${pr.number}.`,
+                '',
+                item.lines.join('\n').trim(),
+                '',
+                '---',
+                `Source: ${pr.title}`,
+                `Author: @${pr.user.login}`,
+                `Merged: ${pr.merged_at}`,
+                `PR: ${pr.html_url}`,
+                '',
+                marker,
+              ].join('\n');
+
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body: issueBody,
+                labels: [LABEL],
+              });
+              core.info(`Item ${itemIndex}: created #${created.data.number}.`);
+              filed.push({ index: itemIndex, number: created.data.number, existed: false });
+            }
+
+            const fresh = filed.filter((f) => !f.existed);
+            if (fresh.length > 0) {
+              const refs = fresh.map((f) => `- #${f.number}`).join('\n');
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: `Filed ${fresh.length} post-merge follow-up issue(s) from this PR's \`${SECTION_HEADER}\` section:\n\n${refs}`,
+              });
+            }


### PR DESCRIPTION
## Summary

Adds `.github/workflows/post-merge-followups.yml`. On merge into the default branch, the workflow parses the merged PR body for a `## Post-merge follow-ups` section (introduced in #142) and opens one tracking issue per unchecked item, labeled `post-merge-followup`. Items the author ticked before merge are skipped (already verified by hand); PRs without the section are a no-op.

Closes the loop on the convention from #142 — instead of relying on someone re-reading old PRs (the gap that prompted this whole effort), every deferred verification surfaces as a tracked issue the moment its PR merges.

### Behavior contract

| Input | Behavior |
|---|---|
| PR has no `## Post-merge follow-ups` section | No-op, no issues filed |
| PR has the section but every item is `- [x]` | No-op (author verified pre-merge) |
| PR has the section with only the template's empty `- [ ]` scaffold | No-op (empty text filtered) |
| PR has N unchecked, non-empty items | N issues filed, one summary comment posted on the PR linking them |
| Workflow re-runs for the same merged PR | Per-item marker matches existing issue, creation skipped |
| Merge target is not the default branch | Job skipped via `if:` condition |

### Implementation notes

- **Action**: `actions/github-script@v9.0.0`, SHA-pinned per the repo's #136 policy.
- **No shell injection surface**: all PR-supplied fields (body, title, author login) are read through `actions/github-script`'s typed event payload (`context.payload.pull_request.*`). Nothing flows into a `run:` step via `${{ github.event.* }}` expansion, so the workflow-injection vectors GitHub Security calls out (CRLF, command substitution, `;rm -rf` in a PR title, etc.) are not reachable.
- **Dedup marker**: each issue body carries `<!-- post-merge-followup:pr-<N>:item-<i> -->`. A re-fired workflow finds prior issues via the search API and skips creation, so a workflow re-run on the same merged PR is idempotent.
- **Empty placeholder filter**: lines matching `- [ ]` with empty/whitespace text after are skipped. This protects against the template's scaffold leaking through if an author deletes the section's content but leaves the lone `- [ ]` behind.
- **Multi-line items**: continuation lines (indented or non-blank after a checkbox) are bundled into the same item; first line becomes the issue title (truncated to 200 chars), full content goes into the body.

### Self-test

This PR is its own end-to-end smoke test — the post-merge follow-up below is the workflow firing on its own merge. The workflow file lands in `main` as part of this merge, GitHub Actions reads it from `main`'s HEAD when scheduling the `pull_request.closed` run, and the very first body it processes is this PR's. If the resulting issue lands cleanly, the parser works.

## Test plan

- [x] YAML loads (regex-based pin check + structural sanity, no `yaml` python module available locally)
- [x] No mutable action refs (`@main`, `@stable`, `@vN` without SHA) — `grep -E 'uses: .+@(main|stable|nightly|v[0-9]+(\.[0-9]+)*)\s*$'` returns empty
- [x] Pre-commit hooks (`cargo fmt --check`, `cargo clippy`) pass
- [x] Workflow file passes manual review for shell-injection risk (no `${{ github.event.* }}` reaches a `run:` step; only `actions/github-script` `with: script:` block, which evaluates as a sandboxed JS script via the GitHub Actions toolkit)

## Post-merge follow-ups

- [ ] On merge of this PR, confirm a `post-merge-followup` issue is auto-filed referencing item-1 of PR #143, with a summary comment posted on this PR linking it (the self-test described in the Implementation notes)