### PR TITLE
fix(ci): anchor post-merge follow-ups heading match to line start

### DIFF
--- a/.github/workflows/post-merge-followups.yml
+++ b/.github/workflows/post-merge-followups.yml
@@ -47,19 +47,29 @@ jobs:
             // are not contaminated by template guidance.
             let body = (pr.body || '').replace(/<!--[\s\S]*?-->/g, '');
 
-            const headerIdx = body.indexOf(SECTION_HEADER);
-            if (headerIdx === -1) {
-              core.info(`PR #${pr.number}: no "${SECTION_HEADER}" section; nothing to file.`);
+            // Match the header as a real markdown heading: at line start,
+            // optional trailing whitespace, end of line. Using indexOf here
+            // would match the header substring inside code spans or table
+            // cells (e.g. a PR body that mentions `## Post-merge follow-ups`
+            // in prose), which then slices the wrong region.
+            const headerRegex = /^## Post-merge follow-ups\s*$/m;
+            const headerMatch = body.match(headerRegex);
+            if (!headerMatch) {
+              core.info(`PR #${pr.number}: no "${SECTION_HEADER}" heading; nothing to file.`);
               return;
             }
 
-            // Section spans from after the header to the next H1/H2 heading
-            // or end of body, whichever comes first.
-            let sectionBody = body.slice(headerIdx + SECTION_HEADER.length);
+            // Section spans from after the heading line to the next H1/H2
+            // heading or end of body, whichever comes first.
+            let sectionBody = body.slice(headerMatch.index + headerMatch[0].length);
             const nextHeading = sectionBody.search(/^#{1,2} /m);
             if (nextHeading !== -1) {
               sectionBody = sectionBody.slice(0, nextHeading);
             }
+            core.info(
+              `PR #${pr.number}: matched heading at offset ${headerMatch.index}, ` +
+              `section body is ${sectionBody.length} chars.`
+            );
 
             // Parse top-level checkbox items. Non-checkbox indented or
             // contiguous non-blank lines after a checkbox are treated as
@@ -86,6 +96,14 @@ jobs:
 
             const targets = items.filter(
               (it) => !it.checked && it.lines.join(' ').trim() !== ''
+            );
+            const checkedCount = items.filter((it) => it.checked).length;
+            const emptyCount = items.filter(
+              (it) => !it.checked && it.lines.join(' ').trim() === ''
+            ).length;
+            core.info(
+              `PR #${pr.number}: parsed ${items.length} item(s) ` +
+              `(${targets.length} actionable, ${checkedCount} pre-checked, ${emptyCount} empty placeholder).`
             );
 
             if (targets.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the parser in #144. The workflow ran cleanly on #144's merge and reported "no unchecked, non-empty post-merge items," even though #144's body had exactly one unchecked item under its real heading.

Root cause: the parser used `body.indexOf('## Post-merge follow-ups')`, which matches the literal substring anywhere in the body — including inside code spans, table cells, and prose. #144's summary referenced the header (`...parses the merged PR body for a \`## Post-merge follow-ups\` section...`) and its behavior-contract table contained the same literal in a cell. `indexOf` matched the first occurrence (inside the Summary prose, offset 143), the parser then sliced from there to the next H2 heading (`## Test plan`), found zero checkboxes in that slice, and reported success.

Fix: replace `indexOf` with a line-anchored regex `^## Post-merge follow-ups\s*$/m`. The `^` requires the match to begin at a line start, so substrings inside code spans, tables, or mid-line prose no longer match. Validated locally against #144's actual body — the old approach matched at offset 143 (inside prose), the new approach matches at offset 3323 (the real H2 heading), and the parser correctly produces 1 actionable item.

Also adds three observability log lines so the next parsing failure does not require dumping the body to a tmp file to debug:
- offset where the heading matched + section body length
- counts of parsed items, actionable, pre-checked, empty placeholders

### Backfill

This fix lands forward — #144's missed self-test issue still needs to be filed once for completeness. GitHub Actions re-runs of a `pull_request.closed` event use the workflow file as of the original event SHA, not current `main`, so re-running run 26306709824 would still use the broken parser. After this PR merges I'll file the one missed issue manually so #144's `Post-merge follow-ups` row has a tracked artifact, matching what the workflow would have produced if the parser had worked.

## Test plan

- [x] Locally replay the parser against #144's actual body (saved from `gh pr view 144 --json body --jq .body`): the regex matches at offset 3323 (the real heading line), section body is 217 chars, 1 actionable item parsed
- [x] Old `indexOf` reproduced offset 143 (inside Summary prose) confirming the diagnosis
- [x] Pre-commit hooks (`cargo fmt --check`, `cargo clippy`) pass
- [x] No mutable action refs reintroduced; SHA-pin on `actions/github-script@v9.0.0` preserved

## Post-merge follow-ups

- [ ] On merge of this PR, confirm the workflow files exactly one tracking issue referencing this PR's self-test item (proves the fixed parser correctly anchors on real H2 headings, not substring occurrences)