### PR TITLE
fix(ci): silence cargo-deny override toolchain error in deny job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823  # v2
+        with:
+          rust-version: "1.88"
 
   critical-path:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Every CI run on `main` since the SHA-pin in #136 prints the following error in the `deny` job's log:

```
error: override toolchain '1.88-x86_64-unknown-linux-musl' is not installed: the toolchain file at '/github/workspace/rust-toolchain.toml' specifies an uninstalled toolchain
```

The job exits success regardless — the action wrapper swallows the error and `cargo deny check` runs against the container's built-in toolchain. Lint output (duplicate-crate warnings) appears normally, so it's been a no-op for correctness, but starting every successful run with a red `error:` line is bad signal hygiene: a future genuine breakage gets camouflaged.

Root cause: `cargo-deny-action` runs in its own (musl-based) Docker container. When cargo enters the workspace, rustup reads `rust-toolchain.toml`, resolves `channel = "1.88"` against the host triple to `1.88-x86_64-unknown-linux-musl`, and that named toolchain isn't installed in the action's container. The action's wrapper logs the error and continues with the container's default Rust.

Fix: set the action's documented `rust-version` input ("The Rust version that is updated to before running cargo deny") to `"1.88"` so the action pre-installs that toolchain via rustup before invoking cargo-deny. The override directive then resolves cleanly and the error is gone.

Closes #151.

## Test plan

- [x] YAML structural sanity (regex pin-check on this file: no new mutable refs added by this PR; preexisting unpinned refs in `cross-platform-driver-file` are unrelated and out of scope)
- [x] Pre-commit hooks (`cargo fmt --check`, `cargo clippy`) pass
- [x] No `${{ github.event.* }}` expansion lands in a shell `run:` step (manual review of the diff)

## Post-merge follow-ups

- [ ] On the next CI run on `main` after merge, confirm the `deny` job's log no longer contains the string `error: override toolchain` — `gh run view <run-id> --log | grep -E 'deny.*override toolchain' | wc -l` should return `0` (was non-zero on every previous run since #136)