### PR TITLE
fix(driver-file): durably flush rename metadata on Windows

### DIFF
--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -205,15 +205,22 @@ fn write_record(dir: &Path, high_water: u64) -> Result<(), FileDriverError> {
 
     crate::failpoint!("file_driver::after_rename_before_dir_fsync");
 
-    // Fsync the directory so the rename is durable.
+    // Force the rename's metadata to durable media. The tmpfile `sync_all`
+    // above keeps the *data* durable on both platforms; this block adds the
+    // *metadata* barrier that makes the new directory entry survive a crash.
     //
-    // Unix-only: opening a directory fd and calling fsync on it forces the
-    // rename's metadata to disk. Windows has no portable equivalent --
-    // `FlushFileBuffers` on a directory handle is undefined for most
-    // filesystems, and NTFS already journals metadata transactions
-    // (including rename) such that the rename is recoverable across crash
-    // even without an explicit metadata flush. Best-effort on Windows;
-    // the tmpfile `sync_all` above still guarantees the data is durable.
+    // Unix: open the parent directory and `fsync` its descriptor. This is
+    // the canonical POSIX barrier for a rename — it flushes the directory
+    // entry that names the new inode.
+    //
+    // Windows: there is no portable directory-level flush. `FlushFileBuffers`
+    // on a directory handle is undefined for most filesystems. NTFS journals
+    // `MoveFileEx` as a metadata transaction, but the `$LogFile` record is
+    // itself only durable after a checkpoint or an explicit
+    // `FlushFileBuffers` on a file on the same volume. Re-opening the
+    // renamed file with write access (required by `FlushFileBuffers`) and
+    // calling `sync_all` flushes the journal entry covering this rename.
+    // This is the pattern SQLite and RocksDB use on Windows.
     #[cfg(unix)]
     {
         let dir_file = fs::File::open(dir)?;
@@ -223,6 +230,14 @@ fn write_record(dir: &Path, high_water: u64) -> Result<(), FileDriverError> {
         if rc != 0 {
             return Err(FileDriverError::Io(std::io::Error::last_os_error()));
         }
+    }
+    #[cfg(not(unix))]
+    {
+        // `write(true)` is required: `FlushFileBuffers` rejects handles
+        // without `GENERIC_WRITE`. Default `truncate: false` leaves the
+        // file contents (the record we just renamed into place) intact.
+        let final_file = fs::OpenOptions::new().write(true).open(&final_path)?;
+        final_file.sync_all()?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- `write_record` on non-Unix returned `Ok` immediately after `fs::rename` with no explicit metadata durability barrier. `persist_high_water` then published the new high-water and the server could begin issuing timestamps from that window, so a host crash or power loss after the rename returned but before NTFS journaled the rename to disk could leave restart loading the previous state record — violating the no-rewind durability guarantee that `crates/tsoracle-driver-file/src/lib.rs` documents.
- Fix: after `fs::rename` on `cfg(not(unix))`, reopen the renamed file with write access and call `sync_all`. On Windows that maps to `FlushFileBuffers` against the renamed inode's handle, which forces the `$LogFile` entry covering this `MoveFileEx` into durable storage. Symmetric to the existing Unix directory `fsync`; closes the post-rename / pre-metadata-flush window without adding a non-stdlib dependency.
- `write(true)` is required because `FlushFileBuffers` rejects handles without `GENERIC_WRITE`; `truncate` stays at its default of `false` so the record just renamed into place is left intact. Reuses the existing `file_driver::after_rename_before_dir_fsync` failpoint position (still upstream of both platform barriers).

## Test plan
- [x] `cargo test -p tsoracle-driver-file --all-features --locked` on host (aarch64-darwin / Linux build path) — 21 unit + 3 + 4 + 2 + 1 integration tests still pass, including `reopen_after_crash_between_rename_and_dir_fsync_is_monotonic`
- [x] `cargo check -p tsoracle-driver-file --all-features --tests --target x86_64-pc-windows-gnu --locked` — cross-compile clean, confirms the new `cfg(not(unix))` branch builds for the `windows-latest` CI matrix
- [x] `cargo clippy -p tsoracle-driver-file --all-targets --all-features --locked -- -D warnings`
- [x] `cargo fmt -p tsoracle-driver-file -- --check`
- [ ] `cross-platform / driver-file` CI matrix across ubuntu-latest / macos-latest / windows-latest — runs on PR