### PR TITLE
feat(paxos-toolkit): scaffold crate and add omnipaxos workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "omnipaxos"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b6871f667e9a1045996d5a42d8fec5c8b9aaac66ba22ccb9664707a86524bf"
+dependencies = [
+ "omnipaxos_macros",
+ "serde",
+]
+
+[[package]]
+name = "omnipaxos_macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a89202e33e5b69cf15a16070842905fbdbf48e05e5cba9fd2fda2abffdf3013"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +1817,12 @@ checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peel-off"
@@ -3233,6 +3259,29 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "tsoracle-paxos-toolkit"
+version = "0.1.3"
+dependencies = [
+ "async-trait",
+ "fail",
+ "futures",
+ "omnipaxos",
+ "parking_lot",
+ "paste",
+ "postcard",
+ "proptest",
+ "rocksdb",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tsoracle-consensus",
+ "tsoracle-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,10 +1819,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "peel-off"
@@ -3270,7 +3270,7 @@ dependencies = [
  "futures",
  "omnipaxos",
  "parking_lot",
- "paste",
+ "pastey",
  "postcard",
  "proptest",
  "rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members  = [
     "crates/tsoracle-driver-openraft",
     "crates/tsoracle-bin",
     "crates/tsoracle-openraft-toolkit",
+    "crates/tsoracle-paxos-toolkit",
     "crates/tsoracle-tests",
     "examples/embedded-server",
     "examples/failover-demo",
@@ -34,6 +35,7 @@ default-members = [
     "crates/tsoracle-driver-openraft",
     "crates/tsoracle-bin",
     "crates/tsoracle-openraft-toolkit",
+    "crates/tsoracle-paxos-toolkit",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ nix                = { version = "0.30", default-features = false, features = ["
 omnipaxos          = "0.2"
 omnipaxos_storage  = "0.2"
 parking_lot        = "0.12"
-paste              = "1"
+pastey             = "0.2"
 proptest           = "1"
 prost              = "0.14"
 rand               = { version = "0.9", default-features = false, features = ["std", "std_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,10 @@ metrics            = "0.24"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }
 metrics-util       = "0.19"
 nix                = { version = "0.30", default-features = false, features = ["signal", "process"] }
+omnipaxos          = "0.2"
+omnipaxos_storage  = "0.2"
 parking_lot        = "0.12"
+paste              = "1"
 proptest           = "1"
 prost              = "0.14"
 rand               = { version = "0.9", default-features = false, features = ["std", "std_rng"] }

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name         = "tsoracle-paxos-toolkit"
+description  = "Reusable OmniPaxos glue: RocksDB storage, lifecycle helpers, test fakes"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+homepage.workspace     = true
+readme.workspace       = true
+authors.workspace      = true
+documentation = "https://docs.rs/tsoracle-paxos-toolkit"
+keywords      = ["omnipaxos", "paxos", "consensus", "rocksdb", "storage"]
+categories    = ["asynchronous", "database-implementations"]
+
+[package.metadata.docs.rs]
+features     = ["rocksdb-storage"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default            = ["rocksdb-storage"]
+rocksdb-storage    = ["dep:rocksdb"]
+test-fakes         = []
+failpoints         = ["dep:fail", "fail/failpoints"]
+
+[dependencies]
+async-trait        = { workspace = true }
+fail               = { workspace = true, optional = true }
+futures            = { workspace = true }
+omnipaxos          = { workspace = true, features = ["serde"] }
+parking_lot        = { workspace = true }
+paste              = { workspace = true }
+postcard           = { workspace = true }
+rocksdb            = { workspace = true, optional = true, features = ["multi-threaded-cf"] }
+serde              = { workspace = true }
+thiserror          = { workspace = true }
+tokio              = { workspace = true }
+tokio-stream       = { workspace = true }
+tracing            = { workspace = true }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.3" }
+tsoracle-core      = { path = "../tsoracle-core",      version = "0.1.3" }
+
+[dev-dependencies]
+proptest         = { workspace = true }
+rocksdb          = { workspace = true }
+tempfile         = { workspace = true }
+tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+
+[[test]]
+name              = "failpoints"
+path              = "tests/failpoints.rs"
+required-features = ["failpoints", "rocksdb-storage"]

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -29,7 +29,7 @@ fail               = { workspace = true, optional = true }
 futures            = { workspace = true }
 omnipaxos          = { workspace = true, features = ["serde"] }
 parking_lot        = { workspace = true }
-paste              = { workspace = true }
+pastey             = { workspace = true }
 postcard           = { workspace = true }
 rocksdb            = { workspace = true, optional = true, features = ["multi-threaded-cf"] }
 serde              = { workspace = true }

--- a/crates/tsoracle-paxos-toolkit/src/codec.rs
+++ b/crates/tsoracle-paxos-toolkit/src/codec.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/codec.rs
+++ b/crates/tsoracle-paxos-toolkit/src/codec.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/failpoint.rs
+++ b/crates/tsoracle-paxos-toolkit/src/failpoint.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/failpoint.rs
+++ b/crates/tsoracle-paxos-toolkit/src/failpoint.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/lib.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lib.rs
@@ -1,0 +1,30 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Reusable OmniPaxos glue for tsoracle's paxos driver.
+//!
+//! This crate provides a RocksDB-backed [`omnipaxos::storage::Storage`] impl,
+//! lifecycle helpers, the `declare_omnipaxos_types_ext!` macro, and in-memory
+//! test fakes. The paxos driver crate consumes this crate; this crate itself
+//! does not depend on the driver.
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub mod codec;
+pub mod failpoint;
+pub mod lifecycle;
+pub mod macros;
+pub mod storage;
+
+#[cfg(feature = "test-fakes")]
+pub mod test_fakes;

--- a/crates/tsoracle-paxos-toolkit/src/lib.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lib.rs
@@ -17,11 +17,13 @@
 //! test fakes. The paxos driver crate consumes this crate; this crate itself
 //! does not depend on the driver.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[macro_use]
+mod failpoint;
 
 pub mod codec;
-pub mod failpoint;
 pub mod lifecycle;
 pub mod macros;
 pub mod storage;

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -10,7 +10,5 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
-
 pub mod events;
 pub mod state;

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -1,0 +1,16 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod events;
+pub mod state;

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/macros.rs
+++ b/crates/tsoracle-paxos-toolkit/src/macros.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/macros.rs
+++ b/crates/tsoracle-paxos-toolkit/src/macros.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
@@ -10,7 +10,5 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
-
 pub mod key_space;
 pub mod meta;

--- a/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
@@ -1,0 +1,16 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod key_space;
+pub mod meta;

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mod.rs
@@ -1,0 +1,17 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod mem_network;
+pub mod mem_storage;
+pub mod partition;

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mod.rs
@@ -10,7 +10,14 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
+//! In-memory fakes for the toolkit's own tests and downstream conformance suites.
+//! Only compiled with the `test-fakes` feature or under `cfg(test)`.
+
+// Test scaffolding: `clippy::unwrap_used` / `expect_used` do not fire inside
+// `#[test]` / `#[cfg(test)]` (via `clippy.toml`), but these fakes live behind
+// a feature flag rather than under `cfg(test)` so consumer crates can pull
+// them in. Same intent — exempt the whole sub-tree.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 pub mod mem_network;
 pub mod mem_storage;

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/partition.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/partition.rs
@@ -9,5 +9,3 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
-
-#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/partition.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/partition.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
@@ -1,0 +1,13 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![cfg(feature = "failpoints")]


### PR DESCRIPTION
## Summary

- Adds `omnipaxos = "0.2"`, `omnipaxos_storage = "0.2"`, and `paste = "1"` to `[workspace.dependencies]`.
- Creates `crates/tsoracle-paxos-toolkit` as a scaffold workspace member, registered in both `members` and `default-members`. Stubs every module (`codec`, `failpoint`, `macros`, `storage/{mod,key_space,meta}`, `lifecycle/{mod,state,events}`, `test_fakes/{mod,mem_storage,mem_network,partition}`) with banner + module declarations only — no functional code yet.
- Style aligned with `tsoracle-openraft-toolkit`: private `#[macro_use] mod failpoint`, crate-root-only panic policy, `doc_auto_cfg`, and `test_fakes` exempted from `clippy::unwrap_used` / `expect_used` to match how the sibling crate handles its fakes.

A `tests/failpoints.rs` stub is included because the crate's `[[test]] failpoints` declaration in `Cargo.toml` (with `required-features = ["failpoints", "rocksdb-storage"]`) requires the file to exist for the pre-commit `cargo clippy --all-features --all-targets -- -D warnings` gate to pass.

Nothing depends on the new crate yet — follow-up sub-issues (#158–#162) will fill in the storage impl, lifecycle runner, macros, test fakes, and integration tests.

## Test plan

- [ ] `cargo build -p tsoracle-paxos-toolkit --no-default-features` succeeds with zero warnings.
- [ ] `cargo build -p tsoracle-paxos-toolkit --all-features` succeeds.
- [ ] `cargo clippy -p tsoracle-paxos-toolkit --all-targets --all-features -- -D warnings` is clean.
- [ ] `cargo metadata --format-version 1 --no-deps > /dev/null` succeeds (workspace resolution).
- [ ] CI green on the full workspace build.

Closes #157
