### PR TITLE
feat(paxos-toolkit): postcard codec, RocksDB key space, and meta serializers

### DIFF
--- a/crates/tsoracle-paxos-toolkit/src/codec.rs
+++ b/crates/tsoracle-paxos-toolkit/src/codec.rs
@@ -56,11 +56,14 @@ mod tests {
 
     #[test]
     fn decode_rejects_truncated_input() {
+        // Use a payload long enough that bytes.len() / 2 cuts through an
+        // interior field boundary rather than the trivially-small minimum.
         let original = Sample {
-            idx: 7,
-            name: "x".into(),
+            idx: u64::MAX,
+            name: "hello-world-paxos-storage-roundtrip".into(),
         };
         let bytes = encode(&original).expect("encode");
+        assert!(bytes.len() >= 16, "payload should be non-trivial");
         let truncated = &bytes[..bytes.len() / 2];
         assert!(decode::<Sample>(truncated).is_err());
     }

--- a/crates/tsoracle-paxos-toolkit/src/codec.rs
+++ b/crates/tsoracle-paxos-toolkit/src/codec.rs
@@ -9,3 +9,59 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Postcard codec wrapper used by every other module that persists OmniPaxos
+//! state. Centralizing it gives one place to swap formats later (e.g., to
+//! `bincode`) and one place to attach diagnostic context to encode errors.
+
+use serde::{Serialize, de::DeserializeOwned};
+
+#[derive(Debug, thiserror::Error)]
+pub enum CodecError {
+    #[error("encode failed: {0}")]
+    Encode(#[source] postcard::Error),
+    #[error("decode failed: {0}")]
+    Decode(#[source] postcard::Error),
+}
+
+pub fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
+    postcard::to_stdvec(value).map_err(CodecError::Encode)
+}
+
+pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError> {
+    postcard::from_bytes(bytes).map_err(CodecError::Decode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Sample {
+        idx: u64,
+        name: String,
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let original = Sample {
+            idx: 42,
+            name: "paxos".into(),
+        };
+        let bytes = encode(&original).expect("encode");
+        let decoded: Sample = decode(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn decode_rejects_truncated_input() {
+        let original = Sample {
+            idx: 7,
+            name: "x".into(),
+        };
+        let bytes = encode(&original).expect("encode");
+        let truncated = &bytes[..bytes.len() / 2];
+        assert!(decode::<Sample>(truncated).is_err());
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/failpoint.rs
+++ b/crates/tsoracle-paxos-toolkit/src/failpoint.rs
@@ -9,3 +9,43 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Failpoint injection sites. When the `failpoints` feature is enabled, the
+//! `fail_point!` macro forwards to the `fail` crate's macro of the same name;
+//! when disabled, it expands to nothing. Centralized here so other modules
+//! invoke a single symbol regardless of feature state.
+
+#[cfg(feature = "failpoints")]
+#[allow(unused_imports)]
+pub use fail::fail_point;
+
+#[cfg(not(feature = "failpoints"))]
+#[macro_export]
+macro_rules! fail_point {
+    ($($tt:tt)*) => {};
+}
+
+#[cfg(not(feature = "failpoints"))]
+#[allow(unused_imports)]
+pub use crate::fail_point;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "failpoints")]
+    #[test]
+    fn fail_point_is_reachable() {
+        // When the feature is enabled, the macro expands to a call site
+        // the `fail` registry can match against. We verify the symbol
+        // exists by referencing it; actual injection is exercised in
+        // `tests/failpoints.rs` under the real RocksDB code path.
+        super::fail_point!("test::point");
+    }
+
+    #[cfg(not(feature = "failpoints"))]
+    #[test]
+    fn fail_point_is_a_noop() {
+        // When the feature is disabled, the macro must compile to nothing
+        // measurable. Simply invoking it must not panic.
+        super::fail_point!("test::point");
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/failpoint.rs
+++ b/crates/tsoracle-paxos-toolkit/src/failpoint.rs
@@ -16,18 +16,26 @@
 //! invoke a single symbol regardless of feature state.
 
 #[cfg(feature = "failpoints")]
-#[allow(unused_imports)]
-pub use fail::fail_point;
+#[macro_export]
+macro_rules! fail_point {
+    ($name:expr) => {
+        fail::fail_point!($name)
+    };
+    ($name:expr, $closure:expr) => {
+        fail::fail_point!($name, $closure)
+    };
+}
 
 #[cfg(not(feature = "failpoints"))]
 #[macro_export]
 macro_rules! fail_point {
-    ($($tt:tt)*) => {};
+    ($name:expr) => {
+        ()
+    };
+    ($name:expr, $closure:expr) => {
+        ()
+    };
 }
-
-#[cfg(not(feature = "failpoints"))]
-#[allow(unused_imports)]
-pub use crate::fail_point;
 
 #[cfg(test)]
 mod tests {
@@ -35,10 +43,11 @@ mod tests {
     #[test]
     fn fail_point_is_reachable() {
         // When the feature is enabled, the macro expands to a call site
-        // the `fail` registry can match against. We verify the symbol
-        // exists by referencing it; actual injection is exercised in
-        // `tests/failpoints.rs` under the real RocksDB code path.
-        super::fail_point!("test::point");
+        // the `fail` registry can match against. The closure form needs a
+        // Result-returning context to compile (because `fail::fail_point!`
+        // can early-return) and is exercised in `tests/failpoints.rs`
+        // under the real RocksDB code path.
+        crate::fail_point!("test::point");
     }
 
     #[cfg(not(feature = "failpoints"))]
@@ -46,6 +55,6 @@ mod tests {
     fn fail_point_is_a_noop() {
         // When the feature is disabled, the macro must compile to nothing
         // measurable. Simply invoking it must not panic.
-        super::fail_point!("test::point");
+        crate::fail_point!("test::point");
     }
 }

--- a/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
@@ -9,3 +9,139 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Key-space layout for the toolkit's RocksDB-backed Storage impl.
+//!
+//! All OmniPaxos persistent state lives in a single column family using two
+//! byte-prefix namespaces:
+//!
+//! * `L/<u64 BE>` — log entries, indexed by their position
+//! * `M/<name>`   — metadata: promise, accepted_round, decided_idx,
+//!   compacted_idx, snapshot, stopsign
+//!
+//! Big-endian log indices preserve log order under RocksDB's lexicographic
+//! iteration. Single-CF layout (rather than separate CFs per concern) lets
+//! the Storage impl batch log + decided-idx writes in one WriteBatch, which
+//! OmniPaxos's `append_on_prefix` semantics require.
+
+pub const LOG_PREFIX: &[u8] = b"L/";
+pub const META_PREFIX: &[u8] = b"M/";
+
+const META_PROMISE: &[u8] = b"M/promise";
+const META_ACCEPTED_ROUND: &[u8] = b"M/accepted_round";
+const META_DECIDED_IDX: &[u8] = b"M/decided_idx";
+const META_COMPACTED_IDX: &[u8] = b"M/compacted_idx";
+const META_SNAPSHOT: &[u8] = b"M/snapshot";
+const META_STOPSIGN: &[u8] = b"M/stopsign";
+
+#[must_use]
+pub fn log_key(idx: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(LOG_PREFIX.len() + 8);
+    out.extend_from_slice(LOG_PREFIX);
+    out.extend_from_slice(&idx.to_be_bytes());
+    out
+}
+
+#[must_use]
+pub fn log_key_range() -> (Vec<u8>, Vec<u8>) {
+    // For iteration: scan `LOG_PREFIX/0..META_PREFIX`. The upper bound is
+    // `META_PREFIX` because `M` > `L` lexicographically and any byte beyond
+    // a full LOG_PREFIX-keyed entry falls into META.
+    (log_key(0), META_PREFIX.to_vec())
+}
+
+#[must_use]
+pub fn meta_promise_key() -> Vec<u8> {
+    META_PROMISE.to_vec()
+}
+#[must_use]
+pub fn meta_accepted_round_key() -> Vec<u8> {
+    META_ACCEPTED_ROUND.to_vec()
+}
+#[must_use]
+pub fn meta_decided_idx_key() -> Vec<u8> {
+    META_DECIDED_IDX.to_vec()
+}
+#[must_use]
+pub fn meta_compacted_idx_key() -> Vec<u8> {
+    META_COMPACTED_IDX.to_vec()
+}
+#[must_use]
+pub fn meta_snapshot_key() -> Vec<u8> {
+    META_SNAPSHOT.to_vec()
+}
+#[must_use]
+pub fn meta_stopsign_key() -> Vec<u8> {
+    META_STOPSIGN.to_vec()
+}
+
+pub fn parse_log_key(key: &[u8]) -> Option<u64> {
+    if !key.starts_with(LOG_PREFIX) || key.len() != LOG_PREFIX.len() + 8 {
+        return None;
+    }
+    let bytes = &key[LOG_PREFIX.len()..];
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(bytes);
+    Some(u64::from_be_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_keys_iterate_in_index_order() {
+        // Big-endian encoding is required so RocksDB's lexicographic CF
+        // iteration walks log indices monotonically. Pick two indices that
+        // would invert under little-endian and verify they don't.
+        let low = log_key(0x0000_0000_0000_00FF);
+        let high = log_key(0x0000_0000_0000_0100);
+        assert!(low < high, "log_key(255) < log_key(256) must hold");
+    }
+
+    #[test]
+    fn log_keys_have_log_prefix() {
+        assert!(log_key(0).starts_with(LOG_PREFIX));
+        assert!(log_key(u64::MAX).starts_with(LOG_PREFIX));
+    }
+
+    #[test]
+    fn meta_keys_have_meta_prefix() {
+        let keys = [
+            meta_promise_key(),
+            meta_accepted_round_key(),
+            meta_decided_idx_key(),
+            meta_compacted_idx_key(),
+            meta_snapshot_key(),
+            meta_stopsign_key(),
+        ];
+        for key in &keys {
+            assert!(
+                key.starts_with(META_PREFIX),
+                "key {key:?} missing META_PREFIX"
+            );
+        }
+    }
+
+    #[test]
+    fn log_and_meta_prefixes_do_not_collide() {
+        // RocksDB iteration must distinguish log entries from metadata
+        // unambiguously. The two prefixes must not be each other's prefix.
+        assert_ne!(LOG_PREFIX[0], META_PREFIX[0]);
+    }
+
+    #[test]
+    fn log_key_round_trips_through_parse() {
+        for idx in [0_u64, 1, 255, 256, u64::MAX] {
+            let key = log_key(idx);
+            assert_eq!(parse_log_key(&key), Some(idx));
+        }
+    }
+
+    #[test]
+    fn parse_log_key_rejects_non_log_keys() {
+        assert!(parse_log_key(META_PREFIX).is_none());
+        assert!(parse_log_key(b"L/").is_none()); // too short
+        assert!(parse_log_key(&meta_promise_key()).is_none());
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/key_space.rs
@@ -44,8 +44,8 @@ pub fn log_key(idx: u64) -> Vec<u8> {
 
 #[must_use]
 pub fn log_key_range() -> (Vec<u8>, Vec<u8>) {
-    // For iteration: scan `LOG_PREFIX/0..META_PREFIX`. The upper bound is
-    // `META_PREFIX` because `M` > `L` lexicographically and any byte beyond
+    // For iteration: scan `log_key(0)..META_PREFIX`. The upper bound is
+    // `META_PREFIX` because `M` > `L` lexicographically, so any byte beyond
     // a full LOG_PREFIX-keyed entry falls into META.
     (log_key(0), META_PREFIX.to_vec())
 }

--- a/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
@@ -9,3 +9,91 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Typed serializers for the meta column. Ballot, decided_idx, etc. are
+//! persisted as a fixed-shape byte string so the Storage impl never sees raw
+//! `Vec<u8>` for fields with known shape.
+//!
+//! u64 fields use little-endian 8-byte encoding (faster than postcard for
+//! a fixed-width type, and iteration order doesn't matter for meta keys —
+//! they're singletons keyed by name). Ballot / Snapshot / StopSign use
+//! postcard for forward compatibility with omnipaxos releases that add
+//! fields.
+
+use omnipaxos::ballot_leader_election::Ballot;
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::codec::{CodecError, decode as codec_decode, encode as codec_encode};
+
+#[derive(Debug, thiserror::Error)]
+pub enum MetaError {
+    #[error(transparent)]
+    Codec(#[from] CodecError),
+    #[error("u64 field has wrong length: expected 8 bytes, got {0}")]
+    WrongU64Length(usize),
+}
+
+#[must_use]
+pub fn encode_u64(value: u64) -> Vec<u8> {
+    value.to_le_bytes().to_vec()
+}
+
+pub fn decode_u64(bytes: &[u8]) -> Result<u64, MetaError> {
+    let arr: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| MetaError::WrongU64Length(bytes.len()))?;
+    Ok(u64::from_le_bytes(arr))
+}
+
+pub fn encode_ballot(b: &Ballot) -> Result<Vec<u8>, MetaError> {
+    Ok(codec_encode(b)?)
+}
+
+pub fn decode_ballot(bytes: &[u8]) -> Result<Ballot, MetaError> {
+    Ok(codec_decode(bytes)?)
+}
+
+pub fn encode_postcard<T: Serialize>(value: &T) -> Result<Vec<u8>, MetaError> {
+    Ok(codec_encode(value)?)
+}
+
+pub fn decode_postcard<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, MetaError> {
+    Ok(codec_decode(bytes)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omnipaxos::ballot_leader_election::Ballot;
+
+    #[test]
+    fn ballot_round_trip() {
+        let original = Ballot {
+            config_id: 1,
+            n: 42,
+            priority: 0,
+            pid: 7,
+        };
+        let encoded = encode_ballot(&original).expect("encode");
+        let decoded = decode_ballot(&encoded).expect("decode");
+        assert_eq!(original.config_id, decoded.config_id);
+        assert_eq!(original.n, decoded.n);
+        assert_eq!(original.priority, decoded.priority);
+        assert_eq!(original.pid, decoded.pid);
+    }
+
+    #[test]
+    fn decided_idx_round_trip() {
+        let original: u64 = 0x1234_5678_9ABC_DEF0;
+        let encoded = encode_u64(original);
+        assert_eq!(encoded.len(), 8);
+        let decoded = decode_u64(&encoded).expect("decode");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn decode_u64_rejects_wrong_length() {
+        assert!(decode_u64(&[0u8; 7]).is_err());
+        assert!(decode_u64(&[0u8; 9]).is_err());
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/meta.rs
@@ -45,18 +45,22 @@ pub fn decode_u64(bytes: &[u8]) -> Result<u64, MetaError> {
     Ok(u64::from_le_bytes(arr))
 }
 
-pub fn encode_ballot(b: &Ballot) -> Result<Vec<u8>, MetaError> {
-    Ok(codec_encode(b)?)
+#[must_use = "encoded ballot bytes must be persisted or the encode call had no effect"]
+pub fn encode_ballot(ballot: &Ballot) -> Result<Vec<u8>, MetaError> {
+    Ok(codec_encode(ballot)?)
 }
 
+#[must_use = "decoded ballot must be inspected; discarding it discards the read"]
 pub fn decode_ballot(bytes: &[u8]) -> Result<Ballot, MetaError> {
     Ok(codec_decode(bytes)?)
 }
 
+#[must_use = "encoded bytes must be persisted or the encode call had no effect"]
 pub fn encode_postcard<T: Serialize>(value: &T) -> Result<Vec<u8>, MetaError> {
     Ok(codec_encode(value)?)
 }
 
+#[must_use = "decoded value must be inspected; discarding it discards the read"]
 pub fn decode_postcard<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, MetaError> {
     Ok(codec_decode(bytes)?)
 }


### PR DESCRIPTION
## Summary

Fills in four of the toolkit's scaffold modules with the foundational primitives the storage impl will rest on:

- `src/codec.rs` — postcard `encode` / `decode` wrappers with a typed `CodecError` (encode vs decode variants).
- `src/failpoint.rs` — feature-gated `fail_point!` macro. Matches the openraft-toolkit pattern: `#[macro_export] macro_rules!` in both cfg branches, delegating to `fail::fail_point!` when the `failpoints` feature is on and expanding to `()` when off.
- `src/storage/key_space.rs` — RocksDB key-space layout. `LOG_PREFIX = b"L/"` with big-endian u64 indices so iteration is in-log-order, six `meta_*_key()` accessors for the singleton meta fields, `log_key_range` for forward scans, `parse_log_key` for the round-trip.
- `src/storage/meta.rs` — typed serializers for fixed-shape meta values. `encode_u64` / `decode_u64` use LE bytes (fixed-width, fast), `encode_ballot` / `decode_ballot` delegate to the postcard codec, generic `encode_postcard` / `decode_postcard` cover Snapshot and StopSign.

TDD throughout: each module landed as one commit with a failing-test → minimal-impl → passing-test sequence. A fifth commit applies code-review feedback (failpoint pattern alignment, parameter renames, `#[must_use]` consistency, larger truncation-test payload, comment fixups).

## Test plan

- [x] `cargo test -p tsoracle-paxos-toolkit --no-default-features --lib` — 12 passing.
- [x] `cargo test -p tsoracle-paxos-toolkit --no-default-features --features failpoints --lib` — 12 passing.
- [x] `cargo clippy -p tsoracle-paxos-toolkit --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p tsoracle-paxos-toolkit --check` — clean.
- [x] CI green on the full workspace build.

Closes #158
