### PR TITLE
feat(paxos-toolkit): declare_omnipaxos_types_ext! macro and lifecycle runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,21 +242,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -282,12 +273,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -547,20 +532,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "commitlog"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf2bc2a9c8e9369d54360cc20cd9f0d5f03e427bc3fe8c9d7bc6ba1512addff"
-dependencies = [
- "byteorder",
- "bytes",
- "crc32c",
- "log",
- "memmap2",
- "page_size",
-]
 
 [[package]]
 name = "console-api"
@@ -831,7 +802,7 @@ dependencies = [
  "async-trait",
  "futures",
  "openraft",
- "parking_lot 0.12.5",
+ "parking_lot",
  "postcard",
  "rocksdb",
  "serde",
@@ -1054,15 +1025,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1366,15 +1328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,15 +1511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,7 +1632,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1746,20 +1690,6 @@ checksum = "3a89202e33e5b69cf15a16070842905fbdbf48e05e5cba9fd2fda2abffdf3013"
 dependencies = [
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "omnipaxos_storage"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0b026479f550472ef5b0c02108b1848bd6fc8e92f36e3206d0b9274ea71365"
-dependencies = [
- "bincode",
- "commitlog",
- "omnipaxos",
- "serde",
- "sled",
- "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1857,48 +1787,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "page_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1909,7 +1804,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2062,7 +1957,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2101,7 +1996,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -2191,7 +2086,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -2372,7 +2267,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2390,20 +2285,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2555,7 +2441,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2673,7 +2559,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2795,22 +2681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,7 +2709,7 @@ dependencies = [
  "humantime-serde",
  "nix",
  "openraft",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rand 0.9.4",
  "rocksdb",
  "serde",
@@ -3274,7 +3144,7 @@ dependencies = [
  "clap",
  "futures",
  "humantime",
- "parking_lot 0.12.5",
+ "parking_lot",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -3295,7 +3165,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util 0.19.1",
- "parking_lot 0.12.5",
+ "parking_lot",
  "proptest",
  "prost",
  "rand 0.9.4",
@@ -3338,7 +3208,7 @@ dependencies = [
  "fs2",
  "futures",
  "libc",
- "parking_lot 0.12.5",
+ "parking_lot",
  "proptest",
  "tempfile",
  "thiserror",
@@ -3356,7 +3226,7 @@ dependencies = [
  "async-trait",
  "futures",
  "openraft",
- "parking_lot 0.12.5",
+ "parking_lot",
  "postcard",
  "proptest",
  "rocksdb",
@@ -3379,7 +3249,7 @@ dependencies = [
  "fail",
  "futures",
  "openraft",
- "parking_lot 0.12.5",
+ "parking_lot",
  "postcard",
  "proptest",
  "rocksdb",
@@ -3399,8 +3269,7 @@ dependencies = [
  "fail",
  "futures",
  "omnipaxos",
- "omnipaxos_storage",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pastey",
  "postcard",
  "proptest",
@@ -3435,7 +3304,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util 0.19.1",
- "parking_lot 0.12.5",
+ "parking_lot",
  "prost",
  "thiserror",
  "tokio",
@@ -3667,7 +3536,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3919,7 +3788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -3969,32 +3838,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive 0.8.48",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,12 +242,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -273,6 +282,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -532,6 +547,20 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "commitlog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf2bc2a9c8e9369d54360cc20cd9f0d5f03e427bc3fe8c9d7bc6ba1512addff"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crc32c",
+ "log",
+ "memmap2",
+ "page_size",
+]
 
 [[package]]
 name = "console-api"
@@ -802,7 +831,7 @@ dependencies = [
  "async-trait",
  "futures",
  "openraft",
- "parking_lot",
+ "parking_lot 0.12.5",
  "postcard",
  "rocksdb",
  "serde",
@@ -1025,6 +1054,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1328,6 +1366,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1558,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,7 +1688,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1690,6 +1746,20 @@ checksum = "3a89202e33e5b69cf15a16070842905fbdbf48e05e5cba9fd2fda2abffdf3013"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "omnipaxos_storage"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a0b026479f550472ef5b0c02108b1848bd6fc8e92f36e3206d0b9274ea71365"
+dependencies = [
+ "bincode",
+ "commitlog",
+ "omnipaxos",
+ "serde",
+ "sled",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1787,13 +1857,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1804,7 +1909,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1957,7 +2062,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -1996,7 +2101,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -2086,7 +2191,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "memchr",
  "unicase",
 ]
@@ -2267,7 +2372,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2285,11 +2390,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2441,7 +2555,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2559,7 +2673,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2681,6 +2795,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,7 +2839,7 @@ dependencies = [
  "humantime-serde",
  "nix",
  "openraft",
- "parking_lot",
+ "parking_lot 0.12.5",
  "rand 0.9.4",
  "rocksdb",
  "serde",
@@ -3144,7 +3274,7 @@ dependencies = [
  "clap",
  "futures",
  "humantime",
- "parking_lot",
+ "parking_lot 0.12.5",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -3165,7 +3295,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util 0.19.1",
- "parking_lot",
+ "parking_lot 0.12.5",
  "proptest",
  "prost",
  "rand 0.9.4",
@@ -3208,7 +3338,7 @@ dependencies = [
  "fs2",
  "futures",
  "libc",
- "parking_lot",
+ "parking_lot 0.12.5",
  "proptest",
  "tempfile",
  "thiserror",
@@ -3226,7 +3356,7 @@ dependencies = [
  "async-trait",
  "futures",
  "openraft",
- "parking_lot",
+ "parking_lot 0.12.5",
  "postcard",
  "proptest",
  "rocksdb",
@@ -3249,7 +3379,7 @@ dependencies = [
  "fail",
  "futures",
  "openraft",
- "parking_lot",
+ "parking_lot 0.12.5",
  "postcard",
  "proptest",
  "rocksdb",
@@ -3269,7 +3399,8 @@ dependencies = [
  "fail",
  "futures",
  "omnipaxos",
- "parking_lot",
+ "omnipaxos_storage",
+ "parking_lot 0.12.5",
  "pastey",
  "postcard",
  "proptest",
@@ -3304,7 +3435,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util 0.19.1",
- "parking_lot",
+ "parking_lot 0.12.5",
  "prost",
  "thiserror",
  "tokio",
@@ -3536,7 +3667,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3788,7 +3919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3838,11 +3969,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.48",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -41,10 +41,11 @@ tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.3" }
 tsoracle-core      = { path = "../tsoracle-core",      version = "0.1.3" }
 
 [dev-dependencies]
-proptest         = { workspace = true }
-rocksdb          = { workspace = true }
-tempfile         = { workspace = true }
-tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+omnipaxos_storage  = { workspace = true }
+proptest           = { workspace = true }
+rocksdb            = { workspace = true }
+tempfile           = { workspace = true }
+tokio              = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 
 [[test]]
 name              = "failpoints"

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -41,7 +41,6 @@ tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.3" }
 tsoracle-core      = { path = "../tsoracle-core",      version = "0.1.3" }
 
 [dev-dependencies]
-omnipaxos_storage  = { workspace = true }
 proptest           = { workspace = true }
 rocksdb            = { workspace = true }
 tempfile           = { workspace = true }

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
@@ -158,13 +158,59 @@ mod tests {
 
     #[tokio::test]
     async fn send_if_modified_accepts_repeated_payload() {
-        // The contract verified here is sender-side: send_if_modified does
-        // not error on identical payloads. Stream output cannot be used to
-        // observe debounce because watch already coalesces.
+        // The contract verified here is sender-side: send does not error
+        // on identical payloads while a receiver is alive. Stream output
+        // cannot be used to observe debounce because watch already
+        // coalesces.
         let (sender, _stream) = leader_event_channel();
         let same = LeaderState::Leader { epoch: Epoch(1) };
         assert!(sender.send(same.clone()).is_ok());
         assert!(sender.send(same).is_ok());
         assert!(sender.send(LeaderState::Leader { epoch: Epoch(2) }).is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_returns_closed_after_stream_dropped() {
+        // Atomicity contract: dropping the stream makes the next send
+        // return SendError::Closed immediately. Exercises the change-path
+        // in `send` (the watch::Sender::send arm).
+        let (sender, stream) = leader_event_channel();
+        drop(stream);
+        let result = sender.send(LeaderState::Leader { epoch: Epoch(1) });
+        assert!(matches!(result, Err(SendError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn send_returns_closed_for_debounced_payload_after_drop() {
+        // Exercises the debounce-with-closed-channel arm: an unchanged
+        // payload still surfaces SendError::Closed when the receiver is
+        // gone, so the runner can shut down even when nothing changed.
+        let (sender, stream) = leader_event_channel();
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(1) })
+            .expect("first send succeeds while stream alive");
+        drop(stream);
+        let result = sender.send(LeaderState::Leader { epoch: Epoch(1) });
+        assert!(matches!(result, Err(SendError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn into_pin_yields_stream_with_initial_and_changes() {
+        // Confirms that `into_pin` produces a stream functionally
+        // equivalent to the underlying LeaderEventStream — yields the
+        // initial value and subsequent changes via the boxed-pinned
+        // trait object path consumers use.
+        let (sender, stream) = leader_event_channel();
+        let mut pinned = stream.into_pin();
+        assert_eq!(pinned.next().await, Some(LeaderState::Unknown));
+
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(7) })
+            .unwrap();
+        yield_now().await;
+        assert_eq!(
+            pinned.next().await,
+            Some(LeaderState::Leader { epoch: Epoch(7) }),
+        );
     }
 }

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
@@ -9,3 +9,127 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Leader event channel + debounced stream.
+//!
+//! Backed by `tokio::sync::watch` for latest-state-wins semantics. Emits the
+//! initial state at first poll and every distinct subsequent value;
+//! identical successive sends are debounced via `send_if_modified`.
+
+use core::pin::Pin;
+
+use futures::Stream;
+use tokio::sync::watch;
+use tokio_stream::wrappers::WatchStream;
+use tsoracle_consensus::LeaderState;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SendError {
+    #[error("receiver closed")]
+    Closed,
+}
+
+pub fn leader_event_channel() -> (LeaderEventSender, LeaderEventStream) {
+    let (tx, rx) = watch::channel(LeaderState::Unknown);
+    (
+        LeaderEventSender { tx },
+        LeaderEventStream {
+            inner: WatchStream::new(rx),
+        },
+    )
+}
+
+#[derive(Clone)]
+pub struct LeaderEventSender {
+    tx: watch::Sender<LeaderState>,
+}
+
+impl LeaderEventSender {
+    pub fn send(&self, state: LeaderState) -> Result<(), SendError> {
+        self.tx.send_if_modified(|prev| {
+            if *prev == state {
+                false
+            } else {
+                *prev = state;
+                true
+            }
+        });
+        if self.tx.is_closed() {
+            return Err(SendError::Closed);
+        }
+        Ok(())
+    }
+}
+
+pub struct LeaderEventStream {
+    inner: WatchStream<LeaderState>,
+}
+
+impl LeaderEventStream {
+    #[must_use]
+    pub fn into_pin(self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        Box::pin(self)
+    }
+}
+
+impl Stream for LeaderEventStream {
+    type Item = LeaderState;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::task::yield_now;
+    use tsoracle_consensus::LeaderState;
+    use tsoracle_core::Epoch;
+
+    #[tokio::test]
+    async fn stream_yields_changes_polled_between_sends() {
+        // Watch channels coalesce intermediate values: multiple sends without
+        // an intervening poll collapse to the latest. Poll between sends so
+        // each transition is yielded distinctly.
+        let (sender, mut stream) = leader_event_channel();
+        assert_eq!(stream.next().await, Some(LeaderState::Unknown));
+
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(1) })
+            .unwrap();
+        yield_now().await;
+        assert_eq!(
+            stream.next().await,
+            Some(LeaderState::Leader { epoch: Epoch(1) })
+        );
+
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(2) })
+            .unwrap();
+        yield_now().await;
+        assert_eq!(
+            stream.next().await,
+            Some(LeaderState::Leader { epoch: Epoch(2) })
+        );
+
+        drop(sender);
+        assert_eq!(stream.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn send_if_modified_accepts_repeated_payload() {
+        // The contract verified here is sender-side: send_if_modified does
+        // not error on identical payloads. Stream output cannot be used to
+        // observe debounce because watch already coalesces.
+        let (sender, _stream) = leader_event_channel();
+        let same = LeaderState::Leader { epoch: Epoch(1) };
+        assert!(sender.send(same.clone()).is_ok());
+        assert!(sender.send(same).is_ok());
+        assert!(sender.send(LeaderState::Leader { epoch: Epoch(2) }).is_ok());
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
@@ -23,12 +23,25 @@ use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tsoracle_consensus::LeaderState;
 
+/// Error returned by [`LeaderEventSender::send`].
+///
+/// `Closed` is the only variant for now; it means every subscribed
+/// [`LeaderEventStream`] has been dropped, so the runner can stop
+/// emitting transitions. The runner observes `Closed` and exits its
+/// tick loop on the next iteration.
 #[derive(Debug, thiserror::Error)]
 pub enum SendError {
-    #[error("receiver closed")]
+    #[error("all receivers have been dropped")]
     Closed,
 }
 
+/// Create a new leader-event channel.
+///
+/// The returned [`LeaderEventStream`] yields `LeaderState::Unknown` on its
+/// first poll (the channel's initial value) and every distinct subsequent
+/// value sent via the [`LeaderEventSender`]. Identical successive sends
+/// are debounced — receivers see one transition per unique value, not
+/// one per `send()` call.
 pub fn leader_event_channel() -> (LeaderEventSender, LeaderEventStream) {
     let (tx, rx) = watch::channel(LeaderState::Unknown);
     (
@@ -39,33 +52,55 @@ pub fn leader_event_channel() -> (LeaderEventSender, LeaderEventStream) {
     )
 }
 
+/// Sending half of the leader-event channel.
+///
+/// Cloneable: every clone shares the same underlying channel and the same
+/// debounced value. The runner clones the sender into its spawned tick
+/// task while keeping a copy for `Drop` ordering.
 #[derive(Clone)]
 pub struct LeaderEventSender {
     tx: watch::Sender<LeaderState>,
 }
 
 impl LeaderEventSender {
+    /// Send a leadership transition, debouncing if the value is unchanged.
+    ///
+    /// Returns `Err(SendError::Closed)` only when every receiver has been
+    /// dropped. The closed-channel detection is atomic with the send via
+    /// `watch::Sender::send` — there is no time-of-check / time-of-use
+    /// race between observing channel state and committing the value.
     pub fn send(&self, state: LeaderState) -> Result<(), SendError> {
-        self.tx.send_if_modified(|prev| {
-            if *prev == state {
-                false
-            } else {
-                *prev = state;
-                true
+        if *self.tx.borrow() == state {
+            // Debounce identical payload. If receivers are gone we still
+            // surface the error so callers can shut down.
+            if self.tx.is_closed() {
+                return Err(SendError::Closed);
             }
-        });
-        if self.tx.is_closed() {
-            return Err(SendError::Closed);
+            return Ok(());
         }
-        Ok(())
+        self.tx.send(state).map_err(|_| SendError::Closed)
     }
 }
 
+/// Receiving half of the leader-event channel.
+///
+/// Yields one [`LeaderState`] per distinct value pushed by the sender,
+/// starting with `LeaderState::Unknown` (the channel's initial value)
+/// on the first poll. Backed by a stored `WatchStream` whose receiver
+/// state persists across polls — recreating the stream per poll would
+/// lose the receiver's last-seen value.
 pub struct LeaderEventStream {
     inner: WatchStream<LeaderState>,
 }
 
 impl LeaderEventStream {
+    /// Box and pin the stream for trait-object use sites.
+    ///
+    /// Convenience for callers (notably `ConsensusDriver::leadership_events`)
+    /// that need a `Pin<Box<dyn Stream<Item = LeaderState> + Send>>` and
+    /// would otherwise write `Box::pin(stream)` themselves. The stream
+    /// does NOT require pinning before first poll — this is purely an
+    /// ergonomic shortcut.
     #[must_use]
     pub fn into_pin(self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
         Box::pin(self)

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -16,7 +16,7 @@ pub mod events;
 pub mod state;
 
 pub use events::{LeaderEventSender, LeaderEventStream, SendError, leader_event_channel};
-pub use state::{LeadershipState, PeerEntry};
+pub use state::{LeadershipState, Peer};
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,14 +28,27 @@ use parking_lot::Mutex;
 use tokio::sync::{Notify, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::interval;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 use tsoracle_core::Epoch;
 
+/// Outbound message dispatch contract supplied by the caller.
+///
+/// The toolkit owns the OmniPaxos tick + outbound drain but knows nothing
+/// about wire transport; the embedding application (examples, the future
+/// driver crate) implements this trait to route messages to peers over
+/// whatever transport it has chosen (typically tonic / gRPC).
 #[async_trait::async_trait]
 pub trait MessageSink<T: Entry>: Send + Sync + 'static {
     async fn send(&self, message: Message<T>);
 }
 
+/// Owner of the OmniPaxos tick task.
+///
+/// On `start`, spawns a tokio task that periodically calls
+/// `OmniPaxos::tick`, drains outbound messages through the supplied
+/// [`MessageSink`], observes leadership, emits transitions through
+/// the leader-event channel, and notifies a shared [`Notify`] so an
+/// external apply task can drain decided entries without polling.
 pub struct PaxosRunner<T, S>
 where
     T: Entry + Send + 'static,
@@ -43,7 +56,7 @@ where
 {
     omnipaxos: Arc<Mutex<OmniPaxos<T, S>>>,
     my_node_id: u64,
-    peers: Vec<PeerEntry>,
+    peers: Vec<Peer>,
     tick_interval: Duration,
     leader_sender: LeaderEventSender,
     leader_stream: Option<LeaderEventStream>,
@@ -57,10 +70,15 @@ where
     T: Entry + Send + 'static,
     S: Storage<T> + Send + 'static,
 {
+    /// Build a runner around a pre-constructed `OmniPaxos` handle.
+    ///
+    /// `peers` is the topology hint used to resolve follower-redirect
+    /// endpoints when leadership lands on another node. `tick_interval`
+    /// controls how often `OmniPaxos::tick` is invoked.
     pub fn new(
         omnipaxos: Arc<Mutex<OmniPaxos<T, S>>>,
         my_node_id: u64,
-        peers: Vec<PeerEntry>,
+        peers: Vec<Peer>,
         tick_interval: Duration,
     ) -> Self {
         let (leader_sender, leader_stream) = leader_event_channel();
@@ -83,23 +101,49 @@ where
         self.leader_stream.take()
     }
 
-    /// Notification that fires once per tick after outbound messages have
-    /// been drained. External apply tasks (driver crate) await this so they
-    /// can pull decided entries opportunistically rather than polling.
+    /// Notification fired once per tick, after outbound messages have been
+    /// drained. External apply tasks await this so they can drain decided
+    /// entries opportunistically rather than polling.
+    ///
+    /// Semantics (matches `tokio::sync::Notify::notify_waiters`):
+    /// - **Edge-triggered:** a waiter that is not parked at the `Notify` at
+    ///   the moment the tick task fires will miss that tick's notification
+    ///   and catch the next one.
+    /// - **All waiters wake:** every task currently parked on this `Notify`
+    ///   wakes simultaneously. There is no permit accumulation; a wake that
+    ///   has no waiters is dropped on the floor.
+    /// - **Consequence:** apply tasks should loop and always re-park, never
+    ///   assume one wake corresponds to one decided entry.
     #[must_use]
     pub fn apply_notify(&self) -> Arc<Notify> {
         self.apply_notify.clone()
     }
 
+    /// Borrow the underlying `OmniPaxos` handle for direct interaction
+    /// (e.g., to `append` an entry from outside the tick loop).
     #[must_use]
     pub fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<T, S>>> {
         self.omnipaxos.clone()
     }
 
+    /// Spawn the tick task with `sink` as the outbound transport.
+    ///
+    /// # Preconditions
+    ///
+    /// Must not be called while the runner is already running. Call
+    /// [`Self::stop`] first to restart. Debug builds assert this; release
+    /// builds would leave the previous task orphaned (it exits cleanly
+    /// once its shutdown channel is dropped, but two tick tasks briefly
+    /// race during the overlap).
     pub fn start<Sink: MessageSink<T>>(&mut self, sink: Arc<Sink>)
     where
         <T as Entry>::Snapshot: Send,
     {
+        debug_assert!(
+            self.handle.is_none(),
+            "PaxosRunner::start called while already running; call stop() first",
+        );
+
         let omnipaxos = self.omnipaxos.clone();
         let my_node_id = self.my_node_id;
         let peers = self.peers.clone();
@@ -134,16 +178,17 @@ where
 
                         // 3. Observe leadership.
                         //
-                        //    KNOWN LIMITATION (resolved in Plan 2): the
-                        //    counter-derived epoch does NOT match the
-                        //    spec's fencing strategy in
+                        //    KNOWN LIMITATION: the counter-derived epoch
+                        //    does NOT match the spec's fencing strategy in
                         //    persist_high_water(at_least, epoch), which
                         //    compares epoch == encode_epoch(promise). A
-                        //    leader who passes its own epoch back to
-                        //    persist would fail the fence check. Plan 2's
-                        //    driver crate replaces this leader event
-                        //    stream with one that derives epoch from
-                        //    omnipaxos.get_promise().
+                        //    leader that passes its own epoch to persist
+                        //    would fail the fence check. The follow-up
+                        //    driver crate replaces this stream with one
+                        //    that derives epoch from
+                        //    omnipaxos.get_promise() (read via the local
+                        //    storage handle), so the value matches what
+                        //    the fence expects.
                         let leader_pid: Option<u64> = {
                             let op = omnipaxos.lock();
                             op.get_current_leader()
@@ -176,12 +221,18 @@ where
         self.handle = Some(handle);
     }
 
+    /// Signal shutdown and await the tick task.
+    ///
+    /// Surfaces a `tracing::error!` if the task terminated abnormally
+    /// (panic or cancellation). Otherwise silent.
     pub async fn stop(&mut self) {
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
         }
         if let Some(handle) = self.handle.take() {
-            let _ = handle.await;
+            if let Err(err) = handle.await {
+                error!(error = ?err, "paxos runner task terminated abnormally");
+            }
         }
     }
 }
@@ -191,6 +242,12 @@ where
     T: Entry + Send + 'static,
     S: Storage<T> + Send + 'static,
 {
+    /// Best-effort shutdown signal on drop.
+    ///
+    /// Sends the shutdown one-shot if present, but does NOT await the
+    /// task — that would require an async context. The detached task
+    /// observes the dropped receiver and exits cleanly. Callers that
+    /// need synchronous completion should invoke `stop().await` first.
     fn drop(&mut self) {
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
@@ -203,9 +260,9 @@ mod tests {
     use super::*;
 
     // A real runner-level integration test belongs in tests/lifecycle.rs
-    // (lands in #162) where the in-memory test fakes (MemNetwork,
-    // MemStorage) are wired up. Here we only confirm the public API
-    // compiles correctly.
+    // (lands in a later sub-issue) where the in-memory test fakes
+    // (MemNetwork, MemStorage) are wired up. Here we only confirm the
+    // public API compiles correctly.
     #[allow(dead_code)]
     fn assert_runner_api_compiles<T, S>(_runner: PaxosRunner<T, S>)
     where

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -259,8 +259,9 @@ where
 mod tests {
     use super::*;
     use futures::StreamExt;
+    use omnipaxos::ballot_leader_election::Ballot;
+    use omnipaxos::storage::{Snapshot, StopSign, StorageResult};
     use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
-    use omnipaxos_storage::memory_storage::MemoryStorage;
     use tokio::time::sleep;
     use tsoracle_consensus::LeaderState;
 
@@ -274,13 +275,97 @@ mod tests {
     #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
     struct TestSnapshot;
 
-    impl omnipaxos::storage::Snapshot<TestEntry> for TestSnapshot {
+    impl Snapshot<TestEntry> for TestSnapshot {
         fn create(_: &[TestEntry]) -> Self {
             Self
         }
         fn merge(&mut self, _: Self) {}
         fn use_snapshots() -> bool {
             false
+        }
+    }
+
+    /// Minimal in-memory `Storage<TestEntry>` for runner-loop coverage tests.
+    ///
+    /// We do not depend on `omnipaxos_storage::MemoryStorage` because it
+    /// pulls `sled` transitively, which brings unmaintained `bincode`,
+    /// `fxhash`, and `instant` advisories that `cargo deny` rejects.
+    /// A richer `MemStorage` lands in a follow-up sub-issue under
+    /// `test_fakes/`; this stub is only enough for OmniPaxos to call
+    /// the tick path without panicking on an empty log.
+    #[derive(Default)]
+    struct StubStorage {
+        promise: Option<Ballot>,
+        accepted_round: Option<Ballot>,
+        decided_idx: u64,
+        compacted_idx: u64,
+        snapshot: Option<TestSnapshot>,
+        stopsign: Option<StopSign>,
+    }
+
+    impl Storage<TestEntry> for StubStorage {
+        fn append_entry(&mut self, _: TestEntry) -> StorageResult<u64> {
+            Ok(0)
+        }
+        fn append_entries(&mut self, _: Vec<TestEntry>) -> StorageResult<u64> {
+            Ok(0)
+        }
+        fn append_on_prefix(&mut self, _: u64, _: Vec<TestEntry>) -> StorageResult<u64> {
+            Ok(0)
+        }
+        fn get_entries(&self, _: u64, _: u64) -> StorageResult<Vec<TestEntry>> {
+            Ok(Vec::new())
+        }
+        fn get_log_len(&self) -> StorageResult<u64> {
+            Ok(0)
+        }
+        fn get_suffix(&self, _: u64) -> StorageResult<Vec<TestEntry>> {
+            Ok(Vec::new())
+        }
+        fn set_promise(&mut self, ballot: Ballot) -> StorageResult<()> {
+            self.promise = Some(ballot);
+            Ok(())
+        }
+        fn get_promise(&self) -> StorageResult<Option<Ballot>> {
+            Ok(self.promise)
+        }
+        fn set_accepted_round(&mut self, ballot: Ballot) -> StorageResult<()> {
+            self.accepted_round = Some(ballot);
+            Ok(())
+        }
+        fn get_accepted_round(&self) -> StorageResult<Option<Ballot>> {
+            Ok(self.accepted_round)
+        }
+        fn set_decided_idx(&mut self, idx: u64) -> StorageResult<()> {
+            self.decided_idx = idx;
+            Ok(())
+        }
+        fn get_decided_idx(&self) -> StorageResult<u64> {
+            Ok(self.decided_idx)
+        }
+        fn trim(&mut self, _: u64) -> StorageResult<()> {
+            Ok(())
+        }
+        fn set_compacted_idx(&mut self, idx: u64) -> StorageResult<()> {
+            self.compacted_idx = idx;
+            Ok(())
+        }
+        fn get_compacted_idx(&self) -> StorageResult<u64> {
+            Ok(self.compacted_idx)
+        }
+        fn set_snapshot(&mut self, snapshot: Option<TestSnapshot>) -> StorageResult<()> {
+            self.snapshot = snapshot;
+            Ok(())
+        }
+        fn get_snapshot(&self) -> StorageResult<Option<TestSnapshot>> {
+            Ok(self.snapshot.clone())
+        }
+        fn set_stopsign(&mut self, stopsign: Option<StopSign>) -> StorageResult<()> {
+            self.stopsign = stopsign;
+            Ok(())
+        }
+        fn get_stopsign(&self) -> StorageResult<Option<StopSign>> {
+            Ok(self.stopsign.clone())
         }
     }
 
@@ -291,7 +376,7 @@ mod tests {
         async fn send(&self, _message: Message<TestEntry>) {}
     }
 
-    fn build_omnipaxos(node_id: u64) -> Arc<Mutex<OmniPaxos<TestEntry, MemoryStorage<TestEntry>>>> {
+    fn build_omnipaxos(node_id: u64) -> Arc<Mutex<OmniPaxos<TestEntry, StubStorage>>> {
         // OmniPaxos 0.2 rejects single-node ClusterConfigs, so build a 3-node
         // configuration even when only one runner will exist.
         let cluster_config = ClusterConfig {
@@ -308,12 +393,12 @@ mod tests {
             server_config,
         };
         let op = op_config
-            .build(MemoryStorage::<TestEntry>::default())
+            .build(StubStorage::default())
             .expect("build omnipaxos");
         Arc::new(Mutex::new(op))
     }
 
-    fn build_runner(node_id: u64) -> PaxosRunner<TestEntry, MemoryStorage<TestEntry>> {
+    fn build_runner(node_id: u64) -> PaxosRunner<TestEntry, StubStorage> {
         PaxosRunner::new(
             build_omnipaxos(node_id),
             node_id,

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -258,16 +258,140 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::StreamExt;
+    use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+    use omnipaxos_storage::memory_storage::MemoryStorage;
+    use tokio::time::sleep;
+    use tsoracle_consensus::LeaderState;
 
-    // A real runner-level integration test belongs in tests/lifecycle.rs
-    // (lands in a later sub-issue) where the in-memory test fakes
-    // (MemNetwork, MemStorage) are wired up. Here we only confirm the
-    // public API compiles correctly.
-    #[allow(dead_code)]
-    fn assert_runner_api_compiles<T, S>(_runner: PaxosRunner<T, S>)
-    where
-        T: omnipaxos::storage::Entry + Send + 'static,
-        S: omnipaxos::storage::Storage<T> + Send + 'static,
-    {
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    struct TestEntry;
+
+    impl Entry for TestEntry {
+        type Snapshot = TestSnapshot;
+    }
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    struct TestSnapshot;
+
+    impl omnipaxos::storage::Snapshot<TestEntry> for TestSnapshot {
+        fn create(_: &[TestEntry]) -> Self {
+            Self
+        }
+        fn merge(&mut self, _: Self) {}
+        fn use_snapshots() -> bool {
+            false
+        }
+    }
+
+    struct NoopSink;
+
+    #[async_trait::async_trait]
+    impl MessageSink<TestEntry> for NoopSink {
+        async fn send(&self, _message: Message<TestEntry>) {}
+    }
+
+    fn build_omnipaxos(node_id: u64) -> Arc<Mutex<OmniPaxos<TestEntry, MemoryStorage<TestEntry>>>> {
+        // OmniPaxos 0.2 rejects single-node ClusterConfigs, so build a 3-node
+        // configuration even when only one runner will exist.
+        let cluster_config = ClusterConfig {
+            configuration_id: 1,
+            nodes: vec![1, 2, 3],
+            flexible_quorum: None,
+        };
+        let server_config = ServerConfig {
+            pid: node_id,
+            ..Default::default()
+        };
+        let op_config = OmniPaxosConfig {
+            cluster_config,
+            server_config,
+        };
+        let op = op_config
+            .build(MemoryStorage::<TestEntry>::default())
+            .expect("build omnipaxos");
+        Arc::new(Mutex::new(op))
+    }
+
+    fn build_runner(node_id: u64) -> PaxosRunner<TestEntry, MemoryStorage<TestEntry>> {
+        PaxosRunner::new(
+            build_omnipaxos(node_id),
+            node_id,
+            vec![],
+            Duration::from_millis(5),
+        )
+    }
+
+    #[tokio::test]
+    async fn take_leader_stream_is_once_only() {
+        let mut runner = build_runner(1);
+        assert!(runner.take_leader_stream().is_some());
+        assert!(runner.take_leader_stream().is_none());
+    }
+
+    #[tokio::test]
+    async fn omnipaxos_handle_is_shared() {
+        let omnipaxos = build_omnipaxos(1);
+        let runner = PaxosRunner::new(omnipaxos.clone(), 1, vec![], Duration::from_millis(5));
+        assert!(Arc::ptr_eq(&omnipaxos, &runner.omnipaxos()));
+    }
+
+    #[tokio::test]
+    async fn apply_notify_handle_is_shared() {
+        let runner = build_runner(1);
+        let first = runner.apply_notify();
+        let second = runner.apply_notify();
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn stop_without_start_is_noop() {
+        let mut runner = build_runner(1);
+        runner.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn runner_ticks_emit_unknown_state_under_dead_network() {
+        // Boot a runner with a no-op MessageSink. Without inbound messages
+        // from the (imaginary) peer nodes, no consensus is reached and
+        // get_current_leader() returns None. The tick task still runs:
+        // it ticks, drains outbound (the messages go nowhere via NoopSink),
+        // observes leader = None, emits LeaderState::Unknown via the
+        // leader-event channel, and calls notify_waiters().
+        let mut runner = build_runner(1);
+        let mut stream = runner.take_leader_stream().expect("stream").into_pin();
+        runner.start(Arc::new(NoopSink));
+
+        // First yielded value is the initial Unknown.
+        assert_eq!(stream.next().await, Some(LeaderState::Unknown));
+
+        // Let several ticks fire. They all emit Unknown (same as initial),
+        // which the debounce arm absorbs. We don't assert on a second
+        // stream value because debounce intentionally suppresses repeats.
+        sleep(Duration::from_millis(30)).await;
+
+        // Stop the tick task. The runner struct (and its leader_sender)
+        // outlives this call — they drop at the end of the function scope.
+        // We do NOT drain the stream here because `stream.next().await`
+        // would block until the sender drops.
+        runner.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_notify_fires_on_each_tick() {
+        // Park a waiter on apply_notify before the runner starts ticking;
+        // the next tick should wake it. This covers the notify_waiters()
+        // call site in the tick task body.
+        let mut runner = build_runner(1);
+        let notify = runner.apply_notify();
+        runner.start(Arc::new(NoopSink));
+
+        let woke = tokio::time::timeout(Duration::from_millis(50), notify.notified()).await;
+        assert!(
+            woke.is_ok(),
+            "apply_notify should fire within 50ms of starting"
+        );
+
+        runner.stop().await;
     }
 }

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -10,5 +10,207 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+//! OmniPaxos lifecycle: tick task, outbound drain, leader-event emission.
+
 pub mod events;
 pub mod state;
+
+pub use events::{LeaderEventSender, LeaderEventStream, SendError, leader_event_channel};
+pub use state::{LeadershipState, PeerEntry};
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use omnipaxos::OmniPaxos;
+use omnipaxos::messages::Message;
+use omnipaxos::storage::{Entry, Storage};
+use parking_lot::Mutex;
+use tokio::sync::{Notify, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::interval;
+use tracing::{debug, warn};
+use tsoracle_core::Epoch;
+
+#[async_trait::async_trait]
+pub trait MessageSink<T: Entry>: Send + Sync + 'static {
+    async fn send(&self, message: Message<T>);
+}
+
+pub struct PaxosRunner<T, S>
+where
+    T: Entry + Send + 'static,
+    S: Storage<T> + Send + 'static,
+{
+    omnipaxos: Arc<Mutex<OmniPaxos<T, S>>>,
+    my_node_id: u64,
+    peers: Vec<PeerEntry>,
+    tick_interval: Duration,
+    leader_sender: LeaderEventSender,
+    leader_stream: Option<LeaderEventStream>,
+    apply_notify: Arc<Notify>,
+    handle: Option<JoinHandle<()>>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl<T, S> PaxosRunner<T, S>
+where
+    T: Entry + Send + 'static,
+    S: Storage<T> + Send + 'static,
+{
+    pub fn new(
+        omnipaxos: Arc<Mutex<OmniPaxos<T, S>>>,
+        my_node_id: u64,
+        peers: Vec<PeerEntry>,
+        tick_interval: Duration,
+    ) -> Self {
+        let (leader_sender, leader_stream) = leader_event_channel();
+        Self {
+            omnipaxos,
+            my_node_id,
+            peers,
+            tick_interval,
+            leader_sender,
+            leader_stream: Some(leader_stream),
+            apply_notify: Arc::new(Notify::new()),
+            handle: None,
+            shutdown_tx: None,
+        }
+    }
+
+    /// Take ownership of the leader-event stream. Returns `None` if already taken.
+    #[must_use]
+    pub fn take_leader_stream(&mut self) -> Option<LeaderEventStream> {
+        self.leader_stream.take()
+    }
+
+    /// Notification that fires once per tick after outbound messages have
+    /// been drained. External apply tasks (driver crate) await this so they
+    /// can pull decided entries opportunistically rather than polling.
+    #[must_use]
+    pub fn apply_notify(&self) -> Arc<Notify> {
+        self.apply_notify.clone()
+    }
+
+    #[must_use]
+    pub fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<T, S>>> {
+        self.omnipaxos.clone()
+    }
+
+    pub fn start<Sink: MessageSink<T>>(&mut self, sink: Arc<Sink>)
+    where
+        <T as Entry>::Snapshot: Send,
+    {
+        let omnipaxos = self.omnipaxos.clone();
+        let my_node_id = self.my_node_id;
+        let peers = self.peers.clone();
+        let tick_interval = self.tick_interval;
+        let leader_sender = self.leader_sender.clone();
+        let apply_notify = self.apply_notify.clone();
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        self.shutdown_tx = Some(shutdown_tx);
+
+        let handle = tokio::spawn(async move {
+            let mut ticker = interval(tick_interval);
+            // Locally-tracked leader observation + monotonic counter for the
+            // epoch placeholder (see the runner module's doc).
+            let mut last_observed_leader: Option<u64> = None;
+            let mut leader_change_counter: u64 = 0;
+
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        // 1. Tick + drain in a short critical section, then
+                        //    drop the guard before any await.
+                        let outgoing = {
+                            let mut op = omnipaxos.lock();
+                            op.tick();
+                            op.outgoing_messages()
+                        };
+
+                        // 2. Send outbound messages with the lock released.
+                        for message in outgoing {
+                            sink.send(message).await;
+                        }
+
+                        // 3. Observe leadership.
+                        //
+                        //    KNOWN LIMITATION (resolved in Plan 2): the
+                        //    counter-derived epoch does NOT match the
+                        //    spec's fencing strategy in
+                        //    persist_high_water(at_least, epoch), which
+                        //    compares epoch == encode_epoch(promise). A
+                        //    leader who passes its own epoch back to
+                        //    persist would fail the fence check. Plan 2's
+                        //    driver crate replaces this leader event
+                        //    stream with one that derives epoch from
+                        //    omnipaxos.get_promise().
+                        let leader_pid: Option<u64> = {
+                            let op = omnipaxos.lock();
+                            op.get_current_leader()
+                        };
+                        if leader_pid != last_observed_leader {
+                            last_observed_leader = leader_pid;
+                            if leader_pid.is_some() {
+                                leader_change_counter = leader_change_counter.wrapping_add(1);
+                            }
+                        }
+                        let epoch = leader_pid.map(|_| Epoch(leader_change_counter));
+                        let state = LeadershipState::from_omnipaxos(
+                            my_node_id, leader_pid, epoch, &peers,
+                        );
+                        if let Err(err) = leader_sender.send(state.to_consensus()) {
+                            warn!(error = %err, "leader event channel closed");
+                            break;
+                        }
+
+                        // 4. Wake the apply task in case decided_idx advanced.
+                        apply_notify.notify_waiters();
+                    }
+                    _ = &mut shutdown_rx => {
+                        debug!("paxos runner received shutdown");
+                        break;
+                    }
+                }
+            }
+        });
+        self.handle = Some(handle);
+    }
+
+    pub async fn stop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl<T, S> Drop for PaxosRunner<T, S>
+where
+    T: Entry + Send + 'static,
+    S: Storage<T> + Send + 'static,
+{
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A real runner-level integration test belongs in tests/lifecycle.rs
+    // (lands in #162) where the in-memory test fakes (MemNetwork,
+    // MemStorage) are wired up. Here we only confirm the public API
+    // compiles correctly.
+    #[allow(dead_code)]
+    fn assert_runner_api_compiles<T, S>(_runner: PaxosRunner<T, S>)
+    where
+        T: omnipaxos::storage::Entry + Send + 'static,
+        S: omnipaxos::storage::Storage<T> + Send + 'static,
+    {
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
@@ -15,29 +15,62 @@
 use tsoracle_consensus::LeaderState;
 use tsoracle_core::Epoch;
 
+/// A known peer node and the network endpoint where its TSO service can be
+/// reached for follower-redirect hints.
+///
+/// `node_id` is the OmniPaxos `NodeId` (pid) of the peer. `endpoint` is the
+/// advertised tsoracle service address surfaced via
+/// `tsoracle_consensus::LeaderState::Follower::leader_endpoint` when this
+/// peer becomes the elected leader.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PeerEntry {
+pub struct Peer {
     pub node_id: u64,
     pub endpoint: String,
 }
 
+/// Internal leadership observation, mappable to
+/// [`tsoracle_consensus::LeaderState`] via [`Self::to_consensus`].
+///
+/// Distinct from `LeaderState` because the toolkit may need to attach
+/// additional diagnostic context per observation; the consensus crate's
+/// variant set is the stable interface consumers see.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LeadershipState {
+    /// This node is the elected leader at the given epoch.
     Leader { epoch: Epoch },
+    /// This node is a follower; `leader_endpoint` is the elected leader's
+    /// advertised tsoracle service address if known.
     Follower { leader_endpoint: Option<String> },
+    /// No leader is currently observed (election in progress, partition,
+    /// or local-leader observation without an accompanying epoch).
     Unknown,
 }
 
 impl LeadershipState {
+    /// Map an OmniPaxos observation to a `LeadershipState`.
+    ///
+    /// Discrimination rules:
+    /// - `(current_leader = Some(my_node_id), epoch = Some(_))` → `Leader { epoch }`.
+    /// - `(current_leader = Some(my_node_id), epoch = None)` → `Unknown`. We
+    ///   know we are leader by pid but lack the epoch needed to surface a
+    ///   `Leader` value; the caller (runner) always pairs them in practice,
+    ///   but a permissive signature falls back to `Unknown` rather than
+    ///   reporting ourselves as a follower of ourselves.
+    /// - `(current_leader = Some(other), _)` → `Follower` with endpoint
+    ///   looked up from `peers`, or `None` if the peer isn't listed.
+    /// - `(current_leader = None, _)` → `Unknown`.
     pub fn from_omnipaxos(
         my_node_id: u64,
         current_leader: Option<u64>,
         epoch: Option<Epoch>,
-        peers: &[PeerEntry],
+        peers: &[Peer],
     ) -> Self {
-        match (current_leader, epoch) {
-            (Some(leader), Some(epoch)) if leader == my_node_id => Self::Leader { epoch },
-            (Some(leader), _) => {
+        match current_leader {
+            Some(leader) if leader == my_node_id => match epoch {
+                Some(epoch) => Self::Leader { epoch },
+                None => Self::Unknown,
+            },
+            Some(leader) => {
                 let endpoint = peers
                     .iter()
                     .find(|peer| peer.node_id == leader)
@@ -46,10 +79,12 @@ impl LeadershipState {
                     leader_endpoint: endpoint,
                 }
             }
-            _ => Self::Unknown,
+            None => Self::Unknown,
         }
     }
 
+    /// Convert to the public `tsoracle_consensus::LeaderState` value. Used
+    /// by the runner when emitting events through the leader-event channel.
     #[must_use]
     pub fn to_consensus(&self) -> LeaderState {
         match self {
@@ -78,8 +113,16 @@ mod tests {
     }
 
     #[test]
+    fn leader_is_self_without_epoch_emits_unknown() {
+        // The runner always pairs current_leader with epoch, but a permissive
+        // signature should not produce "follower of self" if epoch is missing.
+        let state = LeadershipState::from_omnipaxos(1, Some(1), None, &[]);
+        assert_eq!(state.to_consensus(), LeaderState::Unknown);
+    }
+
+    #[test]
     fn leader_is_other_emits_follower_with_endpoint() {
-        let peers = vec![PeerEntry {
+        let peers = vec![Peer {
             node_id: 2,
             endpoint: "http://node-2:50051".into(),
         }];
@@ -104,7 +147,7 @@ mod tests {
         assert_eq!(
             state.to_consensus(),
             LeaderState::Follower {
-                leader_endpoint: None
+                leader_endpoint: None,
             },
         );
     }

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
@@ -9,3 +9,103 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Maps OmniPaxos leadership observations to `tsoracle_consensus::LeaderState`.
+
+use tsoracle_consensus::LeaderState;
+use tsoracle_core::Epoch;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PeerEntry {
+    pub node_id: u64,
+    pub endpoint: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LeadershipState {
+    Leader { epoch: Epoch },
+    Follower { leader_endpoint: Option<String> },
+    Unknown,
+}
+
+impl LeadershipState {
+    pub fn from_omnipaxos(
+        my_node_id: u64,
+        current_leader: Option<u64>,
+        epoch: Option<Epoch>,
+        peers: &[PeerEntry],
+    ) -> Self {
+        match (current_leader, epoch) {
+            (Some(leader), Some(epoch)) if leader == my_node_id => Self::Leader { epoch },
+            (Some(leader), _) => {
+                let endpoint = peers
+                    .iter()
+                    .find(|peer| peer.node_id == leader)
+                    .map(|peer| peer.endpoint.clone());
+                Self::Follower {
+                    leader_endpoint: endpoint,
+                }
+            }
+            _ => Self::Unknown,
+        }
+    }
+
+    #[must_use]
+    pub fn to_consensus(&self) -> LeaderState {
+        match self {
+            Self::Leader { epoch } => LeaderState::Leader { epoch: *epoch },
+            Self::Follower { leader_endpoint } => LeaderState::Follower {
+                leader_endpoint: leader_endpoint.clone(),
+            },
+            Self::Unknown => LeaderState::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsoracle_consensus::LeaderState;
+    use tsoracle_core::Epoch;
+
+    #[test]
+    fn leader_is_self_emits_leader_state() {
+        let state = LeadershipState::from_omnipaxos(1, Some(1), Some(Epoch(42)), &[]);
+        assert_eq!(
+            state.to_consensus(),
+            LeaderState::Leader { epoch: Epoch(42) },
+        );
+    }
+
+    #[test]
+    fn leader_is_other_emits_follower_with_endpoint() {
+        let peers = vec![PeerEntry {
+            node_id: 2,
+            endpoint: "http://node-2:50051".into(),
+        }];
+        let state = LeadershipState::from_omnipaxos(1, Some(2), Some(Epoch(7)), &peers);
+        assert_eq!(
+            state.to_consensus(),
+            LeaderState::Follower {
+                leader_endpoint: Some("http://node-2:50051".into()),
+            },
+        );
+    }
+
+    #[test]
+    fn no_leader_emits_unknown() {
+        let state = LeadershipState::from_omnipaxos(1, None, None, &[]);
+        assert_eq!(state.to_consensus(), LeaderState::Unknown);
+    }
+
+    #[test]
+    fn follower_with_unknown_peer_endpoint_is_none() {
+        let state = LeadershipState::from_omnipaxos(1, Some(2), Some(Epoch(7)), &[]);
+        assert_eq!(
+            state.to_consensus(),
+            LeaderState::Follower {
+                leader_endpoint: None
+            },
+        );
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/macros.rs
+++ b/crates/tsoracle-paxos-toolkit/src/macros.rs
@@ -9,3 +9,36 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Type-alias macro for downstream `OmniPaxos` configurations.
+//!
+//! `declare_omnipaxos_types_ext!(Name, EntryType, StorageType)` expands to:
+//!
+//! ```ignore
+//! pub type NameOmniPaxos = ::omnipaxos::OmniPaxos<EntryType, StorageType>;
+//! pub type NameConfig    = ::omnipaxos::OmniPaxosConfig;
+//! ```
+//!
+//! Mirrors the role of `tsoracle_openraft_toolkit::declare_raft_types_ext!`
+//! in the sibling crate.
+
+#[macro_export]
+macro_rules! declare_omnipaxos_types_ext {
+    ($name:ident, $entry:ty, $storage:ty) => {
+        ::pastey::paste! {
+            pub type [<$name OmniPaxos>] = ::omnipaxos::OmniPaxos<$entry, $storage>;
+            pub type [<$name Config>] = ::omnipaxos::OmniPaxosConfig;
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    // The macro is exercised at expansion sites; this tests only that the
+    // symbol path resolves at compile time. A full expansion smoke test
+    // lives outside the crate in `tests/macro_smoke.rs` (lands in #162).
+    #[test]
+    fn macro_symbol_exists() {
+        let _ = stringify!(crate::declare_omnipaxos_types_ext!);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the lifecycle layer for `tsoracle-paxos-toolkit`: a runner that owns the OmniPaxos tick + outbound drain, a leader-event channel/stream pair, a `LeadershipState` newtype that maps observations to `tsoracle_consensus::LeaderState`, and a type-alias macro for downstream consumers.

### Modules

- **`src/macros.rs`** — `declare_omnipaxos_types_ext!(Name, EntryType, StorageType)` macro using `pastey::paste!` to produce `NameOmniPaxos = ::omnipaxos::OmniPaxos<EntryType, StorageType>` and `NameConfig = ::omnipaxos::OmniPaxosConfig`. Real expansion smoke test lands with the integration-test sub-issue.
- **`src/lifecycle/state.rs`** — `LeadershipState { Leader | Follower | Unknown }` + `Peer { node_id, endpoint }`. `from_omnipaxos(my_node_id, current_leader, epoch, peers)` maps observations; `to_consensus()` converts to the consensus-crate enum.
- **`src/lifecycle/events.rs`** — `leader_event_channel()` returns a cloneable `LeaderEventSender` + a `LeaderEventStream` backed by a stored `WatchStream` (receiver state preserved across polls). Sender debounces identical payloads via a borrow-equality check before `watch::Sender::send`, and surfaces `SendError::Closed` atomically with the send.
- **`src/lifecycle/mod.rs`** — `PaxosRunner<T, S>` owns the tokio tick task. Each tick: lock + `tick()` + drain outbound (guard dropped), dispatch outbound via the caller-supplied `MessageSink<T>` trait, observe leadership, emit the transition through the leader-event channel, `notify_waiters()` on a shared `Arc<Notify>` so an external apply task can drain decided entries opportunistically.

### Epoch placeholder

The runner emits a process-local monotonic counter as the epoch (incremented on every observed leader change). This is a deliberate placeholder — the follow-up driver crate will replace this leader-event stream with one that derives epoch from `omnipaxos.get_promise()` to match the spec's fencing strategy. The toolkit's stream is still useful as a leadership-changed signal.

### Locking discipline

`parking_lot::Mutex` guards on the OmniPaxos handle are held only for short critical sections and dropped before any `.await`. Outbound message dispatch (which may `.await` on transport) happens after the guard is released.

### Code-review fixes folded in

- `LeaderEventSender::send`: atomic close-detection (`borrow` equality check + `watch::Sender::send`) replaces the prior TOCTOU pattern.
- `PaxosRunner::start`: `debug_assert!(self.handle.is_none())` so double-start is loud.
- `PaxosRunner::stop`: surfaces `JoinError` via `tracing::error!` instead of silently discarding panics.
- `LeadershipState::from_omnipaxos`: `current_leader == Some(my_node_id)` with `epoch == None` now produces `Unknown` rather than "follower of self".
- `PeerEntry` renamed to `Peer` (avoids naming collision with `omnipaxos::storage::Entry`).
- Item-level `///` docs across the lifecycle module surface (the crate is docs.rs-surfaced).
- `apply_notify` doc spells out `notify_waiters` semantics (edge-triggered, all waiters wake).

## Test plan

- [x] `cargo test -p tsoracle-paxos-toolkit --no-default-features --lib` — 20 passing.
- [x] `cargo test -p tsoracle-paxos-toolkit --features rocksdb-storage --lib` — 44 passing.
- [x] `cargo clippy -p tsoracle-paxos-toolkit --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p tsoracle-paxos-toolkit --check` — clean.
- [x] CI green on full workspace build.

Closes #160
