### PR TITLE
feat(paxos-toolkit): in-memory test fakes (storage, network, partition controller)

### DIFF
--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
@@ -9,3 +9,169 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Process-local in-memory transport for OmniPaxos cluster tests.
+//!
+//! Each registered node holds a tokio `mpsc::Receiver<Message<T>>`.
+//! `deliver` routes to the destination's inbox, consulting a shared
+//! [`PartitionController`] to drop messages for isolated endpoints.
+//! Messages to unregistered nodes are silently dropped; a full channel
+//! also drops (matches what a best-effort UDP-class transport would do).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use omnipaxos::messages::Message;
+use omnipaxos::storage::Entry;
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+use crate::test_fakes::partition::PartitionController;
+
+const CHANNEL_CAPACITY: usize = 1024;
+
+pub struct MemNetwork<T: Entry> {
+    senders: Mutex<HashMap<u64, mpsc::Sender<Message<T>>>>,
+    partition: Arc<PartitionController>,
+}
+
+impl<T: Entry + Send + 'static> MemNetwork<T> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            senders: Mutex::new(HashMap::new()),
+            partition: Arc::new(PartitionController::new()),
+        }
+    }
+
+    /// Borrow the partition controller. Cluster harnesses isolate / heal
+    /// via the returned `Arc` to inject network chaos.
+    #[must_use]
+    pub fn partition(&self) -> Arc<PartitionController> {
+        self.partition.clone()
+    }
+
+    /// Register a receiving inbox for `node_id`. The returned receiver
+    /// yields every message routed to this node id by [`Self::deliver`].
+    /// Re-registering the same node id silently replaces the previous
+    /// sender; the old receiver will yield no further messages.
+    pub fn register(&self, node_id: u64) -> mpsc::Receiver<Message<T>> {
+        let (sender, receiver) = mpsc::channel(CHANNEL_CAPACITY);
+        self.senders.lock().insert(node_id, sender);
+        receiver
+    }
+
+    /// Route a message to its destination's inbox.
+    ///
+    /// Drops the message silently if:
+    /// - the partition controller has the source OR destination isolated,
+    /// - the destination node has not been registered,
+    /// - the destination's channel is full (best-effort delivery).
+    pub async fn deliver(&self, message: Message<T>) {
+        let (from, to) = endpoints(&message);
+        if self.partition.is_blocked(from, to) {
+            return;
+        }
+        let sender = {
+            let guard = self.senders.lock();
+            guard.get(&to).cloned()
+        };
+        if let Some(sender) = sender {
+            let _ = sender.try_send(message);
+        }
+    }
+}
+
+impl<T: Entry + Send + 'static> Default for MemNetwork<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn endpoints<T: Entry>(message: &Message<T>) -> (u64, u64) {
+    match message {
+        Message::SequencePaxos(paxos) => (paxos.from, paxos.to),
+        Message::BLE(ble) => (ble.from, ble.to),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omnipaxos::messages::Message;
+    use omnipaxos::messages::sequence_paxos::{PaxosMessage, PaxosMsg};
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    struct Cmd(u64);
+
+    impl omnipaxos::storage::Entry for Cmd {
+        type Snapshot = Snap;
+    }
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    struct Snap;
+
+    impl omnipaxos::storage::Snapshot<Cmd> for Snap {
+        fn create(_: &[Cmd]) -> Self {
+            Self
+        }
+        fn merge(&mut self, _: Self) {}
+        fn use_snapshots() -> bool {
+            false
+        }
+    }
+
+    fn proposal_forward(from: u64, to: u64) -> Message<Cmd> {
+        Message::SequencePaxos(PaxosMessage {
+            from,
+            to,
+            msg: PaxosMsg::ProposalForward(vec![Cmd(7)]),
+        })
+    }
+
+    #[tokio::test]
+    async fn message_routes_to_registered_destination() {
+        let network: MemNetwork<Cmd> = MemNetwork::new();
+        let mut inbox = network.register(2);
+        network.deliver(proposal_forward(1, 2)).await;
+        let received = inbox.recv().await.expect("recv");
+        match received {
+            Message::SequencePaxos(p) => {
+                assert_eq!(p.from, 1);
+                assert_eq!(p.to, 2);
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn message_to_unregistered_node_is_silently_dropped() {
+        let network: MemNetwork<Cmd> = MemNetwork::new();
+        // No registration for node 99 — deliver should not panic.
+        network.deliver(proposal_forward(1, 99)).await;
+    }
+
+    #[tokio::test]
+    async fn partitioned_endpoint_drops_message() {
+        let network: MemNetwork<Cmd> = MemNetwork::new();
+        let mut inbox = network.register(2);
+        network.partition().isolate(2);
+        network.deliver(proposal_forward(1, 2)).await;
+        // The isolated node sees no message even though it is registered.
+        let result = tokio::time::timeout(std::time::Duration::from_millis(10), inbox.recv()).await;
+        assert!(result.is_err(), "isolated node must not receive messages");
+    }
+
+    #[tokio::test]
+    async fn healed_partition_resumes_routing() {
+        let network: MemNetwork<Cmd> = MemNetwork::new();
+        let mut inbox = network.register(2);
+        network.partition().isolate(2);
+        network.deliver(proposal_forward(1, 2)).await;
+        // Heal and try again.
+        network.partition().heal();
+        network.deliver(proposal_forward(1, 2)).await;
+        let received = inbox.recv().await.expect("recv");
+        assert!(matches!(received, Message::SequencePaxos(_)));
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
@@ -9,3 +9,295 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! In-memory `omnipaxos::storage::Storage` implementation for unit and
+//! integration tests, and for downstream conformance suites that want to
+//! drive an OmniPaxos cluster without RocksDB.
+//!
+//! Same semantics as the production [`crate::storage::RocksdbStorage`]:
+//! log keys are absolute, `get_log_len` returns `next_abs - compacted_idx`,
+//! `trim` is independent of `set_compacted_idx` (OmniPaxos pairs them),
+//! and `get_entries` returns an empty `Vec` on any gap rather than a
+//! partial prefix.
+
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+
+use omnipaxos::ballot_leader_election::Ballot;
+use omnipaxos::storage::{Entry, StopSign, Storage, StorageResult};
+use parking_lot::Mutex;
+
+/// Cloneable in-memory `Storage<T>` backed by a shared mutex.
+///
+/// Clones share the same underlying state (the toolkit uses interior
+/// mutability so the OmniPaxos handle can take `&mut self` without the
+/// caller needing exclusive ownership of the storage).
+pub struct MemStorage<T: Entry> {
+    inner: Mutex<MemInner<T>>,
+    _marker: PhantomData<T>,
+}
+
+struct MemInner<T: Entry> {
+    log: BTreeMap<u64, T>,
+    promise: Option<Ballot>,
+    accepted_round: Option<Ballot>,
+    decided_idx: u64,
+    compacted_idx: u64,
+    snapshot: Option<T::Snapshot>,
+    stopsign: Option<StopSign>,
+}
+
+impl<T: Entry> Default for MemStorage<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Entry> MemStorage<T> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(MemInner {
+                log: BTreeMap::new(),
+                promise: None,
+                accepted_round: None,
+                decided_idx: 0,
+                compacted_idx: 0,
+                snapshot: None,
+                stopsign: None,
+            }),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Storage<T> for MemStorage<T>
+where
+    T: Entry + Clone,
+    T::Snapshot: Clone,
+{
+    fn append_entry(&mut self, entry: T) -> StorageResult<u64> {
+        let mut inner = self.inner.lock();
+        let next = inner.log.keys().next_back().map(|key| key + 1).unwrap_or(0);
+        inner.log.insert(next, entry);
+        let compacted = inner.compacted_idx;
+        Ok((next + 1).saturating_sub(compacted))
+    }
+
+    fn append_entries(&mut self, entries: Vec<T>) -> StorageResult<u64> {
+        let mut inner = self.inner.lock();
+        let start = inner.log.keys().next_back().map(|key| key + 1).unwrap_or(0);
+        let count = entries.len() as u64;
+        for (offset, entry) in entries.into_iter().enumerate() {
+            inner.log.insert(start + offset as u64, entry);
+        }
+        let compacted = inner.compacted_idx;
+        Ok((start + count).saturating_sub(compacted))
+    }
+
+    fn append_on_prefix(&mut self, from_idx: u64, entries: Vec<T>) -> StorageResult<u64> {
+        let mut inner = self.inner.lock();
+        inner.log.retain(|key, _| *key < from_idx);
+        let count = entries.len() as u64;
+        for (offset, entry) in entries.into_iter().enumerate() {
+            inner.log.insert(from_idx + offset as u64, entry);
+        }
+        let compacted = inner.compacted_idx;
+        Ok((from_idx + count).saturating_sub(compacted))
+    }
+
+    fn get_entries(&self, from: u64, to: u64) -> StorageResult<Vec<T>> {
+        if from >= to {
+            return Ok(Vec::new());
+        }
+        let inner = self.inner.lock();
+        let mut out = Vec::with_capacity((to - from) as usize);
+        for idx in from..to {
+            match inner.log.get(&idx) {
+                Some(entry) => out.push(entry.clone()),
+                None => return Ok(Vec::new()),
+            }
+        }
+        Ok(out)
+    }
+
+    fn get_log_len(&self) -> StorageResult<u64> {
+        let inner = self.inner.lock();
+        let next_abs = inner.log.keys().next_back().map(|key| key + 1).unwrap_or(0);
+        Ok(next_abs.saturating_sub(inner.compacted_idx))
+    }
+
+    fn get_suffix(&self, from: u64) -> StorageResult<Vec<T>> {
+        let inner = self.inner.lock();
+        Ok(inner
+            .log
+            .range(from..)
+            .map(|(_, entry)| entry.clone())
+            .collect())
+    }
+
+    fn set_promise(&mut self, ballot: Ballot) -> StorageResult<()> {
+        self.inner.lock().promise = Some(ballot);
+        Ok(())
+    }
+
+    fn get_promise(&self) -> StorageResult<Option<Ballot>> {
+        Ok(self.inner.lock().promise)
+    }
+
+    fn set_accepted_round(&mut self, ballot: Ballot) -> StorageResult<()> {
+        self.inner.lock().accepted_round = Some(ballot);
+        Ok(())
+    }
+
+    fn get_accepted_round(&self) -> StorageResult<Option<Ballot>> {
+        Ok(self.inner.lock().accepted_round)
+    }
+
+    fn set_decided_idx(&mut self, idx: u64) -> StorageResult<()> {
+        self.inner.lock().decided_idx = idx;
+        Ok(())
+    }
+
+    fn get_decided_idx(&self) -> StorageResult<u64> {
+        Ok(self.inner.lock().decided_idx)
+    }
+
+    fn trim(&mut self, idx: u64) -> StorageResult<()> {
+        self.inner.lock().log.retain(|key, _| *key >= idx);
+        Ok(())
+    }
+
+    fn set_compacted_idx(&mut self, idx: u64) -> StorageResult<()> {
+        self.inner.lock().compacted_idx = idx;
+        Ok(())
+    }
+
+    fn get_compacted_idx(&self) -> StorageResult<u64> {
+        Ok(self.inner.lock().compacted_idx)
+    }
+
+    fn set_snapshot(&mut self, snapshot: Option<T::Snapshot>) -> StorageResult<()> {
+        self.inner.lock().snapshot = snapshot;
+        Ok(())
+    }
+
+    fn get_snapshot(&self) -> StorageResult<Option<T::Snapshot>> {
+        Ok(self.inner.lock().snapshot.clone())
+    }
+
+    fn set_stopsign(&mut self, stopsign: Option<StopSign>) -> StorageResult<()> {
+        self.inner.lock().stopsign = stopsign;
+        Ok(())
+    }
+
+    fn get_stopsign(&self) -> StorageResult<Option<StopSign>> {
+        Ok(self.inner.lock().stopsign.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omnipaxos::ballot_leader_election::Ballot;
+    use omnipaxos::storage::Storage;
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    struct Cmd(u64);
+
+    impl omnipaxos::storage::Entry for Cmd {
+        type Snapshot = Snap;
+    }
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    struct Snap(u64);
+
+    impl omnipaxos::storage::Snapshot<Cmd> for Snap {
+        fn create(entries: &[Cmd]) -> Self {
+            Self(entries.iter().map(|cmd| cmd.0).max().unwrap_or(0))
+        }
+        fn merge(&mut self, other: Self) {
+            self.0 = self.0.max(other.0);
+        }
+        fn use_snapshots() -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn empty_log_defaults() {
+        let storage: MemStorage<Cmd> = MemStorage::new();
+        assert_eq!(storage.get_log_len().unwrap(), 0);
+        assert_eq!(storage.get_decided_idx().unwrap(), 0);
+        assert_eq!(storage.get_compacted_idx().unwrap(), 0);
+        assert!(storage.get_promise().unwrap().is_none());
+        assert!(storage.get_accepted_round().unwrap().is_none());
+        assert!(storage.get_snapshot().unwrap().is_none());
+        assert!(storage.get_stopsign().unwrap().is_none());
+    }
+
+    #[test]
+    fn append_and_read_round_trip() {
+        let mut storage: MemStorage<Cmd> = MemStorage::new();
+        let len = storage
+            .append_entries(vec![Cmd(1), Cmd(2), Cmd(3)])
+            .unwrap();
+        assert_eq!(len, 3);
+        let suffix = storage.get_suffix(0).unwrap();
+        assert_eq!(suffix.len(), 3);
+        assert_eq!(suffix[0].0, 1);
+        assert_eq!(suffix[2].0, 3);
+    }
+
+    #[test]
+    fn get_entries_returns_empty_on_gap() {
+        // Contract: any missing index in [from, to) yields an empty Vec,
+        // never a partial prefix.
+        let mut storage: MemStorage<Cmd> = MemStorage::new();
+        storage.append_entries(vec![Cmd(1), Cmd(2)]).unwrap();
+        // Range [0, 5) crosses missing indices 2, 3, 4.
+        assert!(storage.get_entries(0, 5).unwrap().is_empty());
+        // Fully-present range [0, 2) returns the two entries.
+        let present = storage.get_entries(0, 2).unwrap();
+        assert_eq!(present.len(), 2);
+    }
+
+    #[test]
+    fn trim_then_compacted_yields_physical_remaining_length() {
+        let mut storage: MemStorage<Cmd> = MemStorage::new();
+        storage
+            .append_entries(vec![Cmd(1), Cmd(2), Cmd(3), Cmd(4)])
+            .unwrap();
+        storage.trim(2).unwrap();
+        storage.set_compacted_idx(2).unwrap();
+        // Physical remaining = next_abs (4) - compacted (2) = 2.
+        assert_eq!(storage.get_log_len().unwrap(), 2);
+        let suffix = storage.get_suffix(2).unwrap();
+        assert_eq!(suffix.len(), 2);
+        assert_eq!(suffix[0].0, 3);
+    }
+
+    #[test]
+    fn promise_round_trip() {
+        let mut storage: MemStorage<Cmd> = MemStorage::new();
+        let ballot = Ballot {
+            config_id: 1,
+            n: 5,
+            priority: 0,
+            pid: 2,
+        };
+        storage.set_promise(ballot).unwrap();
+        let got = storage.get_promise().unwrap().expect("present");
+        assert_eq!(got.n, 5);
+        assert_eq!(got.pid, 2);
+    }
+
+    #[test]
+    fn snapshot_round_trip_and_clear() {
+        let mut storage: MemStorage<Cmd> = MemStorage::new();
+        storage.set_snapshot(Some(Snap(99))).unwrap();
+        assert_eq!(storage.get_snapshot().unwrap().expect("present").0, 99);
+        storage.set_snapshot(None).unwrap();
+        assert!(storage.get_snapshot().unwrap().is_none());
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/partition.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/partition.rs
@@ -9,3 +9,103 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Partition controller used by [`MemNetwork`](super::mem_network::MemNetwork)
+//! to drop messages for a subset of nodes.
+//!
+//! Intentionally minimal: only full-node isolation, no partial partitions
+//! (e.g., "node X can reach A and B but not C"). Partial-connectivity chaos
+//! is an explicit non-goal documented in the paxos driver design spec.
+
+use std::collections::HashSet;
+
+use parking_lot::Mutex;
+
+/// Records which node ids are currently isolated. Cheap to clone (the inner
+/// state is shared via interior mutability; clones share the same lock).
+#[derive(Default)]
+pub struct PartitionController {
+    isolated: Mutex<HashSet<u64>>,
+}
+
+impl PartitionController {
+    /// Create a controller with no nodes isolated (all traffic flows).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Isolate `node_id`: every subsequent send originating from OR destined
+    /// for this node is treated as blocked by [`Self::is_blocked`].
+    pub fn isolate(&self, node_id: u64) {
+        self.isolated.lock().insert(node_id);
+    }
+
+    /// Restore traffic to a single node previously isolated by
+    /// [`Self::isolate`]. Other isolated nodes are unaffected.
+    pub fn restore(&self, node_id: u64) {
+        self.isolated.lock().remove(&node_id);
+    }
+
+    /// Clear all isolation; every node is reachable again.
+    pub fn heal(&self) {
+        self.isolated.lock().clear();
+    }
+
+    /// Returns `true` if a message from `from` to `to` would be dropped.
+    /// Traffic is blocked when either endpoint is isolated.
+    #[must_use]
+    pub fn is_blocked(&self, from: u64, to: u64) -> bool {
+        let guard = self.isolated.lock();
+        guard.contains(&from) || guard.contains(&to)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_partition_allows_all_traffic() {
+        let partition = PartitionController::new();
+        assert!(!partition.is_blocked(1, 2));
+        assert!(!partition.is_blocked(2, 1));
+    }
+
+    #[test]
+    fn isolate_blocks_outbound_and_inbound_for_the_node() {
+        let partition = PartitionController::new();
+        partition.isolate(2);
+        // Outbound from 2 to anyone is blocked.
+        assert!(partition.is_blocked(2, 1));
+        assert!(partition.is_blocked(2, 3));
+        // Inbound to 2 from anyone is blocked.
+        assert!(partition.is_blocked(1, 2));
+        assert!(partition.is_blocked(3, 2));
+        // Traffic between non-isolated nodes flows.
+        assert!(!partition.is_blocked(1, 3));
+    }
+
+    #[test]
+    fn restore_clears_a_single_node() {
+        let partition = PartitionController::new();
+        partition.isolate(2);
+        partition.isolate(3);
+        partition.restore(2);
+        // 2 is no longer isolated.
+        assert!(!partition.is_blocked(2, 1));
+        assert!(!partition.is_blocked(1, 2));
+        // 3 is still isolated.
+        assert!(partition.is_blocked(3, 1));
+    }
+
+    #[test]
+    fn heal_clears_all_isolation() {
+        let partition = PartitionController::new();
+        partition.isolate(2);
+        partition.isolate(3);
+        partition.heal();
+        assert!(!partition.is_blocked(2, 1));
+        assert!(!partition.is_blocked(3, 1));
+    }
+}


### PR DESCRIPTION
## Summary

In-memory test fakes for the paxos toolkit. All three modules live behind the `test-fakes` feature flag; downstream crates depending on the toolkit for testing can opt in to compile them via `tsoracle-paxos-toolkit = { ..., features = ["test-fakes"] }`.

### Modules

- **`src/test_fakes/partition.rs`** — `PartitionController` with `isolate(node_id)` / `restore(node_id)` / `heal()` / `is_blocked(from, to)`. Intentionally minimal: partial partitions (node X reaches A and B but not C) are out of scope per the driver spec; the controller blocks all traffic to/from isolated nodes.

- **`src/test_fakes/mem_storage.rs`** — `MemStorage<T: Entry>` implementing the full `omnipaxos::storage::Storage<T>` contract. Backed by `parking_lot::Mutex<MemInner<T>>` with `BTreeMap<u64, T>` for the log + the same meta fields the RocksDB impl persists (promise, accepted_round, decided_idx, compacted_idx, snapshot, stopsign). The gap-empty contract for `get_entries` is mirrored: any missing index in `[from, to)` yields an empty `Vec`, never a partial prefix.

- **`src/test_fakes/mem_network.rs`** — `MemNetwork<T>` with one `tokio::sync::mpsc` channel per registered node. `deliver` routes by destination pid after consulting the shared `PartitionController`. Messages to unregistered nodes are silently dropped; a full channel also drops, matching what a best-effort UDP-class transport would do.

### Tests

14 unit tests across the three modules:
- partition: no-partition allows all, isolate blocks both directions, restore clears one node, heal clears everything.
- mem_storage: defaults are correct, append + read round-trip, get_entries returns empty on gap, trim + set_compacted_idx yields physical remaining length.
- mem_network: routes to registered peer, silently drops to unregistered, partitioned endpoint drops, healed partition resumes routing.

## Test plan

- [x] `cargo test -p tsoracle-paxos-toolkit --features test-fakes --no-default-features --lib` — 33 passing (29 existing + 4 mem_network + extras).
- [x] `cargo test -p tsoracle-paxos-toolkit --features test-fakes,rocksdb-storage --lib` — 67 passing.
- [x] `cargo clippy -p tsoracle-paxos-toolkit --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p tsoracle-paxos-toolkit --check` — clean.
- [x] `cargo deny check advisories` — advisories ok.
- [x] CI green on full workspace build.

Closes #161
