### PR TITLE
test(paxos-toolkit): integration tests and conformance harness

### DIFF
--- a/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
@@ -198,6 +198,7 @@ where
     T::Snapshot: serde::Serialize + serde::de::DeserializeOwned + Clone,
 {
     fn append_entry(&mut self, entry: T) -> omnipaxos::storage::StorageResult<u64> {
+        crate::fail_point!("paxos_toolkit::storage::append_entry");
         let next = self.next_log_idx().map_err(box_err)?;
         self.batch_sync(|cf, batch| self.store_log_entry(batch, &cf, next, &entry))
             .map_err(box_err)?;

--- a/crates/tsoracle-paxos-toolkit/tests/_smoke.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/_smoke.rs
@@ -1,0 +1,23 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Smoke test confirming that the shared `common/` harness compiles into a
+//! test binary and produces a 3-node `MemCluster` without panicking.
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[test]
+fn harness_compiles_with_three_node_cluster() {
+    let cluster = common::build_mem_cluster(3);
+    assert_eq!(cluster.nodes.len(), 3);
+}

--- a/crates/tsoracle-paxos-toolkit/tests/common/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/common/mod.rs
@@ -1,0 +1,180 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Shared harness for the toolkit's integration tests. Pulled into each
+//! test binary via `#[path = "common/mod.rs"] mod common;`.
+//!
+//! Helpers that touch `MemNetwork` / `MemStorage` compile only with the
+//! `test-fakes` feature; helpers that touch RocksDB compile only with the
+//! `rocksdb-storage` feature. The common shared types (`TestCommand`,
+//! `TestSnapshot`, `TEST_CF`) are always available so any combination of
+//! the two features produces a usable harness for the test binaries that
+//! enable them.
+
+#![allow(dead_code, unused_imports)] // not every test uses every helper
+
+use omnipaxos::storage::{Entry, Snapshot};
+
+pub const TEST_CF: &str = "tso_paxos_test";
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct TestCommand(pub u64);
+
+impl Entry for TestCommand {
+    type Snapshot = TestSnapshot;
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct TestSnapshot(pub u64);
+
+impl Snapshot<TestCommand> for TestSnapshot {
+    fn create(entries: &[TestCommand]) -> Self {
+        Self(entries.iter().map(|cmd| cmd.0).max().unwrap_or(0))
+    }
+    fn merge(&mut self, other: Self) {
+        self.0 = self.0.max(other.0);
+    }
+    fn use_snapshots() -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "rocksdb-storage")]
+mod rocksdb_helpers {
+    use std::sync::Arc;
+
+    use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+    use tempfile::TempDir;
+    use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+
+    use super::TestCommand;
+
+    pub fn open_rocksdb_in_tempdir(cf_name: &str) -> (TempDir, Arc<DB>) {
+        let dir = TempDir::new().expect("tempdir");
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let cf = ColumnFamilyDescriptor::new(cf_name, Options::default());
+        let database =
+            Arc::new(DB::open_cf_descriptors(&opts, dir.path(), vec![cf]).expect("open db"));
+        (dir, database)
+    }
+
+    pub fn open_rocksdb_storage(dir: &TempDir, cf_name: &str) -> RocksdbStorage<TestCommand> {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let cf = ColumnFamilyDescriptor::new(cf_name, Options::default());
+        let database =
+            Arc::new(DB::open_cf_descriptors(&opts, dir.path(), vec![cf]).expect("open db"));
+        RocksdbStorage::open_in(database, cf_name).expect("open_in")
+    }
+}
+
+#[cfg(feature = "rocksdb-storage")]
+pub use rocksdb_helpers::{open_rocksdb_in_tempdir, open_rocksdb_storage};
+
+#[cfg(feature = "test-fakes")]
+mod mem_helpers {
+    use std::sync::Arc;
+
+    use omnipaxos::{ClusterConfig, OmniPaxos, OmniPaxosConfig, ServerConfig};
+    use parking_lot::Mutex;
+    use tokio::sync::mpsc;
+
+    use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
+    use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+
+    use super::TestCommand;
+
+    pub struct MemCluster {
+        pub nodes: Vec<MemNode>,
+        pub network: Arc<MemNetwork<TestCommand>>,
+    }
+
+    pub struct MemNode {
+        pub node_id: u64,
+        pub omnipaxos: Arc<Mutex<OmniPaxos<TestCommand, MemStorage<TestCommand>>>>,
+        pub inbox: mpsc::Receiver<omnipaxos::messages::Message<TestCommand>>,
+    }
+
+    pub fn build_mem_cluster(node_count: usize) -> MemCluster {
+        assert!(node_count >= 1, "cluster size must be at least 1");
+        let network: Arc<MemNetwork<TestCommand>> = Arc::new(MemNetwork::new());
+        let node_ids: Vec<u64> = (1..=node_count as u64).collect();
+        let cluster_config = ClusterConfig {
+            configuration_id: 1,
+            nodes: node_ids.clone(),
+            flexible_quorum: None,
+        };
+
+        let mut nodes = Vec::with_capacity(node_count);
+        for &node_id in &node_ids {
+            let server_config = ServerConfig {
+                pid: node_id,
+                election_tick_timeout: 5,
+                resend_message_tick_timeout: 5,
+                ..Default::default()
+            };
+            let storage = MemStorage::<TestCommand>::new();
+            let op_config = OmniPaxosConfig {
+                cluster_config: cluster_config.clone(),
+                server_config,
+            };
+            let omnipaxos = op_config.build(storage).expect("build omnipaxos");
+            let inbox = network.register(node_id);
+            nodes.push(MemNode {
+                node_id,
+                omnipaxos: Arc::new(Mutex::new(omnipaxos)),
+                inbox,
+            });
+        }
+        MemCluster { nodes, network }
+    }
+
+    pub async fn drive_cluster_until<F>(
+        cluster: &mut MemCluster,
+        mut predicate: F,
+        max_ticks: usize,
+    ) where
+        F: FnMut(&MemCluster) -> bool,
+    {
+        for _ in 0..max_ticks {
+            // Tick every node and drain outbound messages with the guard dropped
+            // before the network deliver call (which is async).
+            for node in &cluster.nodes {
+                let outgoing = {
+                    let mut op = node.omnipaxos.lock();
+                    op.tick();
+                    op.outgoing_messages()
+                };
+                for message in outgoing {
+                    cluster.network.deliver(message).await;
+                }
+            }
+            // Drain inboxes back into each OmniPaxos handle.
+            for node in &mut cluster.nodes {
+                while let Ok(message) = node.inbox.try_recv() {
+                    node.omnipaxos.lock().handle_incoming(message);
+                }
+            }
+            if predicate(cluster) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        panic!("predicate did not become true within {max_ticks} ticks");
+    }
+}
+
+#[cfg(feature = "test-fakes")]
+pub use mem_helpers::{MemCluster, MemNode, build_mem_cluster, drive_cluster_until};

--- a/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
@@ -10,4 +10,29 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-#![cfg(feature = "failpoints")]
+//! Verify the RocksDB storage honors injected failpoints.
+
+#![cfg(all(feature = "failpoints", feature = "rocksdb-storage"))]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{TEST_CF, TestCommand, open_rocksdb_in_tempdir};
+use omnipaxos::storage::Storage;
+use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+
+#[test]
+fn append_entry_panics_when_failpoint_armed() {
+    let (_dir, database) = open_rocksdb_in_tempdir(TEST_CF);
+    let mut storage: RocksdbStorage<TestCommand> =
+        RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
+
+    fail::cfg("paxos_toolkit::storage::append_entry", "panic").unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        storage.append_entry(TestCommand(1))
+    }));
+
+    fail::remove("paxos_toolkit::storage::append_entry");
+    assert!(result.is_err(), "expected panic from failpoint");
+}

--- a/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
@@ -1,0 +1,90 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! `PaxosRunner` integration: boot one runner per node in a 3-node cluster,
+//! assert at least one emits a definite (Leader or Follower) event.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{TestCommand, build_mem_cluster};
+use futures::StreamExt;
+use omnipaxos::messages::Message;
+use tsoracle_consensus::LeaderState;
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PaxosRunner, Peer};
+use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
+
+struct NetworkSink {
+    network: Arc<MemNetwork<TestCommand>>,
+}
+
+#[async_trait::async_trait]
+impl MessageSink<TestCommand> for NetworkSink {
+    async fn send(&self, message: Message<TestCommand>) {
+        self.network.deliver(message).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn runners_emit_leader_or_follower_event_after_election() {
+    let cluster = build_mem_cluster(3);
+    let sink = Arc::new(NetworkSink {
+        network: cluster.network.clone(),
+    });
+
+    let mut runners = Vec::with_capacity(3);
+    let mut streams = Vec::with_capacity(3);
+    for node in &cluster.nodes {
+        let peers = cluster
+            .nodes
+            .iter()
+            .filter(|peer_node| peer_node.node_id != node.node_id)
+            .map(|peer_node| Peer {
+                node_id: peer_node.node_id,
+                endpoint: format!("mem://{}", peer_node.node_id),
+            })
+            .collect();
+        let mut runner = PaxosRunner::new(
+            node.omnipaxos.clone(),
+            node.node_id,
+            peers,
+            Duration::from_millis(10),
+        );
+        let stream = runner.take_leader_stream().expect("stream").into_pin();
+        runner.start(sink.clone());
+        runners.push(runner);
+        streams.push(stream);
+    }
+
+    // Wait until at least one stream yields a definite (non-Unknown) state.
+    let saw_definite = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            for stream in &mut streams {
+                if let Some(state) = stream.next().await
+                    && !matches!(state, LeaderState::Unknown)
+                {
+                    return true;
+                }
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
+
+    assert!(saw_definite, "expected a definite leader/follower event");
+    for runner in &mut runners {
+        runner.stop().await;
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/tests/macro_smoke.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/macro_smoke.rs
@@ -1,0 +1,31 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Smoke test for the `declare_omnipaxos_types_ext!` macro: verify the
+//! expansion produces well-formed type aliases that compile.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::TestCommand;
+use tsoracle_paxos_toolkit::declare_omnipaxos_types_ext;
+use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+
+declare_omnipaxos_types_ext!(MyTsoSetup, TestCommand, MemStorage<TestCommand>);
+
+#[test]
+fn macro_produces_expected_aliases() {
+    // Type-check only: reference the produced aliases to force the macro
+    // expansion to compile and resolve.
+    fn _check(_op: Option<MyTsoSetupOmniPaxos>, _cfg: Option<MyTsoSetupConfig>) {}
+    _check(None, None);
+}

--- a/crates/tsoracle-paxos-toolkit/tests/mem_network_negative.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/mem_network_negative.rs
@@ -1,0 +1,83 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Negative tests: isolating a node prevents it from observing decided_idx
+//! advances on the remaining quorum.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{TestCommand, build_mem_cluster, drive_cluster_until};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn isolated_node_does_not_observe_consensus() {
+    let mut cluster = build_mem_cluster(3);
+
+    drive_cluster_until(
+        &mut cluster,
+        |state| {
+            state
+                .nodes
+                .iter()
+                .any(|node| node.omnipaxos.lock().get_current_leader().is_some())
+        },
+        500,
+    )
+    .await;
+
+    cluster.network.partition().isolate(3);
+
+    let leader_id = cluster
+        .nodes
+        .iter()
+        .find_map(|node| node.omnipaxos.lock().get_current_leader())
+        .expect("leader exists");
+    if leader_id == 3 {
+        // If node 3 happened to be leader before isolation, the cluster
+        // loses quorum and the scenario doesn't apply. Skip cleanly.
+        return;
+    }
+    let leader_node = cluster
+        .nodes
+        .iter()
+        .find(|node| node.node_id == leader_id)
+        .expect("leader node");
+    leader_node
+        .omnipaxos
+        .lock()
+        .append(TestCommand(7))
+        .expect("append");
+
+    drive_cluster_until(
+        &mut cluster,
+        |state| {
+            state
+                .nodes
+                .iter()
+                .filter(|node| node.node_id != 3)
+                .all(|node| node.omnipaxos.lock().get_decided_idx() >= 1)
+        },
+        500,
+    )
+    .await;
+
+    let node_three = cluster
+        .nodes
+        .iter()
+        .find(|node| node.node_id == 3)
+        .expect("node 3 in topology");
+    assert_eq!(
+        node_three.omnipaxos.lock().get_decided_idx(),
+        0,
+        "isolated node must not observe quorum decisions",
+    );
+}

--- a/crates/tsoracle-paxos-toolkit/tests/mem_network_smoke.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/mem_network_smoke.rs
@@ -1,0 +1,75 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! End-to-end smoke: a 3-node `MemNetwork`-routed cluster reaches consensus
+//! on a single appended command and converges on a single decided_idx.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{TestCommand, build_mem_cluster, drive_cluster_until};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn three_node_cluster_reaches_consensus() {
+    let mut cluster = build_mem_cluster(3);
+
+    // Step the cluster until a leader emerges (any node observes one).
+    drive_cluster_until(
+        &mut cluster,
+        |state| {
+            state
+                .nodes
+                .iter()
+                .any(|node| node.omnipaxos.lock().get_current_leader().is_some())
+        },
+        500,
+    )
+    .await;
+
+    // Append a command via whichever node is leader.
+    let leader_id = cluster
+        .nodes
+        .iter()
+        .find_map(|node| node.omnipaxos.lock().get_current_leader())
+        .expect("leader exists after election");
+    let leader_node = cluster
+        .nodes
+        .iter()
+        .find(|node| node.node_id == leader_id)
+        .expect("leader node in topology");
+    leader_node
+        .omnipaxos
+        .lock()
+        .append(TestCommand(42))
+        .expect("append");
+
+    // Step until decided_idx >= 1 on every node.
+    drive_cluster_until(
+        &mut cluster,
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| node.omnipaxos.lock().get_decided_idx() >= 1)
+        },
+        500,
+    )
+    .await;
+
+    for node in &cluster.nodes {
+        assert!(
+            node.omnipaxos.lock().get_decided_idx() >= 1,
+            "node {} should have observed the commit",
+            node.node_id,
+        );
+    }
+}

--- a/crates/tsoracle-paxos-toolkit/tests/storage_basic.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/storage_basic.rs
@@ -1,0 +1,86 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Basic RocksDB storage round-trip tests: append + read, prefix replacement,
+//! and persistence across DB close / reopen.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::sync::Arc;
+
+use common::{TEST_CF, TestCommand, open_rocksdb_in_tempdir};
+use omnipaxos::storage::Storage;
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use tempfile::TempDir;
+use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+
+#[test]
+fn append_get_round_trip_over_rocksdb() {
+    let (_dir, database) = open_rocksdb_in_tempdir(TEST_CF);
+    let mut storage: RocksdbStorage<TestCommand> =
+        RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
+    assert_eq!(storage.get_log_len().unwrap(), 0);
+    let len = storage
+        .append_entries(vec![TestCommand(1), TestCommand(2), TestCommand(3)])
+        .unwrap();
+    assert_eq!(len, 3);
+    let suffix = storage.get_suffix(0).unwrap();
+    assert_eq!(suffix.len(), 3);
+    assert_eq!(suffix[0].0, 1);
+    assert_eq!(suffix[2].0, 3);
+}
+
+#[test]
+fn append_on_prefix_truncates_then_appends_over_rocksdb() {
+    let (_dir, database) = open_rocksdb_in_tempdir(TEST_CF);
+    let mut storage: RocksdbStorage<TestCommand> =
+        RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
+    storage
+        .append_entries(vec![TestCommand(1), TestCommand(2), TestCommand(3)])
+        .unwrap();
+    storage
+        .append_on_prefix(1, vec![TestCommand(9), TestCommand(8)])
+        .unwrap();
+    let suffix = storage.get_suffix(0).unwrap();
+    assert_eq!(suffix.len(), 3);
+    assert_eq!(suffix[0].0, 1);
+    assert_eq!(suffix[1].0, 9);
+    assert_eq!(suffix[2].0, 8);
+}
+
+#[test]
+fn reopen_preserves_log_across_db_close() {
+    let dir = TempDir::new().unwrap();
+    {
+        let mut storage = open_rocksdb_storage_in(&dir, TEST_CF);
+        storage
+            .append_entries(vec![TestCommand(7), TestCommand(8)])
+            .unwrap();
+    }
+    {
+        let storage = open_rocksdb_storage_in(&dir, TEST_CF);
+        let suffix = storage.get_suffix(0).unwrap();
+        assert_eq!(suffix.len(), 2);
+        assert_eq!(suffix[0].0, 7);
+        assert_eq!(suffix[1].0, 8);
+    }
+}
+
+fn open_rocksdb_storage_in(dir: &TempDir, cf_name: &str) -> RocksdbStorage<TestCommand> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cf = ColumnFamilyDescriptor::new(cf_name, Options::default());
+    let database = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), vec![cf]).expect("open db"));
+    RocksdbStorage::open_in(database, cf_name).expect("open_in")
+}

--- a/crates/tsoracle-paxos-toolkit/tests/storage_conformance.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/storage_conformance.rs
@@ -1,0 +1,138 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Conformance harness: every scenario runs against both `MemStorage` and
+//! `RocksdbStorage`. Any divergence is a bug in one of the impls.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{TEST_CF, TestCommand, TestSnapshot, open_rocksdb_in_tempdir};
+use omnipaxos::ClusterConfig;
+use omnipaxos::ballot_leader_election::Ballot;
+use omnipaxos::storage::{StopSign, Storage};
+use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+
+fn ballot(round: u32, pid: u64) -> Ballot {
+    Ballot {
+        config_id: 1,
+        n: round,
+        priority: 0,
+        pid,
+    }
+}
+
+fn run_scenario<S: Storage<TestCommand>>(mut storage: S) {
+    // (1) Empty defaults
+    assert_eq!(storage.get_log_len().unwrap(), 0);
+    assert_eq!(storage.get_decided_idx().unwrap(), 0);
+    assert_eq!(storage.get_compacted_idx().unwrap(), 0);
+    assert!(storage.get_promise().unwrap().is_none());
+    assert!(storage.get_accepted_round().unwrap().is_none());
+    assert!(storage.get_snapshot().unwrap().is_none());
+    assert!(storage.get_stopsign().unwrap().is_none());
+
+    // (2) Append + read
+    let new_len = storage
+        .append_entries(vec![TestCommand(1), TestCommand(2), TestCommand(3)])
+        .unwrap();
+    assert_eq!(new_len, 3);
+    assert_eq!(storage.get_log_len().unwrap(), 3);
+
+    // (3) Half-open range
+    let mid = storage.get_entries(1, 3).unwrap();
+    assert_eq!(mid.len(), 2);
+    assert_eq!(mid[0].0, 2);
+    assert_eq!(mid[1].0, 3);
+
+    // (4) Empty ranges
+    assert!(storage.get_entries(5, 5).unwrap().is_empty());
+    assert!(storage.get_entries(10, 20).unwrap().is_empty());
+
+    // (5) append_on_prefix replaces tail
+    storage
+        .append_on_prefix(1, vec![TestCommand(9), TestCommand(8)])
+        .unwrap();
+    let after_replace = storage.get_suffix(0).unwrap();
+    assert_eq!(after_replace.len(), 3);
+    assert_eq!(after_replace[1].0, 9);
+
+    // (6) Promise
+    let promise = ballot(5, 2);
+    storage.set_promise(promise).unwrap();
+    let got = storage.get_promise().unwrap().expect("present");
+    assert_eq!(got.n, 5);
+    assert_eq!(got.pid, 2);
+
+    // (7) Accepted round
+    let accepted = ballot(7, 3);
+    storage.set_accepted_round(accepted).unwrap();
+    assert_eq!(storage.get_accepted_round().unwrap().expect("present").n, 7);
+
+    // (8) Decided idx
+    storage.set_decided_idx(2).unwrap();
+    assert_eq!(storage.get_decided_idx().unwrap(), 2);
+
+    // (9) Compacted idx
+    storage.set_compacted_idx(1).unwrap();
+    assert_eq!(storage.get_compacted_idx().unwrap(), 1);
+
+    // (10) Trim + gap contract: any subsequent get_entries range that
+    //      crosses the trimmed region MUST return empty Vec, never a
+    //      partial prefix.
+    storage.trim(1).unwrap();
+    let after_trim = storage.get_suffix(0).unwrap();
+    assert_eq!(after_trim.len(), 2, "suffix walks present entries");
+    let gapped = storage.get_entries(0, 3).unwrap();
+    assert!(
+        gapped.is_empty(),
+        "get_entries crossing a gap must yield empty, got {} items",
+        gapped.len(),
+    );
+    let present = storage.get_entries(1, 3).unwrap();
+    assert_eq!(present.len(), 2);
+
+    // (11) Snapshot
+    storage.set_snapshot(Some(TestSnapshot(42))).unwrap();
+    assert_eq!(storage.get_snapshot().unwrap().expect("present").0, 42);
+    storage.set_snapshot(None).unwrap();
+    assert!(storage.get_snapshot().unwrap().is_none());
+
+    // (12) Stopsign
+    let stopsign = StopSign::with(
+        ClusterConfig {
+            configuration_id: 2,
+            nodes: vec![1, 2, 3, 4, 5],
+            flexible_quorum: None,
+        },
+        None,
+    );
+    storage.set_stopsign(Some(stopsign)).unwrap();
+    let got = storage.get_stopsign().unwrap().expect("present");
+    assert_eq!(got.next_config.configuration_id, 2);
+    storage.set_stopsign(None).unwrap();
+    assert!(storage.get_stopsign().unwrap().is_none());
+}
+
+#[test]
+fn mem_storage_conforms() {
+    run_scenario(MemStorage::<TestCommand>::new());
+}
+
+#[test]
+fn rocksdb_storage_conforms() {
+    let (_dir, database) = open_rocksdb_in_tempdir(TEST_CF);
+    let storage: RocksdbStorage<TestCommand> =
+        RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
+    run_scenario(storage);
+}


### PR DESCRIPTION
## Summary

The integration test layer for `tsoracle-paxos-toolkit`. Closes the toolkit's sub-issue chain (#157 → #158 → #159 → #160 → #161 → this); after merge, the toolkit is feature-complete and the driver crate (Plan 2) can start.

### Test files

- **`tests/common/mod.rs`** — shared harness: `open_rocksdb_in_tempdir`, `TestCommand` / `TestSnapshot`, `MemCluster`, `MemNode`, `build_mem_cluster(n)`, `drive_cluster_until(&mut cluster, predicate, max_ticks)`. Helpers are feature-gated so each test binary compiles under its narrower feature combo without unused-import warnings.
- **`tests/storage_basic.rs`** — RocksDB append/read/truncate round-trip + reopen-after-close preserves the log.
- **`tests/storage_conformance.rs`** — the highest-value test: identical 12-step scenario runs against both `MemStorage` and `RocksdbStorage`. Asserts byte-identical behavior across all 19 Storage methods including the trim + gap-empty contract.
- **`tests/macro_smoke.rs`** — verifies `declare_omnipaxos_types_ext!(MyTsoSetup, TestCommand, MemStorage<TestCommand>)` expands and produces compilable type aliases.
- **`tests/mem_network_smoke.rs`** — 3-node mem-network cluster reaches consensus on a single appended command; `decided_idx >= 1` across all nodes.
- **`tests/mem_network_negative.rs`** — isolating a node prevents it from observing decided_idx advances on the remaining quorum.
- **`tests/lifecycle.rs`** — boot one `PaxosRunner` per node in a 3-node cluster with a real `NetworkSink` routing through `MemNetwork`; assert at least one runner emits a definite (non-`Unknown`) `LeaderState`.
- **`tests/failpoints.rs`** — RocksDB storage's `append_entry` honors an injected panic failpoint. Required adding ONE line to production code: `crate::fail_point!("paxos_toolkit::storage::append_entry");` at the top of `RocksdbStorage::append_entry`.

### Test counts

- Lib unit tests: 67 (no change — only `src/storage/mod.rs` got the one-line `fail_point!`).
- Integration binaries: 7 (_smoke, storage_basic, storage_conformance, macro_smoke, mem_network_smoke, mem_network_negative, lifecycle) — 10 tests total.
- Failpoint binary: 1 test, gated behind `--features failpoints,rocksdb-storage`.

## Test plan

- [ ] `cargo test -p tsoracle-paxos-toolkit --features test-fakes,rocksdb-storage --lib` — 67 passing.
- [ ] `cargo test -p tsoracle-paxos-toolkit --features test-fakes,rocksdb-storage --tests` — all integration binaries green.
- [ ] `cargo test -p tsoracle-paxos-toolkit --features failpoints,rocksdb-storage --test failpoints` — 1 passing.
- [ ] `cargo clippy -p tsoracle-paxos-toolkit --all-features --all-targets -- -D warnings` — clean.
- [ ] `cargo fmt -p tsoracle-paxos-toolkit --check` — clean.
- [ ] `cargo deny check advisories` — advisories ok.
- [ ] CI green on the full workspace build.

Closes #162
