### PR TITLE
feat(site): add Paxos explainer post with animated diagrams

### DIFF
--- a/site/content/diagrams/paxos-dueling-proposers.json
+++ b/site/content/diagrams/paxos-dueling-proposers.json
@@ -1,0 +1,54 @@
+{
+    "nodes": ["P1", "A1", "A2", "A3", "P2"],
+    "duration": 9000,
+    "events": [
+        {"t": 0,    "type": "state",   "node": "P1", "state": "proposer"},
+        {"t": 0,    "type": "state",   "node": "P2", "state": "proposer"},
+        {"t": 0,    "type": "state",   "node": "A1", "state": "acceptor"},
+        {"t": 0,    "type": "state",   "node": "A2", "state": "acceptor"},
+        {"t": 0,    "type": "state",   "node": "A3", "state": "acceptor"},
+        {"t": 300,  "type": "ballot",  "ballot": 1},
+
+        {"t": 400,  "type": "message", "from": "P1", "to": "A1", "label": "prepare(b=1)"},
+        {"t": 400,  "type": "message", "from": "P1", "to": "A2", "label": "prepare(b=1)"},
+        {"t": 400,  "type": "message", "from": "P1", "to": "A3", "label": "prepare(b=1)"},
+
+        {"t": 1200, "type": "message", "from": "A1", "to": "P1", "label": "promise(b=1, last=∅)", "kind": "reply"},
+        {"t": 1200, "type": "message", "from": "A2", "to": "P1", "label": "promise(b=1, last=∅)", "kind": "reply"},
+        {"t": 1200, "type": "message", "from": "A3", "to": "P1", "label": "promise(b=1, last=∅)", "kind": "reply"},
+
+        {"t": 2000, "type": "node_value", "node": "A1", "value": "promised b=1"},
+        {"t": 2000, "type": "node_value", "node": "A2", "value": "promised b=1"},
+        {"t": 2000, "type": "node_value", "node": "A3", "value": "promised b=1"},
+
+        {"t": 2600, "type": "ballot",  "ballot": 2},
+
+        {"t": 2700, "type": "message", "from": "P2", "to": "A1", "label": "prepare(b=2)"},
+        {"t": 2700, "type": "message", "from": "P2", "to": "A2", "label": "prepare(b=2)"},
+        {"t": 2700, "type": "message", "from": "P2", "to": "A3", "label": "prepare(b=2)"},
+
+        {"t": 3500, "type": "message", "from": "A1", "to": "P2", "label": "promise(b=2, last=∅)", "kind": "reply"},
+        {"t": 3500, "type": "message", "from": "A2", "to": "P2", "label": "promise(b=2, last=∅)", "kind": "reply"},
+        {"t": 3500, "type": "message", "from": "A3", "to": "P2", "label": "promise(b=2, last=∅)", "kind": "reply"},
+
+        {"t": 4300, "type": "node_value", "node": "A1", "value": "promised b=2"},
+        {"t": 4300, "type": "node_value", "node": "A2", "value": "promised b=2"},
+        {"t": 4300, "type": "node_value", "node": "A3", "value": "promised b=2"},
+
+        {"t": 5000, "type": "message", "from": "P1", "to": "A1", "label": "accept(b=1, v=A)"},
+        {"t": 5000, "type": "message", "from": "P1", "to": "A2", "label": "accept(b=1, v=A)"},
+        {"t": 5000, "type": "message", "from": "P1", "to": "A3", "label": "accept(b=1, v=A)"},
+
+        {"t": 5800, "type": "message", "from": "A1", "to": "P1", "label": "reject (promised b=2)", "kind": "reply"},
+        {"t": 5800, "type": "message", "from": "A2", "to": "P1", "label": "reject (promised b=2)", "kind": "reply"},
+        {"t": 5800, "type": "message", "from": "A3", "to": "P1", "label": "reject (promised b=2)", "kind": "reply"}
+    ],
+    "annotations": [
+        {"t": 0,    "text": "Two proposers, P1 and P2, both want to propose into the same Paxos instance."},
+        {"t": 400,  "text": "P1 goes first with prepare(b=1) and collects promises from a quorum of acceptors."},
+        {"t": 2700, "text": "Before P1 can send its accept, P2 starts a competing round with a higher ballot: prepare(b=2)."},
+        {"t": 4300, "text": "Acceptors promise b=2, supplanting their earlier promise. No value has been accepted yet at b=1, so there is no prior value to report."},
+        {"t": 5000, "text": "P1 finally sends accept(b=1, v=A) — too late."},
+        {"t": 5800, "text": "All three acceptors reject: they have promised b=2 and will not honour b=1. Without a stable leader, P1 retries with a higher ballot, P2 retries with a higher one again, and the cycle repeats. This is Paxos livelock — and it is exactly what Multi-Paxos solves with a distinguished leader."}
+    ]
+}

--- a/site/content/diagrams/paxos-leader-takeover.json
+++ b/site/content/diagrams/paxos-leader-takeover.json
@@ -1,0 +1,53 @@
+{
+    "nodes": ["L1", "A1", "A2", "A3", "L2"],
+    "duration": 10000,
+    "events": [
+        {"t": 0,    "type": "state",   "node": "L1", "state": "leader"},
+        {"t": 0,    "type": "state",   "node": "L2", "state": "acceptor"},
+        {"t": 0,    "type": "state",   "node": "A1", "state": "acceptor"},
+        {"t": 0,    "type": "state",   "node": "A2", "state": "acceptor"},
+        {"t": 0,    "type": "state",   "node": "A3", "state": "acceptor"},
+        {"t": 0,    "type": "ballot",  "ballot": 5},
+        {"t": 0,    "type": "node_value", "node": "A1", "value": "accepted (b=5, hwm=21)"},
+
+        {"t": 1000, "type": "state",   "node": "L1", "state": "down"},
+
+        {"t": 1600, "type": "state",   "node": "L2", "state": "proposer"},
+        {"t": 1700, "type": "ballot",  "ballot": 10},
+
+        {"t": 1800, "type": "message", "from": "L2", "to": "A1", "label": "prepare(b=10)"},
+        {"t": 1800, "type": "message", "from": "L2", "to": "A2", "label": "prepare(b=10)"},
+        {"t": 1800, "type": "message", "from": "L2", "to": "A3", "label": "prepare(b=10)"},
+
+        {"t": 2700, "type": "message", "from": "A1", "to": "L2", "label": "promise(b=10, last=(b=5, hwm=21))", "kind": "reply"},
+        {"t": 2700, "type": "message", "from": "A2", "to": "L2", "label": "promise(b=10, last=∅)", "kind": "reply"},
+        {"t": 2700, "type": "message", "from": "A3", "to": "L2", "label": "promise(b=10, last=∅)", "kind": "reply"},
+
+        {"t": 3600, "type": "node_value", "node": "A1", "value": "promised b=10"},
+        {"t": 3600, "type": "node_value", "node": "A2", "value": "promised b=10"},
+        {"t": 3600, "type": "node_value", "node": "A3", "value": "promised b=10"},
+
+        {"t": 5000, "type": "message", "from": "L2", "to": "A1", "label": "accept(b=10, v=hwm=21)"},
+        {"t": 5000, "type": "message", "from": "L2", "to": "A2", "label": "accept(b=10, v=hwm=21)"},
+        {"t": 5000, "type": "message", "from": "L2", "to": "A3", "label": "accept(b=10, v=hwm=21)"},
+
+        {"t": 5800, "type": "message", "from": "A1", "to": "L2", "label": "accepted(b=10)", "kind": "reply"},
+        {"t": 5800, "type": "message", "from": "A2", "to": "L2", "label": "accepted(b=10)", "kind": "reply"},
+        {"t": 5800, "type": "message", "from": "A3", "to": "L2", "label": "accepted(b=10)", "kind": "reply"},
+
+        {"t": 6600, "type": "node_value", "node": "A1", "value": "accepted (b=10, hwm=21)"},
+        {"t": 6600, "type": "node_value", "node": "A2", "value": "accepted (b=10, hwm=21)"},
+        {"t": 6600, "type": "node_value", "node": "A3", "value": "accepted (b=10, hwm=21)"},
+
+        {"t": 7600, "type": "state",   "node": "L2", "state": "leader"}
+    ],
+    "annotations": [
+        {"t": 0,    "text": "L1 is the Multi-Paxos leader at ballot b=5. It has proposed hwm=21, and so far only A1 has accepted. The value is not yet decided across a quorum."},
+        {"t": 1000, "text": "L1 fails. No more accepts are coming from it."},
+        {"t": 1700, "text": "L2 wakes up and runs prepare(b=10) — strictly higher than any ballot L1 ever used."},
+        {"t": 2700, "text": "Promises arrive. A1 reports its previously-accepted value (b=5, hwm=21). A2 and A3 have nothing to report."},
+        {"t": 5000, "text": "By Paxos's safety rule, L2 must propose hwm=21 — any value that might have been decided at an earlier ballot must be re-proposed at the new one. L2 sends accept(b=10, v=hwm=21)."},
+        {"t": 6600, "text": "Quorum acks. hwm=21 is now durably decided across the cluster. Whether L1 had committed it before failing or not, the cluster now agrees."},
+        {"t": 7600, "text": "L2 is the new distinguished leader. The high-water mark survived the handoff with no ambiguity — this is the safety property Paxos is famous for."}
+    ]
+}

--- a/site/content/diagrams/paxos-prepare-accept.json
+++ b/site/content/diagrams/paxos-prepare-accept.json
@@ -1,0 +1,47 @@
+{
+    "nodes": ["P1", "A1", "A2", "A3"],
+    "duration": 7000,
+    "events": [
+        {"t": 0,    "type": "state",   "node": "P1", "state": "proposer"},
+        {"t": 0,    "type": "state",   "node": "A1", "state": "acceptor"},
+        {"t": 0,    "type": "state",   "node": "A2", "state": "acceptor"},
+        {"t": 0,    "type": "state",   "node": "A3", "state": "acceptor"},
+        {"t": 300,  "type": "ballot",  "ballot": 1},
+
+        {"t": 400,  "type": "message", "from": "P1", "to": "A1", "label": "prepare(b=1)"},
+        {"t": 400,  "type": "message", "from": "P1", "to": "A2", "label": "prepare(b=1)"},
+        {"t": 400,  "type": "message", "from": "P1", "to": "A3", "label": "prepare(b=1)"},
+
+        {"t": 1200, "type": "promise", "acceptor": "A1", "proposer": "P1"},
+        {"t": 1200, "type": "promise", "acceptor": "A2", "proposer": "P1"},
+        {"t": 1200, "type": "promise", "acceptor": "A3", "proposer": "P1"},
+        {"t": 1200, "type": "message", "from": "A1", "to": "P1", "label": "promise(b=1, last=∅)", "kind": "reply"},
+        {"t": 1200, "type": "message", "from": "A2", "to": "P1", "label": "promise(b=1, last=∅)", "kind": "reply"},
+        {"t": 1200, "type": "message", "from": "A3", "to": "P1", "label": "promise(b=1, last=∅)", "kind": "reply"},
+
+        {"t": 2050, "type": "node_value", "node": "A1", "value": "promised b=1"},
+        {"t": 2050, "type": "node_value", "node": "A2", "value": "promised b=1"},
+        {"t": 2050, "type": "node_value", "node": "A3", "value": "promised b=1"},
+
+        {"t": 3000, "type": "message", "from": "P1", "to": "A1", "label": "accept(b=1, v=hwm=14)"},
+        {"t": 3000, "type": "message", "from": "P1", "to": "A2", "label": "accept(b=1, v=hwm=14)"},
+        {"t": 3000, "type": "message", "from": "P1", "to": "A3", "label": "accept(b=1, v=hwm=14)"},
+
+        {"t": 3800, "type": "message", "from": "A1", "to": "P1", "label": "accepted(b=1)", "kind": "reply"},
+        {"t": 3800, "type": "message", "from": "A2", "to": "P1", "label": "accepted(b=1)", "kind": "reply"},
+        {"t": 3800, "type": "message", "from": "A3", "to": "P1", "label": "accepted(b=1)", "kind": "reply"},
+
+        {"t": 4600, "type": "node_value", "node": "A1", "value": "accepted (b=1, hwm=14)"},
+        {"t": 4600, "type": "node_value", "node": "A2", "value": "accepted (b=1, hwm=14)"},
+        {"t": 4600, "type": "node_value", "node": "A3", "value": "accepted (b=1, hwm=14)"},
+
+        {"t": 5400, "type": "node_value", "node": "P1", "value": "decided hwm=14"}
+    ],
+    "annotations": [
+        {"t": 0,    "text": "P1 is a proposer with three acceptors. It wants the cluster to agree on hwm=14."},
+        {"t": 400,  "text": "Phase 1 — prepare(b=1). P1 picks ballot b=1 and asks each acceptor to promise not to accept anything lower."},
+        {"t": 2050, "text": "All three acceptors promise b=1, reporting they have nothing previously accepted (last=∅). P1 has quorum and may propose freely."},
+        {"t": 3000, "text": "Phase 2 — accept(b=1, v=hwm=14). The value travels to the acceptors at the promised ballot."},
+        {"t": 4600, "text": "Quorum responds accepted. hwm=14 is durably decided. Any future round must learn this value before proposing anything new."}
+    ]
+}

--- a/site/content/posts/paxos-how-it-works.md
+++ b/site/content/posts/paxos-how-it-works.md
@@ -1,0 +1,88 @@
++++
+title = "Paxos, in pictures: ballots, promises, and the safety rule that makes it all work"
+description = "How classic Paxos decides a single value, why dueling proposers livelock, how Multi-Paxos rescues throughput, and why tsoracle is adding an omnipaxos driver next to the openraft one. With animated diagrams you can play through."
+weight = 7
+[taxonomies]
+tags = ["distributed-systems", "paxos", "consensus", "tsoracle", "internals"]
++++
+
+Paxos is the consensus algorithm Leslie Lamport published in 1989, formalized in 1998's "The Part-Time Parliament", and softened into the much shorter "Paxos Made Simple" in 2001 — and which has quietly been doing the actual work of keeping production distributed systems consistent for the better part of two decades. Google's Chubby uses it. Google Spanner runs it on every shard. Cassandra's lightweight transactions are Paxos under the hood. tsoracle's replicated mode currently runs on Raft via openraft, but a second driver — built on `omnipaxos`, a modern Rust implementation of Multi-Paxos — is the next major addition to the toolkit. This post is the algorithm itself, told once more in tsoracle's context, with animations that show what the messages actually look like on the wire.
+
+If you have already read [Raft, in pictures](/posts/raft-how-it-works/), most of the framing carries over: a quorum agreeing on a single fact, surviving partitions, surviving crashes. Paxos is what Raft is descended from, and the difference between the two is more about *how the safety argument is stated* than about what the algorithms ultimately compute. If you want the formal treatment, Lamport's [Paxos Made Simple](https://lamport.azurewebsites.net/pubs/paxos-simple.pdf) is short and famously the most approachable version. For a practical implementation guide most modern Paxos libraries trace their lineage to, van Renesse and Altinbuken's "Paxos Made Moderately Complex" (ACM Computing Surveys, 2015) is the canonical reference.
+
+## The problem Paxos solves
+
+A cluster of machines needs to agree on a single value. Some of those machines might be down. The network might drop or reorder messages. A majority of machines might still be talking to each other — but they don't know which majority — and the cluster must keep making progress whenever a majority does exist. Whatever value is finally chosen, every machine must agree on it forever.
+
+For tsoracle the value, again, is the high-water mark. Whether the underlying log is openraft or omnipaxos, the question is the same: when the cluster agrees on `hwm=21`, the leader can hand out IDs up to and including `21`, and no two machines should ever disagree about that number. Paxos answers the question at the *single-decree* level — agree on one value — and Multi-Paxos extends that into the per-slot log structure that real systems run on top of.
+
+## Single-decree Paxos: ballots, promises, accepts
+
+Paxos uses two phases. A *proposer* picks a unique, monotonically increasing number called a *ballot* (sometimes "proposal number" or "round number"), and runs:
+
+1. **Phase 1 — `prepare(b)`.** Send the ballot to a quorum of acceptors. Each acceptor that has not already promised a higher ballot promises this one, and replies with whatever value it has previously accepted at any lower ballot (or nothing, if it has accepted nothing yet).
+2. **Phase 2 — `accept(b, v)`.** Once the proposer has promises from a quorum, it picks the value `v` to propose: if any promise reported a previously-accepted value, the proposer **must** propose the one with the highest ballot. Otherwise the proposer is free to propose its own value. It sends `accept(b, v)` to a quorum.
+
+When a quorum returns `accepted(b)`, the value is decided. It will never change.
+
+{{ paxos_animation(name="paxos-prepare-accept", title="One full Paxos round: prepare, promise, accept, accepted. P1 decides hwm=14.") }}
+
+The two invariants are: (1) each acceptor only promises one ballot at a time, and once it promises ballot `b'` it refuses anything `< b'`; and (2) a proposer that runs phase 2 must adopt any previously-accepted value reported in phase 1. Together they guarantee that once a value is chosen, every future round either learns it or learns nothing — and a proposer that learns nothing about a slot is free to choose its own value, but if anything has been chosen, future rounds converge on it. This is the safety property the rest of the algorithm exists to defend.
+
+The phrase "with no previously-accepted value" in step 2 is doing the heavy lifting. It means: even if a previous round failed mid-flight, even if the proposer crashed, even if half the cluster never saw the accept message, the next round's prepare phase will discover whatever might already be decided. Acceptors are the cluster's memory; the prepare phase is how a new proposer reads that memory.
+
+## Dueling proposers
+
+Single-decree Paxos as described above is safe — no two values are ever both decided — but it is not *live*. Two proposers can take turns leapfrogging each other's ballots and never let a value commit.
+
+{{ paxos_animation(name="paxos-dueling-proposers", title="Two proposers leapfrog ballots. P1's accept arrives too late and is rejected. Classic Paxos livelock.") }}
+
+The pathology is visible: P1 prepares, gets promises, picks a value, sends accepts; P2 prepares at a higher ballot before P1's accepts arrive; acceptors reject P1's accepts because they have promised P2; P1 gives up and retries at a higher ballot; the cycle repeats. Lamport's paper acknowledges this directly — the safety argument does not depend on liveness — and points to the practical fix: elect a distinguished proposer that does not have competition, and let only that proposer run rounds. The election does not have to be Paxos-strict; it only has to be *eventually* unique, since safety is preserved no matter how many proposers compete.
+
+For tsoracle, this is the same reason Raft elects a single leader for the same role. If two leaders ran rounds simultaneously, both would still be safe — no two values ever get both decided — but throughput would collapse to zero. The fix is the same fix: pick one leader and let it work.
+
+## Multi-Paxos: one phase 1, many phase 2s
+
+A real system needs to decide a *sequence* of values, not just one. The naive "run a Paxos instance per slot" works for safety but is wasteful: every slot pays two round trips (prepare + accept), even though most slots have no contention.
+
+Multi-Paxos collapses the steady-state cost to one round trip. A stable leader runs `prepare` *once*, with a high ballot, covering all future slots. The prepare phase tells the leader, for each outstanding slot, whether any value has been accepted at any lower ballot — and if so, the leader takes over those proposals and re-issues them at its own ballot. After that initial reconciliation, the leader proposes new values one slot at a time using only `accept` messages. Each new decision is one round trip from leader to quorum and back. The cost matches Raft's `AppendEntries`.
+
+The interesting moment in Multi-Paxos is the *handoff* — when the leader fails and a new candidate runs its own phase 1 across the outstanding slots.
+
+{{ paxos_animation(name="paxos-leader-takeover", title="Multi-Paxos handoff. L2 prepares at a higher ballot, discovers L1's partial accept, and must adopt it.") }}
+
+Two things happen in the handoff that the safety rule from phase 1 makes load-bearing. First, L2 picks a ballot strictly higher than any L1 ever used — typically by stamping its node ID into the ballot's tiebreaker bits, so two concurrent takeovers can't accidentally collide on the same number. Second, L2's prepare collects every previously-accepted value from the quorum that promises, and for each slot it discovers a value at, L2 must propose that value at its own ballot before it can propose any new ones. The animation shows the simplest non-trivial case: a single slot where one acceptor saw L1's accept and two did not. L2 cannot know whether L1's value had already been decided across some quorum it did not see — so it re-proposes the value at `b=10` to remove the ambiguity. If L1 had decided the value, the cluster still agrees with that decision; if not, the cluster now commits to it. Either way the high-water mark does not regress.
+
+This is also where Paxos and Raft diverge most visibly. In Raft, the new leader's log is brought into alignment by overwriting any uncommitted suffixes that conflict with the new leader's committed prefix. In Multi-Paxos, slots can be decided out of order — slot `N+5` can commit before slot `N+3` — and the leader-takeover phase is what fills in the gaps. Both algorithms reach the same safety guarantee; the bookkeeping is different.
+
+## What this means for tsoracle specifically
+
+tsoracle's `ConsensusDriver` trait was designed to make exactly this kind of swap easy. The trait has three operations — `propose_advance`, `await_commit`, `current_leader` — and an implementation of those operations is everything the allocator needs to talk to a replicated log. Today the trait is implemented by `tsoracle-driver-openraft` against an openraft cluster, and by `tsoracle-driver-file` against a single local fsync. An `omnipaxos`-backed driver is the next addition, and the building blocks for it are landing now in `tsoracle-paxos-toolkit` — a glue layer that provides a RocksDB-backed `Storage` implementation for the trait omnipaxos requires, lifecycle helpers for running the omnipaxos state machine inside a tokio runtime, codec wrappers for postcard serialization, and a test-fakes harness for spinning up a paxos cluster in-process.
+
+The reason for shipping a second driver is straightforward: not every stack runs raft. Plenty of services already operate omnipaxos in production, plenty of teams prefer Multi-Paxos's out-of-order slot model for application reasons, and a TSO that requires you to also adopt openraft is not a TSO you can drop into an existing system. The piggyback story from [the openraft post](/posts/wiring-tsoracle-into-openraft/) — where the high-water-mark advance is just another log entry in your service's existing consensus — works identically on omnipaxos. One log, one snapshot, one fsync budget, one election. The variant lives in the envelope.
+
+The "Wiring tsoracle into omnipaxos" companion post is for when the driver layer above the toolkit lands. This post is the algorithmic background that will make that one short.
+
+## Failure modes worth knowing
+
+The failure cases that matter operationally are the same ones the Raft post covers, restated in Paxos's vocabulary.
+
+**A leader fails mid-decree.** Some acceptors may have received the accept and persisted it; others may not have. The new leader's prepare phase reads every acceptor's most-recent accepted value for the slot in question and adopts the one with the highest ballot. If a quorum had already accepted, the value is decided and the new leader propagates it; if not, the new leader could in principle propose freely — but for safety it always propagates whatever it saw, because it cannot distinguish "this almost made quorum" from "this did make quorum, and I just didn't see the proof".
+
+**A network partition isolates a would-be leader.** The minority side cannot collect a quorum of promises, so its prepare phases fail and no new values are accepted. The majority side elects its own leader at a higher ballot. When the partition heals, the minority's would-be leader sees the higher ballot in any acceptor it talks to, gives up, and rejoins as a follower.
+
+**A follower lags.** The leader's accepts include the slot index, and a follower that missed entries between its last-known slot and the leader's current slot simply requests catch-up. As in Raft, this happens through the same plumbing as normal replication — there is no separate recovery protocol — and the cluster's hot path is unaffected by one slow follower.
+
+The interesting safety arguments — the ones that fill the paper — are about preserving the "no two values both decided" invariant while these transitions happen. Practically, for an operator running tsoracle on either driver, the operational story is the same: run an odd number of replicas, keep them on machines that don't share failure domains, and watch the same dashboards you already have for replication lag and leader stability.
+
+## Paxos vs Raft, briefly
+
+Multi-Paxos and Raft converge on the same shape: a stable leader, a replicated log, a quorum commit point, a snapshot-and-catch-up story for slow followers. The differences are real but smaller than the comparison usually makes them out to be.
+
+Raft's log is a strict prefix — slot `N+1` cannot commit before slot `N`. Multi-Paxos's slots can commit out of order, which is occasionally useful (independent commands don't have to serialize behind a stalled earlier slot) and occasionally a bookkeeping burden (the snapshot has to handle gaps). Raft's election is designed for understandability — a vote per term, a randomized timeout, an explicit step-down rule — while Multi-Paxos's leader election is left more open, often layered as a separate Paxos-flavoured election or as a higher-level mechanism. omnipaxos in particular runs a Ballot/Leader Election (BLE) protocol on top of standard Paxos, and is engineered for graceful behaviour under partial connectivity in ways the original Multi-Paxos was not. In the Rust ecosystem today, openraft is the more mature option for general-purpose use; omnipaxos is catching up quickly and brings useful properties — particularly around partial-connectivity tolerance — that the original Multi-Paxos handled less gracefully.
+
+The choice between them is rarely about correctness. It is about the rest of your stack.
+
+## When to dive deeper
+
+Read [Lamport's "Paxos Made Simple"](https://lamport.azurewebsites.net/pubs/paxos-simple.pdf) for the algorithm in its shortest correct form, then van Renesse and Altinbuken's "Paxos Made Moderately Complex" (2015) for the implementation-shaped version most modern libraries trace their lineage to. For the omnipaxos extensions specifically, the [omnipaxos project page](https://omnipaxos.com/) links to the paper and the reference implementation. If you want to keep going inside tsoracle, [How tsoracle's window allocator works](/posts/how-the-window-allocator-works/) is the layer above the consensus driver, and [Wiring tsoracle into openraft](/posts/wiring-tsoracle-into-openraft/) is the integration story for the openraft driver — most of which carries over verbatim once the omnipaxos driver lands. The earlier posts in the series — [Why distributed systems need a TSO](/posts/why-distributed-systems-need-a-tso/), [TSO vs UUIDv7](/posts/tso-vs-uuidv7/), and [When you need a TSO](/posts/when-you-need-a-tso/) — are the *whether* before any of this matters.

--- a/site/static/diagrams/paxos-animation.js
+++ b/site/static/diagrams/paxos-animation.js
@@ -1,0 +1,465 @@
+export default function init(figure) {
+    const dataScript = figure.querySelector('script[type="application/json"]');
+    if (!dataScript) return;
+
+    let data;
+    try {
+        data = JSON.parse(dataScript.textContent);
+    } catch (err) {
+        return;
+    }
+
+    const svg = d3.select(figure).select('svg');
+    svg.selectAll('*').remove();
+
+    const width = 800;
+    const height = 540;
+    svg.attr('viewBox', `0 0 ${width} ${height}`);
+
+    const centerX = width / 2;
+    const centerY = 220;
+    const nodeRadius = 36;
+    const layoutRadius = 140;
+
+    const styles = getComputedStyle(figure);
+    const accent = styles.getPropertyValue('--accent').trim() || '#FFB000';
+    const codeBg = styles.getPropertyValue('--code-bg').trim() || '#17171A';
+    const fg = styles.getPropertyValue('--fg').trim() || '#E8E6E3';
+    const fgDim = styles.getPropertyValue('--fg-dim').trim() || '#8A8A86';
+    const ruleColor = styles.getPropertyValue('--rule').trim() || '#26262A';
+
+    // Node positions
+    const nodePos = {};
+    data.nodes.forEach(function (name, i) {
+        const angle = (2 * Math.PI * i) / data.nodes.length - Math.PI / 2;
+        nodePos[name] = {
+            x: centerX + layoutRadius * Math.cos(angle),
+            y: centerY + layoutRadius * Math.sin(angle),
+        };
+    });
+
+    // Layer order: timeout arcs (below nodes), nodes, messages (above)
+    const arcLayer = svg.append('g').attr('class', 'arc-layer');
+    const nodeLayer = svg.append('g').attr('class', 'node-layer');
+    const messageLayer = svg.append('g').attr('class', 'message-layer');
+
+    // Pre-create node groups; states updated each frame
+    const nodeGroups = {};
+    data.nodes.forEach(function (name) {
+        const pos = nodePos[name];
+        const g = nodeLayer.append('g').attr('transform', `translate(${pos.x}, ${pos.y})`);
+        const circle = g.append('circle')
+            .attr('r', nodeRadius)
+            .attr('fill', codeBg)
+            .attr('stroke', accent)
+            .attr('stroke-width', 2)
+            .style('transition', 'fill 250ms ease, stroke 250ms ease, opacity 250ms ease');
+        const label = g.append('text')
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'middle')
+            .attr('fill', fg)
+            .attr('font-family', 'JetBrainsMono, ui-monospace, monospace')
+            .attr('font-size', 16)
+            .attr('font-weight', 700)
+            .style('transition', 'fill 250ms ease')
+            .text(name);
+        // Per-node value badge below the circle. Empty by default; set by node_value events.
+        const valueBadge = g.append('text')
+            .attr('text-anchor', 'middle')
+            .attr('y', nodeRadius + 22)
+            .attr('fill', fgDim)
+            .attr('font-family', 'JetBrainsMono, ui-monospace, monospace')
+            .attr('font-size', 13)
+            .style('transition', 'fill 250ms ease');
+        nodeGroups[name] = { circle: circle, label: label, valueBadge: valueBadge };
+    });
+
+    // Annotation text below the cluster. Manual line-wrap via tspans, since SVG
+    // doesn't wrap by default.
+    const annotationText = svg.append('text')
+        .attr('text-anchor', 'middle')
+        .attr('fill', fg)
+        .attr('font-family', 'JetBrainsMono, ui-monospace, monospace')
+        .attr('font-size', 16);
+
+    const annotationCharsPerLine = 68;
+
+    function setAnnotationText(text) {
+        annotationText.selectAll('tspan').remove();
+        if (!text) return;
+        const words = text.split(/\s+/);
+        const lines = [];
+        let currentLine = '';
+        for (const word of words) {
+            const testLine = currentLine ? currentLine + ' ' + word : word;
+            if (testLine.length > annotationCharsPerLine && currentLine) {
+                lines.push(currentLine);
+                currentLine = word;
+            } else {
+                currentLine = testLine;
+            }
+        }
+        if (currentLine) lines.push(currentLine);
+
+        // Position the block so there's breathing room between the last line and
+        // the progress bar (bar at y = height - 50).
+        const lineHeight = 26;
+        const blockHeight = lines.length * lineHeight;
+        const startY = height - 90 - blockHeight + lineHeight;
+        lines.forEach(function (line, i) {
+            annotationText.append('tspan')
+                .attr('x', width / 2)
+                .attr('y', startY + i * lineHeight)
+                .text(line);
+        });
+    }
+
+    // Ballot indicator (top-right corner). Shows the current Paxos ballot.
+    const ballotGroup = svg.append('g').attr('class', 'ballot-indicator');
+    const ballotLabel = ballotGroup.append('text')
+        .attr('x', width - 30).attr('y', 38)
+        .attr('text-anchor', 'end')
+        .attr('fill', fgDim)
+        .attr('font-family', 'JetBrainsMono, ui-monospace, monospace')
+        .attr('font-size', 14)
+        .attr('font-weight', 700);
+
+    // Cluster state tracking — declared up-front because applyState references them
+    // before the simulation loop runs, when initializing default node states.
+    let currentBallot = '—';
+    let currentPromises = [];
+    const nodeStateMap = {};
+
+    // Time bar at the bottom: shows simulation progress
+    const barX = 80;
+    const barY = height - 50;
+    const barWidth = width - 160;
+    svg.append('rect')
+        .attr('x', barX).attr('y', barY)
+        .attr('width', barWidth).attr('height', 4)
+        .attr('rx', 2)
+        .attr('fill', ruleColor);
+    const barFill = svg.append('rect')
+        .attr('x', barX).attr('y', barY)
+        .attr('width', 0).attr('height', 4)
+        .attr('rx', 2)
+        .attr('fill', accent);
+
+    // Arc generator for timeout indicators
+    const arcGen = d3.arc()
+        .innerRadius(nodeRadius + 4)
+        .outerRadius(nodeRadius + 8)
+        .startAngle(0);
+
+    // Paxos state vocabulary:
+    //   leader     — distinguished Multi-Paxos proposer (highlighted fill).
+    //   proposer   — running a prepare/accept round (dashed stroke).
+    //   acceptor   — default node style.
+    //   learner    — default style; reserved for future use.
+    //   down       — dimmed, gray stroke.
+    function applyState(name, state) {
+        const node = nodeGroups[name];
+        if (!node) return;
+        nodeStateMap[name] = state;
+        const isLeader = state === 'leader';
+        const isActiveProposer = state === 'proposer';
+        const isDown = state === 'down';
+
+        node.circle
+            .attr('fill', isLeader ? accent : codeBg)
+            .attr('stroke', isDown ? fgDim : accent)
+            .attr('stroke-dasharray', isActiveProposer ? '4 4' : null)
+            .style('opacity', isDown ? 0.35 : 1);
+
+        node.label
+            .attr('fill', isLeader ? codeBg : fg);
+
+        renderBallotTable();
+    }
+
+    // Initialize all nodes to "acceptor" by default. JSON can promote any node
+    // to proposer or distinguished leader via state events.
+    data.nodes.forEach(function (name) { applyState(name, 'acceptor'); });
+
+    // Simulation state
+    const totalDuration = data.duration || 6000;
+    const events = (data.events || []).slice().sort(function (a, b) { return a.t - b.t; });
+    const annotations = (data.annotations || []).slice().sort(function (a, b) { return a.t - b.t; });
+
+    let simTime = 0;          // current simulation time in ms
+    let lastFrameTime = 0;    // for delta calculation
+    let playing = false;
+    let rafId = null;
+    let stopAtTime = null;    // when set, play loop pauses at this time (for step mode)
+
+    // Active visuals (in-flight)
+    const activeTimeouts = [];  // {node, startTime, duration, arcEl}
+    const activeMessages = [];  // {from, to, startTime, duration, label, kind, particleEl, labelEl}
+    let nextEventIdx = 0;
+
+    function clearActiveVisuals() {
+        activeTimeouts.forEach(function (to) { to.arcEl.remove(); });
+        activeTimeouts.length = 0;
+        activeMessages.forEach(function (msg) { msg.particleEl.remove(); msg.labelEl.remove(); });
+        activeMessages.length = 0;
+    }
+
+    function renderBallotTable() {
+        ballotLabel.text('ballot: ' + currentBallot);
+    }
+
+    function reset() {
+        simTime = 0;
+        nextEventIdx = 0;
+        clearActiveVisuals();
+        data.nodes.forEach(function (name) {
+            applyState(name, 'acceptor');
+            if (nodeGroups[name].valueBadge) {
+                nodeGroups[name].valueBadge.text('').style('fill', fgDim).style('font-weight', 400);
+            }
+        });
+        currentBallot = '—';
+        currentPromises = [];
+        renderBallotTable();
+        // Apply any events at t=0 so the initial state matches the data.
+        processEventsUpTo(0);
+        setAnnotationText(currentAnnotation(0));
+        barFill.attr('width', 0);
+    }
+
+    function processEventsUpTo(t) {
+        while (nextEventIdx < events.length && events[nextEventIdx].t <= t) {
+            const ev = events[nextEventIdx];
+            nextEventIdx++;
+            applyEvent(ev);
+        }
+    }
+
+    function applyEvent(ev) {
+        if (ev.type === 'state') {
+            applyState(ev.node, ev.state);
+        } else if (ev.type === 'timeout') {
+            const pos = nodePos[ev.node];
+            if (!pos) return;
+            const arcEl = arcLayer.append('path')
+                .attr('transform', `translate(${pos.x}, ${pos.y})`)
+                .attr('fill', accent);
+            activeTimeouts.push({
+                node: ev.node,
+                startTime: ev.t,
+                duration: ev.duration || 1000,
+                arcEl: arcEl,
+            });
+        } else if (ev.type === 'ballot') {
+            currentBallot = ev.label || String(ev.ballot || '?');
+            currentPromises = [];
+            renderBallotTable();
+        } else if (ev.type === 'promise') {
+            currentPromises.push({ acceptor: ev.acceptor, proposer: ev.proposer });
+            renderBallotTable();
+        } else if (ev.type === 'node_value') {
+            const node = nodeGroups[ev.node];
+            if (node) {
+                node.valueBadge.text(ev.value || '');
+                node.valueBadge
+                    .style('fill', accent)
+                    .style('font-weight', 700)
+                    .transition()
+                    .duration(800)
+                    .style('fill', fgDim)
+                    .style('font-weight', 400);
+            }
+        } else if (ev.type === 'message') {
+            const fromPos = nodePos[ev.from];
+            const toPos = nodePos[ev.to];
+            if (!fromPos || !toPos) return;
+            const isReply = ev.kind === 'reply';
+            const duration = ev.duration || 700;
+            const particleEl = messageLayer.append('circle')
+                .attr('r', 6)
+                .attr('fill', isReply ? codeBg : accent)
+                .attr('stroke', accent)
+                .attr('stroke-width', 2)
+                .attr('cx', fromPos.x)
+                .attr('cy', fromPos.y);
+            const midX = (fromPos.x + toPos.x) / 2;
+            const midY = (fromPos.y + toPos.y) / 2 - 12;
+            const labelEl = messageLayer.append('text')
+                .attr('x', midX).attr('y', midY)
+                .attr('text-anchor', 'middle')
+                .attr('fill', fgDim)
+                .attr('font-family', 'JetBrainsMono, ui-monospace, monospace')
+                .attr('font-size', 11)
+                .text(ev.label || '');
+            activeMessages.push({
+                from: ev.from,
+                to: ev.to,
+                startTime: ev.t,
+                duration: duration,
+                particleEl: particleEl,
+                labelEl: labelEl,
+            });
+        }
+    }
+
+    function currentAnnotation(t) {
+        let text = '';
+        for (let i = 0; i < annotations.length; i++) {
+            if (annotations[i].t <= t) text = annotations[i].text;
+            else break;
+        }
+        return text;
+    }
+
+    function updateVisuals(t) {
+        // Timeout arcs
+        for (let i = activeTimeouts.length - 1; i >= 0; i--) {
+            const to = activeTimeouts[i];
+            const progress = Math.min(1, (t - to.startTime) / to.duration);
+            const endAngle = progress * 2 * Math.PI;
+            to.arcEl.attr('d', arcGen({ startAngle: 0, endAngle: endAngle }));
+            if (progress >= 1) {
+                to.arcEl.remove();
+                activeTimeouts.splice(i, 1);
+            }
+        }
+
+        // Message particles
+        for (let i = activeMessages.length - 1; i >= 0; i--) {
+            const msg = activeMessages[i];
+            const progress = (t - msg.startTime) / msg.duration;
+            if (progress >= 1) {
+                msg.particleEl.remove();
+                msg.labelEl.remove();
+                activeMessages.splice(i, 1);
+                continue;
+            }
+            const fromPos = nodePos[msg.from];
+            const toPos = nodePos[msg.to];
+            // Start and end slightly outside the node circle so the particle
+            // doesn't overlap the node when emerging or arriving.
+            const dx = toPos.x - fromPos.x;
+            const dy = toPos.y - fromPos.y;
+            const len = Math.sqrt(dx * dx + dy * dy);
+            const ux = dx / len;
+            const uy = dy / len;
+            const x0 = fromPos.x + ux * nodeRadius;
+            const y0 = fromPos.y + uy * nodeRadius;
+            const x1 = toPos.x - ux * (nodeRadius + 2);
+            const y1 = toPos.y - uy * (nodeRadius + 2);
+            const cx = x0 + (x1 - x0) * progress;
+            const cy = y0 + (y1 - y0) * progress;
+            msg.particleEl.attr('cx', cx).attr('cy', cy);
+            // Fade in over first 15%, fade out over last 15%
+            const opacity = progress < 0.15 ? progress / 0.15
+                : progress > 0.85 ? (1 - progress) / 0.15
+                : 1;
+            msg.particleEl.style('opacity', opacity);
+            msg.labelEl
+                .attr('x', cx)
+                .attr('y', cy - 14)
+                .style('opacity', opacity);
+        }
+
+        setAnnotationText(currentAnnotation(t));
+        barFill.attr('width', barWidth * Math.min(1, t / totalDuration));
+    }
+
+    function showPlayBtn() {
+        if (playBtn) playBtn.removeAttribute('hidden');
+        if (pauseBtn) pauseBtn.setAttribute('hidden', '');
+    }
+
+    function showPauseBtn() {
+        if (playBtn) playBtn.setAttribute('hidden', '');
+        if (pauseBtn) pauseBtn.removeAttribute('hidden');
+    }
+
+    function tick(timestamp) {
+        if (!playing) return;
+        const delta = lastFrameTime === 0 ? 0 : timestamp - lastFrameTime;
+        lastFrameTime = timestamp;
+        simTime += delta;
+
+        // Hit the stop watermark (step mode) — clamp and pause.
+        if (stopAtTime !== null && simTime >= stopAtTime) {
+            simTime = stopAtTime;
+            processEventsUpTo(simTime);
+            updateVisuals(simTime);
+            playing = false;
+            stopAtTime = null;
+            showPlayBtn();
+            return;
+        }
+
+        processEventsUpTo(simTime);
+        updateVisuals(simTime);
+
+        if (simTime >= totalDuration) {
+            simTime = totalDuration;
+            playing = false;
+            showPlayBtn();
+            return;
+        }
+        rafId = requestAnimationFrame(tick);
+    }
+
+    function play() {
+        if (simTime >= totalDuration) reset();
+        stopAtTime = null;
+        playing = true;
+        lastFrameTime = 0;
+        showPauseBtn();
+        rafId = requestAnimationFrame(tick);
+    }
+
+    function pause() {
+        playing = false;
+        if (rafId) cancelAnimationFrame(rafId);
+        showPlayBtn();
+    }
+
+    function restart() {
+        pause();
+        reset();
+    }
+
+    function stepForward() {
+        // Find the next annotation strictly after current sim time.
+        let nextBeatTime = null;
+        for (let i = 0; i < annotations.length; i++) {
+            if (annotations[i].t > simTime + 1) { // +1ms to skip the current beat
+                nextBeatTime = annotations[i].t;
+                break;
+            }
+        }
+        // If no more annotations, advance to end.
+        if (nextBeatTime === null) nextBeatTime = totalDuration;
+
+        if (simTime >= totalDuration) reset();
+        stopAtTime = nextBeatTime;
+        playing = true;
+        lastFrameTime = 0;
+        showPauseBtn();
+        rafId = requestAnimationFrame(tick);
+    }
+
+    const playBtn = figure.querySelector('[data-action="play"]');
+    const pauseBtn = figure.querySelector('[data-action="pause"]');
+    const restartBtn = figure.querySelector('[data-action="restart"]');
+    const stepBtn = figure.querySelector('[data-action="step"]');
+
+    // Play-through is opt-in via data.allow_play_through. Default: hidden.
+    // Pause is still wired because step mode uses the play loop and may want to pause mid-step.
+    if (!data.allow_play_through) {
+        if (playBtn) playBtn.remove();
+        if (pauseBtn) pauseBtn.remove();
+    }
+
+    if (playBtn) playBtn.addEventListener('click', play);
+    if (pauseBtn) pauseBtn.addEventListener('click', pause);
+    if (restartBtn) restartBtn.addEventListener('click', restart);
+    if (stepBtn) stepBtn.addEventListener('click', stepForward);
+
+    reset();
+}

--- a/site/templates/shortcodes/paxos_animation.html
+++ b/site/templates/shortcodes/paxos_animation.html
@@ -1,0 +1,17 @@
+{% set data = load_data(path="content/diagrams/" ~ name ~ ".json") %}
+{% set caption = title | default(value='') %}
+<figure class="diagram diagram--paxos" data-d3-init="paxos-animation">
+    <svg viewBox="0 0 800 540" role="img" aria-label="{{ caption | default(value='Paxos animation: ' ~ name) }}" preserveAspectRatio="xMidYMid meet">
+        <text x="400" y="270" text-anchor="middle" fill="#8A8A86" font-family="JetBrainsMono, ui-monospace, monospace" font-size="14">
+            cluster: {% for n in data.nodes %}{{ n }}{% if not loop.last %} · {% endif %}{% endfor %}
+        </text>
+    </svg>
+    <div class="diagram-controls">
+        <button type="button" data-action="restart" aria-label="Restart animation">↻ restart</button>
+        <button type="button" data-action="step" aria-label="Step to next beat">▶| step</button>
+        <button type="button" data-action="play" aria-label="Play animation">▶ play through</button>
+        <button type="button" data-action="pause" aria-label="Pause animation" hidden>⏸ pause</button>
+    </div>
+    <script type="application/json">{{ data | json_encode | safe }}</script>
+    {% if caption %}<figcaption>{{ caption }}</figcaption>{% endif %}
+</figure>


### PR DESCRIPTION
## Summary

- New post `paxos-how-it-works.md` at weight 7, paired with the existing Raft post; covers single-decree Paxos, dueling-proposers livelock, Multi-Paxos handoff, the Paxos-vs-Raft comparison, and how an omnipaxos driver slides into tsoracle's existing `ConsensusDriver` trait alongside `tsoracle-driver-openraft`.
- Three new animated D3 diagrams under `site/content/diagrams/`: `paxos-prepare-accept.json`, `paxos-dueling-proposers.json`, `paxos-leader-takeover.json`.
- New `paxos_animation` Tera shortcode and `paxos-animation.js` renderer (adapted from the Raft renderer with Paxos vocabulary: proposer/acceptor/leader states, ballot/promise events). No changes to existing posts, shortcodes, or renderers.

## Test plan

- [x] `zola build` clean (8 pages, 0 warnings)
- [x] All three diagrams render and play in `zola serve` with the controls (restart, step, play, pause); no console errors
- [x] Step button advances annotation beats; message particles fly between nodes with correct labels; ballot indicator updates on `ballot` events; proposer styling (dashed stroke) distinct from acceptor styling
- [ ] CI Pages build picks up the new post in the `og-image` step and generates `/og/paxos-how-it-works.png`
- [ ] Visual / editorial review of post copy