### PR TITLE
feat(driver-paxos): StandaloneHost and PaxosDriver public façade

### DIFF
--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -9,3 +9,229 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! `ConsensusDriver` impl that wraps any [`PaxosHighWaterHost`].
+//!
+//! The driver layer is thin: it derives the fence-aligned epoch from
+//! the OmniPaxos handle on every leader observation and on every fence
+//! check, so the value the server sees matches the value
+//! `persist_high_water` compares against.
+
+use core::pin::Pin;
+
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use parking_lot::Mutex;
+use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
+use tsoracle_core::Epoch;
+use tsoracle_paxos_toolkit::lifecycle::LeaderEventStream;
+
+use crate::host::PaxosHighWaterHost;
+use crate::type_config::encode_epoch;
+
+/// `ConsensusDriver` for any `PaxosHighWaterHost`.
+///
+/// The toolkit's `PaxosRunner` emits leader events with a placeholder
+/// epoch (a process-local monotonic counter). This driver maps that
+/// stream to emit ballot-derived epochs that match what
+/// `persist_high_water`'s fence check sees, so leaders that pass their
+/// own epoch back into persist do not fence themselves out.
+pub struct PaxosDriver<H>
+where
+    H: PaxosHighWaterHost,
+{
+    host: H,
+    leader_stream: Mutex<Option<LeaderEventStream>>,
+}
+
+impl<H> PaxosDriver<H>
+where
+    H: PaxosHighWaterHost,
+{
+    /// Build a driver around a host.
+    ///
+    /// `leader_stream` is taken from the host (typically via
+    /// `StandaloneHost::take_leader_stream`). The driver consumes it
+    /// once on the first call to [`ConsensusDriver::leadership_events`];
+    /// subsequent calls return an empty stream that closes immediately
+    /// (the trait permits this since it is documented as a once-per-
+    /// lifetime subscription).
+    pub fn new(host: H, leader_stream: LeaderEventStream) -> Self {
+        Self {
+            host,
+            leader_stream: Mutex::new(Some(leader_stream)),
+        }
+    }
+
+    /// Borrow the wrapped host for direct interaction (e.g., to call
+    /// `omnipaxos()` from outside the driver path).
+    pub fn host(&self) -> &H {
+        &self.host
+    }
+}
+
+#[async_trait]
+impl<H> ConsensusDriver for PaxosDriver<H>
+where
+    H: PaxosHighWaterHost,
+{
+    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        let raw = self.leader_stream.lock().take();
+        let omnipaxos = self.host.omnipaxos();
+        match raw {
+            Some(stream) => {
+                let mapped = stream.map(move |state| match state {
+                    LeaderState::Leader { .. } => {
+                        // Re-derive epoch from the host's view of the
+                        // current ballot. This is what fence checks see.
+                        let ballot = omnipaxos.lock().get_promise();
+                        LeaderState::Leader {
+                            epoch: encode_epoch(ballot),
+                        }
+                    }
+                    other => other,
+                });
+                Box::pin(mapped)
+            }
+            None => Box::pin(futures::stream::empty()),
+        }
+    }
+
+    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
+        self.host.current_high_water().await
+    }
+
+    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        // Fence: reject the call if the supplied epoch does not match
+        // the host's current ballot-derived epoch. The check + append
+        // are NOT atomic across the OmniPaxos handle, but a stale leader
+        // whose ballot has been superseded will see its append rejected
+        // downstream anyway; this is a cheap pre-flight to avoid wasting
+        // a log slot.
+        let current_epoch = {
+            let handle = self.host.omnipaxos();
+            let guard = handle.lock();
+            encode_epoch(guard.get_promise())
+        };
+        if epoch != current_epoch {
+            return Err(ConsensusError::Fenced {
+                expected: epoch,
+                current: current_epoch,
+            });
+        }
+        self.host.submit_advance(at_least).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::log_entry::HighWaterCommand;
+    use omnipaxos::OmniPaxos;
+    use std::sync::Arc;
+    use tsoracle_paxos_toolkit::lifecycle::leader_event_channel;
+    use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+
+    // A minimal stub host for tests that need to construct a PaxosDriver
+    // without booting a real cluster. The omnipaxos handle is real but
+    // never ticked; current_high_water / submit_advance return errors.
+    struct StubHost {
+        omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, MemStorage<HighWaterCommand>>>>,
+    }
+
+    impl StubHost {
+        fn new() -> Self {
+            use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+            let cluster_config = ClusterConfig {
+                configuration_id: 1,
+                nodes: vec![1, 2, 3],
+                flexible_quorum: None,
+            };
+            let server_config = ServerConfig {
+                pid: 1,
+                ..Default::default()
+            };
+            let config = OmniPaxosConfig {
+                cluster_config,
+                server_config,
+            };
+            let omnipaxos = config
+                .build(MemStorage::<HighWaterCommand>::new())
+                .expect("build");
+            Self {
+                omnipaxos: Arc::new(Mutex::new(omnipaxos)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PaxosHighWaterHost for StubHost {
+        type Storage = MemStorage<HighWaterCommand>;
+
+        fn omnipaxos(
+            &self,
+        ) -> Arc<Mutex<OmniPaxos<HighWaterCommand, MemStorage<HighWaterCommand>>>> {
+            self.omnipaxos.clone()
+        }
+
+        async fn current_high_water(&self) -> Result<u64, ConsensusError> {
+            Ok(0)
+        }
+
+        async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
+            Ok(at_least)
+        }
+    }
+
+    #[tokio::test]
+    async fn persist_with_stale_epoch_returns_fenced() {
+        let host = StubHost::new();
+        let (_sender, stream) = leader_event_channel();
+        let driver = PaxosDriver::new(host, stream);
+
+        let stale_epoch = Epoch(0xDEAD_BEEF);
+        let result = driver.persist_high_water(42, stale_epoch).await;
+        match result {
+            Err(ConsensusError::Fenced { expected, current }) => {
+                assert_eq!(expected, stale_epoch);
+                assert_ne!(current, stale_epoch);
+            }
+            other => panic!("expected Fenced, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn persist_with_matching_epoch_calls_submit_advance() {
+        let host = StubHost::new();
+        let current_ballot = host.omnipaxos().lock().get_promise();
+        let current_epoch = encode_epoch(current_ballot);
+
+        let (_sender, stream) = leader_event_channel();
+        let driver = PaxosDriver::new(host, stream);
+
+        let result = driver.persist_high_water(99, current_epoch).await;
+        // StubHost::submit_advance returns Ok(at_least).
+        assert_eq!(result.unwrap(), 99);
+    }
+
+    #[tokio::test]
+    async fn leadership_events_is_take_once() {
+        let host = StubHost::new();
+        let (_sender, stream) = leader_event_channel();
+        let driver = PaxosDriver::new(host, stream);
+
+        // First call returns a real stream.
+        let _first = driver.leadership_events();
+        // Second call returns an empty stream that closes immediately.
+        let mut second = driver.leadership_events();
+        assert!(second.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_high_water_delegates_to_host() {
+        let host = StubHost::new();
+        let (_sender, stream) = leader_event_channel();
+        let driver = PaxosDriver::new(host, stream);
+        assert_eq!(driver.load_high_water().await.unwrap(), 0);
+    }
+}

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -30,6 +30,7 @@ pub mod standalone;
 pub mod state_machine;
 pub mod type_config;
 
+pub use driver::PaxosDriver;
 pub use log_entry::{HighWaterCommand, HighWaterSnapshot};
 pub use snapshot_policy::SnapshotPolicy;
 pub use standalone::{BuilderError, StandaloneHost, StandaloneHostBuilder};

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -32,5 +32,6 @@ pub mod type_config;
 
 pub use log_entry::{HighWaterCommand, HighWaterSnapshot};
 pub use snapshot_policy::SnapshotPolicy;
+pub use standalone::{BuilderError, StandaloneHost, StandaloneHostBuilder};
 pub use state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
 pub use type_config::{PaxosPeer, decode_epoch, encode_epoch};

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -9,3 +9,342 @@
 //  Licensed under the Apache License, Version 2.0
 //  https://github.com/prisma-risk/tsoracle
 //
+
+//! Standalone host: owns an OmniPaxos cluster handle, the toolkit's
+//! `PaxosRunner`, the spawned apply task, and the in-memory high-water
+//! state. Implements [`PaxosHighWaterHost`] so the driver can drive it
+//! directly.
+//!
+//! Use this host when the embedding service does not already run an
+//! OmniPaxos cluster for other state. Services that do should implement
+//! `PaxosHighWaterHost` directly against their existing cluster instead.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use omnipaxos::OmniPaxos;
+use omnipaxos::storage::Storage;
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tracing::warn;
+use tsoracle_consensus::ConsensusError;
+use tsoracle_paxos_toolkit::lifecycle::{LeaderEventStream, MessageSink, PaxosRunner, Peer};
+
+use crate::host::PaxosHighWaterHost;
+use crate::log_entry::HighWaterCommand;
+use crate::snapshot_policy::SnapshotPolicy;
+use crate::state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
+
+/// Standalone host owning its own paxos cluster + apply pipeline.
+pub struct StandaloneHost<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+{
+    omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+    runner: PaxosRunner<HighWaterCommand, S>,
+    apply_state: ApplyState,
+    leader_stream: Mutex<Option<LeaderEventStream>>,
+    apply_handle: Mutex<Option<JoinHandle<()>>>,
+    apply_shutdown: Arc<Notify>,
+    policy: Arc<Mutex<SnapshotPolicy>>,
+}
+
+impl<S> StandaloneHost<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+    <HighWaterCommand as omnipaxos::storage::Entry>::Snapshot: Send,
+{
+    /// Build a host from a pre-constructed OmniPaxos handle.
+    ///
+    /// Prefer [`StandaloneHost::builder`] for new code; this constructor
+    /// is the lower-level entry point. Caller owns the OmniPaxos handle
+    /// and the storage instance.
+    pub fn new(
+        omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+        my_node_id: u64,
+        peers: Vec<Peer>,
+        tick_interval: Duration,
+        policy: SnapshotPolicy,
+    ) -> Self {
+        let mut runner = PaxosRunner::new(omnipaxos.clone(), my_node_id, peers, tick_interval);
+        let leader_stream = runner.take_leader_stream();
+        Self {
+            omnipaxos,
+            runner,
+            apply_state: ApplyState::new(),
+            leader_stream: Mutex::new(leader_stream),
+            apply_handle: Mutex::new(None),
+            apply_shutdown: Arc::new(Notify::new()),
+            policy: Arc::new(Mutex::new(policy)),
+        }
+    }
+
+    /// Take ownership of the leader-event stream. Returns `None` if
+    /// already taken. The driver consumes this at construction.
+    pub fn take_leader_stream(&self) -> Option<LeaderEventStream> {
+        self.leader_stream.lock().take()
+    }
+
+    /// Borrow the OmniPaxos handle for direct interaction.
+    pub fn omnipaxos_handle(&self) -> Arc<Mutex<OmniPaxos<HighWaterCommand, S>>> {
+        self.omnipaxos.clone()
+    }
+
+    /// Spawn the runner's tick task and the apply task.
+    ///
+    /// `sink` carries outbound paxos messages to peers. The apply task
+    /// awaits the runner's `apply_notify` and drains decided entries
+    /// into the in-memory high-water on each wake.
+    ///
+    /// # Preconditions
+    ///
+    /// Must not be called while the host is already running. Debug
+    /// builds assert this; release builds would leave the previous
+    /// apply task orphaned.
+    pub fn start<Sink: MessageSink<HighWaterCommand>>(&mut self, sink: Arc<Sink>) {
+        debug_assert!(
+            self.apply_handle.lock().is_none(),
+            "StandaloneHost::start called while already running",
+        );
+
+        let omnipaxos = self.omnipaxos.clone();
+        let apply_notify = self.runner.apply_notify();
+        let apply_state = self.apply_state.clone();
+        let policy = self.policy.clone();
+        let shutdown = self.apply_shutdown.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut cursor: u64 = 0;
+            loop {
+                tokio::select! {
+                    _ = apply_notify.notified() => {
+                        let decided_idx = drain_decided_into(&omnipaxos, &mut cursor, &apply_state);
+                        let mut policy = policy.lock();
+                        maybe_snapshot(&omnipaxos, &mut policy, decided_idx);
+                    }
+                    _ = shutdown.notified() => {
+                        break;
+                    }
+                }
+            }
+        });
+        *self.apply_handle.lock() = Some(handle);
+
+        self.runner.start(sink);
+    }
+
+    /// Signal shutdown and await both the runner tick task and the
+    /// apply task. Surfaces a `tracing::warn!` if the apply task
+    /// terminated abnormally.
+    pub async fn stop(&mut self) {
+        self.apply_shutdown.notify_waiters();
+        let handle = self.apply_handle.lock().take();
+        if let Some(handle) = handle {
+            if let Err(err) = handle.await {
+                warn!(error = ?err, "paxos driver apply task terminated abnormally");
+            }
+        }
+        self.runner.stop().await;
+    }
+
+    /// Current in-memory high-water value (no consensus round-trip).
+    /// Used internally by `current_high_water` after a barrier decides.
+    pub fn current_value(&self) -> u64 {
+        self.apply_state.high_water()
+    }
+}
+
+/// Builder for [`StandaloneHost`].
+pub struct StandaloneHostBuilder<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+{
+    omnipaxos: Option<Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>>,
+    my_node_id: Option<u64>,
+    peers: Vec<Peer>,
+    tick_interval: Duration,
+    policy: SnapshotPolicy,
+}
+
+impl<S> Default for StandaloneHostBuilder<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+{
+    fn default() -> Self {
+        Self {
+            omnipaxos: None,
+            my_node_id: None,
+            peers: Vec::new(),
+            tick_interval: Duration::from_millis(20),
+            policy: SnapshotPolicy::disabled(),
+        }
+    }
+}
+
+impl<S> StandaloneHostBuilder<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+    <HighWaterCommand as omnipaxos::storage::Entry>::Snapshot: Send,
+{
+    pub fn omnipaxos(mut self, omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>) -> Self {
+        self.omnipaxos = Some(omnipaxos);
+        self
+    }
+
+    pub fn my_node_id(mut self, node_id: u64) -> Self {
+        self.my_node_id = Some(node_id);
+        self
+    }
+
+    pub fn peers(mut self, peers: Vec<Peer>) -> Self {
+        self.peers = peers;
+        self
+    }
+
+    pub fn tick_interval(mut self, tick_interval: Duration) -> Self {
+        self.tick_interval = tick_interval;
+        self
+    }
+
+    pub fn snapshot_policy(mut self, policy: SnapshotPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    pub fn build(self) -> Result<StandaloneHost<S>, BuilderError> {
+        let omnipaxos = self.omnipaxos.ok_or(BuilderError::MissingOmnipaxos)?;
+        let my_node_id = self.my_node_id.ok_or(BuilderError::MissingNodeId)?;
+        Ok(StandaloneHost::new(
+            omnipaxos,
+            my_node_id,
+            self.peers,
+            self.tick_interval,
+            self.policy,
+        ))
+    }
+}
+
+impl<S> StandaloneHost<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+    <HighWaterCommand as omnipaxos::storage::Entry>::Snapshot: Send,
+{
+    #[must_use]
+    pub fn builder() -> StandaloneHostBuilder<S> {
+        StandaloneHostBuilder::default()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuilderError {
+    #[error("omnipaxos handle is required")]
+    MissingOmnipaxos,
+    #[error("my_node_id is required")]
+    MissingNodeId,
+}
+
+#[async_trait]
+impl<S> PaxosHighWaterHost for StandaloneHost<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+    <HighWaterCommand as omnipaxos::storage::Entry>::Snapshot: Send,
+{
+    type Storage = S;
+
+    fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<HighWaterCommand, S>>> {
+        self.omnipaxos.clone()
+    }
+
+    async fn current_high_water(&self) -> Result<u64, ConsensusError> {
+        let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
+        self.omnipaxos
+            .lock()
+            .append(HighWaterCommand::Barrier)
+            .map_err(|err| {
+                ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
+            })?;
+        let notifier = self.apply_state.apply_notifier();
+        loop {
+            notifier.notified().await;
+            let new_decided = self.omnipaxos.lock().get_decided_idx();
+            if new_decided > snapshot_decided {
+                return Ok(self.apply_state.high_water());
+            }
+        }
+    }
+
+    async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
+        let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
+        self.omnipaxos
+            .lock()
+            .append(HighWaterCommand::Advance { at_least })
+            .map_err(|err| {
+                ConsensusError::TransientDriver(Box::new(AdvanceAppendError(format!("{err:?}"))))
+            })?;
+        let notifier = self.apply_state.apply_notifier();
+        loop {
+            notifier.notified().await;
+            let new_decided = self.omnipaxos.lock().get_decided_idx();
+            if new_decided > snapshot_decided && self.apply_state.high_water() >= at_least {
+                return Ok(self.apply_state.high_water());
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("barrier append failed: {0}")]
+struct BarrierAppendError(String);
+
+#[derive(Debug, thiserror::Error)]
+#[error("advance append failed: {0}")]
+struct AdvanceAppendError(String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(dead_code)]
+    fn assert_builder_api_compiles<S>()
+    where
+        S: Storage<HighWaterCommand> + Send + 'static,
+        <HighWaterCommand as omnipaxos::storage::Entry>::Snapshot: Send,
+    {
+        let _ = StandaloneHost::<S>::builder();
+    }
+
+    #[test]
+    fn builder_missing_omnipaxos_errors() {
+        use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+        let result: Result<StandaloneHost<MemStorage<HighWaterCommand>>, _> =
+            StandaloneHost::builder().my_node_id(1).build();
+        assert!(matches!(result, Err(BuilderError::MissingOmnipaxos)));
+    }
+
+    #[test]
+    fn builder_missing_node_id_errors() {
+        use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+        use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+        let cluster_config = ClusterConfig {
+            configuration_id: 1,
+            nodes: vec![1, 2, 3],
+            flexible_quorum: None,
+        };
+        let server_config = ServerConfig {
+            pid: 1,
+            ..Default::default()
+        };
+        let config = OmniPaxosConfig {
+            cluster_config,
+            server_config,
+        };
+        let omnipaxos = config
+            .build(MemStorage::<HighWaterCommand>::new())
+            .expect("build");
+        let arc = Arc::new(Mutex::new(omnipaxos));
+        let result = StandaloneHost::builder().omnipaxos(arc).build();
+        assert!(matches!(result, Err(BuilderError::MissingNodeId)));
+    }
+}


### PR DESCRIPTION
## Summary

The public façade of the paxos driver. With this PR, `tsoracle-driver-paxos` exposes a working `ConsensusDriver` implementation that callers can plug into `tsoracle-server`.

### `StandaloneHost`

`StandaloneHost<S>` owns the OmniPaxos handle, the toolkit's `PaxosRunner`, the spawned apply task, and the `ApplyState`. On `start(sink)`:

1. Spawns the apply task that awaits the runner's `apply_notify` and calls `drain_decided_into` + `maybe_snapshot` on each wake.
2. Calls `PaxosRunner::start(sink)` to spawn the tick + outbound-drain task.

On `stop()`: signals the apply task's shutdown notifier, awaits its `JoinHandle` (surfacing any abnormal termination via `tracing::warn!`), then stops the runner.

`StandaloneHost::builder()` provides ergonomic construction with `.omnipaxos(...)` / `.my_node_id(...)` / `.peers(...)` / `.tick_interval(...)` / `.snapshot_policy(...)` chains; `BuilderError::{MissingOmnipaxos, MissingNodeId}` flags incomplete builds.

`StandaloneHost` implements `PaxosHighWaterHost`:
- `current_high_water()`: snapshot `decided_idx`, append `Barrier`, loop awaiting `apply_notifier` until `decided_idx > snapshot`, then return the in-memory atomic.
- `submit_advance(at_least)`: snapshot `decided_idx`, append `Advance{at_least}`, loop until `decided_idx > snapshot AND atomic >= at_least`.

### `PaxosDriver`

`PaxosDriver<H: PaxosHighWaterHost>` wraps any host and implements `tsoracle_consensus::ConsensusDriver`:

- `leadership_events()`: takes the toolkit's `LeaderEventStream` (passed at construction) and maps each `Leader { epoch: counter }` to `Leader { epoch: encode_epoch(omnipaxos.get_promise()) }`. This is the load-bearing piece — the driver derives the epoch from the same source the fence check uses, so leaders that pass their own epoch back into `persist_high_water` do not fence themselves out. `Follower` and `Unknown` variants pass through unchanged. The stream is take-once per the trait's documented "server holds for its lifetime" contract.
- `load_high_water()`: delegates to `host.current_high_water()`.
- `persist_high_water(at_least, epoch)`: compares `epoch` against `encode_epoch(omnipaxos.get_promise())`. Mismatch returns `ConsensusError::Fenced { expected, current }` without proposing. Match calls `host.submit_advance(at_least)`.

### Locking discipline

All `parking_lot::Mutex` guards on the OmniPaxos handle and the apply-task `JoinHandle` are dropped before any `.await`. The persist path scopes the `get_promise()` read into its own block to release the guard before awaiting `submit_advance`. The stop path takes the `JoinHandle` out of its Mutex before awaiting it.

## Test plan

- [x] `cargo test -p tsoracle-driver-paxos --no-default-features --lib` — 31 passing (was 25; +6 new).
- [x] `cargo test -p tsoracle-driver-paxos --all-features --lib` — 31 passing.
- [x] `cargo clippy -p tsoracle-driver-paxos --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p tsoracle-driver-paxos --check` — clean.
- [x] `cargo deny check advisories` — advisories ok.
- [x] CI green on full workspace build.

### New tests

- `standalone::builder_missing_omnipaxos_errors`, `standalone::builder_missing_node_id_errors`.
- `driver::persist_with_stale_epoch_returns_fenced` — the fence check rejects a fabricated stale epoch.
- `driver::persist_with_matching_epoch_calls_submit_advance` — match path delegates correctly.
- `driver::leadership_events_is_take_once` — second call returns an empty stream.
- `driver::load_high_water_delegates_to_host` — simple delegation check.

Closes #173
