### PR TITLE
fix(ci): gate stress-nightly matrix cells on dispatch filter

### DIFF
--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -26,8 +26,6 @@ jobs:
   stress:
     name: ${{ matrix.topology }}/${{ matrix.scenario }}
     runs-on: ubuntu-latest
-    # Hard ceiling above the 15-minute --duration budget, leaving margin for
-    # build, smoke, and artifact upload.
     timeout-minutes: 30
     permissions:
       issues: write
@@ -48,34 +46,44 @@ jobs:
           - random-2
           - random-3
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Skip non-matching filters (manual dispatch)
-        if: |
-          github.event_name == 'workflow_dispatch' &&
-          ((github.event.inputs.topology != 'all' && github.event.inputs.topology != matrix.topology) ||
-           (github.event.inputs.scenario != 'all' && github.event.inputs.scenario != matrix.scenario))
+      - id: filter
+        name: Determine whether this matrix cell should run
         env:
+          EVENT_NAME: ${{ github.event_name }}
           MATRIX_TOPOLOGY: ${{ matrix.topology }}
           MATRIX_SCENARIO: ${{ matrix.scenario }}
           REQUESTED_TOPOLOGY: ${{ github.event.inputs.topology }}
           REQUESTED_SCENARIO: ${{ github.event.inputs.scenario }}
         run: |
-          echo "Skipping ${MATRIX_TOPOLOGY}/${MATRIX_SCENARIO} (dispatch requested ${REQUESTED_TOPOLOGY}/${REQUESTED_SCENARIO})"
-          exit 0
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] \
+            && { [[ "$REQUESTED_TOPOLOGY" != "all" && "$REQUESTED_TOPOLOGY" != "$MATRIX_TOPOLOGY" ]] \
+              || [[ "$REQUESTED_SCENARIO" != "all" && "$REQUESTED_SCENARIO" != "$MATRIX_SCENARIO" ]]; }; then
+            echo "Skipping ${MATRIX_TOPOLOGY}/${MATRIX_SCENARIO} (dispatch requested ${REQUESTED_TOPOLOGY}/${REQUESTED_SCENARIO})"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.filter.outputs.skip != 'true'
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.filter.outputs.skip != 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.filter.outputs.skip != 'true'
 
       - name: system deps
+        if: steps.filter.outputs.skip != 'true'
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
 
       - name: build
+        if: steps.filter.outputs.skip != 'true'
         run: cargo build --release --bin tsoracle && cargo build --release -p stress --features stress-failpoints
 
       - name: Determine scenario args
         id: args
+        if: steps.filter.outputs.skip != 'true'
         env:
           SCENARIO: ${{ matrix.scenario }}
           REQUESTED_DURATION: ${{ github.event.inputs.duration }}
@@ -94,6 +102,7 @@ jobs:
 
       - name: Run stress
         id: stress
+        if: steps.filter.outputs.skip != 'true'
         env:
           TOPOLOGY: ${{ matrix.topology }}
           ARGS: ${{ steps.args.outputs.args }}
@@ -122,7 +131,7 @@ jobs:
           exit "$code"
 
       - name: Upload artifacts
-        if: always()
+        if: always() && steps.filter.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: stress-${{ matrix.topology }}-${{ matrix.scenario }}-${{ github.run_id }}
@@ -133,7 +142,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Auto-file deduplicated issue on failure
-        if: failure() && steps.stress.outputs.exit_code != '0'
+        if: failure() && steps.stress.outputs.exit_code != '0' && steps.filter.outputs.skip != 'true'
         uses: ./.github/actions/stress-auto-issue
         with:
           topology: ${{ matrix.topology }}


### PR DESCRIPTION
## Summary

`.github/workflows/stress-nightly.yml` exposes `workflow_dispatch` inputs `topology`, `scenario`, and `duration` so a maintainer can rerun a single matrix cell. The existing `Skip non-matching filters` step exited 0 when the dispatched filter didn't match the cell, but `exit 0` only completes that one step — the subsequent steps (build, run stress, upload artifacts, auto-file issue) had no `if:` gate tied to the filter, so a manual dispatch requesting `topology=raft, scenario=killer-loop` still ran all 21 matrix cells, just with a one-line `Skipping ...` log in 20 of them. The loudest collateral was the auto-file-issue action firing from cells the operator never asked to rerun.

This PR replaces the no-op step with a `filter` step that emits `skip=true` / `skip=false` based on the dispatch inputs, and AND-gates every subsequent step on `steps.filter.outputs.skip != 'true'`, including the `always()` artifact upload and the `failure() && ...` auto-issue. The bash check short-circuits on `EVENT_NAME != workflow_dispatch`, so the scheduled cron path is unaffected.

## Why the per-step gate (not a job-level `if:`)

The issue sketched a job-level `if:` as a cleaner alternative — that was my first attempt — but per [GitHub's context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), `matrix.*` is **not** accessible in `jobs.<id>.if`. actionlint confirms (`context "matrix" is not allowed here. available contexts are "github", "inputs", "needs", "vars"`). The per-step gate is the working shape.

Also dropped the bare `# Hard ceiling...` comment above `timeout-minutes`, keeping the workflow body comment-free.

## Test plan

- [x] `actionlint .github/workflows/stress-nightly.yml` is clean
- [x] Expression walk-through for all four acceptance criteria from #133:
  - dispatch `topology=raft, scenario=killer-loop` on the `raft/killer-loop` cell: bash check evaluates `(workflow_dispatch) && ((raft!=all && raft!=raft) || (killer-loop!=all && killer-loop!=killer-loop))` → `true && (false || false)` → false → `skip=false` → all later steps run
  - same dispatch on the `mem/steady` cell: `true && ((raft!=all && raft!=mem) || ...)` → `true && (true || ...)` → true → `skip=true` → checkout/build/stress/upload/auto-issue all gated off
  - schedule event: outer `[[ "$EVENT_NAME" == "workflow_dispatch" ]]` is false → short-circuits → `skip=false` for every cell, all 21 run
  - skipped cell produces no `stress-<topology>-<scenario>-<run_id>` artifact (upload step gated) and no auto-filed issue (auto-issue step gated)
- [ ] Post-merge: run a `workflow_dispatch` from the Actions UI with `topology=raft, scenario=killer-loop` and confirm only the `raft/killer-loop` cell does real work

## Post-merge follow-ups

- [ ] After this lands on `main`, trigger a `workflow_dispatch` with a narrow filter (e.g. `topology=raft, scenario=killer-loop`) and verify in the Actions UI that the other 20 matrix cells finish in seconds (filter step + skipped subsequent steps) with no artifact uploads and no auto-filed issues.

Closes #133