### PR TITLE
fix(stress): gate topology::process behind cfg(unix)

### DIFF
--- a/benchmarks/stress/src/topology/mod.rs
+++ b/benchmarks/stress/src/topology/mod.rs
@@ -13,6 +13,7 @@
 //! Server topology abstractions: spawn, chaos vocabulary, endpoints.
 
 pub mod mem;
+#[cfg(unix)]
 pub mod process;
 pub mod raft;
 


### PR DESCRIPTION
## Summary

- `benchmarks/stress/src/topology/mod.rs` declared `pub mod process;` unconditionally, but the module imports `nix::sys::signal` / `nix::unistd::Pid` (`nix` is correctly gated to `[target.'cfg(unix)'.dependencies]` in `Cargo.toml`). On Windows the compiler tried to build the module and failed on the `nix::*` imports before the runtime `bail!("process topology is unix-only")` at `lib.rs:182` could ever fire, so any contributor running `cargo check --workspace` on a non-Unix host hit an immediate compile error.
- The `use` of `ProcessTopology` at `lib.rs:75` and the `TopologyKind::Process` match arm at `lib.rs:184-208` were already gated, so only the module declaration itself needed the attribute. One `#[cfg(unix)]` line closes the gap with zero behavior change on Linux/macOS; the runtime bail remains the operator-visible failure path on non-Unix.

Closes #134.

## Test plan

- [x] `cargo build -p stress` on macOS — clean.
- [x] `cargo test -p stress --lib` — 110 passed, 0 failed (including all `topology::process` unit tests).
- [x] `cargo fmt --check` + `cargo clippy` (pre-commit) — clean.
- [ ] `cargo check -p stress --target x86_64-pc-windows-{msvc,gnu}` — could not run locally because `aws-lc-sys`'s build script needs `x86_64-w64-mingw32-gcc` (or MSVC tooling), which isn't installed on the dev host. The change is logical (module excluded from compilation entirely on non-Unix), and the issue itself anticipates this constraint ("if cross-toolchain is configured"); Windows CI / contributors will validate naturally.