### PR TITLE
feat(examples): paxos-standalone — 3-node OmniPaxos cluster on StandaloneHost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-paxos-standalone"
+version = "0.1.4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "omnipaxos",
+ "parking_lot",
+ "postcard",
+ "prost",
+ "rocksdb",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "tracing-subscriber",
+ "tsoracle-consensus",
+ "tsoracle-core",
+ "tsoracle-driver-paxos",
+ "tsoracle-paxos-toolkit",
+ "tsoracle-server",
+]
+
+[[package]]
 name = "example-tls-mtls"
 version = "0.1.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members  = [
     "examples/metrics-prometheus",
     "examples/openraft-piggyback",
     "examples/openraft-standalone",
+    "examples/paxos-standalone",
     "examples/tls-mtls",
     "benchmarks/minimal",
     "benchmarks/stress",

--- a/examples/paxos-standalone/Cargo.toml
+++ b/examples/paxos-standalone/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name                   = "example-paxos-standalone"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+description            = "tsoracle example: HA via OmniPaxos, 3-node multi-process cluster (uses tsoracle-driver-paxos)"
+publish                = false
+
+[[bin]]
+name = "paxos-standalone"
+path = "src/main.rs"
+
+[features]
+default    = []
+reflection = ["tsoracle-server/reflection"]
+
+[dependencies]
+tsoracle-core          = { path = "../../crates/tsoracle-core", version = "0.1.3" }
+tsoracle-consensus     = { path = "../../crates/tsoracle-consensus", version = "0.1.3" }
+tsoracle-server        = { path = "../../crates/tsoracle-server", version = "0.1.3" }
+tsoracle-driver-paxos  = { path = "../../crates/tsoracle-driver-paxos", version = "0.1.4" }
+tsoracle-paxos-toolkit = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.1.4", features = ["rocksdb-storage"] }
+
+omnipaxos          = { workspace = true, features = ["serde"] }
+rocksdb            = { workspace = true }
+tonic              = { workspace = true }
+tonic-prost        = { workspace = true }
+prost              = { workspace = true }
+tokio              = { workspace = true, features = ["signal"] }
+async-trait        = { workspace = true }
+clap               = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+postcard           = { workspace = true }
+parking_lot        = { workspace = true }
+anyhow             = { workspace = true }
+
+[build-dependencies]
+tonic-prost-build = { workspace = true }

--- a/examples/paxos-standalone/README.md
+++ b/examples/paxos-standalone/README.md
@@ -1,0 +1,69 @@
+# Three-node tsoracle cluster on OmniPaxos (standalone)
+
+Multi-process tsoracle cluster backed by [OmniPaxos](https://omnipaxos.com), wired together via [`tsoracle-driver-paxos`](../../crates/tsoracle-driver-paxos/). The driver crate provides the `ConsensusDriver` impl, the `HighWaterCommand` log entry, the apply-task state machine, the `Epoch ↔ Ballot` encoding, and `StandaloneHost` — a host that owns its own OmniPaxos cluster + apply pipeline. This example supplies the rest: a tonic peer transport (`src/network.rs`), the OmniPaxos `ClusterConfig` glue (`src/main.rs`), and CLI plumbing.
+
+If your service already runs OmniPaxos for other state and you want TSO to share it, see the [`paxos-piggyback`](../paxos-piggyback/) example instead.
+
+> **Do not copy this example to production unchanged.** It is *correct enough* to teach the integration boundary, but several layers are deliberately simplified. See [Production caveats](#production-caveats).
+
+## Prerequisites
+
+- Rust 1.88+ (workspace toolchain).
+- `protoc` installed (`brew install protobuf` on macOS).
+- For `GetTs` smoke tests: `grpcurl` (optional but convenient).
+
+## Run a 3-node cluster
+
+Fastest path is the helper script — it starts three node processes in the background and tails their logs into `.data/n*.log`:
+
+    scripts/run.sh
+
+Alternatively start each node by hand in its own terminal:
+
+    # node 1
+    cargo run -p example-paxos-standalone -- \
+      --node-id 1 \
+      --listen 127.0.0.1:53001 --tso-listen 127.0.0.1:50581 \
+      --peers     "1=127.0.0.1:53001,2=127.0.0.1:53002,3=127.0.0.1:53003" \
+      --tso-peers "1=127.0.0.1:50581,2=127.0.0.1:50582,3=127.0.0.1:50583" \
+      --data-dir ./.data/n1
+
+    # node 2 (same args, --node-id 2, ports …002/…582, dir n2)
+    # node 3 (--node-id 3, ports …003/…583, dir n3)
+
+Unlike the openraft variant, OmniPaxos does **not** need a one-time `--bootstrap` flag. Cluster membership is carried in the `ClusterConfig` that every node builds from `--peers`, and leader election runs as soon as quorum is reachable.
+
+## Issue a timestamp
+
+Against any node:
+
+    grpcurl -plaintext -d '{"count":1}' 127.0.0.1:50581 tsoracle.v1.TsoService/GetTs
+
+A follower will respond with a `LeaderHint` trailer pointing at the current leader's tsoracle address (see `--tso-peers`). That trailer comes from `PaxosDriver::leadership_events`, which delegates the per-state mapping to the toolkit's `LeadershipState::from_omnipaxos` over the `Peer` list passed to `StandaloneHost::builder().peers(...)`.
+
+## Observe failover
+
+Find the current leader in the logs (`grep "Leader" .data/n*.log`), kill that process, watch the survivors elect a new leader. Subsequent `GetTs` calls succeed once the new leader has fenced — typically 1–3 seconds with the default OmniPaxos timeouts.
+
+## What's in this example
+
+- `src/main.rs` — CLI parse, RocksDB open with one column family for the paxos log, `OmniPaxos::build`, the three-binding driver wiring: `StandaloneHost::builder` → `host.start(sink)` → `PaxosDriver::new`. About 110 lines including config and storage.
+- `src/network.rs` — tonic peer transport. A single fire-and-forget unary RPC (`Send(PaxosMessage) → Ack`) carries postcard-encoded `omnipaxos::messages::Message<HighWaterCommand>` payloads. The `PeerSink` implements `MessageSink<HighWaterCommand>` (the contract `StandaloneHost::start` consumes); the `PaxosPeerService` server feeds inbound payloads to `OmniPaxos::handle_incoming`.
+- `proto/paxos.proto`, `build.rs` — peer-RPC service definition + tonic codegen.
+- `scripts/run.sh` — 3-node bring-up.
+
+## Production caveats
+
+This example shows the **minimum** wiring to take `ConsensusDriver` end-to-end with OmniPaxos. Several layers are simplified for readability and **must** be replaced before any real deployment:
+
+- **Snapshot transport.** OmniPaxos's snapshot install path is in-band: snapshots ride as a regular `Message` over the peer RPC. Because `HighWaterSnapshot` is a single `u64`, it always fits inside a default-sized gRPC frame, so no chunking is needed. State machines that grow into the hundreds of MiB would need either a larger `max_decoding_message_size` setting on both ends or a dedicated streaming RPC.
+
+- **Reconfiguration.** This example pins a fixed 3-node `ClusterConfig`. OmniPaxos supports reconfiguration via `StopSign`, but the membership change protocol (including the upgrade to a fresh `configuration_id`) is out of scope here.
+
+- **Authentication & TLS.** Every RPC (paxos peer and tsoracle client) is plaintext. Wrap both servers with TLS and require client certs before exposing anything beyond a trusted control plane.
+
+- **Graceful shutdown of the apply task.** Ctrl-C drains in-flight tsoracle RPCs, then drops the `PaxosDriver` (and the wrapped `StandaloneHost`). The runner tick task observes the runner's shutdown one-shot via its `Drop` impl and exits cleanly, but the apply task is parked on a `tokio::sync::Notify` whose source has gone away — the tokio runtime tears it down when the process exits. Production wiring should keep a separate handle on the host so `host.stop().await` can be awaited before the runtime shuts down.
+
+## Cleaning up
+
+    rm -rf examples/paxos-standalone/.data/

--- a/examples/paxos-standalone/build.rs
+++ b/examples/paxos-standalone/build.rs
@@ -1,0 +1,20 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .compile_protos(&["proto/paxos.proto"], &["proto"])?;
+    println!("cargo:rerun-if-changed=proto/paxos.proto");
+    Ok(())
+}

--- a/examples/paxos-standalone/proto/paxos.proto
+++ b/examples/paxos-standalone/proto/paxos.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package tsoracle.example.paxos.v1;
+
+// Peer-transport service for OmniPaxos.
+//
+// OmniPaxos has a single inbound dispatch point (`handle_incoming`), so one
+// fire-and-forget unary RPC is enough. The payload is a postcard-encoded
+// `omnipaxos::messages::Message<HighWaterCommand>` from the
+// `tsoracle-driver-paxos` crate.
+service PaxosPeerService {
+  rpc Send(PaxosMessage) returns (Ack);
+}
+
+message PaxosMessage {
+  bytes payload = 1;
+}
+
+message Ack {}

--- a/examples/paxos-standalone/scripts/run.sh
+++ b/examples/paxos-standalone/scripts/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Start a 3-node tsoracle/paxos cluster locally for demo purposes.
+# Logs go to .data/n<id>.log. Press Ctrl-C to terminate all nodes.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+mkdir -p .data
+rm -rf .data/n1 .data/n2 .data/n3
+
+PAXOS_PEERS="1=127.0.0.1:53001,2=127.0.0.1:53002,3=127.0.0.1:53003"
+TSO_PEERS="1=127.0.0.1:50581,2=127.0.0.1:50582,3=127.0.0.1:50583"
+
+pids=()
+trap 'echo "shutting down..."; kill "${pids[@]}" 2>/dev/null || true; wait' INT TERM
+
+cargo build -p example-paxos-standalone --features reflection
+TARGET_DIR="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys;print(json.load(sys.stdin)["target_directory"])')"
+BIN="$TARGET_DIR/debug/paxos-standalone"
+
+run_node() {
+  local id="$1"; local listen="$2"; local tso="$3"
+  "$BIN" \
+    --node-id "$id" --listen "$listen" --tso-listen "$tso" \
+    --peers "$PAXOS_PEERS" --tso-peers "$TSO_PEERS" \
+    --data-dir ".data/n$id" \
+    > ".data/n$id.log" 2>&1 &
+  pids+=("$!")
+}
+
+run_node 1 127.0.0.1:53001 127.0.0.1:50581
+run_node 2 127.0.0.1:53002 127.0.0.1:50582
+run_node 3 127.0.0.1:53003 127.0.0.1:50583
+
+echo "3-node tsoracle/paxos cluster running."
+echo "  node 1 logs: .data/n1.log  (tsoracle: http://127.0.0.1:50581)"
+echo "  node 2 logs: .data/n2.log  (tsoracle: http://127.0.0.1:50582)"
+echo "  node 3 logs: .data/n3.log  (tsoracle: http://127.0.0.1:50583)"
+echo "Ctrl-C to stop."
+wait

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -1,0 +1,205 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Multi-process 3-node tsoracle cluster backed by `tsoracle-driver-paxos`.
+//!
+//! The integration body is just three calls (`StandaloneHost::builder`,
+//! `host.start(sink)`, `PaxosDriver::new`); everything else is transport
+//! plumbing (`src/network.rs`), RocksDB setup, and config parsing.
+//!
+//! Unlike the openraft variant, OmniPaxos does not need a `--bootstrap` step:
+//! cluster membership is carried in the `ClusterConfig` every node builds
+//! from `--peers`, and leader election runs as soon as quorum is reachable.
+
+mod network;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use clap::Parser;
+use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+use parking_lot::Mutex;
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
+use tsoracle_paxos_toolkit::lifecycle::Peer;
+use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+use tsoracle_server::Server as TsoServer;
+
+use crate::network::{PeerSink, server as peer_server};
+
+/// RocksDB column family that holds the paxos log + meta (promise,
+/// accepted_round, decided_idx, compacted_idx, snapshot, stopsign).
+const PAXOS_CF: &str = "tso_paxos";
+
+/// Tick interval for the OmniPaxos runner. 20 ms is well below the default
+/// election timeouts and matches the test harness's choice; it also keeps the
+/// per-runner CPU cost negligible for a 3-node cluster.
+const TICK_INTERVAL: Duration = Duration::from_millis(20);
+
+#[derive(Parser, Debug)]
+#[command(name = "paxos-standalone")]
+struct Cli {
+    /// This node's numeric id (the OmniPaxos pid). Must be unique across the cluster.
+    #[arg(long)]
+    node_id: u64,
+
+    /// Address on which to listen for paxos peer RPCs (e.g. 127.0.0.1:53001).
+    #[arg(long)]
+    listen: SocketAddr,
+
+    /// Address on which to serve the tsoracle gRPC API (e.g. 127.0.0.1:50581).
+    #[arg(long)]
+    tso_listen: SocketAddr,
+
+    /// Comma-separated `id=host:port` pairs for paxos peer addresses.
+    /// Example: `1=127.0.0.1:53001,2=127.0.0.1:53002,3=127.0.0.1:53003`
+    #[arg(long)]
+    peers: String,
+
+    /// Comma-separated `id=host:port` pairs for tsoracle service addresses
+    /// used to populate `LeaderHint` follower-redirect.
+    /// Example: `1=127.0.0.1:50581,2=127.0.0.1:50582,3=127.0.0.1:50583`
+    #[arg(long)]
+    tso_peers: String,
+
+    /// Directory where the paxos log + meta are persisted.
+    #[arg(long)]
+    data_dir: PathBuf,
+}
+
+fn parse_peer_map(input: &str) -> anyhow::Result<HashMap<u64, String>> {
+    let mut out = HashMap::new();
+    for pair in input.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+        let (id, addr) = pair
+            .split_once('=')
+            .with_context(|| format!("bad peer entry {pair:?}, expected id=host:port"))?;
+        out.insert(id.trim().parse::<u64>()?, addr.trim().to_string());
+    }
+    Ok(out)
+}
+
+fn open_rocksdb(dir: &std::path::Path) -> anyhow::Result<Arc<DB>> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cfs = vec![ColumnFamilyDescriptor::new(PAXOS_CF, Options::default())];
+    Ok(Arc::new(DB::open_cf_descriptors(&opts, dir, cfs)?))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+    let cli = Cli::parse();
+
+    let paxos_addrs = parse_peer_map(&cli.peers)?;
+    let tso_addrs = parse_peer_map(&cli.tso_peers)?;
+
+    // ---- Storage ----
+    std::fs::create_dir_all(&cli.data_dir)?;
+    let db = open_rocksdb(&cli.data_dir)?;
+    let storage = RocksdbStorage::<HighWaterCommand>::open_in(db, PAXOS_CF)?;
+
+    // ---- OmniPaxos handle ----
+    // ClusterConfig.nodes is the full pid set; ordering doesn't matter to
+    // OmniPaxos itself, but sorted output keeps logs readable.
+    let mut node_ids: Vec<u64> = paxos_addrs.keys().copied().collect();
+    node_ids.sort_unstable();
+    let cluster_config = ClusterConfig {
+        configuration_id: 1,
+        nodes: node_ids,
+        flexible_quorum: None,
+    };
+    let server_config = ServerConfig {
+        pid: cli.node_id,
+        ..Default::default()
+    };
+    let omnipaxos_config = OmniPaxosConfig {
+        cluster_config,
+        server_config,
+    };
+    let omnipaxos = Arc::new(Mutex::new(
+        omnipaxos_config
+            .build(storage)
+            .context("build OmniPaxos handle")?,
+    ));
+
+    // ---- Peer-transport server (paxos-internal RPCs) ----
+    // Inbound messages flow straight into `OmniPaxos::handle_incoming` via
+    // the shared handle. The server is spawned before `host.start()` so any
+    // probe messages from peers that come up first are accepted, even though
+    // the local runner is not yet ticking.
+    let peer_service = peer_server(omnipaxos.clone());
+    let listen = cli.listen;
+    tokio::spawn(async move {
+        if let Err(err) = tonic::transport::Server::builder()
+            .add_service(peer_service)
+            .serve(listen)
+            .await
+        {
+            tracing::error!(error = ?err, "paxos peer server died");
+        }
+    });
+
+    // ---- StandaloneHost ----
+    // `peers` carries tsoracle service addresses (not paxos peer RPC); the
+    // toolkit's `LeadershipState::from_omnipaxos` consults this list when a
+    // peer is elected so `LeaderState::Follower::leader_endpoint` points at
+    // the leader's tsoracle gRPC address.
+    let toolkit_peers: Vec<Peer> = tso_addrs
+        .iter()
+        .filter(|(id, _)| **id != cli.node_id)
+        .map(|(id, endpoint)| Peer {
+            node_id: *id,
+            endpoint: format!("http://{endpoint}"),
+        })
+        .collect();
+    let mut host = StandaloneHost::builder()
+        .omnipaxos(omnipaxos)
+        .my_node_id(cli.node_id)
+        .peers(toolkit_peers)
+        .tick_interval(TICK_INTERVAL)
+        .snapshot_policy(SnapshotPolicy::disabled())
+        .build()
+        .context("build StandaloneHost")?;
+
+    let leader_stream = host
+        .take_leader_stream()
+        .context("leader stream available on a fresh host")?;
+
+    // ---- Start runner + apply task ----
+    let sink = Arc::new(PeerSink::new(paxos_addrs));
+    host.start(sink);
+
+    // ---- ConsensusDriver ----
+    let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+
+    // ---- Tsoracle gRPC server ----
+    let tso = TsoServer::builder().consensus_driver(driver).build()?;
+    let shutdown = async {
+        let _ = tokio::signal::ctrl_c().await;
+        tracing::info!("ctrl-c received, draining");
+    };
+    println!(
+        "tsoracle paxos node {} on http://{}",
+        cli.node_id, cli.tso_listen
+    );
+    tso.serve_with_shutdown(cli.tso_listen, shutdown).await?;
+    Ok(())
+}

--- a/examples/paxos-standalone/src/network.rs
+++ b/examples/paxos-standalone/src/network.rs
@@ -1,0 +1,140 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! tonic peer transport for OmniPaxos.
+//!
+//! Wire format: a single `Send(PaxosMessage) → Ack` unary RPC whose `payload`
+//! is a postcard-encoded `omnipaxos::messages::Message<HighWaterCommand>`. The
+//! server decodes and feeds the result to `OmniPaxos::handle_incoming`.
+//!
+//! OmniPaxos's outbound dispatch is itself fire-and-forget; we do not need a
+//! response payload, only a transport-level Ack so the client can observe
+//! connection-level failures and recycle its connection.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use omnipaxos::OmniPaxos;
+use omnipaxos::messages::Message;
+use omnipaxos::storage::Storage;
+use parking_lot::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+use tonic::transport::Channel;
+use tracing::warn;
+use tsoracle_driver_paxos::HighWaterCommand;
+use tsoracle_paxos_toolkit::lifecycle::MessageSink;
+
+pub mod proto {
+    tonic::include_proto!("tsoracle.example.paxos.v1");
+}
+
+use proto::paxos_peer_service_client::PaxosPeerServiceClient;
+use proto::paxos_peer_service_server::{PaxosPeerService, PaxosPeerServiceServer};
+use proto::{Ack, PaxosMessage};
+
+/// Outbound message sink. Holds the peer-address map and a lazy tonic client
+/// cache so each peer's `Channel` is only set up once per process lifetime.
+pub struct PeerSink {
+    addrs: Arc<HashMap<u64, String>>,
+    pool: AsyncMutex<HashMap<u64, PaxosPeerServiceClient<Channel>>>,
+}
+
+impl PeerSink {
+    pub fn new(addrs: HashMap<u64, String>) -> Self {
+        Self {
+            addrs: Arc::new(addrs),
+            pool: AsyncMutex::new(HashMap::new()),
+        }
+    }
+
+    async fn client(&self, target: u64) -> Option<PaxosPeerServiceClient<Channel>> {
+        let mut pool = self.pool.lock().await;
+        if let Some(client) = pool.get(&target) {
+            return Some(client.clone());
+        }
+        let endpoint = self.addrs.get(&target)?;
+        let url = format!("http://{endpoint}");
+        match PaxosPeerServiceClient::connect(url).await {
+            Ok(client) => {
+                pool.insert(target, client.clone());
+                Some(client)
+            }
+            Err(err) => {
+                // Peer reachability is a normal transient condition during
+                // bring-up (the others may not be listening yet). OmniPaxos
+                // retries on its own next tick, so we only log at warn.
+                warn!(target, error = %err, "paxos peer connect failed");
+                None
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl MessageSink<HighWaterCommand> for PeerSink {
+    async fn send(&self, message: Message<HighWaterCommand>) {
+        let target = message.get_receiver();
+        let payload = match postcard::to_stdvec(&message) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                warn!(target, error = %err, "encode outbound paxos message");
+                return;
+            }
+        };
+        let Some(mut client) = self.client(target).await else {
+            return;
+        };
+        if let Err(err) = client.send(PaxosMessage { payload }).await {
+            // Drop the cached client on RPC failure so the next attempt
+            // reconnects rather than re-using a half-broken channel.
+            self.pool.lock().await.remove(&target);
+            warn!(target, error = %err, "send paxos peer rpc");
+        }
+    }
+}
+
+/// Server-side handler: decodes inbound `PaxosMessage` payloads and feeds them
+/// to the shared `OmniPaxos` handle.
+pub struct PaxosPeerServiceImpl<S>
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+{
+    omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+}
+
+#[tonic::async_trait]
+impl<S> PaxosPeerService for PaxosPeerServiceImpl<S>
+where
+    S: Storage<HighWaterCommand> + Send + Sync + 'static,
+{
+    async fn send(
+        &self,
+        request: tonic::Request<PaxosMessage>,
+    ) -> Result<tonic::Response<Ack>, tonic::Status> {
+        let payload = request.into_inner().payload;
+        let message: Message<HighWaterCommand> = postcard::from_bytes(&payload)
+            .map_err(|err| tonic::Status::invalid_argument(format!("decode message: {err}")))?;
+        self.omnipaxos.lock().handle_incoming(message);
+        Ok(tonic::Response::new(Ack {}))
+    }
+}
+
+/// Construct the tonic server-side handler for the peer-transport service.
+pub fn server<S>(
+    omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+) -> PaxosPeerServiceServer<PaxosPeerServiceImpl<S>>
+where
+    S: Storage<HighWaterCommand> + Send + Sync + 'static,
+{
+    PaxosPeerServiceServer::new(PaxosPeerServiceImpl { omnipaxos })
+}


### PR DESCRIPTION
## Summary

- `examples/paxos-standalone`: counterpart of `openraft-standalone` for `tsoracle-driver-paxos`. Three-node OmniPaxos cluster wired through `StandaloneHost`.
- tonic peer transport (single fire-and-forget `Send` unary RPC) carrying postcard-encoded `omnipaxos::messages::Message<HighWaterCommand>`.
- RocksDB storage via `tsoracle-paxos-toolkit::RocksdbStorage` with one `tso_paxos` column family.
- `scripts/run.sh` and `README.md` modeled on the openraft-standalone pair; default ports `53001-3` (paxos) / `50581-3` (tsoracle) so both demos can run in parallel.

Implements one of the three example crates from #175; `paxos-piggyback` and `paxos-embedded` land in follow-up PRs.

## Test plan

- [x] `cargo build -p example-paxos-standalone` (default features)
- [x] `cargo build -p example-paxos-standalone --features reflection`
- [x] `scripts/run.sh` brings up a 3-node cluster; OmniPaxos elects a leader; `grpcurl -plaintext -d '{"count":1}' 127.0.0.1:5058N tsoracle.v1.TsoService/GetTs` returns a real timestamp from the leader and `FailedPrecondition: not leader` from followers
- [x] Workspace `cargo fmt --check` + `cargo clippy` clean (pre-commit hooks)
- [ ] Reviewer: confirm `53001-3` / `50581-3` port choices don't conflict with anything in CI