### PR TITLE
test(driver-paxos): widen post-event catch-up budgets for slower hosts

### DIFF
--- a/crates/tsoracle-driver-paxos/tests/restart_replay.rs
+++ b/crates/tsoracle-driver-paxos/tests/restart_replay.rs
@@ -109,7 +109,7 @@ async fn restart_recovers_decided_state_from_storage() {
 
     // Catch-up: the restarted follower must converge to high_water == 100.
     cluster
-        .drive_until(|state| state.high_water_on(follower_id) >= 100, 3_000)
+        .drive_until(|state| state.high_water_on(follower_id) >= 100, 10_000)
         .await;
 
     assert_eq!(cluster.high_water_on(follower_id), 100);

--- a/crates/tsoracle-driver-paxos/tests/snapshot_restart.rs
+++ b/crates/tsoracle-driver-paxos/tests/snapshot_restart.rs
@@ -113,7 +113,7 @@ async fn snapshot_policy_persists_across_restart() {
 
     // The restarted follower must converge to the latest high-water of 20.
     cluster
-        .drive_until(|state| state.high_water_on(follower_id) >= 20, 3_000)
+        .drive_until(|state| state.high_water_on(follower_id) >= 20, 10_000)
         .await;
     assert_eq!(cluster.high_water_on(follower_id), 20);
 

--- a/crates/tsoracle-driver-paxos/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-paxos/tests/snapshot_transfer.rs
@@ -112,7 +112,7 @@ async fn isolated_node_catches_up_via_snapshot_transfer() {
     cluster.network.partition().heal();
 
     cluster
-        .drive_until(|state| state.high_water_on(joining_id) >= 20, 5_000)
+        .drive_until(|state| state.high_water_on(joining_id) >= 20, 10_000)
         .await;
 
     // Snapshot transfer observable: the joining node's storage now has


### PR DESCRIPTION
## Summary

- The three integration tests that exercise post-event catch-up — snapshot transfer to a freshly-healed joining node, log replay to a restarted follower, snapshot+replay to a restarted follower — sized their final `drive_until` budget at 3_000–5_000 ticks. Under `cargo-llvm-cov` coverage instrumentation (run on the `coverage` job) the OmniPaxos runner, message pumps, and storage writes all slow down enough that these budgets become marginal or insufficient. The suite then hangs in the post-event phase rather than panicking cleanly — observed today on PR #187's `coverage` job, where `isolated_node_catches_up_via_snapshot_transfer` stalled past 60 s while the uninstrumented `test` job had passed it cleanly minutes earlier.
- Bump the final `drive_until` in each of the three tests from 3_000 / 5_000 → 10_000 ticks, matching `partition_churn.rs`'s existing 10_000-tick budgets for its similar post-event chaos phases. Each predicate short-circuits as soon as it's satisfied, so fast-path runtime is unchanged; this only raises the ceiling for heavily-loaded runs.
- Initial leader-election and initial-decision budgets in each file are left untouched — they are not the phases that flake under coverage.

## Test plan

- [x] `cargo fmt --check` + `cargo clippy` (pre-commit) — clean.
- [ ] Confirm the coverage job's `isolated_node_catches_up_via_snapshot_transfer` (and the other two affected tests, run under instrumentation) complete cleanly. The non-instrumented `test` job already passes them today; this PR is gated on the next nightly `coverage` run going green.