### PR TITLE
feat(driver-paxos): generic entry type + paxos-piggyback example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-paxos-piggyback"
+version = "0.1.4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "omnipaxos",
+ "parking_lot",
+ "postcard",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tsoracle-client",
+ "tsoracle-consensus",
+ "tsoracle-core",
+ "tsoracle-driver-paxos",
+ "tsoracle-paxos-toolkit",
+ "tsoracle-server",
+]
+
+[[package]]
 name = "example-paxos-standalone"
 version = "0.1.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members  = [
     "examples/openraft-piggyback",
     "examples/openraft-standalone",
     "examples/paxos-embedded",
+    "examples/paxos-piggyback",
     "examples/paxos-standalone",
     "examples/tls-mtls",
     "benchmarks/minimal",

--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -166,6 +166,7 @@ mod tests {
 
     #[async_trait]
     impl PaxosHighWaterHost for StubHost {
+        type Entry = HighWaterCommand;
         type Storage = MemStorage<HighWaterCommand>;
 
         fn omnipaxos(

--- a/crates/tsoracle-driver-paxos/src/host.rs
+++ b/crates/tsoracle-driver-paxos/src/host.rs
@@ -14,54 +14,68 @@
 //!
 //! Implementations decide where the OmniPaxos handle lives, where storage
 //! is persisted, and how `current_high_water` / `submit_advance` interact
-//! with the underlying paxos log. The bundled `StandaloneHost` (landing in
-//! a follow-up sub-issue) owns its own OmniPaxos cluster + state machine.
-//! A larger service (e.g., one that already runs OmniPaxos for other
-//! state) can implement this trait directly and route TSO commands
-//! through its existing log.
+//! with the underlying paxos log. The bundled [`crate::StandaloneHost`]
+//! owns its own OmniPaxos cluster + apply pipeline keyed on
+//! [`HighWaterCommand`]. A larger service that already runs OmniPaxos for
+//! other state can implement this trait against its existing handle and
+//! pick its own [`Entry`](omnipaxos::storage::Entry) — typically an
+//! envelope enum that carries `HighWaterCommand` as one variant alongside
+//! the service's own commands.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use omnipaxos::OmniPaxos;
-use omnipaxos::storage::Storage;
+use omnipaxos::storage::{Entry, Storage};
 use parking_lot::Mutex;
 use tsoracle_consensus::ConsensusError;
-
-use crate::log_entry::HighWaterCommand;
 
 /// Host that knows how to read and advance the TSO high-water mark via
 /// OmniPaxos.
 ///
 /// The driver crate handles the `ConsensusDriver` trait shape and
-/// leadership-event mapping; the host supplies the storage / submission
-/// semantics.
+/// leadership-event mapping; the host supplies the entry shape, the
+/// storage, and the submission semantics.
 #[async_trait]
 pub trait PaxosHighWaterHost: Send + Sync + 'static {
+    /// The OmniPaxos entry type this host's log replicates.
+    ///
+    /// The bundled [`crate::StandaloneHost`] sets this to
+    /// [`crate::log_entry::HighWaterCommand`] directly. A piggyback host
+    /// typically picks a wider envelope enum (e.g.
+    /// `MyAppCommand::{App(_), HighWater(HighWaterCommand)}`) so its TSO
+    /// proposals ride the same log as its existing commands.
+    ///
+    /// The `Snapshot: Send` bound lets the driver move the OmniPaxos
+    /// handle across `.await` points when mapping leader observations.
+    type Entry: Entry<Snapshot: Send> + Send + 'static;
+
     /// The storage type backing this host's OmniPaxos handle. Each host
     /// picks its own — the standalone host uses the toolkit's
-    /// `RocksdbStorage`, a piggy-back host uses whatever Storage its
+    /// `RocksdbStorage`, a piggyback host uses whatever Storage its
     /// larger OmniPaxos instance is built on.
-    type Storage: Storage<HighWaterCommand> + Send + 'static;
+    type Storage: Storage<Self::Entry> + Send + 'static;
 
     /// The OmniPaxos handle the driver reads leadership state from.
-    fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<HighWaterCommand, Self::Storage>>>;
+    fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<Self::Entry, Self::Storage>>>;
 
     /// Read the current high-water mark linearizably.
     ///
-    /// Implementations append a `HighWaterCommand::Barrier`, await the
-    /// apply task's notification that the cluster's `decided_idx` has
-    /// advanced past the call's snapshot, and then return the in-memory
-    /// high-water.
+    /// Implementations append a barrier entry (the standalone host uses
+    /// [`crate::log_entry::HighWaterCommand::Barrier`]; piggyback hosts
+    /// wrap it in their envelope variant), await the apply task's
+    /// notification that the cluster's `decided_idx` has advanced past
+    /// the call's snapshot, and then return the in-memory high-water.
     async fn current_high_water(&self) -> Result<u64, ConsensusError>;
 
     /// Submit a "bump to at_least" proposal through the host's OmniPaxos
     /// log and return the new high-water value once the cluster has
     /// applied it (or a later higher value).
     ///
-    /// Implementations append a `HighWaterCommand::Advance { at_least }`
-    /// and wait until both (a) the cluster's `decided_idx` has advanced
-    /// past the call's snapshot AND (b) the in-memory high-water is at
-    /// least `at_least`.
+    /// Implementations append an advance entry (the standalone host uses
+    /// [`crate::log_entry::HighWaterCommand::Advance`]; piggyback hosts
+    /// wrap it in their envelope variant) and wait until both (a) the
+    /// cluster's `decided_idx` has advanced past the call's snapshot AND
+    /// (b) the in-memory high-water is at least `at_least`.
     async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError>;
 }

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -259,6 +259,7 @@ where
     S: Storage<HighWaterCommand> + Send + 'static,
     <HighWaterCommand as omnipaxos::storage::Entry>::Snapshot: Send,
 {
+    type Entry = HighWaterCommand;
     type Storage = S;
 
     fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<HighWaterCommand, S>>> {

--- a/crates/tsoracle-driver-paxos/tests/three_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/three_node.rs
@@ -222,6 +222,7 @@ impl FollowerProxyHost {
 
 #[async_trait]
 impl PaxosHighWaterHost for FollowerProxyHost {
+    type Entry = HighWaterCommand;
     type Storage = MemStorage<HighWaterCommand>;
 
     fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<HighWaterCommand, MemStorage<HighWaterCommand>>>> {

--- a/examples/paxos-piggyback/Cargo.toml
+++ b/examples/paxos-piggyback/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name                   = "example-paxos-piggyback"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+description            = "tsoracle example: piggyback TSO on a host service's existing OmniPaxos cluster"
+publish                = false
+
+[[bin]]
+name = "paxos-piggyback"
+path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tsoracle-core          = { path = "../../crates/tsoracle-core", version = "0.1.3" }
+tsoracle-consensus     = { path = "../../crates/tsoracle-consensus", version = "0.1.3" }
+tsoracle-server        = { path = "../../crates/tsoracle-server", version = "0.1.3" }
+tsoracle-client        = { path = "../../crates/tsoracle-client", version = "0.1.3" }
+tsoracle-driver-paxos  = { path = "../../crates/tsoracle-driver-paxos", version = "0.1.4" }
+tsoracle-paxos-toolkit = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.1.4", default-features = false, features = ["test-fakes"] }
+
+omnipaxos          = { workspace = true, features = ["serde"] }
+async-trait        = { workspace = true }
+serde              = { workspace = true }
+postcard           = { workspace = true }
+tokio              = { workspace = true, features = ["signal"] }
+parking_lot        = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow             = { workspace = true }
+futures            = { workspace = true }
+thiserror          = { workspace = true }

--- a/examples/paxos-piggyback/README.md
+++ b/examples/paxos-piggyback/README.md
@@ -1,0 +1,47 @@
+# Piggyback TSO onto an existing OmniPaxos cluster
+
+A single-binary, in-process 3-node demonstration of the envelope pattern: a service that already runs OmniPaxos for its own state (a tiny KV in this example) adds tsoracle high-water replication to the **same** OmniPaxos log, instead of bringing up a second cluster.
+
+For the "I want a dedicated TSO OmniPaxos" case, see [`paxos-standalone`](../paxos-standalone/).
+
+## Run
+
+    cargo run -p example-paxos-piggyback
+
+The demo runs in roughly 3 seconds and prints a scripted walk-through. Output is also asserted by `tests/smoke.rs`.
+
+## What the demo shows
+
+1. **Boot.** Three OmniPaxos nodes connected by the toolkit's `MemNetwork` (no tonic, no peer discovery). Each runs a `tsoracle::Server` bound to an OS-assigned loopback port, so the demo and its smoke test can run repeatedly without port-conflict flake.
+2. **Post-fence high-water.** Once the tsoracle-server leader-watch task fires on the new leader, the fence persists `serving_floor + failover_advance`. The demo prints this value.
+3. **Host KV writes ride the same paxos log.** Appending `MyAppCommand::Kv(Put { ... })` directly on the leader's OmniPaxos handle lands an entry in the shared log. The apply pump folds the KV variant into the host's in-memory map; the TSO field stays at its current value.
+4. **Steady-state TSO is allocator-served.** A burst of `GetTs` calls returns strictly monotonic timestamps **without** moving the durable high-water — high-water advances on fences and on window-extension; steady-state `GetTs` hits the allocator.
+5. **Failover preserves monotonicity.** The leader is shut down; a survivor elects; its fence runs; the demo asserts both `new_high_water > old_high_water` AND `next_ts > last_pre_failover_ts` (the freshness invariant).
+
+## The envelope pattern, in three concepts
+
+**`MyAppCommand::{Kv(KvOp), HighWater(HighWaterCommand)}`.** Your existing entry type becomes an enum. TSO commands ride as one variant; your own commands ride as the others. See `src/host_service.rs`.
+
+**Apply-path responsibility.** TSO monotonicity (`max(prev, target)`) lives in *your* apply pump, in a field next to the rest of your state. The driver crate doesn't enforce it for you in the piggyback case — that's why the trait is split: `PaxosHighWaterHost` is about storage and submission, not the apply contract.
+
+**Snapshot responsibility.** Your snapshot now carries both halves. `MyAppSnap { kv, high_water }` in `src/host_service.rs` shows the shape; `impl Snapshot<MyAppCommand>` folds both at compaction time.
+
+## Who provides what
+
+| Concern | Provider |
+| --- | --- |
+| `HighWaterCommand` (the log entry payload for TSO) | `tsoracle-driver-paxos` |
+| `MyAppCommand` envelope enum + apply pump | **You** (`host_service.rs::MyAppCommand` + `drain_decided_into`) |
+| `MyAppSnap` snapshot type + fold | **You** (`host_service.rs::MyAppSnap`) |
+| `PaxosHighWaterHost` impl wrapping the host | **You** (`host_service.rs::PiggybackHost`) |
+| `ConsensusDriver` glue + leadership-events stream | `tsoracle-driver-paxos` (via `PaxosDriver`) |
+| Linearizable reads | **You** (`current_high_water` appends a `HighWater(Barrier)` and polls `decided_idx`) |
+| Peer transport | **You** (the demo uses `MemNetwork`; production uses your service's existing transport) |
+
+## Production caveats
+
+- **In-process MemNetwork.** Replace with your real OmniPaxos peer transport. Nothing in the envelope pattern requires `MemNetwork`; the demo uses it to stay single-binary.
+- **In-memory `MemStorage`.** This demo uses the toolkit's `MemStorage<MyAppCommand>` test fake. Real services already have a persisted Storage; substitute it (e.g., the toolkit's `RocksdbStorage` if you're starting fresh, or your own existing storage impl).
+- **Snapshotting disabled.** This demo never triggers `OmniPaxos::snapshot`; the apply pump still handles `LogEntry::Snapshotted` so a piggyback host that does enable snapshotting in production gets correct behavior. Re-enable in your own code with a snapshot policy.
+- **Endpoint resolution for `LeaderHint`.** The demo's client is constructed with all three loopback endpoints and rotates across them; the driver returns `LeaderState::Follower { leader_endpoint: None }`. Production piggyback hosts that want `LeaderHint` populated populate the `Peer` list passed to whatever toolkit machinery they use to produce the leader stream.
+- **No add-learner / reconfiguration demo.** Out of scope.

--- a/examples/paxos-piggyback/src/demo.rs
+++ b/examples/paxos-piggyback/src/demo.rs
@@ -1,0 +1,541 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! In-process 3-node piggyback demo.
+//!
+//! Boots three OmniPaxos nodes connected via `MemNetwork`, each running a
+//! tsoracle::Server bound to a unique loopback port. Drives a scripted
+//! sequence: KV writes (appended via the leader's OmniPaxos handle), GetTs
+//! via a tsoracle-client, then a failover — asserting both halves of the
+//! freshness invariant survive.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, anyhow, bail};
+use async_trait::async_trait;
+use omnipaxos::messages::Message;
+use omnipaxos::{ClusterConfig, OmniPaxos, OmniPaxosConfig, ServerConfig};
+use parking_lot::Mutex;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, sleep, timeout};
+use tracing::info;
+use tsoracle_client::Client as TsoClient;
+use tsoracle_core::Timestamp;
+use tsoracle_driver_paxos::PaxosDriver;
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PaxosRunner};
+use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
+use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+use tsoracle_server::{Server as TsoServer, ServingState};
+
+use crate::host_service::{HostState, KvOp, MyAppCommand, PiggybackHost, drain_decided_into};
+
+/// Tick interval for every node's runner. 20 ms with the toolkit defaults
+/// keeps elections in the 100–200 ms range.
+const TICK_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Per-node election + resend tick budget. Same values the test harness
+/// uses; ample for an in-process cluster wired through MemNetwork.
+const ELECTION_TICK_TIMEOUT: u64 = 5;
+const RESEND_MESSAGE_TICK_TIMEOUT: u64 = 5;
+
+/// Per-demo result, returned so the smoke test in `tests/smoke.rs` can
+/// assert on it without re-running the demo internals.
+pub struct DemoOutcome {
+    pub pre_failover_last_ts: Timestamp,
+    pub pre_failover_high_water: u64,
+    pub post_failover_first_ts: Timestamp,
+    pub post_failover_high_water: u64,
+    pub kv_after_writes: BTreeMap<String, Vec<u8>>,
+    pub high_water_unchanged_across_getts: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Mesh sink — outbound messages flow through the shared MemNetwork.
+// ---------------------------------------------------------------------------
+
+struct MeshSink {
+    network: Arc<MemNetwork<MyAppCommand>>,
+}
+
+#[async_trait]
+impl MessageSink<MyAppCommand> for MeshSink {
+    async fn send(&self, message: Message<MyAppCommand>) {
+        self.network.deliver(message).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-node state held by the demo across the script.
+// ---------------------------------------------------------------------------
+
+struct Node {
+    id: u64,
+    omnipaxos: Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>>,
+    state: HostState,
+    runner: Option<PaxosRunner<MyAppCommand, MemStorage<MyAppCommand>>>,
+    pump_shutdowns: Vec<oneshot::Sender<()>>,
+    pump_handles: Vec<JoinHandle<()>>,
+    tso_port: u16,
+    serving_state_rx: tokio::sync::watch::Receiver<ServingState>,
+    tso_shutdown: Option<oneshot::Sender<()>>,
+    tso_handle: Option<JoinHandle<()>>,
+}
+
+impl Node {
+    async fn shutdown(&mut self) {
+        if let Some(tx) = self.tso_shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.tso_handle.take() {
+            let _ = handle.await;
+        }
+        for tx in self.pump_shutdowns.drain(..) {
+            let _ = tx.send(());
+        }
+        for handle in self.pump_handles.drain(..) {
+            let _ = handle.await;
+        }
+        if let Some(mut runner) = self.runner.take() {
+            runner.stop().await;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster bring-up.
+// ---------------------------------------------------------------------------
+
+async fn build_cluster() -> anyhow::Result<(Vec<Node>, Arc<MemNetwork<MyAppCommand>>, ClusterConfig)>
+{
+    let network: Arc<MemNetwork<MyAppCommand>> = Arc::new(MemNetwork::new());
+    let node_ids: Vec<u64> = vec![1, 2, 3];
+    let cluster_config = ClusterConfig {
+        configuration_id: 1,
+        nodes: node_ids.clone(),
+        flexible_quorum: None,
+    };
+
+    let mut nodes: Vec<Node> = Vec::new();
+    for id in node_ids {
+        nodes.push(build_node(id, &network, &cluster_config).await?);
+    }
+    Ok((nodes, network, cluster_config))
+}
+
+async fn build_node(
+    id: u64,
+    network: &Arc<MemNetwork<MyAppCommand>>,
+    cluster_config: &ClusterConfig,
+) -> anyhow::Result<Node> {
+    // ---- OmniPaxos handle ----
+    let server_config = ServerConfig {
+        pid: id,
+        election_tick_timeout: ELECTION_TICK_TIMEOUT,
+        resend_message_tick_timeout: RESEND_MESSAGE_TICK_TIMEOUT,
+        ..Default::default()
+    };
+    let omnipaxos_config = OmniPaxosConfig {
+        cluster_config: cluster_config.clone(),
+        server_config,
+    };
+    let omnipaxos = Arc::new(Mutex::new(
+        omnipaxos_config
+            .build(MemStorage::<MyAppCommand>::new())
+            .context("build OmniPaxos handle")?,
+    ));
+    let state = HostState::new();
+
+    // ---- Runner + leader stream ----
+    let mut runner = PaxosRunner::new(omnipaxos.clone(), id, vec![], TICK_INTERVAL);
+    let leader_stream = runner
+        .take_leader_stream()
+        .context("leader stream is fresh")?;
+    let runner_apply_notify = runner.apply_notify();
+
+    // ---- Pumps: inbox + apply ----
+    let mut pump_shutdowns: Vec<oneshot::Sender<()>> = Vec::new();
+    let mut pump_handles: Vec<JoinHandle<()>> = Vec::new();
+
+    let inbox: mpsc::Receiver<Message<MyAppCommand>> = network.register(id);
+    let inbox_omnipaxos = omnipaxos.clone();
+    let (inbox_stop_tx, inbox_stop_rx) = oneshot::channel::<()>();
+    let inbox_handle = tokio::spawn(async move {
+        run_inbox_pump(inbox_omnipaxos, inbox, inbox_stop_rx).await;
+    });
+    pump_shutdowns.push(inbox_stop_tx);
+    pump_handles.push(inbox_handle);
+
+    let apply_omnipaxos = omnipaxos.clone();
+    let apply_state = state.clone();
+    let (apply_stop_tx, mut apply_stop_rx) = oneshot::channel::<()>();
+    let apply_handle = tokio::spawn(async move {
+        let mut cursor: u64 = 0;
+        loop {
+            tokio::select! {
+                _ = runner_apply_notify.notified() => {
+                    drain_decided_into(&apply_omnipaxos, &mut cursor, &apply_state);
+                }
+                _ = &mut apply_stop_rx => {
+                    break;
+                }
+            }
+        }
+    });
+    pump_shutdowns.push(apply_stop_tx);
+    pump_handles.push(apply_handle);
+
+    // ---- Start runner with mesh sink ----
+    let sink = Arc::new(MeshSink {
+        network: network.clone(),
+    });
+    runner.start(sink);
+
+    // ---- Driver + tsoracle server ----
+    let host = PiggybackHost::new(omnipaxos.clone(), state.clone());
+    let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+    let server = TsoServer::builder().consensus_driver(driver).build()?;
+    let serving_state_rx = server.state_rx.clone();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let tso_port = listener.local_addr()?.port();
+    let (tso_shutdown_tx, tso_shutdown_rx) = oneshot::channel::<()>();
+    let tso_handle = tokio::spawn(async move {
+        let shutdown = async move {
+            let _ = tso_shutdown_rx.await;
+        };
+        if let Err(err) = server.serve_with_listener(listener, shutdown).await {
+            tracing::error!(error = ?err, port = tso_port, "tsoracle server died");
+        }
+    });
+
+    Ok(Node {
+        id,
+        omnipaxos,
+        state,
+        runner: Some(runner),
+        pump_shutdowns,
+        pump_handles,
+        tso_port,
+        serving_state_rx,
+        tso_shutdown: Some(tso_shutdown_tx),
+        tso_handle: Some(tso_handle),
+    })
+}
+
+/// Spawn-target: drain `inbox` into `omnipaxos.handle_incoming` until the
+/// shutdown signal fires (the sender stays in `MemNetwork::senders` for the
+/// process lifetime, so `inbox.recv()` does not naturally return `None`).
+async fn run_inbox_pump(
+    omnipaxos: Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>>,
+    mut inbox: mpsc::Receiver<Message<MyAppCommand>>,
+    mut stop_rx: oneshot::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut stop_rx => {
+                return;
+            }
+            message = inbox.recv() => {
+                match message {
+                    Some(message) => {
+                        omnipaxos.lock().handle_incoming(message);
+                    }
+                    None => return,
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Demo helpers.
+// ---------------------------------------------------------------------------
+
+async fn wait_for_leader(nodes: &[Node]) -> anyhow::Result<usize> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        for (idx, node) in nodes.iter().enumerate() {
+            if let Some(leader_id) = node.omnipaxos.lock().get_current_leader() {
+                if leader_id == node.id {
+                    return Ok(idx);
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            bail!("no leader within 5s");
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn build_client(nodes: &[Node]) -> anyhow::Result<TsoClient> {
+    let endpoints: Vec<String> = nodes
+        .iter()
+        .map(|node| format!("http://127.0.0.1:{}", node.tso_port))
+        .collect();
+    Ok(TsoClient::connect(endpoints).await?)
+}
+
+/// Append `cmd` on the leader's OmniPaxos and wait for it to decide.
+/// Equivalent to openraft-piggyback's `leader_raft.client_write`, but
+/// OmniPaxos's `append` is fire-and-forget so we poll `decided_idx`.
+async fn append_on_leader_and_wait(node: &Node, cmd: MyAppCommand) -> anyhow::Result<()> {
+    let snapshot_decided = node.omnipaxos.lock().get_decided_idx();
+    node.omnipaxos
+        .lock()
+        .append(cmd)
+        .map_err(|err| anyhow!("append on leader: {err:?}"))?;
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        if node.omnipaxos.lock().get_decided_idx() > snapshot_decided {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+    bail!("append did not decide within 3s")
+}
+
+async fn wait_until_serving(
+    rx: &mut tokio::sync::watch::Receiver<ServingState>,
+) -> anyhow::Result<()> {
+    let fence_timeout = Duration::from_secs(10);
+    timeout(fence_timeout, async {
+        loop {
+            if matches!(*rx.borrow_and_update(), ServingState::Serving) {
+                return Ok::<(), anyhow::Error>(());
+            }
+            rx.changed()
+                .await
+                .context("serving-state stream closed before reaching Serving")?;
+        }
+    })
+    .await
+    .with_context(|| format!("server did not reach Serving within {fence_timeout:?}"))??;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The demo script.
+// ---------------------------------------------------------------------------
+
+pub async fn run_demo() -> anyhow::Result<DemoOutcome> {
+    let (mut nodes, _network, _cluster_config) = build_cluster().await?;
+    let leader_idx = wait_for_leader(&nodes).await?;
+    info!(leader = nodes[leader_idx].id, "leader elected");
+
+    // Wait for the leader's tsoracle server to finish the fence + transition
+    // to Serving. The fence flips serving-state to Serving only after the
+    // driver's persist_high_water has committed and applied — so once we
+    // see Serving, the leader's state.high_water reflects the new epoch's
+    // floor.
+    let mut leader_serving_rx = nodes[leader_idx].serving_state_rx.clone();
+    wait_until_serving(&mut leader_serving_rx).await?;
+
+    let initial_high_water = nodes[leader_idx].state.high_water();
+    info!(
+        leader = nodes[leader_idx].id,
+        high_water = initial_high_water,
+        "post-fence high-water (driver persisted serving_floor + failover_advance)"
+    );
+    println!("\n--- Leader elected, fence ran ---");
+    println!("leader: node {}", nodes[leader_idx].id);
+    println!("post-fence high-water: {initial_high_water}");
+
+    // ---- Section 1: host KV writes ride the same paxos log ----
+    println!("\n--- Host KV writes (ride the same paxos log) ---");
+    let leader_node = &nodes[leader_idx];
+    for (key, value) in [("alpha", b"first".to_vec()), ("beta", b"second".to_vec())] {
+        append_on_leader_and_wait(
+            leader_node,
+            MyAppCommand::Kv(KvOp::Put {
+                key: key.into(),
+                value: value.clone(),
+            }),
+        )
+        .await?;
+        println!("  put {key} = {} bytes (tso untouched)", value.len());
+    }
+
+    // Wait for every node's apply pump to absorb the writes — KV writes
+    // happen on the leader's handle but every follower's pump also drains
+    // them. We poll until all nodes' kv maps contain both keys.
+    let kv_observed_deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let all_have_keys = nodes.iter().all(|n| {
+            let map = n.state.kv_dump();
+            map.contains_key("alpha") && map.contains_key("beta")
+        });
+        if all_have_keys {
+            break;
+        }
+        if Instant::now() >= kv_observed_deadline {
+            for n in &nodes {
+                let decided = n.omnipaxos.lock().get_decided_idx();
+                let map = n.state.kv_dump();
+                eprintln!(
+                    "  node {}: decided_idx={decided}, kv_keys={:?}, high_water={}",
+                    n.id,
+                    map.keys().collect::<Vec<_>>(),
+                    n.state.high_water()
+                );
+            }
+            bail!("KV writes did not propagate to all nodes within 3s");
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    let kv_after_writes = nodes[leader_idx].state.kv_dump();
+    let high_water_after_kv = nodes[leader_idx].state.high_water();
+    println!(
+        "host state after KV writes: kv keys={:?} high_water={high_water_after_kv}",
+        kv_after_writes.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        high_water_after_kv, initial_high_water,
+        "KV writes must not mutate the TSO field"
+    );
+
+    // ---- Section 2: GetTs is allocator-served; doesn't advance high-water ----
+    println!("\n--- TSO bursts (allocator-served, no consensus per call) ---");
+    let client = build_client(&nodes).await?;
+    let high_water_before_burst = nodes[leader_idx].state.high_water();
+    let first_ts = {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            match client.get_ts().await {
+                Ok(ts) => break ts,
+                Err(err) if Instant::now() < deadline => {
+                    tracing::warn!(error = ?err, "get_ts retrying");
+                    sleep(Duration::from_millis(25)).await;
+                }
+                Err(err) => return Err(anyhow!("get_ts failed after 3s retries: {err}")),
+            }
+        }
+    };
+    println!("  GetTs #1: {first_ts:?}");
+    let mut last_ts: Option<Timestamp> = Some(first_ts);
+    for i in 2..=5u32 {
+        let ts = client.get_ts().await?;
+        if let Some(prev) = last_ts {
+            assert!(ts > prev, "timestamps must be strictly monotonic");
+        }
+        last_ts = Some(ts);
+        println!("  GetTs #{i}: {ts:?}");
+    }
+    let high_water_after_burst = nodes[leader_idx].state.high_water();
+    let high_water_unchanged_across_getts = high_water_after_burst == high_water_before_burst;
+    println!(
+        "high-water before burst: {high_water_before_burst}; after burst: {high_water_after_burst} (unchanged = {high_water_unchanged_across_getts})"
+    );
+    let pre_failover_last_ts = last_ts.context("at least one timestamp was issued")?;
+    let pre_failover_high_water = high_water_after_burst;
+
+    // ---- Section 3: failover preserves monotonicity ----
+    println!("\n--- Failover: shut down leader, observe new leader fence ---");
+    let old_leader_id = nodes[leader_idx].id;
+    nodes[leader_idx].shutdown().await;
+    println!("  shut down node {old_leader_id}; waiting for new leader...");
+
+    let mut new_leader_idx: Option<usize> = None;
+    let new_leader_deadline = Instant::now() + Duration::from_secs(15);
+    let mut last_progress_log = Instant::now();
+    while Instant::now() < new_leader_deadline {
+        for (idx, node) in nodes.iter().enumerate() {
+            if idx == leader_idx {
+                continue;
+            }
+            if let Some(leader_id) = node.omnipaxos.lock().get_current_leader() {
+                if leader_id == node.id {
+                    new_leader_idx = Some(idx);
+                    break;
+                }
+            }
+        }
+        if new_leader_idx.is_some() {
+            break;
+        }
+        if last_progress_log.elapsed() > Duration::from_secs(2) {
+            for (idx, node) in nodes.iter().enumerate() {
+                if idx == leader_idx {
+                    continue;
+                }
+                let leader = node.omnipaxos.lock().get_current_leader();
+                let decided = node.omnipaxos.lock().get_decided_idx();
+                println!(
+                    "  ...polling: node {} sees leader={leader:?}, decided_idx={decided}",
+                    node.id
+                );
+            }
+            last_progress_log = Instant::now();
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+    let new_leader_idx = new_leader_idx.context("no new leader within 15s")?;
+    let new_leader_id = nodes[new_leader_idx].id;
+    println!("  new leader: node {new_leader_id}");
+
+    // Wait for the new leader's fence to publish Serving.
+    let mut new_serving_rx = nodes[new_leader_idx].serving_state_rx.clone();
+    wait_until_serving(&mut new_serving_rx).await?;
+
+    let post_failover_high_water = nodes[new_leader_idx].state.high_water();
+    println!("  post-failover high-water: {post_failover_high_water}");
+    assert!(
+        post_failover_high_water > pre_failover_high_water,
+        "post-failover high-water ({post_failover_high_water}) must exceed pre-failover ({pre_failover_high_water})"
+    );
+
+    // The dead leader's endpoint is still in the client's rotation; allow
+    // retries while it falls back to a survivor.
+    let post_failover_first_ts = {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match client.get_ts().await {
+                Ok(ts) => break ts,
+                Err(err) if Instant::now() < deadline => {
+                    tracing::warn!(error = ?err, "post-failover get_ts retrying");
+                    sleep(Duration::from_millis(25)).await;
+                }
+                Err(err) => {
+                    return Err(anyhow!(
+                        "get_ts failed after 5s retries post-failover: {err}"
+                    ));
+                }
+            }
+        }
+    };
+    println!("  first post-failover GetTs: {post_failover_first_ts:?}");
+    assert!(
+        post_failover_first_ts > pre_failover_last_ts,
+        "post-failover timestamp ({post_failover_first_ts:?}) must exceed last pre-failover timestamp ({pre_failover_last_ts:?})"
+    );
+
+    // ---- Clean shutdown of remaining nodes ----
+    for (idx, node) in nodes.iter_mut().enumerate() {
+        if idx == leader_idx {
+            continue; // already shut down for the failover step
+        }
+        node.shutdown().await;
+    }
+
+    Ok(DemoOutcome {
+        pre_failover_last_ts,
+        pre_failover_high_water,
+        post_failover_first_ts,
+        post_failover_high_water,
+        kv_after_writes,
+        high_water_unchanged_across_getts,
+    })
+}

--- a/examples/paxos-piggyback/src/host_service.rs
+++ b/examples/paxos-piggyback/src/host_service.rs
@@ -1,0 +1,329 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! The "existing" host service — a tiny in-memory KV — with TSO piggybacked
+//! onto the same OmniPaxos log.
+//!
+//! Envelope shape: `MyAppCommand::{Kv(KvOp), HighWater(HighWaterCommand)}`.
+//! Apply path enforces TSO monotonicity (`max(prev, target)`) inside the
+//! host's apply pump, sitting next to the KV map. The snapshot type carries
+//! both halves.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use omnipaxos::OmniPaxos;
+use omnipaxos::util::LogEntry;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+use tracing::trace;
+use tsoracle_consensus::ConsensusError;
+use tsoracle_driver_paxos::HighWaterCommand;
+use tsoracle_driver_paxos::host::PaxosHighWaterHost;
+use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+
+// ---------- Envelope shape ----------
+
+/// Per-key operation on the host's KV store.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KvOp {
+    Put { key: String, value: Vec<u8> },
+    Delete { key: String },
+}
+
+/// The host's OmniPaxos entry: envelope over its own commands plus TSO.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum MyAppCommand {
+    Kv(KvOp),
+    HighWater(HighWaterCommand),
+}
+
+impl From<HighWaterCommand> for MyAppCommand {
+    fn from(cmd: HighWaterCommand) -> Self {
+        MyAppCommand::HighWater(cmd)
+    }
+}
+
+/// Snapshot payload — carries BOTH halves (KV map and high-water).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MyAppSnap {
+    pub kv: BTreeMap<String, Vec<u8>>,
+    pub high_water: u64,
+}
+
+impl omnipaxos::storage::Entry for MyAppCommand {
+    type Snapshot = MyAppSnap;
+}
+
+impl omnipaxos::storage::Snapshot<MyAppCommand> for MyAppSnap {
+    fn create(entries: &[MyAppCommand]) -> Self {
+        let mut snap = MyAppSnap::default();
+        for entry in entries {
+            apply_into_snapshot(entry, &mut snap);
+        }
+        snap
+    }
+
+    fn merge(&mut self, other: Self) {
+        for (key, value) in other.kv {
+            self.kv.insert(key, value);
+        }
+        self.high_water = self.high_water.max(other.high_water);
+    }
+
+    fn use_snapshots() -> bool {
+        true
+    }
+}
+
+fn apply_into_snapshot(entry: &MyAppCommand, snap: &mut MyAppSnap) {
+    match entry {
+        MyAppCommand::Kv(KvOp::Put { key, value }) => {
+            snap.kv.insert(key.clone(), value.clone());
+        }
+        MyAppCommand::Kv(KvOp::Delete { key }) => {
+            snap.kv.remove(key);
+        }
+        MyAppCommand::HighWater(HighWaterCommand::Advance { at_least }) => {
+            if *at_least > snap.high_water {
+                snap.high_water = *at_least;
+            }
+        }
+        MyAppCommand::HighWater(HighWaterCommand::Barrier) => {}
+    }
+}
+
+// ---------- Host state ----------
+
+/// Per-node host state, shared between the apply pump and the
+/// [`PiggybackHost`].
+///
+/// Cheap to clone (every field is `Arc`-wrapped).
+#[derive(Clone)]
+pub struct HostState {
+    kv: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
+    high_water: Arc<AtomicU64>,
+    apply_notify: Arc<Notify>,
+}
+
+impl Default for HostState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostState {
+    pub fn new() -> Self {
+        Self {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            high_water: Arc::new(AtomicU64::new(0)),
+            apply_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn high_water(&self) -> u64 {
+        self.high_water.load(Ordering::SeqCst)
+    }
+
+    pub fn kv_dump(&self) -> BTreeMap<String, Vec<u8>> {
+        self.kv.lock().clone()
+    }
+
+    /// Cloned `Arc<Notify>` used by readers (`current_high_water`,
+    /// `submit_advance`) to wait on the apply pump's next drain.
+    pub fn apply_notifier(&self) -> Arc<Notify> {
+        self.apply_notify.clone()
+    }
+}
+
+// ---------- Apply pump ----------
+
+/// Drain decided `MyAppCommand` entries from `omnipaxos` starting at
+/// `*cursor`, fold them into `state`, advance `*cursor`, and wake any
+/// pollers parked on `state.apply_notifier()`.
+///
+/// Designed to be called from a per-node apply pump task awoken by the
+/// toolkit runner's `apply_notify` after each tick.
+pub fn drain_decided_into(
+    omnipaxos: &Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>>,
+    cursor: &mut u64,
+    state: &HostState,
+) -> u64 {
+    let (decided_idx, entries) = {
+        let handle = omnipaxos.lock();
+        let decided_idx = handle.get_decided_idx();
+        if decided_idx <= *cursor {
+            return decided_idx;
+        }
+        let entries = handle.read_decided_suffix(*cursor);
+        (decided_idx, entries)
+    };
+
+    if let Some(entries) = entries {
+        for entry in &entries {
+            match entry {
+                LogEntry::Decided(MyAppCommand::Kv(KvOp::Put { key, value })) => {
+                    state.kv.lock().insert(key.clone(), value.clone());
+                }
+                LogEntry::Decided(MyAppCommand::Kv(KvOp::Delete { key })) => {
+                    state.kv.lock().remove(key);
+                }
+                LogEntry::Decided(MyAppCommand::HighWater(HighWaterCommand::Advance {
+                    at_least,
+                })) => {
+                    let prev = state.high_water.load(Ordering::SeqCst);
+                    if *at_least > prev {
+                        state.high_water.store(*at_least, Ordering::SeqCst);
+                        trace!(prev, new = at_least, "piggyback high-water advanced");
+                    }
+                }
+                LogEntry::Decided(MyAppCommand::HighWater(HighWaterCommand::Barrier)) => {}
+                LogEntry::Snapshotted(snapshotted) => {
+                    let snap = &snapshotted.snapshot;
+                    let mut kv = state.kv.lock();
+                    for (k, v) in &snap.kv {
+                        kv.insert(k.clone(), v.clone());
+                    }
+                    drop(kv);
+                    let prev = state.high_water.load(Ordering::SeqCst);
+                    if snap.high_water > prev {
+                        state.high_water.store(snap.high_water, Ordering::SeqCst);
+                    }
+                }
+                LogEntry::Trimmed(_) | LogEntry::StopSign(_, _) | LogEntry::Undecided(_) => {}
+            }
+        }
+    }
+
+    *cursor = decided_idx;
+    state.apply_notify.notify_waiters();
+    decided_idx
+}
+
+// ---------- PaxosHighWaterHost impl ----------
+
+/// The integration. Owns a clone of the host's OmniPaxos handle and its
+/// state; appends `HighWater(...)` envelope variants into the shared log
+/// for `current_high_water` / `submit_advance`.
+pub struct PiggybackHost {
+    omnipaxos: Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>>,
+    state: HostState,
+}
+
+impl PiggybackHost {
+    pub fn new(
+        omnipaxos: Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>>,
+        state: HostState,
+    ) -> Self {
+        Self { omnipaxos, state }
+    }
+}
+
+#[async_trait]
+impl PaxosHighWaterHost for PiggybackHost {
+    type Entry = MyAppCommand;
+    type Storage = MemStorage<MyAppCommand>;
+
+    fn omnipaxos(&self) -> Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>> {
+        self.omnipaxos.clone()
+    }
+
+    async fn current_high_water(&self) -> Result<u64, ConsensusError> {
+        let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
+        self.omnipaxos
+            .lock()
+            .append(MyAppCommand::HighWater(HighWaterCommand::Barrier))
+            .map_err(|err| {
+                ConsensusError::TransientDriver(Box::new(PiggybackAppendError(format!("{err:?}"))))
+            })?;
+        let notify = self.state.apply_notifier();
+        loop {
+            notify.notified().await;
+            let new_decided = self.omnipaxos.lock().get_decided_idx();
+            if new_decided > snapshot_decided {
+                return Ok(self.state.high_water());
+            }
+        }
+    }
+
+    async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
+        let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
+        self.omnipaxos
+            .lock()
+            .append(MyAppCommand::HighWater(HighWaterCommand::Advance {
+                at_least,
+            }))
+            .map_err(|err| {
+                ConsensusError::TransientDriver(Box::new(PiggybackAppendError(format!("{err:?}"))))
+            })?;
+        let notify = self.state.apply_notifier();
+        loop {
+            notify.notified().await;
+            let new_decided = self.omnipaxos.lock().get_decided_idx();
+            if new_decided > snapshot_decided && self.state.high_water() >= at_least {
+                return Ok(self.state.high_water());
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("piggyback append failed: {0}")]
+struct PiggybackAppendError(String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omnipaxos::storage::Snapshot;
+
+    #[test]
+    fn snapshot_create_folds_kv_and_high_water() {
+        let entries = vec![
+            MyAppCommand::Kv(KvOp::Put {
+                key: "a".into(),
+                value: b"1".to_vec(),
+            }),
+            MyAppCommand::HighWater(HighWaterCommand::Advance { at_least: 10 }),
+            MyAppCommand::Kv(KvOp::Put {
+                key: "b".into(),
+                value: b"2".to_vec(),
+            }),
+            MyAppCommand::HighWater(HighWaterCommand::Advance { at_least: 30 }),
+            MyAppCommand::HighWater(HighWaterCommand::Barrier),
+        ];
+        let snap = MyAppSnap::create(&entries);
+        assert_eq!(snap.high_water, 30);
+        assert_eq!(snap.kv.len(), 2);
+        assert_eq!(
+            snap.kv.get("a").map(|v| v.as_slice()),
+            Some(b"1".as_slice())
+        );
+        assert_eq!(
+            snap.kv.get("b").map(|v| v.as_slice()),
+            Some(b"2".as_slice())
+        );
+    }
+
+    #[test]
+    fn from_highwatercommand_wraps_into_envelope() {
+        let wrapped: MyAppCommand = HighWaterCommand::Advance { at_least: 5 }.into();
+        match wrapped {
+            MyAppCommand::HighWater(HighWaterCommand::Advance { at_least }) => {
+                assert_eq!(at_least, 5);
+            }
+            other => panic!("expected envelope wrap, got {other:?}"),
+        }
+    }
+}

--- a/examples/paxos-piggyback/src/lib.rs
+++ b/examples/paxos-piggyback/src/lib.rs
@@ -1,0 +1,20 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Library surface for the smoke test in `tests/smoke.rs`. The bin
+//! (`main.rs`) and the test both pull `run_demo` through here so the test
+//! does not have to compile the bin twice.
+
+mod demo;
+pub mod host_service;
+
+pub use demo::{DemoOutcome, run_demo};

--- a/examples/paxos-piggyback/src/main.rs
+++ b/examples/paxos-piggyback/src/main.rs
@@ -1,0 +1,21 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+use example_paxos_piggyback::run_demo;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+    let _outcome = run_demo().await?;
+    println!("\nDemo completed successfully.");
+    Ok(())
+}

--- a/examples/paxos-piggyback/tests/smoke.rs
+++ b/examples/paxos-piggyback/tests/smoke.rs
@@ -1,0 +1,49 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! End-to-end guard: the piggyback envelope preserves the freshness
+//! invariant across failover and isolates host KV state from the TSO field.
+
+use std::time::Duration;
+
+use tokio::time::timeout;
+
+use example_paxos_piggyback::run_demo;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn piggyback_demo_preserves_freshness_invariant() {
+    let outcome = timeout(Duration::from_secs(30), run_demo())
+        .await
+        .expect("demo finished within 30s")
+        .expect("demo ran without error");
+
+    assert!(
+        outcome.post_failover_high_water > outcome.pre_failover_high_water,
+        "post-failover high-water ({}) must exceed pre-failover ({})",
+        outcome.post_failover_high_water,
+        outcome.pre_failover_high_water,
+    );
+    assert!(
+        outcome.post_failover_first_ts > outcome.pre_failover_last_ts,
+        "post-failover timestamp ({:?}) must exceed last pre-failover timestamp ({:?})",
+        outcome.post_failover_first_ts,
+        outcome.pre_failover_last_ts,
+    );
+    assert!(
+        outcome.high_water_unchanged_across_getts,
+        "steady-state GetTs must not advance the durable high-water",
+    );
+    assert!(
+        !outcome.kv_after_writes.is_empty(),
+        "host KV writes must land in the host state",
+    );
+}


### PR DESCRIPTION
## Summary

Two-commit PR that lands one of the three example crates from #175 plus the trait extension it needs.

**Commit 1 — `feat(driver-paxos): generic entry type on PaxosHighWaterHost`.** The host trait carried `type Storage: Storage<HighWaterCommand>` and returned `Arc<Mutex<OmniPaxos<HighWaterCommand, _>>>`, which forced any implementor to use `HighWaterCommand` as the OmniPaxos entry type — incompatible with #175's described envelope shape. The trait now exposes `type Entry: Entry<Snapshot: Send> + Send + 'static` so piggyback hosts can run OmniPaxos on a wider envelope enum. `StandaloneHost` keeps `type Entry = HighWaterCommand`; `PaxosDriver` is unchanged because the only generic call site (`get_promise()`) is entry-agnostic.

**Commit 2 — `feat(examples): paxos-piggyback`.** Counterpart of `openraft-piggyback`. Single-binary, in-process 3-node cluster wired via the toolkit's `MemNetwork`. `MyAppCommand::{Kv(KvOp), HighWater(HighWaterCommand)}` envelope; custom apply pump that folds both halves into `HostState`; `PiggybackHost` impl of `PaxosHighWaterHost` with `type Entry = MyAppCommand`. `tests/smoke.rs` runs the demo and asserts the freshness invariant across failover.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p tsoracle-driver-paxos` — all integration tests pass (no behavior changes from the trait extension; existing impls just gained a `type Entry = HighWaterCommand` line)
- [x] `cargo test -p example-paxos-piggyback --test smoke` — completes in ~0.75s, asserts post-failover invariants
- [ ] Reviewer: confirm `type Entry<Snapshot: Send>` associated-type-bound is the idiom you want (alternative: separate `where` clause)