### PR TITLE
feat(examples): paxos-embedded — 3-node OmniPaxos in one process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-paxos-embedded"
+version = "0.1.4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "omnipaxos",
+ "parking_lot",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tsoracle-consensus",
+ "tsoracle-core",
+ "tsoracle-driver-paxos",
+ "tsoracle-paxos-toolkit",
+ "tsoracle-server",
+]
+
+[[package]]
 name = "example-paxos-standalone"
 version = "0.1.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members  = [
     "examples/metrics-prometheus",
     "examples/openraft-piggyback",
     "examples/openraft-standalone",
+    "examples/paxos-embedded",
     "examples/paxos-standalone",
     "examples/tls-mtls",
     "benchmarks/minimal",

--- a/examples/paxos-embedded/Cargo.toml
+++ b/examples/paxos-embedded/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name                   = "example-paxos-embedded"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+description            = "tsoracle example: embed an OmniPaxos cluster + tsoracle-server in your own binary"
+publish                = false
+
+[[bin]]
+name = "paxos-embedded"
+path = "src/main.rs"
+
+[dependencies]
+tsoracle-core          = { path = "../../crates/tsoracle-core", version = "0.1.3" }
+tsoracle-consensus     = { path = "../../crates/tsoracle-consensus", version = "0.1.3" }
+tsoracle-server        = { path = "../../crates/tsoracle-server", version = "0.1.3" }
+tsoracle-driver-paxos  = { path = "../../crates/tsoracle-driver-paxos", version = "0.1.4" }
+tsoracle-paxos-toolkit = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.1.4", default-features = false, features = ["test-fakes"] }
+
+omnipaxos          = { workspace = true, features = ["serde"] }
+async-trait        = { workspace = true }
+tokio              = { workspace = true, features = ["signal"] }
+parking_lot        = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow             = { workspace = true }

--- a/examples/paxos-embedded/README.md
+++ b/examples/paxos-embedded/README.md
@@ -1,0 +1,45 @@
+# Embedded tsoracle/paxos cluster
+
+Embed an OmniPaxos consensus driver alongside the tsoracle server in your own binary. Counterpart of [`embedded-server`](../embedded-server/) (which uses `FileDriver` for the single-node case) — this version uses [`tsoracle-driver-paxos`](../../crates/tsoracle-driver-paxos/) for HA.
+
+> **About "single-node":** OmniPaxos has no single-node mode. Leader election (BLE) requires a majority of the configured nodes to be alive, so a 3-node `ClusterConfig` with two unstarted peers stays inert — no leader is ever elected, no proposals decide, the fence never fires. This example therefore runs **all three paxos nodes inside one process**, wired together via the toolkit's `MemNetwork`. If you need a single-node deployment, use `FileDriver` (see `embedded-server`).
+
+## Run
+
+```bash
+cargo run -p example-paxos-embedded
+```
+
+The binary starts a 3-node OmniPaxos cluster in-process and binds three tsoracle gRPC endpoints:
+
+- `http://127.0.0.1:50591` — node 1
+- `http://127.0.0.1:50592` — node 2
+- `http://127.0.0.1:50593` — node 3
+
+Ctrl-C drains in-flight RPCs and exits.
+
+Talk to it from another terminal with `grpcurl` against any node — followers respond with a `LeaderHint` trailer pointing at the leader's address:
+
+```bash
+grpcurl -plaintext -d '{"count":1}' 127.0.0.1:50591 tsoracle.v1.TsoService/GetTs
+```
+
+Or from Rust using the `tsoracle-client` crate; pass all three endpoints so the client honors `LeaderHint` redirects.
+
+## What to look at in `src/main.rs`
+
+- The cluster bring-up is a loop that builds one `StandaloneHost` per node, registers an inbox channel with `MemNetwork`, spawns the inbox pump, calls `host.start(sink)` with a `MeshSink` that delivers messages back through the same network, and constructs a `PaxosDriver` + `TsoServer` on top.
+- All three nodes share the same `MemNetwork`, so outbound messages from one node arrive at another's inbox without any tonic / OS networking. Peer messages are not serialized; the network passes `Message<HighWaterCommand>` values directly.
+- Each node's `StandaloneHost::builder().peers(...)` takes the OTHER nodes' tsoracle endpoints (not their paxos peer addresses, since `MemNetwork` is the paxos transport). Those tsoracle endpoints become `LeaderState::Follower::leader_endpoint` when leadership lands on a peer.
+
+## When this example is *not* the right shape
+
+- **You want a single-node deployment.** Use `FileDriver` (`embedded-server`). OmniPaxos cannot operate single-node.
+- **You want three real processes.** Use `paxos-standalone` instead — it ports the same wiring to tonic.
+- **You want TSO to share an existing OmniPaxos log.** Use `paxos-piggyback`.
+
+## Production caveats
+
+- **`MemNetwork`.** Replace with your real OmniPaxos peer transport (typically tonic; see `paxos-standalone/src/network.rs` for a worked version) before exposing this to anything beyond a single host.
+- **`MemStorage`.** The cluster's paxos log is in-memory only — every restart loses state. Swap to the toolkit's `RocksdbStorage` for durable storage.
+- **No graceful host shutdown.** Ctrl-C drains tsoracle servers but leaves the `StandaloneHost` runner + apply tasks to be torn down by the runtime. Production code should keep handles to call `host.stop().await` before returning from `main`.

--- a/examples/paxos-embedded/src/main.rs
+++ b/examples/paxos-embedded/src/main.rs
@@ -1,0 +1,182 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Embed a 3-node OmniPaxos cluster + tsoracle-server in your own binary.
+//!
+//! OmniPaxos has no single-node mode (BLE election requires majority of the
+//! configured nodes), so "embedded" here means "all three paxos nodes
+//! running inside one process, wired through the toolkit's MemNetwork".
+//! Each node binds tsoracle's gRPC API on its own loopback port; the
+//! tsoracle-client rotates across them.
+//!
+//! Run: `cargo run -p example-paxos-embedded`
+//! Then talk to it on http://127.0.0.1:50591 / 50592 / 50593. Ctrl-C exits.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use omnipaxos::messages::Message;
+use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+use parking_lot::Mutex;
+use tokio::sync::{mpsc, oneshot};
+use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, Peer};
+use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
+use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+use tsoracle_server::Server as TsoServer;
+
+/// Tick interval for every node's runner. With election_tick_timeout=5 this
+/// keeps leader election in the 100–200 ms range.
+const TICK_INTERVAL: Duration = Duration::from_millis(20);
+const ELECTION_TICK_TIMEOUT: u64 = 5;
+const RESEND_MESSAGE_TICK_TIMEOUT: u64 = 5;
+
+const NODE_COUNT: usize = 3;
+const BASE_PORT: u16 = 50591;
+
+struct MeshSink {
+    network: Arc<MemNetwork<HighWaterCommand>>,
+}
+
+#[async_trait]
+impl MessageSink<HighWaterCommand> for MeshSink {
+    async fn send(&self, message: Message<HighWaterCommand>) {
+        self.network.deliver(message).await;
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let network: Arc<MemNetwork<HighWaterCommand>> = Arc::new(MemNetwork::new());
+    let node_ids: Vec<u64> = (1..=NODE_COUNT as u64).collect();
+    let cluster_config = ClusterConfig {
+        configuration_id: 1,
+        nodes: node_ids.clone(),
+        flexible_quorum: None,
+    };
+
+    // Build a `Peer` list of TSO endpoints so each node's StandaloneHost can
+    // populate `LeaderHint` follower-redirect with the leader's address.
+    let tso_endpoints: Vec<(u64, SocketAddr)> = node_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, id)| {
+            (
+                *id,
+                format!("127.0.0.1:{}", BASE_PORT + idx as u16)
+                    .parse()
+                    .unwrap(),
+            )
+        })
+        .collect();
+
+    let mut tso_shutdowns: Vec<oneshot::Sender<()>> = Vec::new();
+
+    for &id in &node_ids {
+        // ---- OmniPaxos handle ----
+        let server_config = ServerConfig {
+            pid: id,
+            election_tick_timeout: ELECTION_TICK_TIMEOUT,
+            resend_message_tick_timeout: RESEND_MESSAGE_TICK_TIMEOUT,
+            ..Default::default()
+        };
+        let omnipaxos_config = OmniPaxosConfig {
+            cluster_config: cluster_config.clone(),
+            server_config,
+        };
+        let omnipaxos = Arc::new(Mutex::new(
+            omnipaxos_config
+                .build(MemStorage::<HighWaterCommand>::new())
+                .context("build OmniPaxos handle")?,
+        ));
+
+        // ---- Inbox pump (drains MemNetwork into handle_incoming) ----
+        let inbox: mpsc::Receiver<Message<HighWaterCommand>> = network.register(id);
+        let inbox_omnipaxos = omnipaxos.clone();
+        tokio::spawn(async move {
+            run_inbox_pump(inbox_omnipaxos, inbox).await;
+        });
+
+        // ---- StandaloneHost ----
+        let toolkit_peers: Vec<Peer> = tso_endpoints
+            .iter()
+            .filter(|(peer_id, _)| *peer_id != id)
+            .map(|(peer_id, addr)| Peer {
+                node_id: *peer_id,
+                endpoint: format!("http://{addr}"),
+            })
+            .collect();
+        let mut host = StandaloneHost::builder()
+            .omnipaxos(omnipaxos)
+            .my_node_id(id)
+            .peers(toolkit_peers)
+            .tick_interval(TICK_INTERVAL)
+            .snapshot_policy(SnapshotPolicy::disabled())
+            .build()
+            .context("build StandaloneHost")?;
+        let leader_stream = host
+            .take_leader_stream()
+            .context("leader stream is fresh")?;
+
+        let sink = Arc::new(MeshSink {
+            network: network.clone(),
+        });
+        host.start(sink);
+
+        // ---- Driver + tsoracle server ----
+        let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+        let server = TsoServer::builder().consensus_driver(driver).build()?;
+
+        let (tso_shutdown_tx, tso_shutdown_rx) = oneshot::channel::<()>();
+        tso_shutdowns.push(tso_shutdown_tx);
+        let addr = tso_endpoints[(id - 1) as usize].1;
+        tokio::spawn(async move {
+            let shutdown = async move {
+                let _ = tso_shutdown_rx.await;
+            };
+            if let Err(err) = server.serve_with_shutdown(addr, shutdown).await {
+                tracing::error!(error = ?err, node = id, "tsoracle server died");
+            }
+        });
+    }
+
+    println!("Embedded tsoracle/paxos cluster running:");
+    for (id, addr) in &tso_endpoints {
+        println!("  node {id}: http://{addr}");
+    }
+    println!("Press Ctrl-C to shut down.");
+
+    // Wait for Ctrl-C.
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!("ctrl-c received, draining");
+
+    for tx in tso_shutdowns {
+        let _ = tx.send(());
+    }
+    // Give server tasks a beat to drain before the runtime tears down.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    Ok(())
+}
+
+async fn run_inbox_pump(
+    omnipaxos: Arc<Mutex<omnipaxos::OmniPaxos<HighWaterCommand, MemStorage<HighWaterCommand>>>>,
+    mut inbox: mpsc::Receiver<Message<HighWaterCommand>>,
+) {
+    while let Some(message) = inbox.recv().await {
+        omnipaxos.lock().handle_incoming(message);
+    }
+}


### PR DESCRIPTION
## Summary

Single-binary embedded cluster, counterpart of `examples/embedded-server` (which uses `FileDriver`). All three OmniPaxos nodes run inside the same process, wired via the toolkit's `MemNetwork`; each node binds tsoracle's gRPC API on its own loopback port (50591–50593).

### Note on "single-node paxos"

#175's description of this crate said "single-node OmniPaxos cluster using a 3-node ClusterConfig with two unstarted peers". That setup doesn't actually work: OmniPaxos's BLE election requires a majority of the configured nodes to be alive, so a 3-node config with two unstarted peers stays inert (the existing `single_started_runner_stays_inert_without_quorum` test confirms this). The README documents this constraint and points users who genuinely need single-node operation at `FileDriver` / `embedded-server`.

If you'd prefer a different shape for this crate (e.g., a `FlexibleQuorum` variant, or skipping the crate entirely and just adding a "single-node? use FileDriver" note in the paxos-standalone README), happy to revise.

## Test plan

- [x] `cargo build -p example-paxos-embedded`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `target/debug/paxos-embedded` boots, elects a leader (node 3 in my local run), serves `GetTs` from the leader and returns `FailedPrecondition: not leader` from followers (epoch decodes to `config_id=1, n=29, pid=3` as expected)
- [ ] Reviewer: confirm port range `50591-50593` doesn't conflict with anything in CI