### PR TITLE
DIAG: instrument paxos integration test harness to locate CI hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,8 @@ coverage:
 	  --workspace --all-features \
 	  $(COV_EXCLUDES) \
 	  --ignore-filename-regex '$(COV_IGNORE)$$' \
-	  --lcov --output-path lcov.info
+	  --lcov --output-path lcov.info \
+	  -- --nocapture
 
 # Local HTML report. Output at target/llvm-cov/html/index.html; `--open` opens
 # it in the default browser. Re-runs the test suite, same as `coverage`.

--- a/crates/tsoracle-driver-paxos/tests/common/mod.rs
+++ b/crates/tsoracle-driver-paxos/tests/common/mod.rs
@@ -200,17 +200,34 @@ where
 
     /// Stop every node's runner + inbox pump.
     pub async fn stop_all(&mut self) {
+        eprintln!("[diag] stop_all begin");
         for node in &mut self.nodes {
+            let node_id = node.node_id;
             if let Some(stop_tx) = node.pump_stop.take() {
                 let _ = stop_tx.send(());
             }
             if let Some(pump) = node.pump_handle.take() {
-                let _ = pump.await;
+                eprintln!("[diag] stop_all: node {node_id} pump_handle await");
+                if tokio::time::timeout(Duration::from_secs(30), pump)
+                    .await
+                    .is_err()
+                {
+                    panic!("[diag] stop_all: node {node_id} pump_handle TIMED OUT after 30s");
+                }
+                eprintln!("[diag] stop_all: node {node_id} pump_handle done");
             }
             if let Some(mut host) = node.host.take() {
-                host.stop().await;
+                eprintln!("[diag] stop_all: node {node_id} host.stop() begin");
+                if tokio::time::timeout(Duration::from_secs(30), host.stop())
+                    .await
+                    .is_err()
+                {
+                    panic!("[diag] stop_all: node {node_id} host.stop() TIMED OUT after 30s");
+                }
+                eprintln!("[diag] stop_all: node {node_id} host.stop() done");
             }
         }
+        eprintln!("[diag] stop_all done");
     }
 
     /// Stop a single node (runner + inbox pump + host) and drop the
@@ -220,6 +237,7 @@ where
     /// storage drop its directory lock, so that
     /// [`Cluster::rebuild_rocksdb_node`] can reopen the same path.
     pub async fn stop_node(&mut self, node_id: u64) {
+        eprintln!("[diag] stop_node({node_id}) begin");
         let node = self
             .nodes
             .iter_mut()
@@ -229,15 +247,29 @@ where
             let _ = stop_tx.send(());
         }
         if let Some(pump) = node.pump_handle.take() {
-            let _ = pump.await;
+            eprintln!("[diag] stop_node({node_id}): pump_handle await");
+            if tokio::time::timeout(Duration::from_secs(30), pump)
+                .await
+                .is_err()
+            {
+                panic!("[diag] stop_node({node_id}): pump_handle TIMED OUT after 30s");
+            }
         }
         if let Some(mut host) = node.host.take() {
-            host.stop().await;
+            eprintln!("[diag] stop_node({node_id}): host.stop() begin");
+            if tokio::time::timeout(Duration::from_secs(30), host.stop())
+                .await
+                .is_err()
+            {
+                panic!("[diag] stop_node({node_id}): host.stop() TIMED OUT after 30s");
+            }
+            eprintln!("[diag] stop_node({node_id}): host.stop() done");
         }
         // Drop the harness-held Arc last; the host has already released
         // its own clone via `host.stop().await + drop`. Once this take()
         // runs, the underlying OmniPaxos + Storage are deallocated.
         node.omnipaxos.take();
+        eprintln!("[diag] stop_node({node_id}) done");
     }
 
     /// Block until `predicate(self)` returns true.
@@ -252,13 +284,39 @@ where
     where
         F: FnMut(&Self) -> bool,
     {
-        for _ in 0..max_ticks {
+        let started = std::time::Instant::now();
+        eprintln!("[diag] drive_until begin max_ticks={max_ticks}");
+        for tick in 0..max_ticks {
             if predicate(self) {
+                eprintln!(
+                    "[diag] drive_until ok after {tick} ticks ({:?} wall)",
+                    started.elapsed()
+                );
                 return;
+            }
+            if tick > 0 && tick.is_multiple_of(500) {
+                eprintln!(
+                    "[diag] drive_until still polling tick={tick} elapsed={:?} \
+                     leader={:?} decided_per_node={:?}",
+                    started.elapsed(),
+                    self.leader_opt(),
+                    self.nodes
+                        .iter()
+                        .map(|node| (
+                            node.node_id,
+                            node.omnipaxos
+                                .as_ref()
+                                .map(|handle| handle.lock().get_decided_idx())
+                        ))
+                        .collect::<Vec<_>>(),
+                );
             }
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
-        panic!("predicate did not become true within {max_ticks} ticks");
+        panic!(
+            "[diag] predicate did not become true within {max_ticks} ticks (elapsed {:?} wall)",
+            started.elapsed()
+        );
     }
 
     /// Returns the current leader's node id, or panics if none.
@@ -329,7 +387,14 @@ async fn pump_inbox<S>(
             message = inbox.recv() => {
                 match message {
                     Some(message) => {
+                        let lock_start = std::time::Instant::now();
                         omnipaxos.lock().handle_incoming(message);
+                        let elapsed = lock_start.elapsed();
+                        if elapsed > Duration::from_millis(100) {
+                            eprintln!(
+                                "[diag] pump_inbox: handle_incoming took {elapsed:?}"
+                            );
+                        }
                     }
                     None => return,
                 }


### PR DESCRIPTION
**Not for merge** — this is a diagnostic-only branch to capture the silent coverage hang that's blocking every PR since 2350e5a merged.

## What's happening

Every PR opened since #185's integration test suite landed hangs in `cargo llvm-cov` on `ubuntu-latest` runners. The hang is at the test level — one of the multi-node paxos integration tests sits past libtest's 60 s watchdog warning and never finishes, no `drive_until` panic, no further output:

```
02:25:03 Running tests/snapshot_transfer.rs
02:25:03 running 1 test
02:26:03 test isolated_node_catches_up_via_snapshot_transfer has been running for over 60 seconds
02:41:59 ##[error]The operation was canceled.
```

PR #187's coverage hung on `snapshot_transfer`. `fix/rocksdb-paxos-log-idx-reset`'s hung on `partition_churn`. Local `cargo llvm-cov --workspace` on macOS (Apple Silicon) passes the full suite cleanly, including both failing tests in <1 s. The deadlock is Linux x86_64-specific and doesn't reproduce locally.

## What this branch adds

Three diagnostic affordances in `crates/tsoracle-driver-paxos/tests/common/mod.rs`, plus `-- --nocapture` on `make coverage` so prints flow live to the GitHub Actions log instead of waiting for libtest to flush captured buffers:

- **`stop_all` / `stop_node` timeouts**: every `.await` (pump join, host.stop) is wrapped in `tokio::time::timeout(30 s)`. Any hang panics with `[diag] ... TIMED OUT after 30s`, giving libtest a clean failure point and routing the captured eprintln markers to the report.
- **`drive_until` progress**: prints `[diag] drive_until begin/ok` markers with elapsed wall time, plus a snapshot of `leader_opt()` + per-node `decided_idx` every 500 ticks. A wedged tokio timer surfaces as a `still polling` line that stops advancing; a slow predicate surfaces as one that eventually fires with a large tick count.
- **`pump_inbox` slow-lock**: any `handle_incoming` call that takes >100 ms prints its elapsed time, exposing per-message lock contention.

## How to read the resulting log

When CI hangs again, the captured stderr should reveal one of:

| Pattern | Implication |
|---|---|
| `[diag] drive_until still polling` lines stop advancing | Tokio timer driver wedged (likely worker-thread starvation under coverage instrumentation) |
| `[diag] drive_until` panic with elapsed wall time >> expected | Predicate genuinely never becomes true — consensus stalled |
| `[diag] stop_all: node N pump_handle TIMED OUT after 30s` | Pump task stuck in `handle_incoming`, OmniPaxos lock contended forever |
| `[diag] stop_all: node N host.stop() TIMED OUT after 30s` | Apply task or runner stop sequence stuck |
| `[diag] pump_inbox: handle_incoming took 10+s` repeatedly | Lock contention from coverage instrumentation slowdown |

Once we know which pattern fires, the fix has a much narrower target. Will close this branch after the underlying hang is fixed.