### PR TITLE
fix(driver-paxos): blocking reads observe drains via Notified::enable()

### DIFF
--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -272,12 +272,21 @@ where
                 ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
             })?;
         let notifier = self.apply_state.apply_notifier();
+        crate::yieldpoint!("standalone_host::current_high_water::after_append_before_await");
         loop {
-            notifier.notified().await;
+            // Register as waiter before checking state; otherwise a notify_waiters
+            // that fires between the previous iteration's check and the next
+            // notified().await is lost. apply_notifier uses notify_waiters which
+            // does not store permits — Notified::enable() is the supported way
+            // to close that window.
+            let notified = notifier.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             let new_decided = self.omnipaxos.lock().get_decided_idx();
             if new_decided > snapshot_decided {
                 return Ok(self.apply_state.high_water());
             }
+            notified.await;
         }
     }
 
@@ -290,12 +299,16 @@ where
                 ConsensusError::TransientDriver(Box::new(AdvanceAppendError(format!("{err:?}"))))
             })?;
         let notifier = self.apply_state.apply_notifier();
+        crate::yieldpoint!("standalone_host::submit_advance::after_append_before_await");
         loop {
-            notifier.notified().await;
+            let notified = notifier.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             let new_decided = self.omnipaxos.lock().get_decided_idx();
             if new_decided > snapshot_decided && self.apply_state.high_water() >= at_least {
                 return Ok(self.apply_state.high_water());
             }
+            notified.await;
         }
     }
 }

--- a/crates/tsoracle-driver-paxos/tests/blocking_reads_missed_notify.rs
+++ b/crates/tsoracle-driver-paxos/tests/blocking_reads_missed_notify.rs
@@ -1,0 +1,137 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Regression: the blocking-read methods on `PaxosHighWaterHost` must
+//! observe the apply task's `notify_waiters` even when the apply task
+//! drained the just-appended entry *before* the reader registered as a
+//! `Notified` waiter.
+//!
+//! The pre-fix loop was:
+//!
+//! ```text
+//! 1. snapshot decided_idx
+//! 2. append Barrier / Advance
+//! 3. notifier.notified().await   <-- only here do we become a waiter
+//! 4. recheck decided_idx
+//! ```
+//!
+//! `apply_notifier` uses `notify_waiters` (which does NOT store a permit)
+//! and `drain_decided_into` early-returns without notifying when there
+//! are no new entries to drain. So if the apply task drained between (2)
+//! and (3), the single notify for the reader's own entry was lost and the
+//! reader hung — no further drain would happen on an idle cluster.
+//!
+//! The fix uses `Notified::enable()` to register as a waiter BEFORE the
+//! synchronous `decided_idx` check, closing the race window. These tests
+//! arm yield points between (2) and (3) so the apply task is forced to
+//! drain (and emit the now-lost notify) before the reader can register;
+//! with the fix in place, the recheck after `enable()` returns the value
+//! immediately. Without the fix the reader hangs and the test panics on
+//! the `tokio::time::timeout`.
+
+#![cfg(feature = "yieldpoints")]
+
+use std::time::Duration;
+
+use tsoracle_driver_paxos::host::PaxosHighWaterHost;
+use tsoracle_driver_paxos::yieldpoint;
+
+#[path = "common/mod.rs"]
+mod common;
+
+const CURRENT_HW_YIELD: &str = "standalone_host::current_high_water::after_append_before_await";
+const SUBMIT_ADVANCE_YIELD: &str = "standalone_host::submit_advance::after_append_before_await";
+
+/// Spawns a task that releases `gate` after `release_after`, giving the
+/// apply task ample time to drain the reader's appended entry while the
+/// reader is parked at the yield point. Returns the join handle so the
+/// test can `.await` it before exiting (otherwise the spawn may outlive
+/// the test if dropping the runtime didn't get to it).
+fn spawn_release(
+    gate: std::sync::Arc<tokio::sync::Notify>,
+    release_after: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tokio::time::sleep(release_after).await;
+        gate.notify_one();
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn current_high_water_returns_when_apply_drained_before_register() {
+    let mut cluster = common::build_mem_cluster(3);
+    cluster.start_all();
+    cluster
+        .drive_until(common::some_leader_elected(), 1_000)
+        .await;
+    let leader_id = cluster.leader();
+
+    // Arm the yield point. The next `current_high_water` call will append
+    // a Barrier and park here before becoming an `apply_notifier` waiter.
+    let gate = yieldpoint::cfg(CURRENT_HW_YIELD);
+
+    // 200 ms is comfortably more than one tick interval (2 ms) plus a
+    // round-trip across the 3-node MemNetwork — the apply task will have
+    // drained the Barrier and fired `apply_notifier.notify_waiters()` long
+    // before this releases.
+    let releaser = spawn_release(gate, Duration::from_millis(200));
+
+    let host_ref = cluster
+        .node(leader_id)
+        .host
+        .as_ref()
+        .expect("leader host present");
+
+    tokio::time::timeout(Duration::from_secs(2), host_ref.current_high_water())
+        .await
+        .expect("current_high_water must complete within 2s of yield-point release")
+        .expect("current_high_water must not return an error");
+
+    let _ = releaser.await;
+    yieldpoint::remove(CURRENT_HW_YIELD);
+
+    cluster.stop_all().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn submit_advance_returns_when_apply_drained_before_register() {
+    let mut cluster = common::build_mem_cluster(3);
+    cluster.start_all();
+    cluster
+        .drive_until(common::some_leader_elected(), 1_000)
+        .await;
+    let leader_id = cluster.leader();
+
+    let gate = yieldpoint::cfg(SUBMIT_ADVANCE_YIELD);
+    let releaser = spawn_release(gate, Duration::from_millis(200));
+
+    let host_ref = cluster
+        .node(leader_id)
+        .host
+        .as_ref()
+        .expect("leader host present");
+
+    let observed = tokio::time::timeout(Duration::from_secs(2), host_ref.submit_advance(42))
+        .await
+        .expect("submit_advance must complete within 2s of yield-point release")
+        .expect("submit_advance must not return an error");
+
+    assert!(
+        observed >= 42,
+        "submit_advance must return a high-water >= the requested floor (saw {observed})",
+    );
+
+    let _ = releaser.await;
+    yieldpoint::remove(SUBMIT_ADVANCE_YIELD);
+
+    cluster.stop_all().await;
+}

--- a/docs/yieldpoint-testing.md
+++ b/docs/yieldpoint-testing.md
@@ -41,11 +41,13 @@ The string is matched verbatim against the registry — typos at the call site o
 
 ## Current sites
 
-### `tsoracle-driver-paxos` — 1 site in `crates/tsoracle-driver-paxos/src/standalone.rs`
+### `tsoracle-driver-paxos` — 3 sites in `crates/tsoracle-driver-paxos/src/standalone.rs`
 
 | Site name | Position | Test |
 |---|---|---|
 | `standalone_host::apply_task::between_iterations` | End of the `apply_notify` branch in the apply task's `tokio::select!`, after `drain_decided_into` + `maybe_snapshot` and before the loop returns to the next `select!`. | `stop_delivers_shutdown_when_apply_task_is_mid_iteration` |
+| `standalone_host::current_high_water::after_append_before_await` | In `PaxosHighWaterHost::current_high_water`, after the `Barrier` append and before the first `Notified::enable()` registers as an `apply_notifier` waiter. | `current_high_water_returns_when_apply_drained_before_register` |
+| `standalone_host::submit_advance::after_append_before_await` | In `PaxosHighWaterHost::submit_advance`, after the `Advance` append and before the first `Notified::enable()` registers as an `apply_notifier` waiter. | `submit_advance_returns_when_apply_drained_before_register` |
 
 ## Writing a yield-point test
 


### PR DESCRIPTION
## Root cause

`PaxosHighWaterHost::current_high_water` and `submit_advance` had the same missed-notification race as the apply-task shutdown bug (#194), but on the **reader side** of `apply_notifier`. Pre-fix loop:

```rust
1. snapshot decided_idx
2. self.omnipaxos.lock().append(Barrier or Advance)?;
3. notifier.notified().await   // ← only here did we become a waiter
4. recheck decided_idx; loop or return
```

`apply_notifier` uses `notify_waiters` (no stored permits), and `drain_decided_into` early-returns without notifying when there are no new entries. So if the apply task drained between (2) and (3) — fast enough that the reader hadn't polled `notified()` yet — the single notify for the reader's own entry was lost. On an idle cluster the reader then hung forever; no further drain would happen, so no further notify would come.

The race window is the gap between the append and the first `notified()` registration. In a typical environment that's microseconds, and the race essentially never observes. Under CI coverage instrumentation it widens enough that this would have surfaced exactly like #194 did — but it hasn't fired yet because no one's running `current_high_water`/`submit_advance` from heavily-loaded async paths on a long-running cluster. The bug shape is identical to #194, so I'd rather not wait for the next coverage stall.

## Fix

Switch the loop to the canonical `Notified::enable()` pattern:

```rust
loop {
    let notified = notifier.notified();
    tokio::pin!(notified);
    notified.as_mut().enable();   // register as waiter synchronously
    let new_decided = self.omnipaxos.lock().get_decided_idx();
    if new_decided > snapshot_decided {
        return Ok(self.apply_state.high_water());
    }
    notified.await;
}
```

`enable()` registers the `Notified` future as a waiter without polling it to completion. Any `notify_waiters` that fires between the previous iteration's check and this iteration's `enable()` is now consumed when the next `notified.await` (or the next iteration's enable) runs — the future is already a waiter at that point.

This is the supported tokio pattern for "check a condition that another task might toggle, with a `Notify`" — see the [`Notified::enable` docs](https://docs.rs/tokio/latest/tokio/sync/struct.Notified.html#method.enable).

## Why fix this now and not at the producer side

`apply_notifier.notify_waiters()` is intentional: multiple readers (think a service with concurrent `GetTs` callers) all wait on the same notifier and should all wake on a single drain. Switching the producer to `notify_one` would only wake one of them. The reader-side `enable()` fix preserves multi-waiter semantics — every reader registers, every reader rechecks, every reader gets the notify. Same reason fail-rs uses reader-side double-checks rather than changing the upstream producer.

## Regression coverage

Two yield-point sites:

- `standalone_host::current_high_water::after_append_before_await`
- `standalone_host::submit_advance::after_append_before_await`

Both sit at the race window — after the append, before the first iteration's `enable()`. Two regression tests in `tests/blocking_reads_missed_notify.rs` arm the gate, park the reader between append and waiter registration, give the apply task 200 ms to drain (multiple tick intervals + MemNetwork round-trips), then release. With the bug: both tests panic at the inner `tokio::time::timeout(2 s, ...)` with `Elapsed(())`. With the fix: both finish in ~10 ms.

```rust
let gate = yieldpoint::cfg(CURRENT_HW_YIELD);
let releaser = spawn_release(gate, Duration::from_millis(200));
tokio::time::timeout(Duration::from_secs(2), host_ref.current_high_water())
    .await
    .expect("current_high_water must complete within 2s of yield-point release")
    .expect(...);
```

## Test plan

- [x] `cargo test -p tsoracle-driver-paxos --features yieldpoints` — 43 tests pass, including the two new regressions.
- [x] Regression confirmed by inversion: temporarily reverting `enable()` to the pre-fix `notifier.notified().await` makes both new tests fail at 2.01 s with `Elapsed(())`.
- [x] `cargo build -p tsoracle-driver-paxos` (default features, no `yieldpoints`) — clean.
- [x] `cargo clippy -p tsoracle-driver-paxos --all-targets --features yieldpoints -- -D warnings` — clean.
- [x] Header check (`scripts/check-ts-header.py`) — clean.

## Docs

`docs/yieldpoint-testing.md`'s "Current sites" table now lists three sites for `tsoracle-driver-paxos` instead of one.
