### PR TITLE
test(driver-paxos): wait for follower promise sync before sampling fence epoch

### DIFF
--- a/crates/tsoracle-driver-paxos/tests/three_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/three_node.rs
@@ -101,8 +101,24 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
 
     // The fence epoch the driver compares against is derived from the
     // host's current promise ballot — every node that has acknowledged
-    // the leader's prepare sees the same Ballot, so encoding either the
-    // leader's or the follower's promise here yields the same Epoch.
+    // the leader's prepare sees the same Ballot. `some_leader_elected`
+    // only proves the elected node observes itself as leader; on slow
+    // runners the follower may not have processed the prepare yet, so
+    // its promise is still `Ballot::default()` (encodes to `Epoch(0)`).
+    // Wait for the follower's encoded promise to match the leader's
+    // before sampling so the assertion against the driver's fence-check
+    // observation is race-free.
+    cluster
+        .drive_until(
+            |c| {
+                let leader_epoch = encode_epoch(c.node(leader_id).omnipaxos().lock().get_promise());
+                let follower_epoch =
+                    encode_epoch(c.node(follower_id).omnipaxos().lock().get_promise());
+                leader_epoch != Epoch(0) && leader_epoch == follower_epoch
+            },
+            1_000,
+        )
+        .await;
     let current_epoch = {
         let handle = cluster.node(follower_id).omnipaxos();
         let promise = handle.lock().get_promise();


### PR DESCRIPTION
## Summary

Fixes a race in `tests/three_node.rs::fence_check_rejects_stale_epoch_and_accepts_current` that's currently failing on PR #191's CI ([run 26323788763](https://github.com/prisma-risk/tsoracle/actions/runs/26323788763/job/77497568962?pr=191)) and reproducible on slow runners more generally.

**Race:** the test sampled the follower's `get_promise()` immediately after `drive_until(some_leader_elected, ...)`. That predicate only proves *some* node observes itself as leader — the chosen follower may not have processed the leader's prepare yet, leaving its promise at `Ballot::default()` (encodes to `Epoch(0)`). When the driver later runs its fence check, the prepare has arrived and the observed `current` no longer matches the sampled `current_epoch`. Assertion panics with the shape `left: Epoch(281474976776195), right: Epoch(0)` we saw on the failing job.

**Fix:** insert a `drive_until(leader_epoch != Epoch(0) && leader_epoch == follower_epoch, 1_000)` between picking the follower and sampling. The predicate short-circuits as soon as both nodes have promised to the same ballot, so fast-path runtime is unchanged; only the upper bound budget changes (and only when needed).

This is a different flake family from PR #190 (`widen post-event catch-up budgets`) — that PR addressed three integration tests' final `drive_until` budgets under coverage instrumentation; this one addresses a ballot-sampling timing assumption in `three_node.rs`.

## Test plan

- [x] `cargo build -p tsoracle-driver-paxos --tests`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p tsoracle-driver-paxos --tests -- -D warnings`
- [x] `cargo test -p tsoracle-driver-paxos --test three_node fence_check_rejects_stale_epoch_and_accepts_current` run 20× in a loop: **20/20 pass**
- [x] `cargo test -p tsoracle-driver-paxos` (full driver-paxos suite still passes)