### PR TITLE
feat(yieldpoint): extract registry into tsoracle-yieldpoint, wire tsoracle-server::fence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,6 +3287,7 @@ dependencies = [
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-paxos-toolkit",
+ "tsoracle-yieldpoint",
 ]
 
 [[package]]
@@ -3364,6 +3365,7 @@ dependencies = [
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-proto",
+ "tsoracle-yieldpoint",
 ]
 
 [[package]]
@@ -3382,6 +3384,14 @@ dependencies = [
  "tsoracle-core",
  "tsoracle-proto",
  "tsoracle-server",
+]
+
+[[package]]
+name = "tsoracle-yieldpoint"
+version = "0.1.4"
+dependencies = [
+ "parking_lot",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members  = [
     "crates/tsoracle-openraft-toolkit",
     "crates/tsoracle-paxos-toolkit",
     "crates/tsoracle-tests",
+    "crates/tsoracle-yieldpoint",
     "examples/embedded-server",
     "examples/failover-demo",
     "examples/metrics-prometheus",
@@ -39,6 +40,7 @@ default-members = [
     "crates/tsoracle-bin",
     "crates/tsoracle-openraft-toolkit",
     "crates/tsoracle-paxos-toolkit",
+    "crates/tsoracle-yieldpoint",
 ]
 
 [workspace.package]
@@ -82,6 +84,7 @@ tempfile           = "3"
 thiserror          = "2"
 tokio              = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "fs"] }
 tokio-stream       = { version = "0.1", features = ["sync"] }
+tsoracle-yieldpoint = { path = "crates/tsoracle-yieldpoint", version = "0.1.4" }
 tonic              = "0.14"
 tonic-prost        = "0.14"
 tonic-prost-build  = "0.14"

--- a/crates/tsoracle-driver-paxos/Cargo.toml
+++ b/crates/tsoracle-driver-paxos/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace      = true
 [features]
 default          = ["rocksdb-storage"]
 rocksdb-storage  = ["tsoracle-paxos-toolkit/rocksdb-storage"]
-yieldpoints      = []
+yieldpoints      = ["tsoracle-yieldpoint/yieldpoints"]
 
 [dependencies]
 async-trait          = { workspace = true }
@@ -28,6 +28,7 @@ tracing              = { workspace = true }
 tsoracle-consensus   = { path = "../tsoracle-consensus", version = "0.1.3" }
 tsoracle-core        = { path = "../tsoracle-core",      version = "0.1.3" }
 tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "0.1.4", default-features = false }
+tsoracle-yieldpoint  = { workspace = true }
 
 [dev-dependencies]
 anyhow           = { workspace = true }

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -29,7 +29,6 @@ pub mod snapshot_policy;
 pub mod standalone;
 pub mod state_machine;
 pub mod type_config;
-pub mod yieldpoint;
 
 pub use driver::PaxosDriver;
 pub use log_entry::{HighWaterCommand, HighWaterSnapshot};

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -125,7 +125,9 @@ where
                             let mut policy = policy.lock();
                             maybe_snapshot(&omnipaxos, &mut policy, decided_idx);
                         }
-                        crate::yieldpoint!("standalone_host::apply_task::between_iterations");
+                        tsoracle_yieldpoint::yieldpoint!(
+                            "standalone_host::apply_task::between_iterations"
+                        );
                     }
                     _ = shutdown.notified() => {
                         break;

--- a/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
@@ -37,10 +37,10 @@ use async_trait::async_trait;
 use omnipaxos::messages::Message;
 use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
 use parking_lot::Mutex;
-use tsoracle_driver_paxos::yieldpoint;
 use tsoracle_driver_paxos::{HighWaterCommand, StandaloneHost};
 use tsoracle_paxos_toolkit::lifecycle::MessageSink;
 use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+use tsoracle_yieldpoint as yieldpoint;
 
 const APPLY_TASK_YIELD: &str = "standalone_host::apply_task::between_iterations";
 

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -15,6 +15,7 @@ categories    = ["network-programming", "database"]
 [features]
 default    = ["tls-rustls", "tracing"]
 failpoints = ["dep:fail", "fail/failpoints"]
+yieldpoints = ["tsoracle-yieldpoint/yieldpoints"]
 metrics    = ["dep:metrics"]
 tls-rustls = ["tonic/tls-aws-lc"]
 tls-native = ["tonic/tls-native-roots"]
@@ -45,6 +46,7 @@ tracing            = { workspace = true, optional = true }
 tsoracle-core      = { path = "../tsoracle-core", version = "0.1.3" }
 tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.3" }
 tsoracle-proto     = { path = "../tsoracle-proto", version = "0.1.3" }
+tsoracle-yieldpoint = { workspace = true }
 
 [dev-dependencies]
 tokio        = { workspace = true, features = ["test-util"] }

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -76,6 +76,7 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                         )))
                     }
                 );
+                tsoracle_yieldpoint::yieldpoint!("server::fence::after_load_before_persist");
 
                 // Compute the serving floor and the requested ceiling.
                 // serving_floor is the first physical_ms the new leader may

--- a/crates/tsoracle-server/tests/fence_yieldpoint.rs
+++ b/crates/tsoracle-server/tests/fence_yieldpoint.rs
@@ -1,0 +1,95 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Smoke test for the `server::fence::after_load_before_persist` yield
+//! point. Exercises the mechanism end-to-end against the real
+//! `run_leader_watch` task: arms the gate, drives a leader transition,
+//! verifies the fence is parked (state stays `NotServing`), releases the
+//! gate, and confirms the fence completes through to `Serving`.
+//!
+//! This is the async sibling of the sync failpoint at the same call
+//! site. The failpoint variant covers error injection (typed-error
+//! return / panic / sleep); the yield-point variant unlocks tests that
+//! need to deliver a *concurrent driver event* — a follower transition
+//! or a second leader event at a different epoch — while the fence is
+//! parked mid-iteration. A `fail`-crate `pause` action would have
+//! blocked the worker thread and wedged the timer driver. See
+//! `docs/yieldpoint-testing.md` for the full rationale.
+
+#![cfg(feature = "yieldpoints")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tsoracle_consensus::ConsensusDriver;
+use tsoracle_core::Epoch;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::{Server, ServingState};
+use tsoracle_yieldpoint as yieldpoint;
+
+const FENCE_GATE: &str = "server::fence::after_load_before_persist";
+
+#[tokio::test]
+async fn fence_parks_at_after_load_yieldpoint_until_released() {
+    let driver = Arc::new(InMemoryDriver::new());
+
+    // Seed a prior high-water so the load step has something to return.
+    driver.persist_high_water(1_000, Epoch(0)).await.unwrap();
+
+    let server = Arc::new(
+        Server::builder()
+            .consensus_driver(driver.clone())
+            .failover_advance(Duration::from_millis(0))
+            .build()
+            .unwrap(),
+    );
+    let mut state_rx = server.state_rx.clone();
+
+    // Arm the yield point BEFORE spawning the watch task so the first
+    // Leader iteration is guaranteed to park.
+    let gate = yieldpoint::cfg(FENCE_GATE);
+
+    let watch_server = server.clone();
+    let watch_handle = tokio::spawn(async move { watch_server.run_leader_watch_for_tests().await });
+
+    driver.become_leader(Epoch(1));
+
+    // Give the fence ample time to reach the yield point. Without the
+    // yield point the fence would reach `Serving` within a handful of
+    // milliseconds; if `Serving` is observed before we release, the gate
+    // didn't fire and the test should fail.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let state = state_rx.borrow().clone();
+    assert!(
+        matches!(state, ServingState::NotServing { .. }),
+        "fence must still be parked at the yield point; observed {state:?}"
+    );
+
+    gate.notify_one();
+
+    // After release the fence persists, seeds the allocator, and publishes
+    // `Serving`. Wait for that to land.
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if matches!(*state_rx.borrow_and_update(), ServingState::Serving) {
+                return;
+            }
+            state_rx.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("fence must reach Serving within 2s of yield-point release");
+
+    yieldpoint::remove(FENCE_GATE);
+    watch_handle.abort();
+}

--- a/crates/tsoracle-yieldpoint/Cargo.toml
+++ b/crates/tsoracle-yieldpoint/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name         = "tsoracle-yieldpoint"
+description  = "Async yield points: tokio::sync::Notify-backed test injection sites, the async sibling of fail-rs failpoints"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+homepage.workspace     = true
+readme.workspace       = true
+authors.workspace      = true
+keywords      = ["testing", "async", "tokio", "yield", "failpoint"]
+categories    = ["asynchronous", "development-tools::testing"]
+
+[features]
+default     = []
+# Enables the registry + macro body. Off by default so production builds
+# carry zero overhead; `cargo test --all-features` activates it in CI.
+yieldpoints = []
+
+[dependencies]
+parking_lot = { workspace = true }
+tokio       = { workspace = true }

--- a/crates/tsoracle-yieldpoint/src/lib.rs
+++ b/crates/tsoracle-yieldpoint/src/lib.rs
@@ -12,28 +12,47 @@
 
 //! Async yield points — the structural analogue of [`fail-rs`] failpoints,
 //! but driven by a `tokio::sync::Notify` so the production code yields its
-//! tokio worker while parked instead of blocking the thread. A
-//! fail-crate `pause` action wedges the tokio timer driver, which is
-//! the symptom that motivated this module.
+//! tokio worker while parked instead of blocking the thread.
 //!
-//! Each call site is named:
+//! A fail-crate `pause` action uses `std::thread::park` / a condvar, which
+//! blocks the OS thread the failpoint fires on. Inside a tokio task that
+//! starves the runtime's timer driver — `tokio::time::sleep` stops
+//! returning for every task on that worker, and any race the test is
+//! trying to observe gets masked. Yield points exist for exactly the case
+//! where the call site is in an async path that must keep yielding to
+//! the runtime while parked.
 //!
-//! ```ignore
-//! tsoracle_driver_paxos::yieldpoint!("standalone_host::apply_task::between_iterations");
+//! # Quick reference
+//!
+//! Opt in by declaring a feature on the consumer crate that flips
+//! `tsoracle-yieldpoint/yieldpoints`:
+//!
+//! ```toml
+//! # consumer Cargo.toml
+//! [features]
+//! yieldpoints = ["tsoracle-yieldpoint/yieldpoints"]
+//!
+//! [dependencies]
+//! tsoracle-yieldpoint = { workspace = true }
 //! ```
 //!
-//! When the `yieldpoints` feature is off the macro expands to nothing.
-//! When on, the macro consults the registry; if the named yield point
-//! is armed, the production code awaits the registered `Notify`.
-//!
-//! From a test:
+//! Insert the macro at the call site:
 //!
 //! ```ignore
-//! let handle = yieldpoint::cfg("name");
+//! tsoracle_yieldpoint::yieldpoint!("module::site::after_X_before_Y");
+//! ```
+//!
+//! Arm and release from a test:
+//!
+//! ```ignore
+//! let handle = tsoracle_yieldpoint::cfg("module::site::after_X_before_Y");
 //! // ... drive code into the yield point ...
 //! handle.notify_one(); // release
-//! yieldpoint::remove("name");
+//! tsoracle_yieldpoint::remove("module::site::after_X_before_Y");
 //! ```
+//!
+//! The registry is process-global (same pattern as `fail-rs`). Tests that
+//! arm the same name must serialize.
 //!
 //! [`fail-rs`]: https://docs.rs/fail
 
@@ -78,16 +97,17 @@ pub use registry::{cfg, get, remove};
 
 /// Await the registered `Notify` at this site if armed; no-op otherwise.
 ///
-/// Expands to `{}` when the `yieldpoints` cargo feature is off, so
-/// production builds carry zero overhead. When on, an armed entry parks
-/// the calling task on `Notify::notified().await` — yielding the tokio
-/// worker so timers and other tasks continue to run. Release with
-/// `notify_one()` on the handle returned by [`cfg`].
+/// Expands to `{}` when the `yieldpoints` cargo feature is off (on
+/// `yield-rs` itself), so production builds of consuming crates carry
+/// zero overhead. When on, an armed entry parks the calling task on
+/// `Notify::notified().await` — yielding the tokio worker so timers and
+/// other tasks continue to run. Release with `notify_one()` on the
+/// handle returned by [`cfg`].
 #[cfg(feature = "yieldpoints")]
 #[macro_export]
 macro_rules! yieldpoint {
     ($name:expr) => {{
-        if let Some(yp) = $crate::yieldpoint::get($name) {
+        if let Some(yp) = $crate::get($name) {
             yp.notified().await;
         }
     }};

--- a/docs/yieldpoint-testing.md
+++ b/docs/yieldpoint-testing.md
@@ -15,7 +15,18 @@ Don't add a yield point when a failpoint would already serve — sync injection 
 
 ## Feature gating
 
-Crates that opt in declare a `yieldpoints` Cargo feature. The feature is empty (it gates only macro expansion, not a dep). The macro lives in a `yieldpoint` module on each opting-in crate; the `yieldpoint!(...)` macro is exported at the crate root via `#[macro_export]`. With the feature off, the macro expands to `{}` — production builds carry zero overhead and the `tokio::sync::Notify` registry is never linked. With the feature on, the call site consults the per-process registry and `.await`s the registered `Notify` if armed.
+The registry and the `yieldpoint!` macro live in a shared workspace crate, `tsoracle-yieldpoint`. Consumer crates opt in by adding a thin Cargo feature that pulls in the `yieldpoints` feature on `tsoracle-yieldpoint`:
+
+```toml
+# consumer Cargo.toml
+[features]
+yieldpoints = ["tsoracle-yieldpoint/yieldpoints"]
+
+[dependencies]
+tsoracle-yieldpoint = { workspace = true }
+```
+
+With `tsoracle-yieldpoint/yieldpoints` off the macro expands to `{}` — production builds carry zero overhead and the `tokio::sync::Notify` registry is never linked. With it on, the call site consults the per-process registry and `.await`s the registered `Notify` if armed.
 
 Run the yield-point suite with:
 
@@ -23,15 +34,15 @@ Run the yield-point suite with:
 
 `--all-features` activates `yieldpoints` on every opting-in crate, so the yield-point tests are part of the normal CI gate (same model as failpoints).
 
-## The wrapper macro
+## The macro
 
-Each opting-in crate has a `yieldpoint` module with a small `yieldpoint!` macro. Source sites use the crate's macro and never construct the `Notify` directly. The macro has a single form — yield points have no typed return; they only pause and resume:
+Source sites call `tsoracle_yieldpoint::yieldpoint!(...)` directly — there is no per-crate wrapper. The macro has a single form, since yield points have no typed return; they only pause and resume:
 
 ```rust
-crate::yieldpoint!("standalone_host::apply_task::between_iterations");
+tsoracle_yieldpoint::yieldpoint!("standalone_host::apply_task::between_iterations");
 ```
 
-With `feature = "yieldpoints"` off, the call expands to `{}` — zero code, no `tokio::sync::Notify`, no registry lookup.
+With the feature off, the call expands to `{}` — zero code, no `tokio::sync::Notify`, no registry lookup.
 
 ## Naming convention
 
@@ -47,25 +58,31 @@ The string is matched verbatim against the registry — typos at the call site o
 |---|---|---|
 | `standalone_host::apply_task::between_iterations` | End of the `apply_notify` branch in the apply task's `tokio::select!`, after `drain_decided_into` + `maybe_snapshot` and before the loop returns to the next `select!`. | `stop_delivers_shutdown_when_apply_task_is_mid_iteration` |
 
+### `tsoracle-server` — 1 site in `crates/tsoracle-server/src/fence.rs`
+
+| Site name | Position | Test |
+|---|---|---|
+| `server::fence::after_load_before_persist` | Inside `run_leader_watch`'s Leader branch, between `consensus.load_high_water().await` and the `persist_high_water(requested, epoch)` call. Co-located with the sync failpoint of the same name — the sync variant injects typed-error returns / panics; the async variant parks the fence so a test can deliver a concurrent driver event before releasing. | `fence_parks_at_after_load_yieldpoint_until_released` |
+
 ## Writing a yield-point test
 
 Tests live in `crates/<crate>/tests/<topic>.rs` with `#![cfg(feature = "yieldpoints")]` at the top so cargo silently skips the binary when the feature is off rather than failing the compile.
 
 Each test:
 
-1. Calls `yieldpoint::cfg("name")` to arm the gate. The returned `Arc<Notify>` is the release handle.
+1. Calls `tsoracle_yieldpoint::cfg("name")` to arm the gate. The returned `Arc<Notify>` is the release handle.
 2. Drives production code into the yield point (start the host / spawn the task / fire the input that wakes the await).
 3. Performs the test's side-effect (call `stop()`, or whatever shutdown / interleaving the bug requires).
 4. Calls `handle.notify_one()` on the release handle to wake the production code.
 5. Asserts the observable invariant — typically with `tokio::time::timeout` around the join, so the test fails with `Elapsed(())` rather than hanging if the bug is back.
-6. Calls `yieldpoint::remove("name")` to clear the gate. (Tests that share the registry across iterations also need this; the registry is process-global, like `fail`'s.)
+6. Calls `tsoracle_yieldpoint::remove("name")` to clear the gate. (Tests that share the registry across iterations also need this; the registry is process-global, like `fail`'s.)
 
 The release handle is an ordinary `Arc<Notify>`, so all of `notify_one`, `notify_waiters`, and `notified().await` are available — pick the method whose semantics the test wants. `notify_one` is the common case (single waiter, store-permit-if-no-waiter semantics).
 
 ## Adding a new site
 
 1. Pick a name following `{module}::{site}::{temporal_phrase}`.
-2. Insert `crate::yieldpoint!("name")` at the source position. The crate must already have a `yieldpoint` module and a `yieldpoints` cargo feature — see `tsoracle-driver-paxos` as the canonical reference.
+2. Insert `tsoracle_yieldpoint::yieldpoint!("name")` at the source position. The consumer crate must already declare a `yieldpoints` Cargo feature that pulls in `tsoracle-yieldpoint/yieldpoints` and depend on `tsoracle-yieldpoint = { workspace = true }` — see `tsoracle-driver-paxos` or `tsoracle-server` as the canonical references.
 3. If the call site is inside a critical section guarded by a `parking_lot` mutex (or any non-`Send`-across-`.await` guard), drop the guard before the macro invocation. The macro contains `.await`, so a guard held across it would make the enclosing future `!Send` and `tokio::spawn` would reject it.
 4. Add a test in `crates/<crate>/tests/<topic>.rs`. Follow the pattern in this doc.
 5. Run `cargo test -p <crate> --features yieldpoints` locally and confirm everything still passes. To confirm the test actually catches the bug it's claimed to: temporarily invert the fix, re-run, observe the `Elapsed(())` timeout. Revert the production code before committing.
@@ -81,9 +98,9 @@ Renaming an existing site is a breaking change for any test that referenced it. 
 | Worker behavior while parked | OS thread blocked | Task yielded, worker free |
 | Actions | `off`, `panic`, `pause`, `sleep(ms)`, `print(text)`, `return` / `return(...)` | Implicit single action: pause until released |
 | Typed return injection | Yes (closure form) | No |
-| Crate | [`fail`](https://docs.rs/fail/0.5/) | First-party, per opting-in crate |
+| Crate | [`fail`](https://docs.rs/fail/0.5/) | first-party `tsoracle-yieldpoint` (shared workspace crate) |
 | Cargo feature name | `failpoints` | `yieldpoints` |
-| Source macro | `crate::failpoint!(...)` | `crate::yieldpoint!(...)` |
+| Source macro | `crate::failpoint!(...)` (per-crate wrapper) | `tsoracle_yieldpoint::yieldpoint!(...)` (called directly) |
 | Doc | [Failpoint Testing](failpoint-testing.md) | this file |
 
 Reach for failpoints first if the site is sync or needs to inject a typed return. Reach for yield points when the site is async and the test needs to pause production code without blocking a tokio worker.


### PR DESCRIPTION
## Motivation

The `yieldpoint` module introduced inside `tsoracle-driver-paxos` (#194) is useful in more than one crate — the immediate need was a regression test for `tsoracle-server`'s fence path, but I didn't want to copy/paste ~50 lines of registry code into every consumer. Promotes the registry into a shared workspace crate (`tsoracle-yieldpoint`) following the same shape as `fail-rs`, then wires the first new consumer.

## What's in this PR

### 1. `crates/tsoracle-yieldpoint` — new workspace crate

Holds the `OnceLock<Mutex<HashMap<&'static str, Arc<Notify>>>>` registry, the `cfg` / `remove` / `get` API, and the `#[macro_export]`'d `yieldpoint!` macro. Everything past the macro definition is gated on the crate's `yieldpoints` Cargo feature; with the feature off the macro expands to `{}` and the registry isn't linked.

Consumer crates opt in by adding:

```toml
[features]
yieldpoints = ["tsoracle-yieldpoint/yieldpoints"]

[dependencies]
tsoracle-yieldpoint = { workspace = true }
```

and calling the macro directly at the site:

```rust
tsoracle_yieldpoint::yieldpoint!("module::site::after_X_before_Y");
```

Unlike `fail-rs`'s per-crate wrapper-macro pattern, there's no `crate::yieldpoint!` wrapper — the macro is short, the registry is per-process anyway, and a wrapper would just rename the symbol.

### 2. Refactor `tsoracle-driver-paxos`

- Removes the in-tree `src/yieldpoint.rs` module + `pub mod yieldpoint;` line.
- Adds the workspace dep + `yieldpoints` feature passthrough.
- Updates the existing `apply_task::between_iterations` call site to `tsoracle_yieldpoint::yieldpoint!(...)`.
- Updates `tests/standalone_shutdown.rs` to `use tsoracle_yieldpoint as yieldpoint;` for the `cfg`/`remove` calls.

The existing `stop_delivers_shutdown_when_apply_task_is_mid_iteration` regression still passes under the refactor.

### 3. First `tsoracle-server` consumer

- New `yieldpoints` feature on `tsoracle-server` (passthrough to `tsoracle-yieldpoint/yieldpoints`).
- New yield point `server::fence::after_load_before_persist` in `run_leader_watch`'s Leader branch, co-located with the **sync** failpoint of the same name. The sync failpoint stays for typed-error injection (`return(transient)`) and crash injection (`panic`); the async yield point covers cases that need to deliver a *concurrent driver event* (a follower transition or a second leader event at a different epoch) while the fence is parked. A `fail`-crate `pause` action would block the worker thread and wedge the timer driver — the original CI hang from #194 was exactly that shape.
- Smoke test in `tests/fence_yieldpoint.rs` exercising the mechanism end-to-end against the real `run_leader_watch` task: arms the gate, drives a leader transition, asserts the fence is parked (`state_rx` reports `NotServing` after 200 ms), releases the gate, asserts the fence completes through to `Serving` within 2 s. Inversion check: removing the `yieldpoint!` call from `fence.rs` makes the test fail with `fence must still be parked at the yield point; observed Serving`, confirming the test actually exercises the call site.

### 4. Docs

`docs/yieldpoint-testing.md` updated for the shared-crate architecture: "Feature gating", "The macro", "Writing a yield-point test", and "Adding a new site" sections; "Current sites" now lists two sites across two crates; the failpoints comparison table notes the direct-call-site pattern.

## Test plan

- [x] `cargo test -p tsoracle-driver-paxos --features yieldpoints` — 44 tests pass (including the existing apply-task shutdown regression unchanged).
- [x] `cargo test -p tsoracle-server --features yieldpoints,test-fakes,test-support` — all pass, including the new `fence_parks_at_after_load_yieldpoint_until_released`.
- [x] Inversion: removing the `yieldpoint!` call from `fence.rs` makes the new test fail with the expected "observed Serving" message.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo build` (default features, no `yieldpoints` anywhere) — clean; registry not linked.
- [x] Header check (`scripts/check-ts-header.py`) — clean.
