### PR TITLE
fix(driver-paxos): qualify yieldpoint! macro path on the new sites

### DIFF
--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -274,7 +274,9 @@ where
                 ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
             })?;
         let notifier = self.apply_state.apply_notifier();
-        crate::yieldpoint!("standalone_host::current_high_water::after_append_before_await");
+        tsoracle_yieldpoint::yieldpoint!(
+            "standalone_host::current_high_water::after_append_before_await"
+        );
         loop {
             // Register as waiter before checking state; otherwise a notify_waiters
             // that fires between the previous iteration's check and the next
@@ -301,7 +303,9 @@ where
                 ConsensusError::TransientDriver(Box::new(AdvanceAppendError(format!("{err:?}"))))
             })?;
         let notifier = self.apply_state.apply_notifier();
-        crate::yieldpoint!("standalone_host::submit_advance::after_append_before_await");
+        tsoracle_yieldpoint::yieldpoint!(
+            "standalone_host::submit_advance::after_append_before_await"
+        );
         loop {
             let notified = notifier.notified();
             tokio::pin!(notified);

--- a/crates/tsoracle-driver-paxos/tests/blocking_reads_missed_notify.rs
+++ b/crates/tsoracle-driver-paxos/tests/blocking_reads_missed_notify.rs
@@ -43,7 +43,7 @@
 use std::time::Duration;
 
 use tsoracle_driver_paxos::host::PaxosHighWaterHost;
-use tsoracle_driver_paxos::yieldpoint;
+use tsoracle_yieldpoint as yieldpoint;
 
 #[path = "common/mod.rs"]
 mod common;


### PR DESCRIPTION
## What's broken

`cargo test --workspace --all-features` and the `coverage` job fail on main with:

```
error[E0433]: failed to resolve: could not find `yieldpoint` in the crate root
   --> crates/tsoracle-driver-paxos/src/standalone.rs:277:16
    |
277 |         crate::yieldpoint!("standalone_host::current_high_water::after_append_before_await");
    |                ^^^^^^^^^^ could not find `yieldpoint` in the crate root
```

(and the matching error at line 304 for `submit_advance`).

## How it landed broken

PR #196's two new yield points were originally written against the pre-#198 layout, where each consumer crate had its own `pub mod yieldpoint;` module and the call sites used `crate::yieldpoint!(...)`. #198 retired the in-tree module in favor of the shared `tsoracle-yieldpoint` crate, and #196's pre-merge rebase included a fixup that qualified the new call sites accordingly.

That fixup never reached the remote — the force-push was rejected as "stale info" because the squash merge had already happened seconds earlier. So the version on main is the pre-fixup one. With the `yieldpoints` feature off the macro expands to `{}` and there's no resolution to do, which is why default `cargo test --workspace` passed both at PR-CI time and immediately after the merge. `--all-features` is what activates the feature and trips the bad path.

## The fix

Three lines, in two files:

- `crates/tsoracle-driver-paxos/src/standalone.rs` — `crate::yieldpoint!(...)` → `tsoracle_yieldpoint::yieldpoint!(...)` on lines 277 and 304.
- `crates/tsoracle-driver-paxos/tests/blocking_reads_missed_notify.rs` — `use tsoracle_driver_paxos::yieldpoint;` → `use tsoracle_yieldpoint as yieldpoint;`.

## Test plan

- [x] `cargo test --workspace --all-features --no-run` — workspace builds.
- [x] `cargo test -p tsoracle-driver-paxos --test blocking_reads_missed_notify --features yieldpoints` — both regressions pass.
- [x] `cargo check --workspace` (default features) — unchanged behavior; with the feature off the macro is a no-op either way.
