### PR TITLE
feat(stress): add paxos topology + nightly CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
         run: cargo run --release -p stress -- run --topology mem --ci-smoke
       - name: smoke (raft)
         run: cargo run --release -p stress -- run --topology raft --ci-smoke --nodes 3
+      - name: smoke (paxos)
+        run: cargo run --release -p stress -- run --topology paxos --ci-smoke --nodes 3
       - name: smoke (process)
         run: cargo run --release -p stress -- run --topology process --ci-smoke --nodes 1
       - name: positive control (inject-violation)

--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       topology:
-        description: "Topology (mem | raft | process | all)"
+        description: "Topology (mem | raft | paxos | process | all)"
         required: false
         default: all
         type: string
@@ -36,6 +36,7 @@ jobs:
         topology:
           - mem
           - raft
+          - paxos
           - process
         scenario:
           - steady

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,6 +2774,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "nix",
+ "omnipaxos",
  "openraft",
  "parking_lot",
  "rand 0.9.4",
@@ -2789,7 +2790,9 @@ dependencies = [
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-driver-openraft",
+ "tsoracle-driver-paxos",
  "tsoracle-openraft-toolkit",
+ "tsoracle-paxos-toolkit",
  "tsoracle-server",
 ]
 

--- a/benchmarks/stress/Cargo.toml
+++ b/benchmarks/stress/Cargo.toml
@@ -14,7 +14,11 @@ publish = false
 default = []
 # Enables in-process failpoint chaos in mem/raft topologies. When off,
 # `arm_failpoint`/`disarm_failpoint` log a warning and return Skipped.
-stress-failpoints = ["dep:fail", "tsoracle-server/failpoints"]
+stress-failpoints = [
+    "dep:fail",
+    "tsoracle-server/failpoints",
+    "tsoracle-paxos-toolkit/failpoints",
+]
 
 [dependencies]
 anyhow             = { workspace = true }
@@ -23,8 +27,9 @@ clap               = { workspace = true, features = ["derive"] }
 hdrhistogram       = { workspace = true }
 humantime          = { workspace = true }
 humantime-serde    = { workspace = true }
+omnipaxos          = { workspace = true, features = ["serde"] }
 openraft           = { workspace = true }
-parking_lot       = { workspace = true }
+parking_lot        = { workspace = true }
 rand               = { workspace = true }
 rocksdb            = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
@@ -35,12 +40,14 @@ tonic              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-tsoracle-openraft-toolkit         = { path = "../../crates/tsoracle-openraft-toolkit", version = "0.1.3", features = ["test-fakes"] }
-tsoracle-server    = { path = "../../crates/tsoracle-server", version = "0.1.3", features = ["test-fakes"] }
-tsoracle-client    = { path = "../../crates/tsoracle-client", version = "0.1.3" }
-tsoracle-core      = { path = "../../crates/tsoracle-core", version = "0.1.3" }
-tsoracle-consensus = { path = "../../crates/tsoracle-consensus", version = "0.1.3" }
+tsoracle-client          = { path = "../../crates/tsoracle-client", version = "0.1.3" }
+tsoracle-consensus       = { path = "../../crates/tsoracle-consensus", version = "0.1.3" }
+tsoracle-core            = { path = "../../crates/tsoracle-core", version = "0.1.3" }
 tsoracle-driver-openraft = { path = "../../crates/tsoracle-driver-openraft", version = "0.1.3" }
+tsoracle-driver-paxos    = { path = "../../crates/tsoracle-driver-paxos", version = "0.1.4" }
+tsoracle-openraft-toolkit = { path = "../../crates/tsoracle-openraft-toolkit", version = "0.1.3", features = ["test-fakes"] }
+tsoracle-paxos-toolkit   = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.1.4", features = ["rocksdb-storage"] }
+tsoracle-server          = { path = "../../crates/tsoracle-server", version = "0.1.3", features = ["test-fakes"] }
 
 fail = { workspace = true, optional = true }
 

--- a/benchmarks/stress/Cargo.toml
+++ b/benchmarks/stress/Cargo.toml
@@ -46,7 +46,7 @@ tsoracle-core            = { path = "../../crates/tsoracle-core", version = "0.1
 tsoracle-driver-openraft = { path = "../../crates/tsoracle-driver-openraft", version = "0.1.3" }
 tsoracle-driver-paxos    = { path = "../../crates/tsoracle-driver-paxos", version = "0.1.4" }
 tsoracle-openraft-toolkit = { path = "../../crates/tsoracle-openraft-toolkit", version = "0.1.3", features = ["test-fakes"] }
-tsoracle-paxos-toolkit   = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.1.4", features = ["rocksdb-storage"] }
+tsoracle-paxos-toolkit   = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.1.4", features = ["rocksdb-storage", "test-fakes"] }
 tsoracle-server          = { path = "../../crates/tsoracle-server", version = "0.1.3", features = ["test-fakes"] }
 
 fail = { workspace = true, optional = true }

--- a/benchmarks/stress/src/bin/stress.rs
+++ b/benchmarks/stress/src/bin/stress.rs
@@ -68,6 +68,8 @@ struct RunArgs {
     grace_mem: HumantimeDuration,
     #[arg(long, default_value = "750ms")]
     grace_raft: HumantimeDuration,
+    #[arg(long, default_value = "1s")]
+    grace_paxos: HumantimeDuration,
     #[arg(long, default_value = "2s")]
     grace_process: HumantimeDuration,
     #[arg(long, default_value_t = 3)]
@@ -103,6 +105,7 @@ struct InjectArgs {
 enum TopologyArg {
     Mem,
     Raft,
+    Paxos,
     Process,
 }
 
@@ -111,6 +114,7 @@ impl From<TopologyArg> for TopologyKind {
         match t {
             TopologyArg::Mem => TopologyKind::Mem,
             TopologyArg::Raft => TopologyKind::Raft,
+            TopologyArg::Paxos => TopologyKind::Paxos,
             TopologyArg::Process => TopologyKind::Process,
         }
     }
@@ -145,6 +149,7 @@ fn build_config(a: &RunArgs) -> StressConfig {
         liveness_deadline: Duration::from(a.liveness_deadline),
         grace_mem: Duration::from(a.grace_mem),
         grace_raft: Duration::from(a.grace_raft),
+        grace_paxos: Duration::from(a.grace_paxos),
         grace_process: Duration::from(a.grace_process),
         nodes: a.nodes,
         bind: a.bind,
@@ -229,6 +234,7 @@ fn replay_cmd(args: ReplayArgs) -> ExitCode {
         liveness_deadline: Duration::from_secs(5),
         grace_mem: Duration::from_millis(100),
         grace_raft: Duration::from_millis(750),
+        grace_paxos: Duration::from_millis(1000),
         grace_process: Duration::from_secs(2),
         nodes: 1,
         bind: "127.0.0.1:0"
@@ -275,6 +281,7 @@ fn inject_violation_cmd(args: InjectArgs) -> ExitCode {
         liveness_deadline: Duration::from_secs(5),
         grace_mem: Duration::from_millis(100),
         grace_raft: Duration::from_millis(750),
+        grace_paxos: Duration::from_millis(1000),
         grace_process: Duration::from_secs(2),
         nodes: 1,
         bind: SocketAddr::from(([127, 0, 0, 1], 0)),

--- a/benchmarks/stress/src/config.rs
+++ b/benchmarks/stress/src/config.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 pub enum TopologyKind {
     Mem,
     Raft,
+    Paxos,
     Process,
 }
 
@@ -44,6 +45,7 @@ pub struct StressConfig {
     pub liveness_deadline: Duration,
     pub grace_mem: Duration,
     pub grace_raft: Duration,
+    pub grace_paxos: Duration,
     pub grace_process: Duration,
     pub nodes: usize,
     pub bind: SocketAddr,
@@ -75,8 +77,12 @@ impl StressConfig {
         if self.server_threads == 0 {
             return Err("--server-threads must be >= 1".into());
         }
-        if matches!(self.topology, TopologyKind::Raft | TopologyKind::Process) && self.nodes < 1 {
-            return Err("--nodes must be >= 1 for raft/process topology".into());
+        if matches!(
+            self.topology,
+            TopologyKind::Raft | TopologyKind::Paxos | TopologyKind::Process
+        ) && self.nodes < 1
+        {
+            return Err("--nodes must be >= 1 for raft/paxos/process topology".into());
         }
         // `tsoracle serve` is single-node (FileDriver, no cluster protocol).
         // Spawning multiple of them under process topology gives independent
@@ -98,6 +104,7 @@ impl StressConfig {
         match self.topology {
             TopologyKind::Mem => self.grace_mem,
             TopologyKind::Raft => self.grace_raft,
+            TopologyKind::Paxos => self.grace_paxos,
             TopologyKind::Process => self.grace_process,
         }
     }
@@ -123,6 +130,7 @@ mod tests {
             liveness_deadline: Duration::from_secs(5),
             grace_mem: Duration::from_millis(100),
             grace_raft: Duration::from_millis(750),
+            grace_paxos: Duration::from_millis(1000),
             grace_process: Duration::from_secs(2),
             nodes: 3,
             bind: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
@@ -187,6 +195,14 @@ mod tests {
     fn raft_topology_requires_nodes() {
         let mut cfg = ok_config();
         cfg.topology = TopologyKind::Raft;
+        cfg.nodes = 0;
+        assert!(cfg.validate().unwrap_err().contains("--nodes"));
+    }
+
+    #[test]
+    fn paxos_topology_requires_nodes() {
+        let mut cfg = ok_config();
+        cfg.topology = TopologyKind::Paxos;
         cfg.nodes = 0;
         assert!(cfg.validate().unwrap_err().contains("--nodes"));
     }

--- a/benchmarks/stress/src/config.rs
+++ b/benchmarks/stress/src/config.rs
@@ -84,6 +84,13 @@ impl StressConfig {
         {
             return Err("--nodes must be >= 1 for raft/paxos/process topology".into());
         }
+        // OmniPaxos rejects single-node `ClusterConfig`s — BLE requires a
+        // quorum of configured nodes alive for leader election.
+        if matches!(self.topology, TopologyKind::Paxos) && self.nodes < 3 {
+            return Err(
+                "--nodes must be >= 3 for paxos topology (OmniPaxos requires a quorum)".into(),
+            );
+        }
         // `tsoracle serve` is single-node (FileDriver, no cluster protocol).
         // Spawning multiple of them under process topology gives independent
         // oracles with independent physical-clock baselines; client failover
@@ -205,6 +212,20 @@ mod tests {
         cfg.topology = TopologyKind::Paxos;
         cfg.nodes = 0;
         assert!(cfg.validate().unwrap_err().contains("--nodes"));
+    }
+
+    #[test]
+    fn paxos_topology_requires_three_nodes() {
+        for n in [1, 2] {
+            let mut cfg = ok_config();
+            cfg.topology = TopologyKind::Paxos;
+            cfg.nodes = n;
+            let err = cfg.validate().unwrap_err();
+            assert!(
+                err.contains(">= 3 for paxos"),
+                "expected paxos quorum error for nodes={n}, got: {err}",
+            );
+        }
     }
 
     #[test]

--- a/benchmarks/stress/src/lib.rs
+++ b/benchmarks/stress/src/lib.rs
@@ -208,7 +208,27 @@ pub fn run(cfg: StressConfig) -> Result<Report, anyhow::Error> {
             }
         }
         TopologyKind::Paxos => {
-            anyhow::bail!("paxos topology not yet implemented");
+            let topo = server_rt.block_on(crate::topology::paxos::PaxosTopology::spawn(
+                cfg.nodes, grace,
+            ))?;
+            let endpoints = topo.controller.endpoints();
+            // `PaxosTopology` returns one server `JoinHandle<()>` per node;
+            // same adapter shape as `RaftTopology` above — see its comment.
+            let mut handles = topo.server_handles.into_iter();
+            let first = handles
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("paxos topology returned zero server handles"))?;
+            for extra in handles {
+                server_rt.spawn(async move {
+                    let _ = extra.await;
+                });
+            }
+            let server_handle: tokio::task::JoinHandle<Result<(), tsoracle_server::ServerError>> =
+                server_rt.spawn(async move {
+                    let _ = first.await;
+                    Ok(())
+                });
+            (Box::new(topo.controller), endpoints, server_handle)
         }
     };
 

--- a/benchmarks/stress/src/lib.rs
+++ b/benchmarks/stress/src/lib.rs
@@ -207,6 +207,9 @@ pub fn run(cfg: StressConfig) -> Result<Report, anyhow::Error> {
                 (controller, endpoints, server_handle)
             }
         }
+        TopologyKind::Paxos => {
+            anyhow::bail!("paxos topology not yet implemented");
+        }
     };
 
     // --- Supervisor task on control runtime. ---
@@ -526,6 +529,7 @@ mod resolve_schedule_tests {
             liveness_deadline: Duration::from_secs(5),
             grace_mem: Duration::from_millis(100),
             grace_raft: Duration::from_millis(750),
+            grace_paxos: Duration::from_millis(1000),
             grace_process: Duration::from_secs(2),
             nodes: 1,
             bind: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),

--- a/benchmarks/stress/src/report.rs
+++ b/benchmarks/stress/src/report.rs
@@ -116,6 +116,7 @@ impl Report {
         let topo = match self.topology {
             TopologyKind::Mem => "Mem",
             TopologyKind::Raft => "Raft",
+            TopologyKind::Paxos => "Paxos",
             TopologyKind::Process => "Process",
         };
         format!(
@@ -164,6 +165,7 @@ impl Report {
         let topology = match self.topology {
             TopologyKind::Mem => "Mem",
             TopologyKind::Raft => "Raft",
+            TopologyKind::Paxos => "Paxos",
             TopologyKind::Process => "Process",
         };
         let value = serde_json::json!({
@@ -309,6 +311,7 @@ mod tests {
                 liveness_deadline: Duration::from_secs(5),
                 grace_mem: Duration::from_millis(100),
                 grace_raft: Duration::from_millis(750),
+                grace_paxos: Duration::from_millis(1000),
                 grace_process: Duration::from_secs(2),
                 nodes: 1,
                 bind: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
@@ -444,13 +447,18 @@ mod tests {
 
     #[test]
     fn renders_non_mem_topologies() {
-        for topo in [TopologyKind::Raft, TopologyKind::Process] {
+        for topo in [
+            TopologyKind::Raft,
+            TopologyKind::Paxos,
+            TopologyKind::Process,
+        ] {
             let mut r = sample_report();
             r.topology = topo;
             let text = r.render_text();
             let expect = match topo {
                 TopologyKind::Mem => "Mem",
                 TopologyKind::Raft => "Raft",
+                TopologyKind::Paxos => "Paxos",
                 TopologyKind::Process => "Process",
             };
             assert!(text.contains(&format!("topology={expect}")), "{text}");

--- a/benchmarks/stress/src/topology/mod.rs
+++ b/benchmarks/stress/src/topology/mod.rs
@@ -13,6 +13,7 @@
 //! Server topology abstractions: spawn, chaos vocabulary, endpoints.
 
 pub mod mem;
+pub mod paxos;
 #[cfg(unix)]
 pub mod process;
 pub mod raft;

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -1,0 +1,105 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! In-process OmniPaxos cluster on `MemNetwork`; chaos by partitioning the
+//! leader's outbound messages.
+//!
+//! Mirrors `examples/paxos-embedded/src/main.rs`'s cluster bringup: a single
+//! shared `MemNetwork`, per-node `RocksdbStorage` in a fresh tempdir, an
+//! explicit inbox pump per node (paxos `MemNetwork::register` returns a
+//! `Receiver`, not a factory), and a `tsoracle::Server` bound to a loopback
+//! port. No membership-init step — OmniPaxos accepts the full `ClusterConfig`
+//! at construction.
+//!
+//! `kill_leader` isolates the current leader on the shared `MemNetwork`'s
+//! partition controller for a short window, forcing the remaining quorum to
+//! elect a new leader, then restores reachability so subsequent chaos ops
+//! still have a quorum to work with. `pause_leader` runs the same partition
+//! shape for a caller-provided duration. `arm_failpoint`/`disarm_failpoint`
+//! are feature-gated on `stress-failpoints`: enabled, they drive the
+//! process-wide `fail` registry (which affects every in-process node at
+//! once); disabled, they return `Skipped`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use omnipaxos::OmniPaxos;
+use parking_lot::Mutex;
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+use tsoracle_driver_paxos::HighWaterCommand;
+use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
+
+use crate::chaos::ChaosEvent;
+use crate::topology::{ChaosController, NodeId};
+
+/// In-process OmniPaxos cluster with one `tsoracle::Server` per node.
+#[allow(dead_code)]
+pub struct PaxosTopology {
+    pub controller: PaxosController,
+    pub server_handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
+/// Owns the per-node OmniPaxos handles, the shared `MemNetwork`, and the
+/// oneshot shutdown senders for each node's tsoracle server.
+#[allow(dead_code)]
+pub struct PaxosController {
+    nodes: Vec<PaxosNode>,
+    network: Arc<MemNetwork<HighWaterCommand>>,
+    grace: Duration,
+}
+
+#[allow(dead_code)]
+struct PaxosNode {
+    node_id: NodeId,
+    endpoint: String,
+    omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, RocksdbStorage<HighWaterCommand>>>>,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Keep the rocksdb tempdir alive for the node's lifetime.
+    _storage_dir: TempDir,
+}
+
+// `ChaosController` impl. Method bodies are stubbed; subsequent commits
+// replace each `unimplemented!()` with the real implementation.
+
+#[async_trait]
+impl ChaosController for PaxosController {
+    async fn kill_leader(&self) -> ChaosEvent {
+        unimplemented!()
+    }
+
+    async fn pause_leader(&self, _dur: Duration) -> ChaosEvent {
+        unimplemented!()
+    }
+
+    async fn arm_failpoint(&self, _name: &str, _action: &str) -> ChaosEvent {
+        unimplemented!()
+    }
+
+    async fn disarm_failpoint(&self, _name: &str) -> ChaosEvent {
+        unimplemented!()
+    }
+
+    fn endpoints(&self) -> Vec<String> {
+        unimplemented!()
+    }
+
+    fn current_leader(&self) -> Option<NodeId> {
+        unimplemented!()
+    }
+
+    async fn shutdown(self: Box<Self>) {
+        unimplemented!()
+    }
+}

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -34,18 +34,25 @@ use std::time::Duration;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use omnipaxos::OmniPaxos;
+use omnipaxos::messages::Message;
+use omnipaxos::{ClusterConfig, OmniPaxos, OmniPaxosConfig, ServerConfig};
 use parking_lot::Mutex;
 use rocksdb::{DB, Options};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tsoracle_driver_paxos::HighWaterCommand;
+use tsoracle_paxos_toolkit::lifecycle::MessageSink;
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 
 use crate::chaos::ChaosEvent;
 use crate::topology::{ChaosController, NodeId};
+
+#[allow(dead_code)]
+const TICK_INTERVAL: Duration = Duration::from_millis(20);
+const ELECTION_TICK_TIMEOUT: u64 = 5;
+const RESEND_MESSAGE_TICK_TIMEOUT: u64 = 5;
 
 /// In-process OmniPaxos cluster with one `tsoracle::Server` per node.
 #[allow(dead_code)]
@@ -129,6 +136,51 @@ impl PaxosBackend for DefaultPaxosBackend {
         TcpListener::bind("127.0.0.1:0")
             .await
             .context("paxos topology: bind loopback")
+    }
+}
+
+/// Build an `OmniPaxosConfig` for node `node_id` in the given `cluster`.
+/// Election timing matches `examples/paxos-embedded` — tick interval 20 ms,
+/// election timeout 5 ticks (~100 ms). This is shorter than the raft
+/// topology's 300–600 ms election timeout, but well inside `grace_paxos`'s
+/// 1000 ms default so the fence-freshness gate still has headroom.
+#[allow(dead_code)]
+fn paxos_config(node_id: u64, cluster: &ClusterConfig) -> OmniPaxosConfig {
+    OmniPaxosConfig {
+        cluster_config: cluster.clone(),
+        server_config: ServerConfig {
+            pid: node_id,
+            election_tick_timeout: ELECTION_TICK_TIMEOUT,
+            resend_message_tick_timeout: RESEND_MESSAGE_TICK_TIMEOUT,
+            ..Default::default()
+        },
+    }
+}
+
+/// `MessageSink` that routes outbound paxos messages back through the
+/// shared `MemNetwork`. Lifted from `examples/paxos-embedded`.
+#[allow(dead_code)]
+struct MeshSink {
+    network: Arc<MemNetwork<HighWaterCommand>>,
+}
+
+#[async_trait]
+impl MessageSink<HighWaterCommand> for MeshSink {
+    async fn send(&self, message: Message<HighWaterCommand>) {
+        self.network.deliver(message).await;
+    }
+}
+
+/// Drains the per-node `MemNetwork` inbox into the node's OmniPaxos handle.
+/// Lifted from `examples/paxos-embedded`. One pump task per node; lives for
+/// the lifetime of the topology.
+#[allow(dead_code)]
+async fn run_inbox_pump(
+    omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, RocksdbStorage<HighWaterCommand>>>>,
+    mut inbox: mpsc::Receiver<Message<HighWaterCommand>>,
+) {
+    while let Some(message) = inbox.recv().await {
+        omnipaxos.lock().handle_incoming(message);
     }
 }
 

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -47,6 +47,7 @@ use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, Stand
 use tsoracle_paxos_toolkit::lifecycle::{MessageSink, Peer};
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
+use tsoracle_paxos_toolkit::test_fakes::partition::PartitionController;
 use tsoracle_server::Server;
 
 use crate::chaos::ChaosEvent;
@@ -343,6 +344,24 @@ async fn wait_for_leader(nodes: &[PaxosNode], timeout: Duration) -> anyhow::Resu
             }
         }
         sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// RAII guard that restores reachability for a single node on drop. Used to
+/// make `kill_leader` / `pause_leader` cancel-safe: if the harness's outer
+/// `select!` (e.g. the `--duration` timer) drops the chaos future while it
+/// is parked at the mid-window `sleep`, the guard's `Drop` still fires and
+/// restores reachability — without this, the cluster would remain
+/// partitioned for the rest of the run.
+#[allow(dead_code)]
+struct HealOnDrop {
+    partition: Arc<PartitionController>,
+    node: u64,
+}
+
+impl Drop for HealOnDrop {
+    fn drop(&mut self) {
+        self.partition.restore(self.node);
     }
 }
 

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -32,10 +32,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use omnipaxos::OmniPaxos;
 use parking_lot::Mutex;
+use rocksdb::{DB, Options};
 use tempfile::TempDir;
+use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
@@ -68,6 +71,65 @@ struct PaxosNode {
     shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     /// Keep the rocksdb tempdir alive for the node's lifetime.
     _storage_dir: TempDir,
+}
+
+#[allow(dead_code)]
+fn open_paxos_storage(dir: &std::path::Path) -> anyhow::Result<RocksdbStorage<HighWaterCommand>> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    // RocksdbStorage uses a single column family; DB::open always registers
+    // the "default" CF, which is the one we target here.
+    let db = Arc::new(DB::open(&opts, dir).context("paxos topology: open rocksdb at storage dir")?);
+    RocksdbStorage::open_in(db, "default")
+        .map_err(|e| anyhow::anyhow!("paxos topology: open RocksdbStorage: {e:?}"))
+}
+
+/// Pluggable backend for the spawn-time I/O dependencies that production
+/// `PaxosTopology::spawn` cannot otherwise force into a failure mode.
+///
+/// Production code uses [`DefaultPaxosBackend`]; tests inject impls that
+/// fail at a chosen step to exercise the `?` propagation paths in
+/// `spawn_with`. The `id` parameter lets a test backend differentiate
+/// behavior per node (fail only on node 1, succeed on the rest, etc.).
+/// Production ignores it.
+#[async_trait]
+pub trait PaxosBackend: Send + Sync {
+    /// Allocate a fresh, writable directory for node `id`'s rocksdb storage
+    /// and open the store on it. The returned `TempDir` must be kept alive
+    /// for the node's lifetime; dropping it deletes the directory and
+    /// invalidates the storage.
+    async fn prepare_node_storage(
+        &self,
+        id: u64,
+    ) -> anyhow::Result<(TempDir, RocksdbStorage<HighWaterCommand>)>;
+
+    /// Bind the loopback listener that node `id`'s tsoracle server will
+    /// serve from. Production uses `127.0.0.1:0`.
+    async fn bind_loopback(&self, id: u64) -> anyhow::Result<TcpListener>;
+}
+
+/// Production [`PaxosBackend`]: real `tempfile::TempDir`, real
+/// `RocksdbStorage`, real `TcpListener::bind("127.0.0.1:0")`.
+pub struct DefaultPaxosBackend;
+
+#[async_trait]
+impl PaxosBackend for DefaultPaxosBackend {
+    async fn prepare_node_storage(
+        &self,
+        _id: u64,
+    ) -> anyhow::Result<(TempDir, RocksdbStorage<HighWaterCommand>)> {
+        let dir = TempDir::new().context("paxos topology: create tempdir")?;
+        let storage = open_paxos_storage(dir.path())
+            .with_context(|| format!("paxos topology: open storage at {:?}", dir.path()))?;
+        Ok((dir, storage))
+    }
+
+    async fn bind_loopback(&self, _id: u64) -> anyhow::Result<TcpListener> {
+        TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("paxos topology: bind loopback")
+    }
 }
 
 // `ChaosController` impl. Method bodies are stubbed; subsequent commits

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -50,8 +50,8 @@ use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 use tsoracle_paxos_toolkit::test_fakes::partition::PartitionController;
 use tsoracle_server::Server;
 
-use crate::chaos::ChaosEvent;
-use crate::topology::{ChaosController, NodeId};
+use crate::chaos::{ChaosEvent, ChaosKind, ChaosOutcome};
+use crate::topology::{ChaosController, NodeId, timed_event};
 
 #[allow(dead_code)]
 const TICK_INTERVAL: Duration = Duration::from_millis(20);
@@ -378,12 +378,55 @@ impl ChaosController for PaxosController {
         unimplemented!()
     }
 
-    async fn arm_failpoint(&self, _name: &str, _action: &str) -> ChaosEvent {
-        unimplemented!()
+    async fn arm_failpoint(&self, name: &str, action: &str) -> ChaosEvent {
+        let kind = ChaosKind::FailpointArm { name: name.into() };
+        #[cfg(feature = "stress-failpoints")]
+        {
+            let name = name.to_string();
+            let action = action.to_string();
+            return timed_event(kind, self.grace, move || async move {
+                match fail::cfg(name.as_str(), action.as_str()) {
+                    Ok(()) => ChaosOutcome::Applied,
+                    Err(e) => ChaosOutcome::Failed {
+                        reason: format!("fail::cfg: {e}"),
+                    },
+                }
+            })
+            .await;
+        }
+        #[cfg(not(feature = "stress-failpoints"))]
+        {
+            let _ = (name, action);
+            timed_event(kind, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "stress-failpoints feature off; failpoints not linked".into(),
+                }
+            })
+            .await
+        }
     }
 
-    async fn disarm_failpoint(&self, _name: &str) -> ChaosEvent {
-        unimplemented!()
+    async fn disarm_failpoint(&self, name: &str) -> ChaosEvent {
+        let kind = ChaosKind::FailpointDisarm { name: name.into() };
+        #[cfg(feature = "stress-failpoints")]
+        {
+            let name = name.to_string();
+            return timed_event(kind, self.grace, move || async move {
+                fail::remove(name.as_str());
+                ChaosOutcome::Applied
+            })
+            .await;
+        }
+        #[cfg(not(feature = "stress-failpoints"))]
+        {
+            let _ = name;
+            timed_event(kind, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "stress-failpoints feature off".into(),
+                }
+            })
+            .await
+        }
     }
 
     fn endpoints(&self) -> Vec<String> {

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -371,11 +371,66 @@ impl Drop for HealOnDrop {
 #[async_trait]
 impl ChaosController for PaxosController {
     async fn kill_leader(&self) -> ChaosEvent {
-        unimplemented!()
+        // Find the OmniPaxos pid (u64) of the current leader by polling each
+        // node's handle. The pid is what `PartitionController` uses to gate
+        // edges, so we keep it in its native u64 width rather than going
+        // through `current_leader()`'s narrowed `NodeId(u32)`.
+        let leader_pid: Option<u64> = self
+            .nodes
+            .iter()
+            .find_map(|n| n.omnipaxos.lock().get_current_leader());
+        let Some(leader_pid) = leader_pid else {
+            return timed_event(ChaosKind::LeaderKill, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "no current leader".into(),
+                }
+            })
+            .await;
+        };
+        let partition = self.network.partition();
+        timed_event(ChaosKind::LeaderKill, self.grace, move || async move {
+            partition.isolate(leader_pid);
+            // Heal-on-drop guarantees reachability is restored even if the
+            // outer future is cancelled at the `sleep` below.
+            let _guard = HealOnDrop {
+                partition,
+                node: leader_pid,
+            };
+            // OmniPaxos BLE runs on a 20 ms tick with `election_tick_timeout = 5`
+            // (~100 ms for followers to escalate after losing the leader).
+            // 1500 ms keeps the chaos window short while reliably producing a
+            // re-election; matches raft.rs's window.
+            tokio::time::sleep(Duration::from_millis(1500)).await;
+            ChaosOutcome::Applied
+        })
+        .await
     }
 
-    async fn pause_leader(&self, _dur: Duration) -> ChaosEvent {
-        unimplemented!()
+    async fn pause_leader(&self, dur: Duration) -> ChaosEvent {
+        // Same leader-discovery shape as `kill_leader` — see its comment.
+        let leader_pid: Option<u64> = self
+            .nodes
+            .iter()
+            .find_map(|n| n.omnipaxos.lock().get_current_leader());
+        let Some(leader_pid) = leader_pid else {
+            return timed_event(ChaosKind::LeaderPause, self.grace, || async {
+                ChaosOutcome::Skipped {
+                    reason: "no current leader".into(),
+                }
+            })
+            .await;
+        };
+        let partition = self.network.partition();
+        timed_event(ChaosKind::LeaderPause, self.grace, move || async move {
+            partition.isolate(leader_pid);
+            let _guard = HealOnDrop {
+                partition,
+                node: leader_pid,
+            };
+            tokio::time::sleep(dur).await;
+            ChaosOutcome::Applied
+        })
+        .await
     }
 
     async fn arm_failpoint(&self, name: &str, action: &str) -> ChaosEvent {

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -717,4 +717,85 @@ mod tests {
             Ok(_) => panic!("spawn should propagate the injected bind failure"),
         }
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shutdown_completes_server_tasks() {
+        let topology = PaxosTopology::spawn(3, Duration::from_millis(1000))
+            .await
+            .expect("spawn 3-node paxos topology");
+        let server_handles = topology.server_handles;
+        // Fire the per-node shutdown signals.
+        Box::new(topology.controller).shutdown().await;
+        // Each server task must complete within a generous window after
+        // its shutdown oneshot fires. A hung handle means `shutdown` is
+        // not actually triggering the server's drain path.
+        for (idx, handle) in server_handles.into_iter().enumerate() {
+            match tokio::time::timeout(Duration::from_secs(5), handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(join_err)) => panic!("server task {idx} did not exit cleanly: {join_err:?}"),
+                Err(_elapsed) => {
+                    panic!("server task {idx} did not complete within 5s after shutdown")
+                }
+            }
+        }
+    }
+
+    #[cfg(not(feature = "stress-failpoints"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn arm_failpoint_returns_skipped_without_feature() {
+        let topology = PaxosTopology::spawn(3, Duration::from_millis(1000))
+            .await
+            .expect("spawn 3-node paxos topology");
+        let event = topology
+            .controller
+            .arm_failpoint("paxos-coverage-test", "panic")
+            .await;
+        match &event.outcome {
+            ChaosOutcome::Skipped { reason } => {
+                assert!(
+                    reason.contains("stress-failpoints"),
+                    "unexpected reason: {reason}"
+                );
+            }
+            other => panic!("expected Skipped, got {other:?}"),
+        }
+        let event = topology
+            .controller
+            .disarm_failpoint("paxos-coverage-test")
+            .await;
+        match &event.outcome {
+            ChaosOutcome::Skipped { reason } => {
+                assert!(
+                    reason.contains("stress-failpoints"),
+                    "unexpected reason: {reason}"
+                );
+            }
+            other => panic!("expected Skipped, got {other:?}"),
+        }
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[cfg(feature = "stress-failpoints")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn arm_then_disarm_failpoint_round_trip() {
+        let topology = PaxosTopology::spawn(3, Duration::from_millis(1000))
+            .await
+            .expect("spawn 3-node paxos topology");
+        // Use a unique name so concurrent test runs don't race on a shared
+        // failpoint registry slot.
+        let name = "paxos-stress-coverage-arm-disarm";
+        let armed = topology.controller.arm_failpoint(name, "off").await;
+        assert!(
+            armed.outcome.is_applied(),
+            "arm_failpoint expected Applied, got {:?}",
+            armed.outcome
+        );
+        let disarmed = topology.controller.disarm_failpoint(name).await;
+        assert!(
+            disarmed.outcome.is_applied(),
+            "disarm_failpoint expected Applied, got {:?}",
+            disarmed.outcome
+        );
+        Box::new(topology.controller).shutdown().await;
+    }
 }

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -38,7 +38,7 @@ use async_trait::async_trait;
 use omnipaxos::messages::Message;
 use omnipaxos::{ClusterConfig, OmniPaxos, OmniPaxosConfig, ServerConfig};
 use parking_lot::Mutex;
-use rocksdb::{DB, Options};
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
@@ -84,15 +84,19 @@ struct PaxosNode {
     _storage_dir: TempDir,
 }
 
+const PAXOS_CF: &str = "tso_paxos";
+
 #[allow(dead_code)]
 fn open_paxos_storage(dir: &std::path::Path) -> anyhow::Result<RocksdbStorage<HighWaterCommand>> {
     let mut opts = Options::default();
     opts.create_if_missing(true);
     opts.create_missing_column_families(true);
-    // RocksdbStorage uses a single column family; DB::open always registers
-    // the "default" CF, which is the one we target here.
-    let db = Arc::new(DB::open(&opts, dir).context("paxos topology: open rocksdb at storage dir")?);
-    RocksdbStorage::open_in(db, "default")
+    let cfs = vec![ColumnFamilyDescriptor::new(PAXOS_CF, Options::default())];
+    let db = Arc::new(
+        DB::open_cf_descriptors(&opts, dir, cfs)
+            .context("paxos topology: open rocksdb at storage dir")?,
+    );
+    RocksdbStorage::open_in(db, PAXOS_CF)
         .map_err(|e| anyhow::anyhow!("paxos topology: open RocksdbStorage: {e:?}"))
 }
 
@@ -504,6 +508,213 @@ impl ChaosController for PaxosController {
             if let Some(tx) = node.shutdown_tx.lock().take() {
                 let _ = tx.send(());
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant as StdInstant;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn spawn_3_nodes_reports_endpoints_and_leader() {
+        let topology = PaxosTopology::spawn(3, Duration::from_millis(50))
+            .await
+            .expect("spawn 3-node paxos topology");
+        let endpoints = topology.controller.endpoints();
+        assert_eq!(
+            endpoints.len(),
+            3,
+            "expected 3 endpoints, got {endpoints:?}"
+        );
+        assert!(
+            topology.controller.current_leader().is_some(),
+            "expected a leader after spawn"
+        );
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kill_leader_triggers_reelection() {
+        let topology = PaxosTopology::spawn(3, Duration::from_millis(1000))
+            .await
+            .expect("spawn 3-node paxos topology");
+        let original_leader = topology
+            .controller
+            .current_leader()
+            .expect("leader at boot");
+
+        let event = topology.controller.kill_leader().await;
+        assert!(
+            event.outcome.is_applied(),
+            "kill_leader expected Applied, got {:?}",
+            event.outcome
+        );
+
+        // Poll for a different leader. OmniPaxos's BLE election runs on a
+        // 20 ms tick, so a re-election typically completes within a few
+        // hundred ms after the partition window. The 30 s wall-clock cap
+        // tolerates CI slowdown.
+        let deadline = StdInstant::now() + Duration::from_secs(30);
+        let mut new_leader = None;
+        while StdInstant::now() < deadline {
+            if let Some(candidate) = topology.controller.current_leader() {
+                if candidate != original_leader {
+                    new_leader = Some(candidate);
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let new_leader = match new_leader {
+            Some(id) => id,
+            None => {
+                let snapshots: Vec<String> = topology
+                    .controller
+                    .nodes
+                    .iter()
+                    .map(|n| {
+                        let leader = n.omnipaxos.lock().get_current_leader();
+                        format!("node {} sees leader={:?}", n.node_id.0, leader)
+                    })
+                    .collect();
+                panic!(
+                    "re-election should have produced a different leader (was {:?}); \
+                     snapshots:\n  {}",
+                    original_leader,
+                    snapshots.join("\n  ")
+                );
+            }
+        };
+        assert_ne!(original_leader, new_leader);
+
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kill_leader_heals_on_cancel() {
+        // The outer `--duration` timer in the stress harness wins the
+        // top-level `select!` and drops the in-flight chaos future. Before
+        // the `HealOnDrop` guard, that cancellation parked at the mid-window
+        // `sleep` and `restore` never ran, stranding the cluster partitioned
+        // for the rest of the run. The guard's `Drop` impl is what makes
+        // this test pass: the partition is restored even though the chaos
+        // future never reached its end-of-window point.
+        let topology = PaxosTopology::spawn(3, Duration::from_millis(1000))
+            .await
+            .expect("spawn 3-node paxos topology");
+        let leader_pid: u64 = topology
+            .controller
+            .nodes
+            .iter()
+            .find_map(|n| n.omnipaxos.lock().get_current_leader())
+            .expect("a leader at boot");
+        let partition = topology.controller.network.partition();
+        // kill_leader's mid-window sleep is 1500ms; cancelling at 50ms
+        // reliably parks the future inside it on any sane machine.
+        match tokio::time::timeout(Duration::from_millis(50), topology.controller.kill_leader())
+            .await
+        {
+            Err(_elapsed) => {} // expected: future was dropped mid-sleep
+            Ok(event) => panic!(
+                "kill_leader should not have finished within 50ms; got {:?}",
+                event.outcome,
+            ),
+        }
+        // After the cancel, the partition guard must have restored
+        // reachability — i.e., the leader pid is no longer in the isolated
+        // set. `is_blocked(x, x)` returns true iff x is isolated, so the
+        // probe below asserts the un-isolated state.
+        assert!(
+            !partition.is_blocked(leader_pid, leader_pid),
+            "partition for node {leader_pid} must be restored after the \
+             chaos future is dropped; the node is still in the isolated set"
+        );
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pause_leader_returns_applied() {
+        let topology = PaxosTopology::spawn(3, Duration::from_millis(1000))
+            .await
+            .expect("spawn 3-node paxos topology");
+        let event = topology
+            .controller
+            .pause_leader(Duration::from_millis(200))
+            .await;
+        assert!(
+            event.outcome.is_applied(),
+            "pause_leader expected Applied, got {:?}",
+            event.outcome
+        );
+        Box::new(topology.controller).shutdown().await;
+    }
+
+    struct FailingBackend {
+        fail_step: SpawnStep,
+        fail_at_node: u64,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum SpawnStep {
+        PrepareStorage,
+        BindLoopback,
+    }
+
+    #[async_trait]
+    impl PaxosBackend for FailingBackend {
+        async fn prepare_node_storage(
+            &self,
+            id: u64,
+        ) -> anyhow::Result<(TempDir, RocksdbStorage<HighWaterCommand>)> {
+            if self.fail_step == SpawnStep::PrepareStorage && id == self.fail_at_node {
+                bail!("injected: prepare_node_storage failed for node {id}");
+            }
+            DefaultPaxosBackend.prepare_node_storage(id).await
+        }
+
+        async fn bind_loopback(&self, id: u64) -> anyhow::Result<TcpListener> {
+            if self.fail_step == SpawnStep::BindLoopback && id == self.fail_at_node {
+                bail!("injected: bind_loopback failed for node {id}");
+            }
+            DefaultPaxosBackend.bind_loopback(id).await
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn spawn_propagates_storage_failure() {
+        let backend = FailingBackend {
+            fail_step: SpawnStep::PrepareStorage,
+            fail_at_node: 1,
+        };
+        match PaxosTopology::spawn_with(&backend, 3, Duration::from_millis(50)).await {
+            Err(err) => {
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("prepare_node_storage failed"),
+                    "expected storage-failure message, got: {msg}"
+                );
+            }
+            Ok(_) => panic!("spawn should propagate the injected storage failure"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn spawn_propagates_bind_failure() {
+        let backend = FailingBackend {
+            fail_step: SpawnStep::BindLoopback,
+            fail_at_node: 2,
+        };
+        match PaxosTopology::spawn_with(&backend, 3, Duration::from_millis(50)).await {
+            Err(err) => {
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("bind_loopback failed"),
+                    "expected bind-failure message, got: {msg}"
+                );
+            }
+            Ok(_) => panic!("spawn should propagate the injected bind failure"),
         }
     }
 }

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -387,14 +387,25 @@ impl ChaosController for PaxosController {
     }
 
     fn endpoints(&self) -> Vec<String> {
-        unimplemented!()
+        self.nodes.iter().map(|n| n.endpoint.clone()).collect()
     }
 
     fn current_leader(&self) -> Option<NodeId> {
-        unimplemented!()
+        for node in &self.nodes {
+            if let Some(leader_pid) = node.omnipaxos.lock().get_current_leader() {
+                // OmniPaxos pids are assigned 1..=node_count by spawn_with;
+                // the cast is safe for any sane cluster size.
+                return Some(NodeId(leader_pid as u32));
+            }
+        }
+        None
     }
 
     async fn shutdown(self: Box<Self>) {
-        unimplemented!()
+        for node in &self.nodes {
+            if let Some(tx) = node.shutdown_tx.lock().take() {
+                let _ = tx.send(());
+            }
+        }
     }
 }

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -29,10 +29,11 @@
 //! process-wide `fail` registry (which affects every in-process node at
 //! once); disabled, they return `Skipped`.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use omnipaxos::messages::Message;
 use omnipaxos::{ClusterConfig, OmniPaxos, OmniPaxosConfig, ServerConfig};
@@ -41,10 +42,12 @@ use rocksdb::{DB, Options};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
-use tsoracle_driver_paxos::HighWaterCommand;
-use tsoracle_paxos_toolkit::lifecycle::MessageSink;
+use tokio::time::{Instant, sleep};
+use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, Peer};
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
+use tsoracle_server::Server;
 
 use crate::chaos::ChaosEvent;
 use crate::topology::{ChaosController, NodeId};
@@ -181,6 +184,165 @@ async fn run_inbox_pump(
 ) {
     while let Some(message) = inbox.recv().await {
         omnipaxos.lock().handle_incoming(message);
+    }
+}
+
+impl PaxosTopology {
+    /// Boot an N-node in-process cluster, each node running its own
+    /// `tsoracle::Server` bound to a fresh loopback port. Returns once
+    /// a leader has been observed.
+    ///
+    /// Uses [`DefaultPaxosBackend`] for the spawn-time I/O steps. Tests
+    /// that need to exercise the failure paths call [`Self::spawn_with`]
+    /// with a fake backend.
+    pub async fn spawn(node_count: usize, grace: Duration) -> anyhow::Result<Self> {
+        Self::spawn_with(&DefaultPaxosBackend, node_count, grace).await
+    }
+
+    /// Like [`Self::spawn`] but with a caller-supplied [`PaxosBackend`]
+    /// for the spawn-time I/O. Useful for tests that want to inject
+    /// failures at the storage-preparation or listener-binding steps.
+    pub async fn spawn_with(
+        backend: &dyn PaxosBackend,
+        node_count: usize,
+        grace: Duration,
+    ) -> anyhow::Result<Self> {
+        if node_count == 0 {
+            bail!("paxos topology requires at least one node");
+        }
+
+        let network: Arc<MemNetwork<HighWaterCommand>> = Arc::new(MemNetwork::new());
+        let node_ids: Vec<u64> = (1..=node_count as u64).collect();
+        let cluster = ClusterConfig {
+            configuration_id: 1,
+            nodes: node_ids.clone(),
+            flexible_quorum: None,
+        };
+
+        // Allocate every node's loopback listener first so we know every
+        // node's address before constructing per-node `StandaloneHost`s
+        // (each `StandaloneHost` needs its peers' addresses for the
+        // `LeaderHint` follower-redirect trailer).
+        let mut listeners: Vec<(u64, TcpListener, SocketAddr)> = Vec::with_capacity(node_count);
+        for &id in &node_ids {
+            let listener = backend.bind_loopback(id).await?;
+            let addr = listener.local_addr()?;
+            listeners.push((id, listener, addr));
+        }
+
+        let tso_endpoints: Vec<(u64, SocketAddr)> =
+            listeners.iter().map(|(id, _, addr)| (*id, *addr)).collect();
+
+        let mut nodes: Vec<PaxosNode> = Vec::with_capacity(node_count);
+        let mut server_handles: Vec<tokio::task::JoinHandle<()>> = Vec::with_capacity(node_count);
+
+        for (id, listener, addr) in listeners {
+            // ---- Storage ----
+            let (storage_dir, storage) = backend.prepare_node_storage(id).await?;
+
+            // ---- OmniPaxos handle ----
+            let omnipaxos_config = paxos_config(id, &cluster);
+            let omnipaxos = Arc::new(Mutex::new(omnipaxos_config.build(storage).with_context(
+                || format!("paxos topology: build OmniPaxos handle for node {id}"),
+            )?));
+
+            // ---- Inbox pump ----
+            let inbox: mpsc::Receiver<Message<HighWaterCommand>> = network.register(id);
+            let inbox_omnipaxos = omnipaxos.clone();
+            tokio::spawn(async move {
+                run_inbox_pump(inbox_omnipaxos, inbox).await;
+            });
+
+            // ---- StandaloneHost ----
+            let toolkit_peers: Vec<Peer> = tso_endpoints
+                .iter()
+                .filter(|(peer_id, _)| *peer_id != id)
+                .map(|(peer_id, peer_addr)| Peer {
+                    node_id: *peer_id,
+                    endpoint: format!("http://{peer_addr}"),
+                })
+                .collect();
+            let mut host = StandaloneHost::builder()
+                .omnipaxos(omnipaxos.clone())
+                .my_node_id(id)
+                .peers(toolkit_peers)
+                .tick_interval(TICK_INTERVAL)
+                .snapshot_policy(SnapshotPolicy::disabled())
+                .build()
+                .with_context(|| format!("paxos topology: build StandaloneHost for node {id}"))?;
+            let leader_stream = host.take_leader_stream().ok_or_else(|| {
+                anyhow::anyhow!("paxos topology: leader stream for node {id} already taken")
+            })?;
+
+            let sink = Arc::new(MeshSink {
+                network: network.clone(),
+            });
+            host.start(sink);
+
+            // ---- Driver + tsoracle server ----
+            let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+            let server = Server::builder()
+                .consensus_driver(driver)
+                .build()
+                .map_err(|e| anyhow::anyhow!("paxos topology: server build: {e:?}"))?;
+
+            let endpoint = format!("http://{addr}");
+            let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+            let endpoint_for_log = endpoint.clone();
+            let handle = tokio::spawn(async move {
+                let shutdown = async move {
+                    let _ = shutdown_rx.await;
+                };
+                if let Err(e) = server.serve_with_listener(listener, shutdown).await {
+                    tracing::error!(error = ?e, endpoint = %endpoint_for_log, "tsoracle server died");
+                }
+            });
+
+            nodes.push(PaxosNode {
+                node_id: NodeId(id as u32),
+                endpoint,
+                omnipaxos,
+                shutdown_tx: Mutex::new(Some(shutdown_tx)),
+                _storage_dir: storage_dir,
+            });
+            server_handles.push(handle);
+        }
+
+        wait_for_leader(&nodes, Duration::from_secs(5)).await?;
+
+        Ok(PaxosTopology {
+            controller: PaxosController {
+                nodes,
+                network,
+                grace,
+            },
+            server_handles,
+        })
+    }
+}
+
+async fn wait_for_leader(nodes: &[PaxosNode], timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if Instant::now() >= deadline {
+            let snapshots: Vec<String> = nodes
+                .iter()
+                .map(|n| {
+                    let leader = n.omnipaxos.lock().get_current_leader();
+                    format!("node {} sees leader={:?}", n.node_id.0, leader)
+                })
+                .collect();
+            bail!(
+                "paxos topology: no leader within {timeout:?}; snapshots:\n  {}",
+                snapshots.join("\n  ")
+            );
+        }
+        for node in nodes {
+            if node.omnipaxos.lock().get_current_leader().is_some() {
+                return Ok(());
+            }
+        }
+        sleep(Duration::from_millis(50)).await;
     }
 }
 

--- a/benchmarks/stress/tests/smoke.rs
+++ b/benchmarks/stress/tests/smoke.rs
@@ -32,6 +32,7 @@ fn base_cfg(scenario: &str, duration_s: u64) -> StressConfig {
         liveness_deadline: Duration::from_secs(5),
         grace_mem: Duration::from_millis(100),
         grace_raft: Duration::from_millis(750),
+        grace_paxos: Duration::from_millis(1000),
         grace_process: Duration::from_secs(2),
         nodes: 1,
         bind: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),


### PR DESCRIPTION
## Summary

Adds a paxos topology variant to the stress / chaos benchmark harness, backed by an in-process 3-node OmniPaxos cluster wired through `tsoracle-paxos-toolkit`. Brings paxos under the same chaos-suite + nightly-CI coverage that already exists for the openraft topology.

- New file `benchmarks/stress/src/topology/paxos.rs` (~530 lines including tests). Direct parallel of the existing `topology/raft.rs` shape — `PaxosBackend` trait + `DefaultPaxosBackend`, `PaxosTopology::spawn` / `spawn_with`, `wait_for_leader`, `HealOnDrop` RAII guard, full `ChaosController` impl, six integration tests.
- Cluster bring-up mirrors `examples/paxos-embedded` with three deltas: per-node RocksDB-backed `RocksdbStorage` instead of `MemStorage`, an explicit inbox pump per node (paxos `MemNetwork::register` returns a `Receiver`, not a factory), and a held `Arc<Mutex<OmniPaxos<...>>>` per node so the controller can read leader state via `get_current_leader()`.
- Chaos is via the paxos toolkit's `PartitionController::isolate` / `restore`, wrapped in a `HealOnDrop` guard for cancellation safety. Same partition-and-elect strategy `topology/raft.rs` uses.
- `stress-failpoints` feature now fans out to `tsoracle-paxos-toolkit/failpoints` alongside the existing `tsoracle-server/failpoints`.
- `TopologyKind::Paxos` added with `grace_paxos: Duration` (default 1000 ms) and a `nodes >= 3` validation guard (OmniPaxos rejects single-node `ClusterConfig`s).
- Nightly stress matrix (`stress-nightly.yml`) and PR-time `stress-smoke` job (`ci.yml`) both gain a paxos entry.

Closes #176.

## Test plan

- [ ] CI green on this PR — the `stress-smoke` job's new "smoke (paxos)" step covers the boot path
- [ ] First post-merge nightly run finishes for the paxos × {steady, killer-loop, fence-stress, failpoint-cycle, random-1/2/3} matrix
- [x] Local `cargo test -p stress` — 19 tests pass (12 lib including 6 paxos; 7 smoke tests)
- [x] Local `cargo run --release -p stress --features stress-failpoints -- run --topology paxos --ci-smoke --nodes 3` exits 0 with 0 invariant violations and 9 chaos events fired
- [x] `cargo check --workspace` clean
- [x] `cargo build -p stress` + `cargo build -p stress --features stress-failpoints` + `cargo build --release -p stress --features stress-failpoints` all clean
- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean

## Post-merge follow-ups

- [ ] tsoracle-server: restart leader-watch after a fence error rather than exiting

  During the local `--ci-smoke` paxos run, the harness emitted ~2k transient retries with 0 successful client calls (outcome=Ok, 0 violations, 9 chaos events fired). Root cause: `tsoracle-server` terminates its leader-watch loop on fence errors when leadership shifts, so paxos's frequent leader churn under chaos eventually exits all three server tasks. The chaos primitives themselves work correctly — no invariant violations are reported — but the server-side fence handling makes the harness unable to record client throughput on paxos under chaos. Reasonable fix: have the server restart its leader-watch after a fence rather than exiting. This is a property of the server's fence handling, not of the topology, so tracking it separately keeps #176's scope clean.

## Notes

- `examples/paxos-embedded` is the canonical reference for the in-process bringup pattern; the stress topology is essentially the same wiring with RocksDB-backed storage and a `ChaosController` impl added.
- Partial-connectivity nemesis ("node X can reach A and B but not C") remains out of scope (issue's stated non-goal — would require both toolkits' `PartitionController`s to grow per-edge isolation).