### PR TITLE
chore(github): add issue templates for bug and work-scope

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: A defect with a concrete reproduction and evidence in tree
+title: ''
+labels: bug
+---
+
+## Summary
+
+<!-- One paragraph: what's wrong, what the contract was supposed to be, and severity. Severity reflects observable impact, not theoretical worst case. -->
+
+## Reproduction trace
+
+<!-- Numbered steps that walk the reader from a known starting state to the broken outcome. Quote the calls and the resulting state at each step. End with the observable damage (return values, persisted state, log output). -->
+
+1.
+
+## Affected code
+
+<!-- `path/to/file.rs:start-end` bullets with a one-sentence note per location. The file:line references carry the reader; no need to inline the source. -->
+
+-
+
+## Proposed fix
+
+<!-- A code block showing the smallest change that restores the invariant, plus one or two sentences on why. Omit this section if the fix is not yet known. -->
+
+## Regression tests
+
+<!-- Numbered tests that would fail today and pass once the fix lands. Each test should be runnable with `cargo test` and live next to the affected module. -->
+
+1.
+
+## Existing tests that would have caught this
+
+<!-- Either: a list of tests that should have covered this case with a note on why they didn't, or "None." plus a short explanation of the coverage gap. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/work_scope.md
+++ b/.github/ISSUE_TEMPLATE/work_scope.md
@@ -1,0 +1,26 @@
+---
+name: Work scope
+about: Bounded work item (docs, refactor, new component, hardening) with scope + exit criteria
+title: ''
+---
+
+<!-- Opening paragraph naming the work and its motivation. No section heading for this paragraph. -->
+
+## Scope
+
+<!-- Concrete deliverables, ideally by file path. Each bullet should be small enough to evaluate in a single PR. -->
+
+-
+
+## Exit criteria
+
+<!-- Verifiable conditions for "done." Prefer commands a reviewer can run (`cargo build -p ...`, `cargo doc`, `grpcurl ...`) over subjective criteria. -->
+
+-
+
+## Explicit non-goal
+
+<!-- Optional. State what this issue is deliberately not covering, with a one-line reason. Delete the section if not applicable. -->
+
+Parent:
+<!-- #issue if part of a larger initiative; delete this line otherwise. -->


### PR DESCRIPTION
## Summary

Adds two markdown issue templates and a picker config under `.github/ISSUE_TEMPLATE/`:

- `bug_report.md` — mirrors the section shape of #186 (`## Summary` with severity → `## Reproduction trace` → `## Affected code` → `## Proposed fix` → `## Regression tests` → `## Existing tests that would have caught this`). Pre-fills the `bug` label.
- `work_scope.md` — mirrors #176, #177, #202 (opening paragraph → `## Scope` → `## Exit criteria` → optional `## Explicit non-goal` → `Parent:` line). No pre-set label, since the existing scope-style issues are unlabeled.
- `config.yml` — sets `blank_issues_enabled: false` so the picker stops offering "open a blank issue."

HTML-comment guidance per section, matching `PULL_REQUEST_TEMPLATE.md`'s style. No YAML-form templates — freeform markdown fits the way issues are actually written here.

Motivated by the discussion on #202; the templates capture the shape that hardening/scope issues have organically converged on.

## Test plan

GitHub renders issue templates only from `main` (the picker reads the default branch), so most verification has to happen post-merge. Pre-merge checks that are possible:

- [x] `cat .github/ISSUE_TEMPLATE/bug_report.md` and `work_scope.md` — frontmatter parses (no trailing whitespace, valid YAML).

## Post-merge follow-ups

- [ ] Open one bug and one work-scope issue from the picker on `main` and confirm the rendered body matches expectation; tweak if a section heading is off.
- [ ] Visit `https://github.com/prisma-risk/tsoracle/issues/new/choose?ref=docs/issue-templates` and confirm both templates appear with the expected names and descriptions. (GitHub honors `?ref=` on the picker URL for branch previews.)
- [ ] Confirm the picker no longer offers "Open a blank issue" at the bottom.