### PR TITLE
chore(ci): harden pages workflow permissions and pin third-party deps

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,8 +12,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -26,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Cache cargo registry and og-image build
         uses: actions/cache@v4
@@ -43,8 +41,10 @@ jobs:
       - name: Install Zola
         run: |
           ZOLA_VERSION="0.22.1"
+          ZOLA_SHA256="0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef"
           curl -fsSL -o zola.tar.gz \
             "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${ZOLA_SHA256}  zola.tar.gz" | sha256sum --check -
           tar -xzf zola.tar.gz
           sudo mv zola /usr/local/bin/zola
           zola --version
@@ -65,6 +65,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Three CI/CD supply-chain hardening changes to `.github/workflows/pages.yml`:

1. **Scope `pages: write` and `id-token: write` to the deploy job.** Previously declared at workflow level and inherited by the build job. The build job doesn't need them — only `actions/deploy-pages` does. After this change the build job runs with `contents: read` only; the deploy job carries the two privileged scopes.

2. **Pin `dtolnay/rust-toolchain` to a commit SHA.** Was `@stable`, a mutable third-party ref. An upstream force-push or account compromise could otherwise silently substitute action code into a workflow that until now held `pages: write` and `id-token: write`. After (1), inheritance is gone too, so the blast radius is much smaller — but a SHA pin is still the right default for third-party actions.

3. **Verify the Zola release tarball against a known SHA256.** Same supply-chain class as (2): the `curl` of `getzola/zola` releases had no integrity check, so a tampered release would silently run with the build job's permissions. Adds `sha256sum --check` between download and extract.

No YAML comments next to the SHA pin or the SHA256 constant, to match the project's bare-config convention. The trade-off: Dependabot is already configured for github-actions weekly and will continue to bump the SHA pin, but without the trailing `# stable` machine hint it loses the explicit "track the stable branch" signal. For this action that's acceptable — dtolnay/rust-toolchain's stability is high and the bumps it surfaces are small.

The five `actions/*` references in the file (checkout, cache, configure-pages, upload-pages-artifact, deploy-pages) are intentionally left at major-version pins. The scanner finding scoped specifically to third-party; first-party actions under GitHub's `actions/` org have stronger publisher-trust signals and Dependabot will major-version-bump them. Going to SHA pins for those is a separate decision.

## Test plan

- [x] `actionlint .github/workflows/pages.yml` passes (run locally).
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass (pre-commit hook, against the workspace).
- [x] Manual `workflow_dispatch` on this branch verified the **build** job end-to-end — [run 26339211779](https://github.com/prisma-risk/tsoracle/actions/runs/26339211779). The build job is what this PR actually changes; deploy is unchanged:
  - [x] Build succeeded with `contents: read` only — no `pages: write` / `id-token: write` inherited.
  - [x] `dtolnay/rust-toolchain@29eef33...` resolved and installed.
  - [x] zola download passed its SHA256 check; site built.
  - [x] `actions/upload-pages-artifact@v5` uploaded successfully without privileged scopes on the build job.
- [ ] The **deploy** job (`actions/deploy-pages@v5`) cannot be verified pre-merge. GitHub Pages deploys only from the configured source ref (main), so `workflow_dispatch` on a feature branch fails the deploy step by design — not a regression introduced by this PR. End-to-end deploy verification is moved to post-merge below.

## Post-merge follow-ups

- [ ] The push-to-main that lands this PR matches the workflow's `paths` filter (`.github/workflows/pages.yml`) and will auto-trigger `Deploy to Pages`. Confirm the deploy job succeeds end-to-end on that run — the case we couldn't dry-run pre-merge.
- [ ] Watch the next weekly Dependabot run and confirm it produces a clean SHA bump PR for `dtolnay/rust-toolchain` (verifies that Dependabot tracks the action correctly without the trailing version comment).
- [ ] When zola is next upgraded (e.g., to 0.23.x), confirm contributors know to update `ZOLA_SHA256` alongside `ZOLA_VERSION`. Consider documenting the bump procedure in `site/README.md` or similar if there's a natural home.