### PR TITLE
docs(paxos): per-crate READMEs + driver-choice comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@
     
 </div>
 
-A distributed timestamp oracle for Rust — highly available and fault-tolerant, issuing strictly monotonic integer timestamps over gRPC, Raft-replicated via openraft with pluggable consensus.
+A distributed timestamp oracle for Rust — highly available and fault-tolerant, issuing strictly monotonic integer timestamps over gRPC, replicated via openraft or OmniPaxos (or your own log) with pluggable consensus.
 
 ## Features
 
 - 🔢 **Strictly monotonic** — every issued timestamp is strictly greater than every previously issued one; no duplicates and no regression, ever. The packed integer space is not dense (logical resets when `physical_ms` advances, so some integer values are unused), but the issued sequence is total-ordered and unique.
 - 🛡️ **Crash-safe** — window state is fsync'd before any timestamp in that window is handed out, so a restart never rewinds.
-- 🔌 **Pluggable consensus, openraft included** — `tsoracle-driver-openraft` ships a production-ready replicated driver; implement one trait (`ConsensusDriver`) to back tsoracle with raft-rs, etcd, or your own replicated log instead.
+- 🔌 **Pluggable consensus, openraft + OmniPaxos included** — `tsoracle-driver-openraft` and `tsoracle-driver-paxos` ship production-ready replicated drivers; implement one trait (`ConsensusDriver`) to back tsoracle with raft-rs, etcd, or your own replicated log instead. See [`docs/consensus-integration.md`](docs/consensus-integration.md#choosing-a-driver) for picking between drivers.
 - 📦 **gRPC client included** — `tsoracle-client` handles leader discovery, request coalescing, and reconnection for you.
 - 📈 **Operational metrics** — enable the `metrics` feature on `tsoracle-server` to emit allocator, leader, and request metrics through the `metrics` facade.
 - 🧪 **Hardened** — coverage-guided fuzzing on the postcard decoders, failpoint-driven crash tests, and a stress harness covering single-process and multi-process raft topologies.
@@ -94,6 +94,9 @@ tsoracle is a small, embeddable Rust implementation. The consensus layer is left
 - [examples/failover-demo](examples/failover-demo) — pedagogy: watch the failover fence keep timestamps strictly monotonic across simulated leadership changes, in-process, no openraft.
 - [examples/openraft-standalone](examples/openraft-standalone) — HA: three-node multi-process cluster on a dedicated openraft, wired through [`tsoracle-driver-openraft`](crates/tsoracle-driver-openraft/) with a tonic peer transport and follower-redirect via `LeaderHint`.
 - [examples/openraft-piggyback](examples/openraft-piggyback) — HA: in-process three-node demo of the envelope pattern, where your service's existing openraft carries both your `AppData` and the tsoracle `HighWaterCommand` on a single log, with one snapshot covering both halves.
+- [examples/paxos-standalone](examples/paxos-standalone) — HA: three-node multi-process cluster on a dedicated OmniPaxos, wired through [`tsoracle-driver-paxos`](crates/tsoracle-driver-paxos/) with a tonic peer transport and follower-redirect via `LeaderHint`.
+- [examples/paxos-piggyback](examples/paxos-piggyback) — HA: in-process three-node demo of the envelope pattern on OmniPaxos, where your service's existing paxos log carries both your `AppData` and the tsoracle `HighWaterCommand`, with one snapshot covering both halves.
+- [examples/paxos-embedded](examples/paxos-embedded) — HA: single-process 3-node OmniPaxos cluster (OmniPaxos rejects single-node configs, so even "embedded" runs all three nodes in-memory). The closest paxos equivalent to `embedded-server`.
 - [examples/metrics-prometheus](examples/metrics-prometheus) — embed `tsoracle-server` with `metrics-exporter-prometheus` installed before the server starts, exposing `/metrics` on a separate port for Prometheus to scrape; swap recorders with a one-line change.
 
 Each example is its own crate. Build with `cargo run -p example-<name>`.

--- a/crates/tsoracle-driver-paxos/README.md
+++ b/crates/tsoracle-driver-paxos/README.md
@@ -1,0 +1,35 @@
+# tsoracle-driver-paxos
+
+`ConsensusDriver` implementation for [tsoracle](https://github.com/prisma-risk/tsoracle) backed by [OmniPaxos](https://github.com/haraldng/omnipaxos) via [`tsoracle-paxos-toolkit`](../tsoracle-paxos-toolkit/).
+
+## What it provides
+
+- `PaxosDriver` — the `tsoracle_consensus::ConsensusDriver` impl. Holds a `PaxosHighWaterHost` and a leader-event stream; bridges them to tsoracle's `leadership_events`, `load_high_water`, and `persist_high_water` contract.
+- `PaxosHighWaterHost` — the single trait a host service implements to expose its OmniPaxos handle to the driver. Lets a service share one paxos log between its own state and the tsoracle `HighWaterCommand`.
+- `StandaloneHost` — turnkey `PaxosHighWaterHost` impl for services that don't already run their own OmniPaxos. Build via `StandaloneHost::builder()` with the toolkit's storage + your network sink + your peer list.
+- `SnapshotPolicy` — controls when snapshots are taken: `disabled`, every-N-decisions, or callback-driven.
+- `HighWaterCommand` / `HighWaterSnapshot` — the typed log entry and snapshot payload the driver injects into the host's OmniPaxos log.
+- `encode_epoch` / `decode_epoch` — codec for the `Epoch ↔ Ballot` mapping (see below).
+
+## Patterns
+
+### Standalone services
+
+If your service is greenfield — no existing OmniPaxos — wire `StandaloneHost::builder()` with `tsoracle_paxos_toolkit::storage::RocksdbStorage`, your network sink (implementing `MessageSink<HighWaterCommand>` from the toolkit), and the list of peer endpoints. Hand the resulting `PaxosDriver` to `Server::builder().consensus_driver(driver)`. See [`examples/paxos-standalone`](../../examples/paxos-standalone/) for the full wiring with a tonic peer transport.
+
+### Piggyback on an existing OmniPaxos
+
+If your service already runs an OmniPaxos for its own state, implement `PaxosHighWaterHost` directly against that handle. `HighWaterCommand` becomes a tagged variant of your application command type and is decided on the same log alongside your own commands; one snapshot covers both halves. See [`examples/paxos-piggyback`](../../examples/paxos-piggyback/) for the worked envelope pattern.
+
+### Linearizable reads
+
+The driver's read path consults a `Barrier` synchronized with the local OmniPaxos handle's `accepted_idx`. A read that lands on the leader waits at most the configured grace window for the barrier to clear, then returns a fresh high water mark; a read that lands on a follower returns a `LeaderHint` redirect so the client retries against the current leader.
+
+### Epoch ↔ Ballot encoding
+
+tsoracle's `Epoch` (the fence-watermark identifier persisted with each `HighWaterCommand`) is encoded as a 48-bit value combining OmniPaxos's `Ballot.n` (the round counter) and `Ballot.pid` (the proposer id) via `encode_epoch` / `decode_epoch`. This gives the driver a stable per-leader epoch that the failover fence uses to reject stale writes after a leader change — every advance carries the proposer's ballot, and a write that races a re-election will fence against the new leader's epoch.
+
+## Documentation
+
+- [`docs/consensus-integration.md`](../../docs/consensus-integration.md) — the `ConsensusDriver` trait reference, including the **Choosing a driver** comparison (file vs openraft vs paxos) and a worked example for the openraft side.
+- [`tsoracle-paxos-toolkit`](../tsoracle-paxos-toolkit/) — the reusable OmniPaxos glue this crate is built on.

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -10,15 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! OmniPaxos-backed `ConsensusDriver` for tsoracle.
-//!
-//! This crate replicates the TSO high-water mark across an OmniPaxos cluster
-//! and exposes the result via the [`tsoracle_consensus::ConsensusDriver`]
-//! trait. The caller supplies a pre-built host (typically [`StandaloneHost`]
-//! once it lands) that owns the OmniPaxos handle, the storage, and the
-//! tick task; this crate provides the log-entry type, the `Epoch ↔ Ballot`
-//! encoding, the `PaxosHighWaterHost` trait, and the trait bridge.
-
+#![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 

--- a/crates/tsoracle-paxos-toolkit/README.md
+++ b/crates/tsoracle-paxos-toolkit/README.md
@@ -1,0 +1,27 @@
+# tsoracle-paxos-toolkit
+
+Reusable glue for building services on top of [OmniPaxos](https://github.com/haraldng/omnipaxos).
+
+## What's in the box
+
+- `declare_omnipaxos_types_ext!` — wraps the upstream `OmniPaxos` type declarations with curated defaults so consumers supply only the slots that actually vary (entry type, application data).
+- `RocksdbStorage<T>` — generic `omnipaxos::storage::Storage` implementation backed by RocksDB. Passes OmniPaxos's bundled storage conformance suite; `T: omnipaxos::storage::Entry` is the host's log entry type.
+- Lifecycle helpers: `PaxosRunner<T, S>` (the tick task + apply task lifecycle wrapper), the `MessageSink<T>` outbound trait, `LeadershipState`, the leader-event stream (`LeaderEventStream` + `LeaderEventSender`), and the `Peer` struct used for follower-redirect endpoints.
+- Test fakes (feature-gated): `MemNetwork<T>` for in-process clusters, `PartitionController` for chaos coverage, `MemStorage<T>` for storage-free smoke tests.
+- Wire codec: `encode` / `decode` helpers using a `[version_byte | postcard(payload)]` framing, suitable for both paxos RPCs and storage records.
+
+## Feature flags
+
+- `rocksdb-storage` (default) — pulls in `rocksdb` and exposes `RocksdbStorage`. Disable if you bring your own storage backend.
+- `test-fakes` — exposes in-memory test fixtures (`MemNetwork`, `MemStorage`, `PartitionController`) for downstream conformance suites and chaos harnesses. Off by default.
+- `failpoints` — enables `fail` crate integration so the toolkit's instrumented sites can be driven from chaos tests. Off by default.
+
+## Out of scope (today)
+
+The toolkit deliberately stops short of shipping:
+
+- A `Network` implementation. Single-group services can roll their own with the codec helpers; multi-group routing belongs in the host runtime that owns the cluster lifecycle.
+- A snapshot-streaming transport. Filesystem-backed sidecar transports are opinionated enough that lifting one would constrain its callers.
+- Multi-group host orchestration. Hosting N omnipaxos instances per process is a deployment-shaped concern, not a library concern.
+
+These may move into the toolkit when a clear shared shape emerges.

--- a/crates/tsoracle-paxos-toolkit/src/lib.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lib.rs
@@ -10,13 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! Reusable OmniPaxos glue for tsoracle's paxos driver.
-//!
-//! This crate provides a RocksDB-backed [`omnipaxos::storage::Storage`] impl,
-//! lifecycle helpers, the `declare_omnipaxos_types_ext!` macro, and in-memory
-//! test fakes. The paxos driver crate consumes this crate; this crate itself
-//! does not depend on the driver.
-
+#![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 

--- a/docs/consensus-integration.md
+++ b/docs/consensus-integration.md
@@ -72,6 +72,24 @@ Per-driver recipes:
 - **etcd:** transactional update: read current value, compare-and-swap with `max(current, at_least)`. The lease + revision number gives you epoch fencing.
 - **Single-node:** read current value under a mutex, take max, write the record atomically (write-then-rename + dir fsync), return.
 
+## Choosing a driver
+
+Three driver crates ship in this repo, all on the same `ConsensusDriver` trait. They answer different operational questions.
+
+| Driver | HA | Persistence durability | Partial-connectivity behavior |
+| --- | --- | --- | --- |
+| [`tsoracle-driver-file`](https://github.com/prisma-risk/tsoracle/tree/main/crates/tsoracle-driver-file) | No — single process, single binary. | File-backed; an `fsync` is taken on every high-water advance. | N/A (single node). |
+| [`tsoracle-driver-openraft`](https://github.com/prisma-risk/tsoracle/tree/main/crates/tsoracle-driver-openraft) | Yes — raft quorum (majority of N must be reachable). | Replicated log + state machine; durability tracks the replication factor. | Standard raft: any cut that leaves the leader without majority forces a re-election. Asymmetric partial connectivity can churn leadership repeatedly. |
+| [`tsoracle-driver-paxos`](https://github.com/prisma-risk/tsoracle/tree/main/crates/tsoracle-driver-paxos) | Yes — paxos quorum (majority of N). | Same replicated-log shape as openraft. | OmniPaxos's BLE election is more tolerant of asymmetric reachability — a leader still able to talk to some peers may retain leadership where a raft leader would step down. |
+
+**Pick the file driver** for single-node demos, embedded use, or when an outage of the timestamp oracle is acceptable. It's the slowest of the three under load (fsync-per-advance) but has zero operational overhead — no cluster to deploy.
+
+**Pick the openraft driver** when you need HA and your failure model is full partitions or process death. It's the most thoroughly exercised path in the existing examples and benchmarks; the worked example below documents the trait wiring.
+
+**Pick the paxos driver** when you need HA and your operational environment is prone to asymmetric reachability (cross-AZ links that drop one direction, half-broken NICs, byzantine middleboxes). OmniPaxos's BLE pays a small steady-state cost for richer election logic but degrades more gracefully under conditions that would churn a raft leader.
+
+All three drivers are interchangeable from the server's perspective — `tsoracle-server` accepts any `ConsensusDriver` impl, so swapping is a one-line change in your binary.
+
 ## Worked example: openraft
 
 The canonical openraft integration ships in [`tsoracle-driver-openraft`](https://github.com/prisma-risk/tsoracle/tree/main/crates/tsoracle-driver-openraft). The crate provides `OpenraftDriver` (the generic `ConsensusDriver` bridge), `HighWaterStateMachine` (the state machine + postcard snapshot codec, with a pluggable `SnapshotStore` for persistence — an in-memory default plus an optional `RocksdbSnapshotStore` behind the `rocksdb-snapshot-store` feature), and the `OpenraftHighWaterHost` trait — the integration boundary.


### PR DESCRIPTION
## Summary

Paxos consensus driver and its toolkit reach feature-parity with the openraft side on user-facing documentation:

- New `crates/tsoracle-paxos-toolkit/README.md` — mirrors the existing `tsoracle-openraft-toolkit/README.md` in shape (intro, "What's in the box", feature flags, "Out of scope today"). Grounded against the actual `src/lib.rs` surface.
- New `crates/tsoracle-driver-paxos/README.md` — written from scratch (no existing openraft driver README as model). Covers `PaxosDriver`, `PaxosHighWaterHost`, `StandaloneHost` + builder, `SnapshotPolicy`, `HighWaterCommand`, the standalone-vs-piggyback patterns, the `Barrier`-based linearizable read, and the `Epoch ↔ Ballot` encoding.
- Added `#![doc = include_str!("../README.md")]` to both paxos crates' `src/lib.rs` (matching `crates/tsoracle-openraft-toolkit/src/lib.rs:13`). Replaces the inline `//!` module docs since the README is the canonical landing page. `cargo doc --no-deps -p tsoracle-paxos-toolkit -p tsoracle-driver-paxos` now produces non-empty rustdoc landing pages.
- New `## Choosing a driver` section in `docs/consensus-integration.md` between the `persist_high_water` reference and the `Worked example: openraft` section. One comparison table (file vs openraft vs paxos across HA, persistence durability, partial-connectivity behavior) + three "pick X when…" paragraphs + one closing line on driver interchangeability.
- Root `README.md` tagline updated to "replicated via openraft or OmniPaxos (or your own log)", pluggable-consensus feature bullet now names both production drivers and links into the new "Choosing a driver" section, examples list grows three entries (paxos-standalone / paxos-piggyback / paxos-embedded).
- Confirmation pass on `docs/architecture-deep-dive.md` — searched for "raft"/"openraft" mentions and found zero. The document is already driver-agnostic; no edits.

Closes #177.

## Test plan

- [x] `cargo doc --no-deps -p tsoracle-paxos-toolkit -p tsoracle-driver-paxos` produces a non-empty rustdoc landing page for both crates (the README content renders there)
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --check` clean
- [x] Manual GitHub diff render — markdown for new sections renders correctly (tables, links, headings)
- [ ] CI green on this PR

## Out of scope

- No `crates/tsoracle-driver-openraft/README.md`. That crate has shipped without a README until now; writing one for openraft just for symmetry is a pre-existing gap, not in #177.
- No "Worked example: paxos" section in `consensus-integration.md` parallel to the existing openraft worked example. The paxos driver README + per-crate rustdoc cover the equivalent material without duplicating it.
- No new examples; the three paxos example crates already shipped (#175).

## Post-merge follow-ups

- [ ] Root README "stress harness covering single-process and multi-process raft topologies" line is now outdated post-#176

  The "Hardened" bullet at the existing line 28 says: "coverage-guided fuzzing on the postcard decoders, failpoint-driven crash tests, and a stress harness covering single-process and multi-process raft topologies." Since #176 landed, the stress harness also covers paxos. Updating this bullet to mention paxos topology coverage is a small documentation refresh that didn't fit cleanly into #177's "per-crate READMEs + driver-choice section" scope. Worth a single-line tweak when convenient.