### PR TITLE
fix(driver-paxos): linearize current_high_water via per-node barrier nonces

### DIFF
--- a/crates/tsoracle-driver-paxos/src/log_entry.rs
+++ b/crates/tsoracle-driver-paxos/src/log_entry.rs
@@ -15,22 +15,35 @@
 //! Two variants:
 //! - [`Advance`](HighWaterCommand::Advance) — bump the high-water to at least
 //!   the given value. Apply is `max(prev, at_least)`.
-//! - [`Barrier`](HighWaterCommand::Barrier) — no-op marker used to linearize
-//!   reads. `current_high_water` appends a Barrier and reads the in-memory
-//!   high-water once it decides; the explicit variant keeps the apply path
-//!   from needing to compute `max(prev, 0)` for every read.
+//! - [`Barrier`](HighWaterCommand::Barrier) — identified no-op used to
+//!   linearize reads. `current_high_water` mints a `(node, seq)` nonce,
+//!   appends `Barrier { node, seq }`, and waits until the apply path
+//!   observes that specific nonce — not merely until `decided_idx`
+//!   advances. The nonce is required to distinguish "my read's barrier
+//!   committed" from "some unrelated earlier entry committed" when the
+//!   local node has prior-leader entries between its `decided_idx`
+//!   snapshot and the appended barrier's log index.
+
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum HighWaterCommand {
     Advance { at_least: u64 },
-    Barrier,
+    Barrier { node: u64, seq: u64 },
 }
 
+/// Compacted view of a log range. Carries the high-water value and the
+/// per-appending-node ledger of barrier sequences observed in the range.
+/// The latter is needed so a node that catches up via snapshot transfer
+/// (rather than by streaming individual entries) still sees its own
+/// barriers as "applied" — otherwise `current_high_water` would hang
+/// after recovery, waiting on a seq it can never observe.
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct HighWaterSnapshot {
     pub value: u64,
+    pub applied_barriers: HashMap<u64, u64>,
 }
 
 impl omnipaxos::storage::Entry for HighWaterCommand {
@@ -39,19 +52,37 @@ impl omnipaxos::storage::Entry for HighWaterCommand {
 
 impl omnipaxos::storage::Snapshot<HighWaterCommand> for HighWaterSnapshot {
     fn create(entries: &[HighWaterCommand]) -> Self {
-        let max = entries
-            .iter()
-            .filter_map(|command| match command {
-                HighWaterCommand::Advance { at_least } => Some(*at_least),
-                HighWaterCommand::Barrier => None,
-            })
-            .max()
-            .unwrap_or(0);
-        Self { value: max }
+        let mut value = 0u64;
+        let mut applied_barriers: HashMap<u64, u64> = HashMap::new();
+        for command in entries {
+            match command {
+                HighWaterCommand::Advance { at_least } => {
+                    if *at_least > value {
+                        value = *at_least;
+                    }
+                }
+                HighWaterCommand::Barrier { node, seq } => {
+                    let slot = applied_barriers.entry(*node).or_insert(0);
+                    if *seq > *slot {
+                        *slot = *seq;
+                    }
+                }
+            }
+        }
+        Self {
+            value,
+            applied_barriers,
+        }
     }
 
     fn merge(&mut self, other: Self) {
         self.value = self.value.max(other.value);
+        for (node, seq) in other.applied_barriers {
+            let slot = self.applied_barriers.entry(node).or_insert(0);
+            if seq > *slot {
+                *slot = seq;
+            }
+        }
     }
 
     fn use_snapshots() -> bool {
@@ -68,7 +99,7 @@ mod tests {
     fn snapshot_create_picks_max_advance() {
         let entries = vec![
             HighWaterCommand::Advance { at_least: 10 },
-            HighWaterCommand::Barrier,
+            HighWaterCommand::Barrier { node: 1, seq: 1 },
             HighWaterCommand::Advance { at_least: 30 },
             HighWaterCommand::Advance { at_least: 20 },
         ];
@@ -84,23 +115,65 @@ mod tests {
 
     #[test]
     fn snapshot_merge_picks_higher_value() {
-        let mut first = HighWaterSnapshot { value: 5 };
-        let second = HighWaterSnapshot { value: 12 };
+        let mut first = HighWaterSnapshot {
+            value: 5,
+            ..Default::default()
+        };
+        let second = HighWaterSnapshot {
+            value: 12,
+            ..Default::default()
+        };
         first.merge(second);
         assert_eq!(first.value, 12);
     }
 
     #[test]
     fn snapshot_merge_keeps_higher_value() {
-        let mut first = HighWaterSnapshot { value: 50 };
-        let second = HighWaterSnapshot { value: 12 };
+        let mut first = HighWaterSnapshot {
+            value: 50,
+            ..Default::default()
+        };
+        let second = HighWaterSnapshot {
+            value: 12,
+            ..Default::default()
+        };
         first.merge(second);
         assert_eq!(first.value, 50);
     }
 
     #[test]
-    fn barrier_does_not_affect_snapshot() {
-        let snap = HighWaterSnapshot::create(&[HighWaterCommand::Barrier]);
+    fn barrier_does_not_affect_snapshot_value() {
+        let snap = HighWaterSnapshot::create(&[HighWaterCommand::Barrier { node: 42, seq: 7 }]);
         assert_eq!(snap.value, 0);
+    }
+
+    #[test]
+    fn snapshot_create_folds_barriers_into_ledger() {
+        let entries = vec![
+            HighWaterCommand::Barrier { node: 1, seq: 3 },
+            HighWaterCommand::Advance { at_least: 100 },
+            HighWaterCommand::Barrier { node: 1, seq: 5 },
+            HighWaterCommand::Barrier { node: 2, seq: 9 },
+        ];
+        let snap = HighWaterSnapshot::create(&entries);
+        assert_eq!(snap.value, 100);
+        assert_eq!(snap.applied_barriers.get(&1).copied(), Some(5));
+        assert_eq!(snap.applied_barriers.get(&2).copied(), Some(9));
+    }
+
+    #[test]
+    fn snapshot_merge_takes_max_barrier_seq_per_node() {
+        let mut first = HighWaterSnapshot {
+            value: 0,
+            applied_barriers: HashMap::from([(1, 5), (2, 3)]),
+        };
+        let second = HighWaterSnapshot {
+            value: 0,
+            applied_barriers: HashMap::from([(1, 7), (3, 2)]),
+        };
+        first.merge(second);
+        assert_eq!(first.applied_barriers.get(&1).copied(), Some(7));
+        assert_eq!(first.applied_barriers.get(&2).copied(), Some(3));
+        assert_eq!(first.applied_barriers.get(&3).copied(), Some(2));
     }
 }

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -20,6 +20,7 @@
 //! `PaxosHighWaterHost` directly against their existing cluster instead.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -43,6 +44,8 @@ where
     S: Storage<HighWaterCommand> + Send + 'static,
 {
     omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+    my_node_id: u64,
+    barrier_seq: AtomicU64,
     runner: PaxosRunner<HighWaterCommand, S>,
     apply_state: ApplyState,
     leader_stream: Mutex<Option<LeaderEventStream>>,
@@ -72,6 +75,8 @@ where
         let leader_stream = runner.take_leader_stream();
         Self {
             omnipaxos,
+            my_node_id,
+            barrier_seq: AtomicU64::new(0),
             runner,
             apply_state: ApplyState::new(),
             leader_stream: Mutex::new(leader_stream),
@@ -267,10 +272,17 @@ where
     }
 
     async fn current_high_water(&self) -> Result<u64, ConsensusError> {
-        let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
+        // Mint a (my_node_id, seq) nonce, append a Barrier carrying it,
+        // and wait until the apply path folds *this specific* barrier
+        // into the ledger. Tracking by appending-node lets two nodes'
+        // independent counters coexist without trampling each other.
+        let seq = self.barrier_seq.fetch_add(1, Ordering::SeqCst) + 1;
         self.omnipaxos
             .lock()
-            .append(HighWaterCommand::Barrier)
+            .append(HighWaterCommand::Barrier {
+                node: self.my_node_id,
+                seq,
+            })
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
             })?;
@@ -279,16 +291,13 @@ where
             "standalone_host::current_high_water::after_append_before_await"
         );
         loop {
-            // Register as waiter before checking state; otherwise a notify_waiters
-            // that fires between the previous iteration's check and the next
-            // notified().await is lost. apply_notifier uses notify_waiters which
-            // does not store permits — Notified::enable() is the supported way
-            // to close that window.
+            // Register as waiter before checking state; otherwise a
+            // notify_waiters that fires between the previous iteration's
+            // check and the next notified().await is lost.
             let notified = notifier.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            let new_decided = self.omnipaxos.lock().get_decided_idx();
-            if new_decided > snapshot_decided {
+            if self.apply_state.applied_barrier_seq(self.my_node_id) >= seq {
                 return Ok(self.apply_state.high_water());
             }
             notified.await;

--- a/crates/tsoracle-driver-paxos/src/state_machine.rs
+++ b/crates/tsoracle-driver-paxos/src/state_machine.rs
@@ -12,19 +12,22 @@
 
 //! Apply-task state machine.
 //!
-//! Owns the in-memory high-water mark (an `AtomicU64`) and the apply
-//! notifier the host's blocking-read methods loop on. The apply task is
-//! spawned by the host (`StandaloneHost` in a follow-up sub-issue),
-//! awaits the toolkit runner's `apply_notify`, then drains the
-//! OmniPaxos log's decided suffix into the AtomicU64 — exactly once per
-//! decided entry.
+//! Owns the in-memory high-water mark (an `AtomicU64`), the per-node
+//! barrier-nonce ledger that linearizes `current_high_water`, and the
+//! apply notifier the host's blocking-read methods loop on. The apply
+//! task is spawned by the host (`StandaloneHost`), awaits the toolkit
+//! runner's `apply_notify`, then drains the OmniPaxos log's decided
+//! suffix into the apply state — exactly once per decided entry.
 //!
-//! No per-proposal tracking. Blocking-read methods (`submit_advance`,
-//! `current_high_water`) snapshot `decided_idx` and the AtomicU64
-//! before they append, then loop on the `apply_notifier` until their
-//! waitcondition is satisfied. This is the consequence of
-//! `OmniPaxos::append` not returning a log index for the proposing node.
+//! Why per-node barrier nonces. `OmniPaxos::append` does not return a
+//! log index, and the apply path only sees decided entries in order. To
+//! make `current_high_water` a linearized read, the reader mints a
+//! `(my_node, seq)` nonce, appends `Barrier { node, seq }`, and waits
+//! until the ledger reports `applied_barrier_seq(my_node) >= seq`. The
+//! ledger is keyed by appending-node so two nodes' independent nonce
+//! counters don't trample each other; size is bounded by cluster size.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -47,6 +50,7 @@ use crate::snapshot_policy::SnapshotPolicy;
 pub struct ApplyState {
     high_water: Arc<AtomicU64>,
     apply_notifier: Arc<Notify>,
+    applied_barriers: Arc<Mutex<HashMap<u64, u64>>>,
 }
 
 impl Default for ApplyState {
@@ -61,6 +65,7 @@ impl ApplyState {
         Self {
             high_water: Arc::new(AtomicU64::new(0)),
             apply_notifier: Arc::new(Notify::new()),
+            applied_barriers: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -68,6 +73,17 @@ impl ApplyState {
     #[must_use]
     pub fn high_water(&self) -> u64 {
         self.high_water.load(Ordering::SeqCst)
+    }
+
+    /// Latest applied barrier sequence for `node`. Returns 0 if the
+    /// apply path has never folded a `Barrier { node, .. }` entry.
+    #[must_use]
+    pub fn applied_barrier_seq(&self, node: u64) -> u64 {
+        self.applied_barriers
+            .lock()
+            .get(&node)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Notifier the host's blocking-read methods loop on.
@@ -116,17 +132,33 @@ where
                         trace!(prev, new = at_least, "high-water advanced");
                     }
                 }
-                LogEntry::Decided(HighWaterCommand::Barrier) => {
-                    // No-op marker; the AtomicU64 is unchanged.
+                LogEntry::Decided(HighWaterCommand::Barrier { node, seq }) => {
+                    let mut ledger = state.applied_barriers.lock();
+                    let slot = ledger.entry(*node).or_insert(0);
+                    if *seq > *slot {
+                        *slot = *seq;
+                    }
                 }
                 LogEntry::Snapshotted(snapshotted) => {
                     // OmniPaxos may surface a Snapshotted entry on log
-                    // catch-up; reflect its value if it's higher.
+                    // catch-up; reflect its value if it's higher and
+                    // merge the snapshot's per-node barrier ledger.
+                    // Without merging the ledger, a node that catches
+                    // up via snapshot transfer would never see its own
+                    // barriers as applied and current_high_water would
+                    // hang.
                     let prev = state.high_water.load(Ordering::SeqCst);
                     if snapshotted.snapshot.value > prev {
                         state
                             .high_water
                             .store(snapshotted.snapshot.value, Ordering::SeqCst);
+                    }
+                    let mut ledger = state.applied_barriers.lock();
+                    for (node, seq) in &snapshotted.snapshot.applied_barriers {
+                        let slot = ledger.entry(*node).or_insert(0);
+                        if *seq > *slot {
+                            *slot = *seq;
+                        }
                     }
                 }
                 LogEntry::Trimmed(_) | LogEntry::StopSign(_, _) | LogEntry::Undecided(_) => {
@@ -406,7 +438,9 @@ mod drain_tests {
             handle
                 .append(HighWaterCommand::Advance { at_least: 17 })
                 .expect("append");
-            handle.append(HighWaterCommand::Barrier).expect("append");
+            handle
+                .append(HighWaterCommand::Barrier { node: 1, seq: 1 })
+                .expect("append");
         }
 
         drive_until(
@@ -426,6 +460,54 @@ mod drain_tests {
         drain_decided_into(&leader_handle(&cluster), &mut cursor, &state);
 
         assert_eq!(state.high_water(), 17, "Barrier must not lower or zero out");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn drain_records_latest_barrier_seq_per_node() {
+        let mut cluster = build_cluster(3);
+        drive_to_leader_election(&mut cluster).await;
+
+        {
+            let leader = leader_handle(&cluster);
+            let mut handle = leader.lock();
+            handle
+                .append(HighWaterCommand::Barrier { node: 1, seq: 5 })
+                .expect("append");
+            handle
+                .append(HighWaterCommand::Barrier { node: 1, seq: 7 })
+                .expect("append");
+            handle
+                .append(HighWaterCommand::Barrier { node: 2, seq: 3 })
+                .expect("append");
+        }
+
+        drive_until(
+            &mut cluster,
+            |state| {
+                state
+                    .nodes
+                    .iter()
+                    .all(|node| node.omnipaxos.lock().get_decided_idx() >= 3)
+            },
+            500,
+        )
+        .await;
+
+        let state = ApplyState::new();
+        let mut cursor = 0u64;
+        drain_decided_into(&leader_handle(&cluster), &mut cursor, &state);
+
+        assert_eq!(state.applied_barrier_seq(1), 7);
+        assert_eq!(state.applied_barrier_seq(2), 3);
+        assert_eq!(state.applied_barrier_seq(99), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn drain_does_not_regress_barrier_seq_on_lower_value() {
+        let state = ApplyState::new();
+        state.applied_barriers.lock().insert(1, 42);
+        // No drain — just verify the helper observes the seeded ledger.
+        assert_eq!(state.applied_barrier_seq(1), 42);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/tsoracle-driver-paxos/tests/linearized_barrier.rs
+++ b/crates/tsoracle-driver-paxos/tests/linearized_barrier.rs
@@ -1,0 +1,136 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+//
+//! Regression: `current_high_water` must wait for its own appended
+//! Barrier to be applied, not merely for `decided_idx` to advance past
+//! the pre-append snapshot.
+//!
+//! The pre-fix predicate was `decided_idx > snapshot_decided`. That fires
+//! whenever any entry decides — including entries appended by a prior
+//! leader that the local node was lagging on. If the apply task has not
+//! yet folded the reader's Barrier into state, the reader can return a
+//! stale `high_water()` while the Barrier remains undecided. In failover
+//! this seeds the new leader's allocator below the prior leader's true
+//! ceiling and lets it issue timestamps the prior leader already served.
+//!
+//! These tests construct that interleaving with yield-point gating: park
+//! every node's apply task between iterations, decide an Advance beneath
+//! the reader's eventual Barrier, park the reader between its
+//! `append(Barrier)` and its wait, let the Barrier decide while apply
+//! stays paused, then release. With the pre-fix predicate the reader
+//! returns the stale `high_water` (0) the moment `decided_idx` advances;
+//! with the fix it waits until the apply task folds its own barrier and
+//! returns the correct post-fold value (500).
+
+#![cfg(feature = "yieldpoints")]
+
+use std::time::Duration;
+
+use tsoracle_driver_paxos::HighWaterCommand;
+use tsoracle_driver_paxos::host::PaxosHighWaterHost;
+use tsoracle_yieldpoint as yieldpoint;
+
+#[path = "common/mod.rs"]
+mod common;
+
+const APPLY_TASK_YIELD: &str = "standalone_host::apply_task::between_iterations";
+const CURRENT_HW_YIELD: &str = "standalone_host::current_high_water::after_append_before_await";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn current_high_water_returns_value_advanced_before_call_under_paused_apply() {
+    let mut cluster = common::build_mem_cluster(3);
+    cluster.start_all();
+    cluster
+        .drive_until(common::some_leader_elected(), 1_000)
+        .await;
+    let leader_id = cluster.leader();
+
+    // Pause every node's apply task between iterations. Until released,
+    // decided entries are NOT folded into apply state.
+    let apply_gate = yieldpoint::cfg(APPLY_TASK_YIELD);
+
+    // Wait for every apply task to actually hit and park at the yield
+    // point. Without this beat, the upcoming append can race the in-
+    // flight drain and get folded before apply ever parks.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Decide an Advance(500) the apply task cannot yet fold.
+    cluster
+        .node(leader_id)
+        .omnipaxos()
+        .lock()
+        .append(HighWaterCommand::Advance { at_least: 500 })
+        .expect("append Advance on leader");
+    cluster
+        .drive_until(common::all_decided_at_least(1), 1_000)
+        .await;
+
+    assert_eq!(
+        cluster.high_water_on(leader_id),
+        0,
+        "apply paused: Advance(500) decided but not yet folded",
+    );
+
+    // Park the reader between its `append(Barrier)` and its wait so the
+    // Barrier can decide while the reader's loop has not yet had a
+    // chance to observe it.
+    let reader_park_gate = yieldpoint::cfg(CURRENT_HW_YIELD);
+
+    let observed = {
+        let host_ref = cluster
+            .node(leader_id)
+            .host
+            .as_ref()
+            .expect("leader host present");
+        let mut read_future = Box::pin(host_ref.current_high_water());
+
+        // Drive the reader to its yield-point park, then let the runner
+        // tick the Barrier to a decision (decided_idx 1 → 2) in the
+        // background. The reader must not return during this window.
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(300)) => {}
+            _ = &mut read_future => panic!("read returned before yieldpoint was released"),
+        }
+
+        // Release the parked reader. Under the pre-fix predicate the
+        // next loop iteration sees `decided_idx (2) > snapshot_decided
+        // (1)` and returns the stale `high_water()` (0). Under the fix
+        // it sees `applied_barrier_seq(self) < seq` and keeps waiting.
+        reader_park_gate.notify_one();
+
+        // Release the apply task shortly after. notify_waiters wakes
+        // every parked node's apply task at once — notify_one would
+        // release only one and there's no guarantee it's the leader's.
+        // remove() drops the registry entry so the next yieldpoint hit
+        // is a no-op; otherwise the apply task would re-park and miss
+        // the shutdown signal during cluster.stop_all().
+        let apply_release_gate = apply_gate.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            apply_release_gate.notify_waiters();
+            yieldpoint::remove(APPLY_TASK_YIELD);
+        });
+
+        tokio::time::timeout(Duration::from_secs(3), &mut read_future)
+            .await
+            .expect("current_high_water must complete")
+            .expect("current_high_water must not error")
+    };
+
+    assert_eq!(
+        observed, 500,
+        "current_high_water must reflect entries decided before the call (Advance(500) folded after the apply task drains)",
+    );
+
+    yieldpoint::remove(CURRENT_HW_YIELD);
+    cluster.stop_all().await;
+}

--- a/examples/paxos-piggyback/src/demo.rs
+++ b/examples/paxos-piggyback/src/demo.rs
@@ -203,7 +203,7 @@ async fn build_node(
     runner.start(sink);
 
     // ---- Driver + tsoracle server ----
-    let host = PiggybackHost::new(omnipaxos.clone(), state.clone());
+    let host = PiggybackHost::new(omnipaxos.clone(), state.clone(), id);
     let driver = Arc::new(PaxosDriver::new(host, leader_stream));
     let server = TsoServer::builder().consensus_driver(driver).build()?;
     let serving_state_rx = server.state_rx.clone();

--- a/examples/paxos-piggyback/src/host_service.rs
+++ b/examples/paxos-piggyback/src/host_service.rs
@@ -18,7 +18,7 @@
 //! host's apply pump, sitting next to the KV map. The snapshot type carries
 //! both halves.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -56,11 +56,16 @@ impl From<HighWaterCommand> for MyAppCommand {
     }
 }
 
-/// Snapshot payload — carries BOTH halves (KV map and high-water).
+/// Snapshot payload — carries BOTH halves (KV map and high-water) plus
+/// the per-appending-node barrier ledger. The ledger is required so a
+/// node that catches up via snapshot transfer still sees its own
+/// barriers as "applied" — otherwise `current_high_water` would hang
+/// after recovery waiting on a seq it can never observe.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct MyAppSnap {
     pub kv: BTreeMap<String, Vec<u8>>,
     pub high_water: u64,
+    pub applied_barriers: HashMap<u64, u64>,
 }
 
 impl omnipaxos::storage::Entry for MyAppCommand {
@@ -81,6 +86,12 @@ impl omnipaxos::storage::Snapshot<MyAppCommand> for MyAppSnap {
             self.kv.insert(key, value);
         }
         self.high_water = self.high_water.max(other.high_water);
+        for (node, seq) in other.applied_barriers {
+            let slot = self.applied_barriers.entry(node).or_insert(0);
+            if seq > *slot {
+                *slot = seq;
+            }
+        }
     }
 
     fn use_snapshots() -> bool {
@@ -101,7 +112,12 @@ fn apply_into_snapshot(entry: &MyAppCommand, snap: &mut MyAppSnap) {
                 snap.high_water = *at_least;
             }
         }
-        MyAppCommand::HighWater(HighWaterCommand::Barrier) => {}
+        MyAppCommand::HighWater(HighWaterCommand::Barrier { node, seq }) => {
+            let slot = snap.applied_barriers.entry(*node).or_insert(0);
+            if *seq > *slot {
+                *slot = *seq;
+            }
+        }
     }
 }
 
@@ -116,6 +132,7 @@ pub struct HostState {
     kv: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
     high_water: Arc<AtomicU64>,
     apply_notify: Arc<Notify>,
+    applied_barriers: Arc<Mutex<HashMap<u64, u64>>>,
 }
 
 impl Default for HostState {
@@ -130,6 +147,7 @@ impl HostState {
             kv: Arc::new(Mutex::new(BTreeMap::new())),
             high_water: Arc::new(AtomicU64::new(0)),
             apply_notify: Arc::new(Notify::new()),
+            applied_barriers: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -146,6 +164,16 @@ impl HostState {
     pub fn apply_notifier(&self) -> Arc<Notify> {
         self.apply_notify.clone()
     }
+
+    /// Latest applied barrier sequence for `node`. Returns 0 if the
+    /// pump has never folded a `Barrier { node, .. }` entry.
+    pub fn applied_barrier_seq(&self, node: u64) -> u64 {
+        self.applied_barriers
+            .lock()
+            .get(&node)
+            .copied()
+            .unwrap_or(0)
+    }
 }
 
 // ---------- Apply pump ----------
@@ -157,8 +185,11 @@ impl HostState {
 /// invoke this per entry and then call [`HostState::apply_notify`].
 ///
 /// Half-isolation: `Kv` variants touch only the KV map; `HighWater` variants
-/// touch only the high-water cell. `Advance` is monotonic — high_water moves
-/// only forward, never backward.
+/// touch only the high-water cell (or the barrier ledger). `Advance` is
+/// monotonic — high_water moves only forward, never backward. `Barrier`
+/// records `(node, seq)` so `current_high_water` can wait for its own
+/// barrier to be applied instead of trusting `decided_idx` advancement
+/// alone.
 pub fn apply_decided_into(cmd: &MyAppCommand, state: &HostState) {
     match cmd {
         MyAppCommand::Kv(KvOp::Put { key, value }) => {
@@ -174,13 +205,20 @@ pub fn apply_decided_into(cmd: &MyAppCommand, state: &HostState) {
                 trace!(prev, new = at_least, "piggyback high-water advanced");
             }
         }
-        MyAppCommand::HighWater(HighWaterCommand::Barrier) => {}
+        MyAppCommand::HighWater(HighWaterCommand::Barrier { node, seq }) => {
+            let mut ledger = state.applied_barriers.lock();
+            let slot = ledger.entry(*node).or_insert(0);
+            if *seq > *slot {
+                *slot = *seq;
+            }
+        }
     }
 }
 
 /// Apply a [`MyAppSnap`] (e.g., delivered as a `LogEntry::Snapshotted`) to
-/// `state`. Merges the snapshot's KV map into the host KV and lifts
-/// `high_water` to `max(prev, snap.high_water)`.
+/// `state`. Merges the snapshot's KV map into the host KV, lifts
+/// `high_water` to `max(prev, snap.high_water)`, and merges the
+/// per-node barrier ledger (taking the max per node).
 pub fn apply_snapshot_into(snap: &MyAppSnap, state: &HostState) {
     let mut kv = state.kv.lock();
     for (k, v) in &snap.kv {
@@ -190,6 +228,13 @@ pub fn apply_snapshot_into(snap: &MyAppSnap, state: &HostState) {
     let prev = state.high_water.load(Ordering::SeqCst);
     if snap.high_water > prev {
         state.high_water.store(snap.high_water, Ordering::SeqCst);
+    }
+    let mut ledger = state.applied_barriers.lock();
+    for (node, seq) in &snap.applied_barriers {
+        let slot = ledger.entry(*node).or_insert(0);
+        if *seq > *slot {
+            *slot = *seq;
+        }
     }
 }
 
@@ -246,14 +291,22 @@ pub fn drain_decided_into(
 pub struct PiggybackHost {
     omnipaxos: Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>>,
     state: HostState,
+    my_node_id: u64,
+    barrier_seq: AtomicU64,
 }
 
 impl PiggybackHost {
     pub fn new(
         omnipaxos: Arc<Mutex<OmniPaxos<MyAppCommand, MemStorage<MyAppCommand>>>>,
         state: HostState,
+        my_node_id: u64,
     ) -> Self {
-        Self { omnipaxos, state }
+        Self {
+            omnipaxos,
+            state,
+            my_node_id,
+            barrier_seq: AtomicU64::new(0),
+        }
     }
 }
 
@@ -267,26 +320,31 @@ impl PaxosHighWaterHost for PiggybackHost {
     }
 
     async fn current_high_water(&self) -> Result<u64, ConsensusError> {
-        let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
+        // Mint a (my_node_id, seq) nonce and wait for *this specific
+        // barrier* to be folded into the state — not merely for
+        // `decided_idx` to advance past a pre-append snapshot, which
+        // would fire on any unrelated earlier entry and let the read
+        // return a stale `high_water` while the barrier is still
+        // undecided. This mirrors the StandaloneHost fix.
+        let seq = self.barrier_seq.fetch_add(1, Ordering::SeqCst) + 1;
         self.omnipaxos
             .lock()
-            .append(MyAppCommand::HighWater(HighWaterCommand::Barrier))
+            .append(MyAppCommand::HighWater(HighWaterCommand::Barrier {
+                node: self.my_node_id,
+                seq,
+            }))
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(PiggybackAppendError(format!("{err:?}"))))
             })?;
         let notify = self.state.apply_notifier();
         loop {
-            // Register as a waiter before re-reading decided_idx; otherwise a
-            // notify_waiters that fires between the previous iteration's check
-            // and the next notified().await is lost. apply_notifier uses
-            // notify_waiters, which does not store permits — Notified::enable
-            // is the supported way to close the window. Mirrors the driver-paxos
-            // reader fix in #196.
+            // Register as a waiter before checking state; apply_notifier
+            // uses notify_waiters which does not store permits, so an
+            // unregistered check would race against the wake.
             let notified = notify.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            let new_decided = self.omnipaxos.lock().get_decided_idx();
-            if new_decided > snapshot_decided {
+            if self.state.applied_barrier_seq(self.my_node_id) >= seq {
                 return Ok(self.state.high_water());
             }
             notified.await;
@@ -341,8 +399,8 @@ mod tests {
         MyAppCommand::HighWater(HighWaterCommand::Advance { at_least })
     }
 
-    fn barrier() -> MyAppCommand {
-        MyAppCommand::HighWater(HighWaterCommand::Barrier)
+    fn barrier(node: u64, seq: u64) -> MyAppCommand {
+        MyAppCommand::HighWater(HighWaterCommand::Barrier { node, seq })
     }
 
     // ---------- Envelope ----------
@@ -367,7 +425,7 @@ mod tests {
             advance(10),
             put("b", b"2"),
             advance(30),
-            barrier(),
+            barrier(1, 1),
         ];
         let snap = MyAppSnap::create(&entries);
         assert_eq!(snap.high_water, 30);
@@ -407,14 +465,14 @@ mod tests {
 
     #[test]
     fn snapshot_create_high_water_only_leaves_kv_empty() {
-        let snap = MyAppSnap::create(&[advance(10), advance(20), barrier()]);
+        let snap = MyAppSnap::create(&[advance(10), advance(20), barrier(1, 1)]);
         assert!(snap.kv.is_empty(), "TSO commands must not touch the KV map");
         assert_eq!(snap.high_water, 20);
     }
 
     #[test]
     fn snapshot_create_barrier_is_no_op() {
-        let snap = MyAppSnap::create(&[barrier(), barrier()]);
+        let snap = MyAppSnap::create(&[barrier(1, 1), barrier(1, 1)]);
         assert!(snap.kv.is_empty());
         assert_eq!(snap.high_water, 0);
     }
@@ -424,12 +482,12 @@ mod tests {
     #[test]
     fn snapshot_merge_takes_max_high_water() {
         let mut left = MyAppSnap {
-            kv: BTreeMap::new(),
             high_water: 100,
+            ..Default::default()
         };
         let right = MyAppSnap {
-            kv: BTreeMap::new(),
             high_water: 50,
+            ..Default::default()
         };
         left.merge(right);
         assert_eq!(
@@ -438,12 +496,12 @@ mod tests {
         );
 
         let mut left = MyAppSnap {
-            kv: BTreeMap::new(),
             high_water: 50,
+            ..Default::default()
         };
         let right = MyAppSnap {
-            kv: BTreeMap::new(),
             high_water: 100,
+            ..Default::default()
         };
         left.merge(right);
         assert_eq!(left.high_water, 100, "merge takes the higher of the two");
@@ -453,14 +511,14 @@ mod tests {
     fn snapshot_merge_overwrites_kv_on_conflict() {
         let mut left = MyAppSnap {
             kv: BTreeMap::from([("a".into(), b"left".to_vec())]),
-            high_water: 0,
+            ..Default::default()
         };
         let right = MyAppSnap {
             kv: BTreeMap::from([
                 ("a".into(), b"right".to_vec()),
                 ("b".into(), b"only-right".to_vec()),
             ]),
-            high_water: 0,
+            ..Default::default()
         };
         left.merge(right);
         assert_eq!(
@@ -537,15 +595,38 @@ mod tests {
     }
 
     #[test]
-    fn apply_decided_barrier_does_not_change_state() {
+    fn apply_decided_barrier_leaves_kv_and_high_water_unchanged() {
         let state = HostState::new();
         apply_decided_into(&put("k", b"v"), &state);
         apply_decided_into(&advance(99), &state);
         let kv_before = state.kv_dump();
         let hw_before = state.high_water();
-        apply_decided_into(&barrier(), &state);
+        apply_decided_into(&barrier(1, 1), &state);
         assert_eq!(state.kv_dump(), kv_before);
         assert_eq!(state.high_water(), hw_before);
+    }
+
+    #[test]
+    fn apply_decided_barrier_records_latest_seq_per_node() {
+        let state = HostState::new();
+        apply_decided_into(&barrier(1, 5), &state);
+        apply_decided_into(&barrier(1, 7), &state);
+        apply_decided_into(&barrier(2, 3), &state);
+        assert_eq!(state.applied_barrier_seq(1), 7);
+        assert_eq!(state.applied_barrier_seq(2), 3);
+        assert_eq!(state.applied_barrier_seq(99), 0);
+    }
+
+    #[test]
+    fn apply_decided_barrier_seq_is_monotonic_per_node() {
+        let state = HostState::new();
+        apply_decided_into(&barrier(1, 10), &state);
+        apply_decided_into(&barrier(1, 5), &state);
+        assert_eq!(
+            state.applied_barrier_seq(1),
+            10,
+            "an out-of-order replay must not regress the per-node seq",
+        );
     }
 
     // ---------- Half-isolation (the piggyback invariant) ----------
@@ -572,7 +653,7 @@ mod tests {
         let kv_before = state.kv_dump();
         apply_decided_into(&advance(10), &state);
         apply_decided_into(&advance(20), &state);
-        apply_decided_into(&barrier(), &state);
+        apply_decided_into(&barrier(1, 1), &state);
         assert_eq!(
             state.kv_dump(),
             kv_before,
@@ -588,6 +669,7 @@ mod tests {
         let snap = MyAppSnap {
             kv: BTreeMap::from([("a".into(), b"1".to_vec()), ("b".into(), b"2".to_vec())]),
             high_water: 99,
+            ..Default::default()
         };
         apply_snapshot_into(&snap, &state);
         assert_eq!(state.high_water(), 99);
@@ -605,6 +687,7 @@ mod tests {
         let snap = MyAppSnap {
             kv: BTreeMap::from([("only-snap".into(), b"x".to_vec())]),
             high_water: 30, // lower than existing 50
+            ..Default::default()
         };
         apply_snapshot_into(&snap, &state);
 
@@ -624,11 +707,44 @@ mod tests {
         apply_decided_into(&advance(10), &state);
         apply_snapshot_into(
             &MyAppSnap {
-                kv: BTreeMap::new(),
                 high_water: 100,
+                ..Default::default()
             },
             &state,
         );
         assert_eq!(state.high_water(), 100);
+    }
+
+    #[test]
+    fn apply_snapshot_merges_barrier_ledger() {
+        let state = HostState::new();
+        apply_decided_into(&barrier(1, 3), &state);
+        apply_snapshot_into(
+            &MyAppSnap {
+                applied_barriers: HashMap::from([(1, 5), (2, 7)]),
+                ..Default::default()
+            },
+            &state,
+        );
+        assert_eq!(state.applied_barrier_seq(1), 5, "snapshot lifts seq");
+        assert_eq!(state.applied_barrier_seq(2), 7, "snapshot introduces nodes");
+    }
+
+    #[test]
+    fn apply_snapshot_does_not_regress_barrier_ledger() {
+        let state = HostState::new();
+        apply_decided_into(&barrier(1, 10), &state);
+        apply_snapshot_into(
+            &MyAppSnap {
+                applied_barriers: HashMap::from([(1, 5)]),
+                ..Default::default()
+            },
+            &state,
+        );
+        assert_eq!(
+            state.applied_barrier_seq(1),
+            10,
+            "merge must not move seq backward",
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `StandaloneHost::current_high_water` waited on `decided_idx > snapshot_decided`, which fires whenever any entry decides — not specifically when the reader's own appended `Barrier` commits. When the local node has prior-leader entries between its `decided_idx` snapshot and the appended barrier's log index (textbook Multi-Paxos leader-transition scenario), the predicate fires early and the read returns a stale `apply_state.high_water()`. The failover fence in `tsoracle-server` uses that value as `prior_max`, seeding the new leader's allocator below the prior leader's true ceiling and re-issuing timestamps the prior leader had already served. This violates the timestamp oracle's no-duplicate / no-regression invariant.
- **Fix:** `HighWaterCommand::Barrier` carries a `{ node: u64, seq: u64 }` nonce. `ApplyState` gains a per-appending-node `applied_barriers: HashMap<u64, u64>` ledger that `drain_decided_into` writes to. `StandaloneHost` carries `my_node_id` + a monotonic `barrier_seq` counter and waits on `applied_barrier_seq(self) >= seq` — i.e., on that specific Barrier being folded into state. Per-node keying lets multiple appending nodes coexist without trampling each other's seq spaces; size is bounded by cluster membership.
- **Snapshot-recovery edge case also fixed:** `HighWaterSnapshot` now carries the ledger too. Without this, a node that catches up via snapshot transfer would never observe its own pre-snapshot Barriers as applied and `current_high_water` would hang post-recovery.
- **Mirrored in the `paxos-piggyback` example** (`MyAppCommand` / `MyAppSnap` / `PiggybackHost`) — the same pattern is the recommended integration for embedders.

## Regression test

`crates/tsoracle-driver-paxos/tests/linearized_barrier.rs` uses the existing yield-point gating to construct the exact interleaving the security finding describes:

1. Pause every node's apply task between iterations.
2. Decide an `Advance(500)` the apply task cannot fold yet.
3. Park the reader between its `append(Barrier)` and its wait.
4. Let the runner drive the Barrier to a decision while apply stays paused.
5. Release the reader, then the apply task.

Against the pre-fix predicate the test returns `0` (stale read). Against the fix it returns `500` (linearized — the value the apply task folds once it drains).

## Test plan

- [x] `cargo test -p tsoracle-driver-paxos --features yieldpoints` — 35 unit + 14 integration tests pass (was 31)
- [x] `cargo test -p example-paxos-piggyback` — 25 tests pass (was 21)
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy -p tsoracle-driver-paxos --features yieldpoints --all-targets` — clean
- [x] `cargo clippy -p example-paxos-piggyback` — clean
- [x] Rebased on latest `origin/main` (`adad90b`)

## Breaking change

`HighWaterCommand::Barrier` is a public enum variant; this PR changes it from `Barrier` to `Barrier { node, seq }`. Any external embedder constructing `Barrier` directly must update. The crate is pre-1.0 (`0.1.x`) and this is a security-critical correctness fix, so the break is justified. The single in-tree consumer (`paxos-piggyback` example) is updated in this PR.