### PR TITLE
ci: cache apt system deps and bound install steps with a timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,11 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler clang libclang-dev
+          version: 1
       - name: fmt
         run: cargo fmt --all -- --check
       - name: clippy
@@ -130,7 +134,11 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: system deps
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler clang libclang-dev
+          version: 1
       - name: coverage
         run: make coverage
       - uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e  # v2
@@ -150,7 +158,11 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler clang libclang-dev
+          version: 1
       - name: build
         run: cargo build --release --bin tsoracle && cargo build --release -p stress
       - name: smoke (mem)

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -63,7 +63,11 @@ jobs:
           components: rust-src, llvm-tools-preview
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler
+          version: 1
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -37,7 +37,11 @@ jobs:
           components: rust-src, llvm-tools-preview
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler
+          version: 1
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2

--- a/.github/workflows/leak-nightly.yml
+++ b/.github/workflows/leak-nightly.yml
@@ -37,7 +37,11 @@ jobs:
           cache-targets: true
 
       - name: System deps
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler clang libclang-dev
+          version: 1
 
       - name: Run workspace tests under LeakSanitizer
         env:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,7 +38,11 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler clang libclang-dev
+          version: 1
       - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db  # v0.5
         with:
           command: release
@@ -73,7 +77,11 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: system deps
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler clang libclang-dev
+          version: 1
       - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db  # v0.5
         with:
           command: release-pr

--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -76,7 +76,11 @@ jobs:
 
       - name: system deps
         if: steps.filter.outputs.skip != 'true'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+        timeout-minutes: 5
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        with:
+          packages: protobuf-compiler clang libclang-dev
+          version: 1
 
       - name: build
         if: steps.filter.outputs.skip != 'true'


### PR DESCRIPTION
## Problem

The `apt-get install protobuf-compiler clang libclang-dev` step on `ubuntu-latest` runners can hang for the full 6-hour job timeout when the runner's dpkg lock is held by `unattended-upgrades` or an apt mirror stalls. A live `release-plz` run hit exactly this and stayed stuck for 20+ minutes while the parallel job ran the identical command in ~13s — confirming it's a per-runner flake, not a workflow bug.

On the `release-plz` **release** job the hang is especially costly: that job's concurrency group runs serial with `cancel-in-progress: false` (so a half-done cargo publish is never cancelled), which means one stuck run blocks every queued release behind it.

## Changes

Applied to every workflow that installs these system packages (`ci.yml`, `release-plz.yml`, `stress-nightly.yml`, `leak-nightly.yml`, `fuzz-pr.yml`, `fuzz-nightly.yml`):

- **`timeout-minutes: 5`** on each install step — a stuck runner now fails fast and releases the concurrency lock instead of burning up to 6 hours.
- **Replace the raw `apt-get` call with `awalsh128/cache-apt-pkgs-action`** — warm caches restore the `.deb` files directly and skip the apt mirrors entirely (the common case); only cold caches touch the network, where the `timeout-minutes` still applies. `protobuf-compiler` + `libclang-dev` are heavy enough that caching also speeds up the happy path.

The action is SHA-pinned to `v1.6.0` (`acb598e`) to match the repo's third-party action pinning convention. `version: 1` is a manual cache-bust knob.

## Validation

`actionlint` passes on all changed steps (the only output is two pre-existing info-level shellcheck notes in the fuzz *run* scripts, unrelated to these edits).