### PR TITLE
fix(driver-paxos): reject out-of-range ballots in encode_epoch instead of truncating

### DIFF
--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -26,6 +26,8 @@ use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::Epoch;
 use tsoracle_paxos_toolkit::lifecycle::LeaderEventStream;
 
+use tracing::error;
+
 use crate::host::PaxosHighWaterHost;
 use crate::type_config::encode_epoch;
 
@@ -85,8 +87,16 @@ where
                         // Re-derive epoch from the host's view of the
                         // current ballot. This is what fence checks see.
                         let ballot = omnipaxos.lock().get_promise();
-                        LeaderState::Leader {
-                            epoch: encode_epoch(ballot),
+                        match encode_epoch(ballot) {
+                            Ok(epoch) => LeaderState::Leader { epoch },
+                            // A ballot we cannot fence-encode (node id or
+                            // reconfiguration count out of range) must not be
+                            // reported as a leader at a fabricated epoch.
+                            // Surface it loudly and report no leader observed.
+                            Err(err) => {
+                                error!(%err, "paxos leader ballot is not fence-encodable");
+                                LeaderState::Unknown
+                            }
                         }
                     }
                     other => other,
@@ -108,11 +118,16 @@ where
         // whose ballot has been superseded will see its append rejected
         // downstream anyway; this is a cheap pre-flight to avoid wasting
         // a log slot.
+        // An out-of-range ballot here means the local node id or the
+        // reconfiguration count exceeds what the fence can encode — an
+        // invariant violation that will not clear on retry, so fail with a
+        // permanent error rather than silently fencing on a colliding epoch.
         let current_epoch = {
             let handle = self.host.omnipaxos();
             let guard = handle.lock();
             encode_epoch(guard.get_promise())
-        };
+        }
+        .map_err(|err| ConsensusError::PermanentDriver(Box::new(err)))?;
         if epoch != current_epoch {
             return Err(ConsensusError::Fenced {
                 expected: epoch,
@@ -205,7 +220,7 @@ mod tests {
     async fn persist_with_matching_epoch_calls_submit_advance() {
         let host = StubHost::new();
         let current_ballot = host.omnipaxos().lock().get_promise();
-        let current_epoch = encode_epoch(current_ballot);
+        let current_epoch = encode_epoch(current_ballot).expect("default ballot is in-bounds");
 
         let (_sender, stream) = leader_event_channel();
         let driver = PaxosDriver::new(host, stream);
@@ -234,5 +249,48 @@ mod tests {
         let (_sender, stream) = leader_event_channel();
         let driver = PaxosDriver::new(host, stream);
         assert_eq!(driver.load_high_water().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn paxos_driver_persist_surfaces_encoding_error() {
+        use omnipaxos::ballot_leader_election::Ballot;
+        use omnipaxos::storage::Storage;
+        use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+
+        // Seed the node's persisted promise with a pid that overflows the
+        // 16-bit fence encoding. On recovery the OmniPaxos handle reports this
+        // ballot via get_promise(), so the driver's fence cannot encode it and
+        // must surface a permanent error rather than silently fence on a
+        // truncated, collision-prone epoch.
+        let mut storage = MemStorage::<HighWaterCommand>::new();
+        storage
+            .set_promise(Ballot {
+                config_id: 1,
+                n: 0,
+                priority: 0,
+                pid: 0x1_0000,
+            })
+            .expect("seed promise");
+        let config = OmniPaxosConfig {
+            cluster_config: ClusterConfig {
+                configuration_id: 1,
+                nodes: vec![1, 2, 3],
+                flexible_quorum: None,
+            },
+            server_config: ServerConfig {
+                pid: 1,
+                ..Default::default()
+            },
+        };
+        let omnipaxos = Arc::new(Mutex::new(config.build(storage).expect("build")));
+        let host = StubHost { omnipaxos };
+
+        let (_sender, stream) = leader_event_channel();
+        let driver = PaxosDriver::new(host, stream);
+
+        match driver.persist_high_water(42, Epoch(0)).await {
+            Err(ConsensusError::PermanentDriver(_)) => {}
+            other => panic!("expected PermanentDriver encoding error, got {other:?}"),
+        }
     }
 }

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -27,4 +27,4 @@ pub use log_entry::{HighWaterCommand, HighWaterSnapshot};
 pub use snapshot_policy::SnapshotPolicy;
 pub use standalone::{BuilderError, StandaloneHost, StandaloneHostBuilder};
 pub use state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
-pub use type_config::{PaxosPeer, decode_epoch, encode_epoch};
+pub use type_config::{EpochEncodingError, PaxosPeer, decode_epoch, encode_epoch};

--- a/crates/tsoracle-driver-paxos/src/type_config.rs
+++ b/crates/tsoracle-driver-paxos/src/type_config.rs
@@ -20,6 +20,23 @@
 use omnipaxos::ballot_leader_election::Ballot;
 use tsoracle_core::Epoch;
 
+/// Error returned by [`encode_epoch`] when a `Ballot` field falls outside the
+/// range the 64-bit `Epoch` packing can represent without loss.
+///
+/// The fence in [`crate::PaxosDriver`] decides "same leader or not" by exact
+/// `Epoch` equality, so a silent truncation that mapped two distinct ballots
+/// to the same `Epoch` would let a superseded leader's commit pass the fence.
+/// Encoding therefore refuses out-of-range inputs rather than truncating them.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum EpochEncodingError {
+    /// `config_id` does not fit the 16 bits reserved for it in the `Epoch`.
+    #[error("config_id {0} exceeds the 16-bit fence-encoding bound (max 65535)")]
+    ConfigIdOutOfRange(u32),
+    /// `pid` (node id) does not fit the 16 bits reserved for it in the `Epoch`.
+    #[error("pid {0} exceeds the 16-bit fence-encoding bound (max 65535)")]
+    PidOutOfRange(u64),
+}
+
 /// A peer node in the paxos cluster, with the endpoint used to populate
 /// `LeaderState::Follower::leader_endpoint` for follower-redirect hints.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,16 +52,30 @@ pub struct PaxosPeer {
 /// - `n` (round number) → bits 16..48 (32 bits)
 /// - `pid` (node id) → bits 0..16 (16 bits)
 ///
-/// The 16-bit truncation on `config_id` and `pid` is acceptable for
-/// realistic tsoracle deployments (<65k reconfigurations and <65k node
-/// ids). Monotonicity holds across reconfigurations (config_id bumps
-/// dominate) and across elections (n bumps dominate within a config).
-#[must_use]
-pub fn encode_epoch(ballot: Ballot) -> Epoch {
-    let config = u64::from(ballot.config_id & 0xFFFF) << 48;
+/// `priority` is intentionally not encoded: it is a static per-node
+/// tiebreaker fully determined by `pid`, so `(config_id, n, pid)` already
+/// identifies a leader-round uniquely.
+///
+/// The 64-bit `Epoch` cannot hold the full `Ballot` domain (`config_id` and
+/// `n` are `u32`, `pid` is `u64`), so `config_id` and `pid` each get 16 bits.
+/// Rather than silently truncate — which would collide distinct ballots and
+/// defeat the equality fence in [`crate::PaxosDriver`] — out-of-range inputs
+/// are rejected. Within the bound, monotonicity holds across reconfigurations
+/// (`config_id` bumps dominate) and elections (`n` bumps dominate in a config).
+///
+/// # Errors
+///
+/// Returns [`EpochEncodingError`] if `config_id` or `pid` exceeds 65535.
+pub fn encode_epoch(ballot: Ballot) -> Result<Epoch, EpochEncodingError> {
+    if ballot.config_id > 0xFFFF {
+        return Err(EpochEncodingError::ConfigIdOutOfRange(ballot.config_id));
+    }
+    if ballot.pid > 0xFFFF {
+        return Err(EpochEncodingError::PidOutOfRange(ballot.pid));
+    }
+    let config = u64::from(ballot.config_id) << 48;
     let round = u64::from(ballot.n) << 16;
-    let pid = ballot.pid & 0xFFFF;
-    Epoch(config | round | pid)
+    Ok(Epoch(config | round | ballot.pid))
 }
 
 /// Inverse of [`encode_epoch`]; returns `(config_id, n, pid)`. The encoding
@@ -73,10 +104,13 @@ mod tests {
         }
     }
 
+    fn encode(config_id: u32, n: u32, pid: u64) -> Epoch {
+        encode_epoch(ballot(config_id, n, pid)).expect("in-bounds ballot")
+    }
+
     #[test]
     fn encode_then_decode_round_trip() {
-        let original = ballot(7, 42, 3);
-        let epoch = encode_epoch(original);
+        let epoch = encode(7, 42, 3);
         let (config_id, n, pid) = decode_epoch(epoch);
         assert_eq!(config_id, 7);
         assert_eq!(n, 42);
@@ -85,8 +119,8 @@ mod tests {
 
     #[test]
     fn higher_config_id_dominates_lower_round() {
-        let early = encode_epoch(ballot(1, u32::MAX, 5));
-        let later = encode_epoch(ballot(2, 0, 5));
+        let early = encode(1, u32::MAX, 5);
+        let later = encode(2, 0, 5);
         assert!(
             later > early,
             "config_id bump must outrank a saturated round"
@@ -95,20 +129,22 @@ mod tests {
 
     #[test]
     fn higher_round_dominates_within_same_config() {
-        let earlier = encode_epoch(ballot(1, 5, 9));
-        let later = encode_epoch(ballot(1, 6, 1));
+        let earlier = encode(1, 5, 9);
+        let later = encode(1, 6, 1);
         assert!(later > earlier, "round bump must outrank a pid change");
     }
 
     #[test]
     fn distinct_pids_at_same_round_have_distinct_epochs() {
-        let first = encode_epoch(ballot(1, 5, 2));
-        let second = encode_epoch(ballot(1, 5, 3));
-        assert_ne!(first, second);
+        assert_ne!(encode(1, 5, 2), encode(1, 5, 3));
     }
 
     #[test]
-    fn priority_field_is_ignored() {
+    fn priority_is_intentionally_excluded() {
+        // priority is a static per-node tiebreaker fully determined by pid,
+        // so two ballots that differ only in priority denote the same
+        // leader-round and must encode identically. This is a deliberate
+        // omission, distinct from the truncation bug on config_id/pid.
         let with_priority = Ballot {
             config_id: 1,
             n: 5,
@@ -121,6 +157,33 @@ mod tests {
             priority: 0,
             pid: 2,
         };
-        assert_eq!(encode_epoch(with_priority), encode_epoch(without_priority));
+        assert_eq!(
+            encode_epoch(with_priority).unwrap(),
+            encode_epoch(without_priority).unwrap(),
+        );
+    }
+
+    #[test]
+    fn encode_epoch_rejects_oversized_config_id() {
+        let err = encode_epoch(ballot(0x1_0000, 7, 1)).unwrap_err();
+        assert_eq!(err, EpochEncodingError::ConfigIdOutOfRange(0x1_0000));
+    }
+
+    #[test]
+    fn encode_epoch_rejects_oversized_pid() {
+        let err = encode_epoch(ballot(1, 7, 0x1_0000)).unwrap_err();
+        assert_eq!(err, EpochEncodingError::PidOutOfRange(0x1_0000));
+    }
+
+    #[test]
+    fn encode_epoch_distinct_pids_no_longer_silently_collide() {
+        // Before the fix, pid=1 and pid=65537 both masked to 1 and produced
+        // the same Epoch. Now the in-bounds pid encodes and the oversized one
+        // is rejected, so the two can never share a fence-distinguishing value.
+        assert!(encode_epoch(ballot(1, 7, 1)).is_ok());
+        assert_eq!(
+            encode_epoch(ballot(1, 7, 65537)).unwrap_err(),
+            EpochEncodingError::PidOutOfRange(65537),
+        );
     }
 }

--- a/crates/tsoracle-driver-paxos/tests/three_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/three_node.rs
@@ -111,9 +111,11 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
     cluster
         .drive_until(
             |c| {
-                let leader_epoch = encode_epoch(c.node(leader_id).omnipaxos().lock().get_promise());
+                let leader_epoch = encode_epoch(c.node(leader_id).omnipaxos().lock().get_promise())
+                    .expect("cluster node id is in-bounds");
                 let follower_epoch =
-                    encode_epoch(c.node(follower_id).omnipaxos().lock().get_promise());
+                    encode_epoch(c.node(follower_id).omnipaxos().lock().get_promise())
+                        .expect("cluster node id is in-bounds");
                 leader_epoch != Epoch(0) && leader_epoch == follower_epoch
             },
             1_000,
@@ -122,7 +124,7 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
     let current_epoch = {
         let handle = cluster.node(follower_id).omnipaxos();
         let promise = handle.lock().get_promise();
-        encode_epoch(promise)
+        encode_epoch(promise).expect("cluster node id is in-bounds")
     };
 
     // We cannot move the cluster's StandaloneHost into a PaxosDriver


### PR DESCRIPTION
## Summary

`encode_epoch` packs a `Ballot` into the 64-bit `Epoch` that `PaxosDriver`'s stale-leader fence compares by **exact equality**. The packing masked `config_id` (`u32` → 16 bits) and `pid` (`u64` → 16 bits) and dropped `priority`, so distinct ballots could silently collide onto the same `Epoch` — e.g. `pid = 1` and `pid = 65537` both encoded to the same value, as did `config_id = 1` and `config_id = 65537`.

A collision is load-bearing: `persist_high_water` (`driver.rs`) rejects a call only when `epoch != current_epoch`, and `Allocator::try_commit_window_extension` (`allocator.rs`) accepts a late commit only when `*epoch == expected_epoch`. Two colliding ballots therefore let a superseded leader's persisted high-water pass the fence and incorrectly advance the durable `committed_high_water`. Impact is bounded today only because the paxos driver is not yet wired into the shipped binary.

The 64-bit `Epoch` cannot represent the full `Ballot` domain, so a lossless total encoding is impossible. The fix makes the lossy boundary **loud instead of silent**: `encode_epoch` now returns `Result` and rejects `config_id` or `pid` above 65535 rather than truncating.

- `persist_high_water` maps the error to `ConsensusError::PermanentDriver` (documented as a non-retryable invariant violation) so the server steps down rather than fencing on a colliding epoch.
- `leadership_events` reports `LeaderState::Unknown` and logs, rather than emitting a leader at a fabricated epoch.
- `priority` remains intentionally unencoded — it is a static per-node tiebreaker fully determined by `pid`, so `(config_id, n, pid)` already identifies a leader-round uniquely. (The old `priority_field_is_ignored` test is reframed as `priority_is_intentionally_excluded` rather than deleted, since priority-omission is correct and distinct from the truncation bug. Flagging in case you'd still prefer it removed.)

The signature change is contained to `tsoracle-driver-paxos`; no examples or benchmarks use `encode_epoch`.

Closes #206

## Test plan

- [x] 4 new tests (`encode_epoch_rejects_oversized_config_id`, `encode_epoch_rejects_oversized_pid`, `encode_epoch_distinct_pids_no_longer_silently_collide`, `paxos_driver_persist_surfaces_encoding_error`) fail before the validation and pass after; the driver test seeds an oversized `pid` into storage and asserts `PermanentDriver`, not `Fenced`
- [x] All pre-existing `encode_epoch`/`decode_epoch` tests updated to the `Result` API and still pass
- [x] `cargo test -p tsoracle-driver-paxos` — 39 unit + all integration tests pass (single_node, three_node, partition_churn, reconfiguration, restart_replay, snapshot_restart, snapshot_transfer), so real consensus still works through the changed encode path
- [x] `cargo clippy -p tsoracle-driver-paxos --all-targets --all-features` clean; workspace pre-commit hook (fmt + clippy) passed