### PR TITLE
test(driver-paxos): widen standalone shutdown liveness bound to 10s

### DIFF
--- a/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
@@ -107,9 +107,18 @@ async fn stop_delivers_shutdown_when_apply_task_is_mid_iteration() {
     // the loop.
     gate.notify_one();
 
-    tokio::time::timeout(Duration::from_secs(2), stop_handle)
+    // Liveness guard, not a latency assertion. Once the gate releases, the
+    // apply task consumes the stored `apply_shutdown` permit on its next
+    // `select!` turn and `stop()` returns in microseconds. The pre-fix
+    // `notify_waiters` regression livelocked here *forever*, so any generous
+    // finite bound distinguishes "fixed" from "regressed". The bound is wide
+    // (10s) because the `coverage` CI job runs the whole instrumented suite
+    // in parallel: a tighter 2s budget expired intermittently from pure
+    // scheduler starvation — this task simply not getting a worker in time —
+    // not from a lost wakeup.
+    tokio::time::timeout(Duration::from_secs(10), stop_handle)
         .await
-        .expect("host.stop() must complete within 2s after yield-point release")
+        .expect("host.stop() must complete after yield-point release (shutdown livelock?)")
         .expect("stop task must not panic");
 
     yieldpoint::remove(APPLY_TASK_YIELD);


### PR DESCRIPTION
## Problem

The `coverage` CI job intermittently fails `stop_delivers_shutdown_when_apply_task_is_mid_iteration` while the `test` job passes:

```
crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs:112
  host.stop() must complete within 2s after yield-point release: Elapsed(())
```

The `coverage` job is the only place it surfaces because it runs the entire suite under `cargo llvm-cov` instrumentation, in parallel, on a constrained runner.

## Root cause

This is **test timing fragility, not a bug in `stop()` or the apply loop.** The 2s assertion read as a latency bound, but its real purpose is a *liveness* guard against the pre-fix `notify_waiters` livelock (which hangs forever).

Under heavy instrumented load the apply task occasionally does not get scheduled to wake from the released yield point within 2s — pure scheduler starvation, not a lost wakeup. Once it runs, `stop()` returns in microseconds:

- `apply_shutdown` uses `notify_one`, whose stored permit is always consumed by the next `select!` turn;
- the competing `apply_notify` is edge-triggered (`notify_waiters`) and cannot make a freshly-created `notified()` ready, so it cannot steal that turn.

Evidence the failure is a scheduling artifact rather than a logic bug:

1. Reproduces only under full CPU saturation (~1/30) with the pristine binary, always hitting exactly the 2s ceiling.
2. A `tokio_test` manual-poll harness driving every interleaving of the loop loses the signal in none of them (including `notify_one`-to-a-registered-waiter-then-dropped, which restores the permit).
3. Changing only the timeout *constant* makes it disappear — a genuine lost wakeup is immune to timeout values; only a timing artifact behaves this way.

Production is unaffected: the yield point compiles out without the `yieldpoints` feature, so the apply branch body never suspends off the `select!`.

## Fix

Widen the liveness bound from 2s to **10s** (matching the sibling driver tests' generous liveness timeouts), and reword the message/comment to reflect liveness rather than latency. The old buggy code livelocked forever, so a generous finite bound still cleanly catches a real regression.

## Verification

- `cargo test` (plain): pass
- `cargo llvm-cov` (the failing mode): pass across repeated runs
- Production `standalone.rs` untouched