### PR TITLE
docs(paxos-standalone): surface the no-auth warning and default to loopback binds

### DIFF
--- a/examples/paxos-standalone/README.md
+++ b/examples/paxos-standalone/README.md
@@ -6,6 +6,8 @@ If your service already runs OmniPaxos for other state and you want TSO to share
 
 > **Do not copy this example to production unchanged.** It is *correct enough* to teach the integration boundary, but several layers are deliberately simplified. See [Production caveats](#production-caveats).
 
+> **⚠️ Warning — no authentication or encryption.** Every RPC here (the paxos peer transport *and* the tsoracle client API) is **unauthenticated plaintext**. The peer server feeds any deserialize-valid message straight into `OmniPaxos::handle_incoming` with no peer-identity or membership check, so a reachable peer port lets anyone disrupt elections, advance ballots, or get values decided. The `--listen`/`--tso-listen` defaults bind to **loopback only** (`127.0.0.1:0`); exposing the ports off-loopback requires an explicit override, and you must add TLS with client-cert auth first. See [Authentication & TLS](#production-caveats).
+
 ## Prerequisites
 
 - Rust 1.88+ (workspace toolchain).

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -57,11 +57,18 @@ struct Cli {
     node_id: u64,
 
     /// Address on which to listen for paxos peer RPCs (e.g. 127.0.0.1:53001).
-    #[arg(long)]
+    ///
+    /// Defaults to `127.0.0.1:0` (loopback, OS-assigned port). The peer
+    /// transport is unauthenticated plaintext, so binding off-loopback must be
+    /// an explicit, deliberate override — never the default.
+    #[arg(long, default_value = "127.0.0.1:0")]
     listen: SocketAddr,
 
     /// Address on which to serve the tsoracle gRPC API (e.g. 127.0.0.1:50581).
-    #[arg(long)]
+    ///
+    /// Defaults to `127.0.0.1:0` (loopback, OS-assigned port) for the same
+    /// reason as `--listen`: the client API is also unauthenticated plaintext.
+    #[arg(long, default_value = "127.0.0.1:0")]
     tso_listen: SocketAddr,
 
     /// Comma-separated `id=host:port` pairs for paxos peer addresses.


### PR DESCRIPTION
## Summary

`examples/paxos-standalone` exposes a tonic peer transport that feeds any deserialize-valid `Message<HighWaterCommand>` straight into `OmniPaxos::handle_incoming` with no peer-identity or membership check, and every RPC (peer + client API) is plaintext. The example is `publish = false` and documents this — but the "Authentication & TLS" note sat *below* the `cargo run` block, where a copy-paster could miss it, and `--listen`/`--tso-listen` were required args with no safe default.

- **README:** add a `> **Warning** — no authentication or encryption` callout immediately above the run instructions, stating the plaintext/no-auth exposure and the loopback-by-default posture.
- **Bind defaults:** default `--listen` and `--tso-listen` to `127.0.0.1:0`, so binding off-loopback is an explicit operator override rather than something an omitted flag can produce.

## Sibling audit (per the issue)

No change needed for the other paxos examples — neither exposes the unauthenticated peer transport:
- `paxos-piggyback` routes paxos messages in-process via `MeshSink` (no tonic peer server).
- `paxos-embedded` likewise uses an in-process `MeshSink`; its only network bind, the tsoracle API, is already hardcoded to `127.0.0.1`.

So there's no off-loopback or unauthenticated exposure to fix or to file a follow-up for.

Closes #202

## Test plan

- [x] README "Authentication & TLS" warning visible above the first `cargo run` invocation
- [x] `cargo doc --no-deps -p example-paxos-standalone` renders cleanly (no warnings)
- [x] Running node 1 with no `--listen`/`--tso-listen` binds **loopback only** — `lsof -nP -iTCP -sTCP:LISTEN` shows the process's two sockets on `127.0.0.1` (OS-assigned ports), no `0.0.0.0`/`*`
- [x] `scripts/run.sh` unaffected — it passes `--listen`/`--tso-listen` explicitly, overriding the new defaults
- [x] `cargo build`/`cargo clippy -p example-paxos-standalone` clean; pre-commit hook (workspace fmt + clippy) passed