### PR TITLE
chore(release): version crates independently to fix release-plz resolution

### DIFF
--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-client"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-consensus/Cargo.toml
+++ b/crates/tsoracle-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-consensus"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-core/Cargo.toml
+++ b/crates/tsoracle-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-core"
 description  = "Sync algorithm core for tsoracle: window allocator, 46/18-bit timestamp packing, monotonicity invariants."
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-driver-file/Cargo.toml
+++ b/crates/tsoracle-driver-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-driver-file"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-driver-openraft"
 description  = "openraft-backed ConsensusDriver for tsoracle"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-driver-paxos/Cargo.toml
+++ b/crates/tsoracle-driver-paxos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-driver-paxos"
 description  = "OmniPaxos-backed ConsensusDriver for tsoracle"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-openraft-toolkit/Cargo.toml
+++ b/crates/tsoracle-openraft-toolkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-openraft-toolkit"
 description  = "Reusable openraft glue: TypeConfig macro, RocksDB log store, lifecycle helpers"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-paxos-toolkit"
 description  = "Reusable OmniPaxos glue: RocksDB storage, lifecycle helpers, test fakes"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-proto/Cargo.toml
+++ b/crates/tsoracle-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-proto"
 description  = "Generated protobuf/gRPC wire types for the timestamp oracle."
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-server"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-yieldpoint/Cargo.toml
+++ b/crates/tsoracle-yieldpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-yieldpoint"
 description  = "Async yield points: tokio::sync::Notify-backed test injection sites, the async sibling of fail-rs failpoints"
-version.workspace      = true
+version      = "0.1.4"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Problem

The `release-plz PR` job fails with `failed to select a version for the requirement tsoracle-yieldpoint = "^0.1.4" ... candidate versions found which didn't match: 0.2.0`, aborting the release PR ([example run](https://github.com/prisma-risk/tsoracle/actions/runs/26342019244/job/77545613361)).

## Root cause

Three things collide: shared workspace versioning (`version.workspace = true`), the breaking `fix(core)!` (#221) bump that moves the shared version to `0.2.0`, and caret-locked internal pins (`^0.1.x`). release-plz only rewrites the internal version requirements of crates it actually releases; it leaves unchanged leaf crates (`tsoracle-yieldpoint`, `tsoracle-openraft-toolkit`) out of the release set, so their inbound `^0.1.x` pins are never rewritten — yet inheritance still drags those crates to `0.2.0`. Pre-1.0 a minor bump is a breaking bump, so `^0.1.x` cannot span `0.2.0` and `cargo update` fails.

## Fix

Version the 12 publishable crates independently (drop `version.workspace = true`). Unchanged crates keep their version so their inbound pins keep resolving, while release-plz bumps and rewrites pins only for the crates that changed. This is release-plz's native versioning model. Non-published members (examples, benchmarks, `tsoracle-tests`) keep inheriting `[workspace.package].version` and are unaffected.

## Verification

Reproduced and validated locally with release-plz 0.3.158: `release-plz update` resolves cleanly (no `cargo update` failure, `Cargo.lock` updates, inbound pins rewritten correctly), and `cargo metadata` parses the workspace. This release produces:

- `0.2.0`: tsoracle-proto, tsoracle-core, tsoracle-server, tsoracle-client, tsoracle-driver-openraft, tsoracle-driver-paxos, tsoracle-paxos-toolkit
- `0.1.5`: tsoracle-consensus, tsoracle-driver-file, tsoracle (bin)
- `0.1.4`: tsoracle-openraft-toolkit, tsoracle-yieldpoint

## Note

Crate versions are **no longer uniform** across the workspace — each version now reflects that crate's actual change magnitude. Anyone assuming all `tsoracle-*` crates share a single version should be aware this no longer holds. Committed as `chore(release):` so it doesn't itself trigger spurious leaf-crate bumps; the existing breaking commit already drives the `0.2.0` release once this lands and the release PR (#195) re-runs.
