### PR TITLE
fix(server): require test-fakes for fence_yieldpoint integration test

### DIFF
--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -80,3 +80,7 @@ required-features = ["test-fakes"]
 [[test]]
 name = "metrics"
 required-features = ["test-support", "metrics"]
+
+[[test]]
+name = "fence_yieldpoint"
+required-features = ["yieldpoints", "test-fakes"]


### PR DESCRIPTION
## Problem

The `fence_yieldpoint` integration test (`crates/tsoracle-server/tests/fence_yieldpoint.rs`) is cfg-gated only on the `yieldpoints` feature, but it imports `test_fakes::InMemoryDriver` and calls `Server::run_leader_watch_for_tests()` — both exported only under `#[cfg(any(test, feature = "test-fakes"))]`.

Integration tests compile the library as an ordinary dependency, so the library's own `cfg(test)` does **not** expose those items to the test. With no `[[test]]` entry declaring the required features, the documented per-crate command fails to compile:

```
cargo test -p tsoracle-server --features yieldpoints
# error[E0432]: unresolved import `tsoracle_server::test_fakes`
# error[E0599]: no method named `run_leader_watch_for_tests` ...
```

The all-features CI path enables `test-fakes`, which masks the gap.

## Fix

Add a `[[test]]` target declaring `required-features = ["yieldpoints", "test-fakes"]`, matching the convention already used by the other server integration tests (`leader_watch`, `serve_shutdown`, etc.). Cargo now **skips** the target when the feature set is insufficient instead of failing to build.

## Verification

- `cargo test -p tsoracle-server --features yieldpoints` — finishes cleanly, no compile errors (target skipped).
- `cargo test -p tsoracle-server --features yieldpoints,test-fakes --test fence_yieldpoint` — compiles and `1 passed; 0 failed`.

Originally surfaced as a build/test feature-gating defect (informational, no security impact).