### PR TITLE
test(paxos-toolkit): gate test-fakes integration tests behind required-features

### DIFF
--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -50,3 +50,33 @@ tokio              = { workspace = true, features = ["macros", "rt-multi-thread"
 name              = "failpoints"
 path              = "tests/failpoints.rs"
 required-features = ["failpoints", "rocksdb-storage"]
+
+[[test]]
+name              = "_smoke"
+path              = "tests/_smoke.rs"
+required-features = ["test-fakes"]
+
+[[test]]
+name              = "lifecycle"
+path              = "tests/lifecycle.rs"
+required-features = ["test-fakes"]
+
+[[test]]
+name              = "macro_smoke"
+path              = "tests/macro_smoke.rs"
+required-features = ["test-fakes"]
+
+[[test]]
+name              = "mem_network_negative"
+path              = "tests/mem_network_negative.rs"
+required-features = ["test-fakes"]
+
+[[test]]
+name              = "mem_network_smoke"
+path              = "tests/mem_network_smoke.rs"
+required-features = ["test-fakes"]
+
+[[test]]
+name              = "storage_conformance"
+path              = "tests/storage_conformance.rs"
+required-features = ["test-fakes", "rocksdb-storage"]


### PR DESCRIPTION
## Problem

`cargo test -p tsoracle-paxos-toolkit` with default features fails to compile. The default feature set is `["rocksdb-storage"]`, leaving `test-fakes` optional, but several integration tests import symbols re-exported only under `#[cfg(feature = "test-fakes")]`:

- `_smoke` — `common::build_mem_cluster`
- `lifecycle`, `mem_network_smoke`, `mem_network_negative` — `test_fakes::mem_network::MemNetwork` and the gated `common` mem helpers
- `macro_smoke` — gated mem helpers
- `storage_conformance` — `test_fakes::mem_storage::MemStorage`

None of these declared `required-features`, so the default build tried to compile them without those symbols and errored (`E0425`/`E0432`/`E0433`). Only `failpoints` had a `required-features` entry. CI never caught it because every CI job runs with `--all-features`, which enables `test-fakes`.

## Fix

Add per-test `required-features` declarations in `crates/tsoracle-paxos-toolkit/Cargo.toml`, mirroring the existing `failpoints` entry:

- `_smoke`, `lifecycle`, `macro_smoke`, `mem_network_negative`, `mem_network_smoke` → `["test-fakes"]`
- `storage_conformance` → `["test-fakes", "rocksdb-storage"]` (it constructs both `MemStorage` and `RocksdbStorage`)

With `required-features`, the default build now skips these tests instead of failing to compile them; `--all-features` builds and runs them as before. `storage_basic` is intentionally left untouched — it depends only on the default `rocksdb-storage` feature and was never broken.

## Verification

- `cargo test -p tsoracle-paxos-toolkit --no-run` (default features): previously 7 compile errors, now builds clean (gated tests skipped).
- `cargo test -p tsoracle-paxos-toolkit --all-features`: all test targets build and pass.