### PR TITLE
fix(driver-paxos): mint a fresh apply-shutdown Notify per start

### DIFF
--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -50,7 +50,18 @@ where
     apply_state: ApplyState,
     leader_stream: Mutex<Option<LeaderEventStream>>,
     apply_handle: Mutex<Option<JoinHandle<()>>>,
-    apply_shutdown: Arc<Notify>,
+    /// Shutdown handle for the *currently running* apply task, installed by
+    /// `start` and taken by `stop`. `None` whenever no apply task is live.
+    ///
+    /// Each `start` mints a fresh `Notify` rather than reusing one across the
+    /// host's lifetime. `stop` signals shutdown with `notify_one`, which
+    /// stores a permit when no task is parked on `notified()`; a reused
+    /// `Notify` would carry such a stale permit into the next `start`, where
+    /// the newly spawned apply task would consume it and exit immediately. A
+    /// per-`start` `Notify` confines every permit to the task it was minted
+    /// for, and the `Option` lets `stop` skip signalling entirely when no
+    /// task is running (stop-before-start, double-stop, stop-after-exit).
+    apply_shutdown: Mutex<Option<Arc<Notify>>>,
     policy: Arc<Mutex<SnapshotPolicy>>,
 }
 
@@ -101,7 +112,7 @@ where
             apply_state,
             leader_stream: Mutex::new(leader_stream),
             apply_handle: Mutex::new(None),
-            apply_shutdown: Arc::new(Notify::new()),
+            apply_shutdown: Mutex::new(None),
             policy: Arc::new(Mutex::new(policy)),
         }
     }
@@ -138,7 +149,11 @@ where
         let apply_notify = self.runner.apply_notify();
         let apply_state = self.apply_state.clone();
         let policy = self.policy.clone();
-        let shutdown = self.apply_shutdown.clone();
+        // Mint a fresh shutdown Notify for this apply task and publish it for
+        // stop(). A per-start Notify cannot carry a stale permit from an
+        // earlier stop() into this task's select! loop.
+        let shutdown = Arc::new(Notify::new());
+        *self.apply_shutdown.lock() = Some(shutdown.clone());
 
         let handle = tokio::spawn(async move {
             let mut cursor: u64 = 0;
@@ -169,10 +184,16 @@ where
     /// apply task. Surfaces a `tracing::warn!` if the apply task
     /// terminated abnormally.
     pub async fn stop(&mut self) {
-        // notify_one stores a permit; notify_waiters would be lost if the
-        // apply task is mid-drain when stop() fires, livelocking against
-        // the runner's per-tick apply_notify.
-        self.apply_shutdown.notify_one();
+        // Signal only the apply task that start() installed. notify_one (not
+        // notify_waiters) is required because the apply task may be mid-drain
+        // rather than parked on notified() when stop() fires; the stored
+        // permit is consumed on its next select! turn instead of being lost
+        // and livelocking against the runner's per-tick apply_notify. Taking
+        // the Option means a stop() with no running task signals nothing, so
+        // no permit can survive to poison a later start().
+        if let Some(shutdown) = self.apply_shutdown.lock().take() {
+            shutdown.notify_one();
+        }
         let handle = self.apply_handle.lock().take();
         if let Some(handle) = handle {
             if let Err(err) = handle.await {

--- a/crates/tsoracle-driver-paxos/tests/standalone_stale_permit.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_stale_permit.rs
@@ -1,0 +1,88 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Regression: a `StandaloneHost::stop` that fires while no apply task is
+//! waiting must not poison the apply task spawned by a later `start`.
+//!
+//! `stop` signals shutdown with `Notify::notify_one`, which stores a permit
+//! when no task is currently parked on `notified()`. If that permit lives on
+//! a single host-lifetime `Notify`, a `stop` with no running apply task
+//! (stop-before-start, double-stop, or stop after the task already exited)
+//! leaves a stale permit behind. The next `start` then spawns an apply task
+//! that consumes the permit on its first `select!` turn and breaks out of the
+//! loop immediately — so decided entries are never drained into the in-memory
+//! high-water, and reads that wait on the apply notifier hang forever.
+
+use tsoracle_driver_paxos::HighWaterCommand;
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stop_before_start_does_not_poison_apply_task() {
+    let mut cluster = common::build_mem_cluster(3);
+
+    // Poison every host: call stop() before it has ever started. No apply
+    // task is waiting, so under the bug each host's reused shutdown Notify
+    // now holds a stored permit. The runner's stop() is a no-op here (it has
+    // not been started), so this only exercises the apply-shutdown path.
+    for node in &mut cluster.nodes {
+        node.host.as_mut().expect("host present").stop().await;
+    }
+
+    cluster.start_all();
+    cluster
+        .drive_until(common::some_leader_elected(), 1_000)
+        .await;
+    let leader_id = cluster.leader();
+
+    // Append directly on the leader's handle; the apply task is the only
+    // thing that folds the decided entry into the in-memory high-water.
+    cluster
+        .node(leader_id)
+        .omnipaxos()
+        .lock()
+        .append(HighWaterCommand::Advance { at_least: 25 })
+        .expect("append succeeds on leader");
+
+    cluster
+        .drive_until(common::all_decided_at_least(1), 1_000)
+        .await;
+
+    // Consensus decides the Advance regardless of the apply task, so the
+    // poison is invisible until here: a live apply task must drain the
+    // decided entry into every node's high-water. Under the bug the apply
+    // tasks exited on the stale permit, this never becomes true, and
+    // drive_until panics.
+    cluster
+        .drive_until(
+            |state| {
+                state
+                    .nodes
+                    .iter()
+                    .all(|node| state.high_water_on(node.node_id) >= 25)
+            },
+            1_000,
+        )
+        .await;
+
+    for node in &cluster.nodes {
+        assert_eq!(
+            cluster.high_water_on(node.node_id),
+            25,
+            "node {} converged to high-water 25 after a pre-start stop()",
+            node.node_id
+        );
+    }
+
+    cluster.stop_all().await;
+}


### PR DESCRIPTION
## Problem

`StandaloneHost` reused a single `Arc<Notify>` for apply-task shutdown across its entire lifetime, and `stop()` signalled it with `notify_one()`. `notify_one` **stores a permit** when no task is parked on `notified()`. So a `stop()` called with no running apply task — stop-before-start, double-stop, or stop after the apply task already exited — left a stale permit on the shared `Notify`.

The next `start()` cloned that same `Notify` into a freshly spawned apply task, whose `tokio::select!` consumed the stale permit on its first poll and `break`ed out of the loop immediately. The `PaxosRunner` then ran normally and kept deciding entries, but with **no apply task to drain them** the in-memory high-water never advanced. `current_high_water()` and `submit_advance()` wait in a loop on the apply notifier, so they hung indefinitely.

This is a latent lifecycle/availability bug (not remotely triggerable — the affected APIs are embedder lifecycle calls, and the default CLI uses `FileDriver`), surfaced by a security-scan finding and confirmed against the code.

## Fix

Mint a **fresh `Notify` in each `start()`** and publish it to `stop()` through an `Option`:

- `apply_shutdown: Arc<Notify>` → `Mutex<Option<Arc<Notify>>>`
- `start()` creates `Arc::new(Notify::new())` and stores a clone
- `stop()` only signals when a handle is present: `if let Some(shutdown) = …take() { shutdown.notify_one() }`

A per-`start` `Notify` confines every permit to the task it was minted for, so no signal can cross a `start` boundary. Taking the `Option` means a `stop()` with no live task signals nothing. This covers all three poison paths (and the apply-task-panicked case a `stop`-only guard would miss) while preserving the deliberate `notify_one`-over-`notify_waiters` choice that handles a `stop()` firing mid-drain — pinned by the existing `standalone_shutdown.rs` regression test.

## Tests

- New regression test `standalone_stale_permit.rs`: poisons each host with a pre-`start` `stop()`, then asserts a decided `Advance` still folds into every node's high-water. Fails before the fix (apply tasks exit on the stale permit; high-water stays 0), passes after.
- Written test-first: confirmed RED (got past leader election + `decided_idx`, failed only on the high-water fold), then GREEN.
- Full `cargo test -p tsoracle-driver-paxos --all-features` green; `clippy --all-features --all-targets` and `cargo fmt --check` clean. The existing mid-iteration shutdown regression still passes.