### PR TITLE
fix(server): retry fence transient errors while racing the leadership stream (#229)

### DIFF
--- a/crates/tsoracle-server/src/docs/operations.md
+++ b/crates/tsoracle-server/src/docs/operations.md
@@ -31,6 +31,7 @@ The server emits the following signals through the [`metrics`](https://docs.rs/m
 - `tsoracle.window.extension_latency` — duration of persist_high_water (histogram, seconds)
 - `tsoracle.leader_transition.total` — leader-watch saw a state change (counter)
 - `tsoracle.leader_transition.fence_latency` — duration of the failover fence (histogram, seconds)
+- `tsoracle.leader_transition.fence_transient_retries.total` — fence retried a transient consensus error during failover (counter)
 - `tsoracle.not_leader.total` — RPCs rejected with `NOT_LEADER` (counter)
 
 The library is exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the [`Server`]. The example below wires Prometheus over an HTTP listener:

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -30,23 +30,56 @@ use tsoracle_consensus::{ConsensusError, LeaderState};
 
 use crate::server::{Server, ServerError, ServingState};
 
-/// Bounded retry budget for a fence that hits a recoverable (`TransientDriver`)
-/// consensus error in the volatile post-election window. After this many
-/// retries the fence stops trying for the current leadership event, steps down
-/// to `NotServing`, and awaits the next event rather than tearing the server
-/// down. Backoff grows exponentially from `FENCE_RETRY_BASE`, capped at
-/// `FENCE_RETRY_CAP`; the default budget spans well under two seconds — enough
-/// to ride out a failover flap without masking a sustained outage.
-const FENCE_MAX_TRANSIENT_RETRIES: u32 = 8;
+// Fence retry tuning for the volatile post-election window. When a fence hits
+// `TransientDriver`, the retry loop does NOT give up: a still-elected leader
+// has no fresh leadership event coming to re-drive it, so abandoning the fence
+// would strand the node `NotServing` indefinitely. Instead the loop retries
+// with capped exponential backoff and, on every backoff, concurrently watches
+// the leadership stream — so a genuine leadership change (which some drivers,
+// e.g. the paxos host, report as `TransientDriver` rather than `NotLeader`) is
+// observed and dispatched instead of spun past. The loop exits only on success,
+// a `NotLeader`/`Fenced` classification, a permanent fault, or an observed
+// leadership transition. Backoff grows exponentially from `FENCE_RETRY_BASE`,
+// capped at `FENCE_RETRY_CAP`.
 const FENCE_RETRY_BASE: Duration = Duration::from_millis(25);
 const FENCE_RETRY_CAP: Duration = Duration::from_millis(250);
 
+// Rate-limiting for the "fence still stuck" warning (tracing only): warn once
+// when retries first reach WARN_AFTER, then again every WARN_INTERVAL retries
+// (~5s of stuck time at FENCE_RETRY_CAP). Gated with the warn so they don't
+// read as dead code when `tracing` is disabled.
+#[cfg(feature = "tracing")]
+const FENCE_TRANSIENT_RETRY_WARN_AFTER: u32 = 8;
+#[cfg(feature = "tracing")]
+const FENCE_TRANSIENT_RETRY_WARN_INTERVAL: u32 = 20;
+
+/// Whether the stuck-fence warning should fire at this retry count: once at
+/// `FENCE_TRANSIENT_RETRY_WARN_AFTER`, then every `FENCE_TRANSIENT_RETRY_WARN_INTERVAL`
+/// retries after that. The `>=` guards the subtraction against underflow.
+#[cfg(feature = "tracing")]
+fn warn_on_stuck_fence(transient_retries: u32) -> bool {
+    transient_retries >= FENCE_TRANSIENT_RETRY_WARN_AFTER
+        && (transient_retries - FENCE_TRANSIENT_RETRY_WARN_AFTER)
+            % FENCE_TRANSIENT_RETRY_WARN_INTERVAL
+            == 0
+}
+
 pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerError> {
     let mut stream = server.consensus.leadership_events();
-    while let Some(evt) = stream.next().await {
-        // Every state change (Leader, Follower, Unknown) counts as a
-        // transition observed from the driver: the total counter answers
-        // "how often is leadership churning".
+    // A leadership event observed while a fence is mid-retry is stashed here and
+    // dispatched on the next iteration instead of being awaited fresh.
+    let mut pending: Option<LeaderState> = None;
+    loop {
+        let evt = match pending.take() {
+            Some(evt) => evt,
+            None => match stream.next().await {
+                Some(evt) => evt,
+                None => break,
+            },
+        };
+        // Every state change (Leader, Follower, Unknown) counts as a transition
+        // observed from the driver: the total counter answers "how often is
+        // leadership churning".
         #[cfg(feature = "metrics")]
         metrics::counter!("tsoracle.leader_transition.total").increment(1);
         match evt {
@@ -57,40 +90,34 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                 #[cfg(feature = "metrics")]
                 let fence_started_at = std::time::Instant::now();
 
-                // Clear serving so new GetTs requests return NOT_LEADER until
-                // the fence republishes Serving below.
+                // Clear serving so new GetTs requests return NOT_LEADER until the
+                // fence republishes Serving below.
                 let _ = server.state_tx.send(ServingState::NotServing {
                     leader_endpoint: None,
                     leader_epoch: None,
                 });
                 server.allocator.lock().on_leadership_lost();
 
-                // Fence with bounded retry. A consensus error here is not
-                // automatically fatal: the post-election window is volatile and
-                // `ConsensusError` already separates the recoverable classes
-                // from the permanent ones. We honor that split instead of
-                // tearing the whole server down on the first hiccup:
+                // Fence with retry. A consensus error here is not automatically
+                // fatal: the post-election window is volatile and `ConsensusError`
+                // separates the recoverable classes from the permanent ones.
                 //
-                //   * TransientDriver — momentary quorum loss / transport flap
-                //     while this node is still the elected leader. Retry with
-                //     backoff; no fresh leadership event is coming to re-drive
-                //     us.
-                //   * NotLeader / Fenced — leadership moved under us. Step down
-                //     to NotServing and continue the watch loop; the stream
-                //     will deliver the new state (and another Leader event if
-                //     we re-win).
+                //   * TransientDriver — momentary quorum loss / transport flap.
+                //     Retry with backoff, racing the leadership stream so a real
+                //     leadership change is observed even if the driver keeps
+                //     classifying it as transient.
+                //   * NotLeader / Fenced — leadership moved under us. Step down to
+                //     NotServing and continue the watch loop.
                 //   * anything else (PermanentDriver, allocator invariant) —
-                //     fatal: propagate so `into_router` poisons serving state
-                //     and stops serving.
+                //     fatal: propagate so `into_router` poisons serving state.
                 //
-                // Serving stays NotServing until an attempt fully succeeds, so
-                // the invariant "never publish Serving at a stale epoch" holds
-                // on every path.
+                // Serving stays NotServing until an attempt fully succeeds, so the
+                // invariant "never publish Serving at a stale epoch" holds.
                 let mut transient_retries: u32 = 0;
                 loop {
-                    // One fence attempt. `?` short-circuits to `attempt`
-                    // (the async block's output), NOT out of run_leader_watch,
-                    // so the error can be classified below.
+                    // One fence attempt. `?` short-circuits to `attempt` (the async
+                    // block's output), NOT out of run_leader_watch, so the error
+                    // can be classified below.
                     let attempt: Result<(), ServerError> = async {
                         // Drain in-flight extensions from the prior epoch.
                         let drain_guard = server.extension_gate.write().await;
@@ -161,9 +188,9 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                                 .record(fence_started_at.elapsed().as_secs_f64());
                             break;
                         }
-                        // Leadership moved under us. Already NotServing; await
-                        // the next leadership event rather than retrying a
-                        // persist that can only keep failing at this epoch.
+                        // Leadership moved under us. Already NotServing; await the
+                        // next leadership event rather than retrying a persist that
+                        // can only keep failing at this epoch.
                         Err(ServerError::Consensus(
                             ConsensusError::NotLeader { .. } | ConsensusError::Fenced { .. },
                         )) => {
@@ -173,31 +200,41 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                             });
                             break;
                         }
-                        // Recoverable driver hiccup; retry while still leader.
+                        // Recoverable driver hiccup. Retry, but race the backoff
+                        // against the leadership stream so a genuine transition is
+                        // observed instead of spun past.
                         Err(ServerError::Consensus(ConsensusError::TransientDriver(_source))) => {
                             transient_retries += 1;
-                            if transient_retries > FENCE_MAX_TRANSIENT_RETRIES {
-                                // Budget exhausted: stay up, NotServing, and
-                                // await the next leadership event rather than
-                                // tearing down a still-elected leader.
-                                #[cfg(feature = "tracing")]
+                            #[cfg(feature = "metrics")]
+                            metrics::counter!(
+                                "tsoracle.leader_transition.fence_transient_retries.total"
+                            )
+                            .increment(1);
+                            #[cfg(feature = "tracing")]
+                            if warn_on_stuck_fence(transient_retries) {
                                 tracing::warn!(
                                     error = %_source,
                                     retries = transient_retries,
-                                    "fence exhausted transient retries; awaiting next leadership event"
+                                    "fence still retrying a transient consensus error; serving is paused while this node remains leader"
                                 );
-                                let _ = server.state_tx.send(ServingState::NotServing {
-                                    leader_endpoint: None,
-                                    leader_epoch: None,
-                                });
-                                break;
                             }
                             let backoff = core::cmp::min(
                                 FENCE_RETRY_BASE
                                     .saturating_mul(1u32 << (transient_retries - 1).min(16)),
                                 FENCE_RETRY_CAP,
                             );
-                            tokio::time::sleep(backoff).await;
+                            tokio::select! {
+                                _ = tokio::time::sleep(backoff) => {}
+                                next = stream.next() => {
+                                    match next {
+                                        Some(evt) => {
+                                            pending = Some(evt);
+                                            break;
+                                        }
+                                        None => return Err(ServerError::WatchStreamClosed),
+                                    }
+                                }
+                            }
                         }
                         // Permanent fault or allocator invariant: fail fast so
                         // into_router poisons serving state and stops serving.

--- a/crates/tsoracle-server/tests/leadership_churn.rs
+++ b/crates/tsoracle-server/tests/leadership_churn.rs
@@ -34,9 +34,10 @@ use std::time::Duration;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::{Epoch, testing::MockClock};
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
-use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_fakes::{FaultKind, FaultyDriver, InMemoryDriver};
 use tsoracle_server::test_support::{
-    BootedServer, boot_server, wait_for_grpc_handshake, wait_until_not_serving, wait_until_serving,
+    BootedServer, boot_server, wait_for_grpc_handshake, wait_until, wait_until_not_serving,
+    wait_until_serving,
 };
 use tsoracle_server::{Server, ServerError, ServingState};
 
@@ -118,6 +119,55 @@ impl ConsensusDriver for FaultyLoadDriver {
     }
 
     async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        self.inner.persist_high_water(at_least, epoch).await
+    }
+}
+
+/// Returns `TransientDriver` from every `persist_high_water` call while the
+/// latch is set, modelling a driver (e.g. the paxos host) that reports
+/// leadership loss as a transient append failure rather than `NotLeader`.
+/// Leadership events and `load_high_water` delegate to the inner driver.
+struct LatchingTransientDriver {
+    inner: Arc<InMemoryDriver>,
+    fail_persists: AtomicBool,
+    persist_calls: AtomicUsize,
+}
+
+impl LatchingTransientDriver {
+    fn new(inner: Arc<InMemoryDriver>) -> Self {
+        Self {
+            inner,
+            fail_persists: AtomicBool::new(true),
+            persist_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn clear_faults(&self) {
+        self.fail_persists.store(false, Ordering::SeqCst);
+    }
+
+    fn persist_call_count(&self) -> usize {
+        self.persist_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsensusDriver for LatchingTransientDriver {
+    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        self.inner.leadership_events()
+    }
+
+    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
+        self.inner.load_high_water().await
+    }
+
+    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        self.persist_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_persists.load(Ordering::SeqCst) {
+            return Err(ConsensusError::TransientDriver(Box::new(
+                std::io::Error::other("latched transient persist fault"),
+            )));
+        }
         self.inner.persist_high_water(at_least, epoch).await
     }
 }
@@ -329,4 +379,112 @@ async fn serve_with_shutdown_exits_when_watch_returns_error() {
         matches!(*state_rx.borrow(), ServingState::NotServing { .. }),
         "state must be poisoned to NotServing when watch terminates"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fence_recovers_after_transient_burst_exceeding_old_budget() {
+    // 10 transient persist faults is past the historical bound of 8. The fence
+    // must keep retrying — on a node that never stops being leader — until the
+    // 11th persist succeeds and the server reaches Serving. No leadership
+    // transition is ever emitted, so recovery proves the retry loop does not
+    // give up while still leader.
+    let driver = Arc::new(FaultyDriver::new());
+    driver.fail_next_persists(10, FaultKind::Transient);
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .clock(Arc::new(MockClock::new(1_000)))
+        .build()
+        .unwrap();
+    let mut booted = boot_server(server).await;
+
+    driver.become_leader(Epoch(1));
+
+    tokio::time::timeout(
+        Duration::from_secs(15),
+        wait_until_serving(&mut booted.state_rx),
+    )
+    .await
+    .expect("fence must reach Serving despite a transient burst past the old budget");
+
+    assert_eq!(
+        driver.persist_call_count(),
+        11,
+        "expected 10 failed persists + 1 success"
+    );
+
+    booted.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fence_observes_follower_transition_during_unbounded_transient_retry() {
+    let inner = Arc::new(InMemoryDriver::new());
+    let driver = Arc::new(LatchingTransientDriver::new(inner.clone()));
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .clock(Arc::new(MockClock::new(1_000)))
+        .build()
+        .unwrap();
+    let mut booted = boot_server(server).await;
+
+    // Fence enters an effectively infinite transient-retry loop.
+    inner.become_leader(Epoch(1));
+
+    // Retries must climb well past the historical bound of 8 — proving the loop
+    // no longer gives up while still leader.
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            if driver.persist_call_count() >= 12 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("fence must keep retrying past the old budget while latched transient");
+
+    // A real leadership change arrives while the fence is mid-retry. The race
+    // against the leadership stream must observe it. The Follower handler
+    // publishes NotServing carrying the hint; the fence's own NotServing uses
+    // leader_endpoint: None, so observing Some(hint) proves the event was
+    // dispatched rather than spun past.
+    inner.become_follower(Some("10.1.2.3:50551".into()));
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        wait_until(&mut booted.state_rx, |s| {
+            matches!(
+                s,
+                ServingState::NotServing {
+                    leader_endpoint: Some(_),
+                    ..
+                }
+            )
+        }),
+    )
+    .await
+    .expect("Follower transition during retry must be observed and published with its hint");
+
+    // Once the Follower is dispatched the loop is back on stream.next(), so no
+    // further persist attempts occur.
+    let settled = driver.persist_call_count();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        driver.persist_call_count(),
+        settled,
+        "no more fence persist attempts after stepping down to Follower"
+    );
+
+    // Recovery: clear the fault and re-win leadership at a new epoch.
+    driver.clear_faults();
+    inner.become_leader(Epoch(2));
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        wait_until_serving(&mut booted.state_rx),
+    )
+    .await
+    .expect("fence must reach Serving after re-winning leadership");
+
+    booted.shutdown().await.unwrap();
 }

--- a/crates/tsoracle-server/tests/metrics.rs
+++ b/crates/tsoracle-server/tests/metrics.rs
@@ -27,7 +27,7 @@ use metrics_util::{
 use tokio::time::sleep;
 use tsoracle_core::Epoch;
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
-use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_fakes::{FaultKind, FaultyDriver};
 use tsoracle_server::test_support::{
     boot_server, wait_for_grpc_handshake, wait_until, wait_until_serving,
 };
@@ -74,10 +74,14 @@ fn histogram_sample_count(snapshot: &[RecordedMetric], name: &str) -> usize {
 async fn emits_documented_signals_end_to_end() {
     let snapshotter = install_recorder();
 
-    let driver = Arc::new(InMemoryDriver::new());
+    let driver = Arc::new(FaultyDriver::new());
+    // Two transient persist faults make the initial fence retry twice (driving
+    // the fence_transient_retries counter) before succeeding; the queue is empty
+    // by the time extend_window persists, so the rest of the scenario is intact.
+    driver.fail_next_persists(2, FaultKind::Transient);
     // Small failover_advance so sleeping past it forces a WindowExhausted
     // retry in the GetTs handler, which drives extend_window → the
-    // documented window.* signals. The InMemoryDriver's persist is in-
+    // documented window.* signals. The FaultyDriver's persist is in-
     // memory, so the latency sample we record is tiny but nonzero.
     let server = Server::builder()
         .consensus_driver(driver.clone())
@@ -161,6 +165,13 @@ async fn emits_documented_signals_end_to_end() {
     assert!(
         counter_value(&snapshot, "tsoracle.leader_transition.total") >= 2,
         "tsoracle.leader_transition.total missed at least one of Leader/Follower transitions"
+    );
+    assert!(
+        counter_value(
+            &snapshot,
+            "tsoracle.leader_transition.fence_transient_retries.total"
+        ) >= 1,
+        "tsoracle.leader_transition.fence_transient_retries.total never incremented despite injected transient faults"
     );
     assert!(
         histogram_sample_count(&snapshot, "tsoracle.leader_transition.fence_latency") >= 1,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,6 +24,7 @@ Both `tsoracle-server` and `tsoracle-client` emit signals through the [`metrics`
 - `tsoracle.window.extension_latency` — duration of persist_high_water (histogram, seconds)
 - `tsoracle.leader_transition.total` — leader-watch saw a state change (counter)
 - `tsoracle.leader_transition.fence_latency` — duration of the failover fence (histogram, seconds)
+- `tsoracle.leader_transition.fence_transient_retries.total` — fence retried a transient consensus error during failover (counter)
 - `tsoracle.not_leader.total` — RPCs rejected with `NOT_LEADER` (counter)
 
 **Client signals**


### PR DESCRIPTION
## Summary

Fixes #229. A post-election fence that exhausted its bounded `TransientDriver` retry budget (`FENCE_MAX_TRANSIENT_RETRIES = 8`) published `NotServing` and broke out of the retry loop. A node still elected leader at the same term then received no fresh leadership event — the leadership stream dedups identical `Leader { term }` projections — so it stayed `NotServing` indefinitely: a cluster-wide timestamp-allocation outage until an operator restarted the process or forced a leadership transition.

This change retries `TransientDriver` indefinitely instead, **racing each capped backoff against the leadership stream** via `tokio::select!`. That self-terminates correctly regardless of how a driver classifies its errors: when leadership genuinely moves, the event arrives on the stream and is dispatched rather than spun past. This matters because the paxos host maps not-current-leader `append` failures to `TransientDriver` with no `NotLeader` escape — a naive "retry transient forever" without watching the stream would livelock a stepped-down paxos leader. An event observed mid-retry is stashed in a `pending` slot and handled on the next watch iteration.

The fix deliberately stays off the `Err`/poisoning path, so it is orthogonal to #204.

### Observability
- New feature-gated counter `tsoracle.leader_transition.fence_transient_retries.total` (documented in both `operations.md` copies).
- A rate-limited `tracing::warn!` that fires once after 8 retries, then every 20 retries (~5s of stuck time at the 250ms cap), so a sustained stuck fence is loud rather than silent.

## Test Plan
- [x] `cargo test -p tsoracle-server --features test-support,metrics,tracing,yieldpoints` — all unit + integration binaries pass
- [x] `cargo clippy -p tsoracle-server --all-targets --features test-support,metrics,tracing,yieldpoints` — clean
- [x] New regression test: a transient burst past the old budget on a still-leader node recovers to `Serving` on its own (`fence_recovers_after_transient_burst_exceeding_old_budget`)
- [x] New regression test: a `Follower` transition observed mid-retry is dispatched (surfaced as `NotServing { leader_endpoint: Some(_) }`, distinct from the fence's own `None`), not spun past (`fence_observes_follower_transition_during_unbounded_transient_retry`)
- [x] Metrics end-to-end test asserts the new counter fires under injected transient faults