### PR TITLE
fix(client): stop clearing leader cache on unactionable NOT_LEADER (#236)

### DIFF
--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -190,10 +190,6 @@ impl ChannelPool {
         }
     }
 
-    pub fn clear_leader(&self) {
-        *self.leader.lock() = None;
-    }
-
     /// Returns a tonic client for `endpoint`, opening the channel on first use.
     pub async fn client(&self, endpoint: &str) -> Result<TsoServiceClient<Channel>, ClientError> {
         if let Some(channel) = self.channels.lock().get(endpoint).cloned() {
@@ -359,23 +355,6 @@ mod tests {
         );
         let order = pool.iter_round_robin();
         assert_eq!(order, vec!["a:1", "b:1", "c:1"]);
-    }
-
-    #[test]
-    fn clear_leader_drops_cached_leader() {
-        let pool = ChannelPool::new(
-            vec!["a:1".into(), "b:1".into()],
-            None,
-            false,
-            RetryPolicy::default(),
-        );
-        pool.record_success("b:1", 1);
-        assert_eq!(pool.cached_leader().as_deref(), Some("b:1"));
-        pool.clear_leader();
-        // With the cache cleared, round-robin order falls back to the
-        // configured order — the cleared leader is not re-prepended.
-        assert!(pool.cached_leader().is_none());
-        assert_eq!(pool.iter_round_robin(), vec!["a:1", "b:1"]);
     }
 
     /// Direct table-test of the epoch-monotone rule. The rule is the

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -129,7 +129,13 @@ pub(crate) async fn issue_rpc(
                 continue;
             }
             AttemptOutcome::HintRejected(status) => {
-                pool.clear_leader();
+                // A NOT_LEADER whose hint we could not act on — absent or
+                // malformed trailer, or a hinted endpoint dropped by the
+                // TLS-downgrade guard — is not evidence the cached leader is
+                // wrong, only that this peer could not redirect us. Leave the
+                // cache intact (clearing it stampedes every coalesced caller
+                // back onto a cold worklist on each flap) and advance the
+                // worklist, preserving the status to surface once exhausted.
                 last_err = Some(ClientError::Rpc(status));
                 attempt_index = attempt_index.saturating_add(1);
                 continue;
@@ -742,5 +748,88 @@ mod tests {
             AttemptOutcome::HintRejected(_) => {}
             other => panic!("expected HintRejected, got {other:?}"),
         }
+    }
+
+    /// A NOT_LEADER answer that carries no actionable hint (here: no trailer
+    /// at all → `AttemptOutcome::HintRejected`) must leave the cached leader
+    /// in place. The cached leader is not evidence-wrong just because the
+    /// contacted peer could not redirect us; clearing it stampedes every
+    /// coalesced caller back onto a cold worklist on each NOT_LEADER flap.
+    ///
+    /// Drives the real `issue_rpc` loop against a loopback fake server so the
+    /// `attempt → classify_not_leader_hint → HintRejected` path — and the
+    /// loop's reaction to it — is exercised end to end, not stubbed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hint_rejected_preserves_cached_leader() {
+        use tsoracle_proto::v1::tso_service_server::{TsoService, TsoServiceServer};
+
+        struct HintlessFollower;
+
+        #[tonic::async_trait]
+        impl TsoService for HintlessFollower {
+            async fn get_ts(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetTsRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetTsResponse>, tonic::Status>
+            {
+                // No `tsoracle-leader-hint-bin` trailer → LeaderHintLookup::Absent
+                // → AttemptOutcome::HintRejected in the retry loop.
+                Err(tonic::Status::failed_precondition("not leader"))
+            }
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let addr = listener.local_addr().expect("local_addr");
+        let incoming = tonic::transport::server::TcpIncoming::from(listener);
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(TsoServiceServer::new(HintlessFollower))
+                .serve_with_incoming(incoming)
+                .await
+                .ok();
+        });
+
+        let endpoint = format!("http://{addr}");
+        let pool = ChannelPool::new(vec![endpoint.clone()], None, false, short_policy());
+
+        // Wait until the fake server accepts and replies FAILED_PRECONDITION.
+        // The first successful connect also caches the channel in the pool, so
+        // the later `issue_rpc` reaches the RPC layer instead of racing the dial.
+        let ready_deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(mut client) = pool.client(&endpoint).await {
+                let replied_not_leader = client
+                    .get_ts(tsoracle_proto::v1::GetTsRequest { count: 1 })
+                    .await
+                    .err()
+                    .is_some_and(|status| status.code() == tonic::Code::FailedPrecondition);
+                if replied_not_leader {
+                    break;
+                }
+            }
+            assert!(
+                Instant::now() < ready_deadline,
+                "fake follower never came up",
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Seed a cached leader, as a prior successful RPC against it would.
+        pool.record_success(&endpoint, 1);
+        assert_eq!(pool.cached_leader().as_deref(), Some(endpoint.as_str()));
+
+        // The only endpoint answers NOT_LEADER without a usable hint, so the
+        // loop exhausts the worklist and surfaces the preserved status.
+        let result = issue_rpc(&pool, 1).await;
+        assert!(result.is_err(), "hintless NOT_LEADER must surface as Err");
+
+        assert_eq!(
+            pool.cached_leader().as_deref(),
+            Some(endpoint.as_str()),
+            "HintRejected (absent/malformed/TLS-rejected hint) must not \
+             invalidate the cached leader",
+        );
     }
 }

--- a/crates/tsoracle-tests/tests/client_e2e.rs
+++ b/crates/tsoracle-tests/tests/client_e2e.rs
@@ -103,9 +103,10 @@ async fn client_follows_leader_hint_on_first_call() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn client_surfaces_error_when_only_endpoint_is_a_hintless_follower() {
     // A follower with no known leader replies FailedPrecondition with an empty
-    // LeaderHint. The retry loop must clear its cached leader (the cache is
-    // now stale), exhaust the worklist, and surface the RPC error — not loop
-    // on the same dead endpoint or swallow the status.
+    // LeaderHint. With no actionable hint to follow, the retry loop exhausts
+    // the worklist and surfaces the RPC error — not loop on the same dead
+    // endpoint or swallow the status. The cached leader is left untouched: an
+    // unactionable NOT_LEADER is not evidence the cache is wrong.
     let driver = Arc::new(InMemoryDriver::new());
 
     let server = Server::builder()

--- a/docs/client-api-and-usage.md
+++ b/docs/client-api-and-usage.md
@@ -33,7 +33,7 @@ The client never asks "who's the leader" before issuing an RPC. It picks an endp
 
 - **`Ok(response)`** — the endpoint is the leader. Cache it.
 - **`Err(FAILED_PRECONDITION)` with a `tsoracle-leader-hint-bin` trailer pointing at an unvisited endpoint** — move the hinted endpoint to the front of the retry worklist and try it next.
-- **`Err(FAILED_PRECONDITION)` without a usable hint** — clear the cached leader, fall back to the next endpoint in the worklist (round-robin across configured endpoints).
+- **`Err(FAILED_PRECONDITION)` without a usable hint** — fall back to the next endpoint in the worklist (round-robin across configured endpoints). The cached leader is left in place: an unactionable NOT_LEADER (no trailer, a malformed trailer, or a hint dropped by the TLS-downgrade guard) is not evidence the cached leader is wrong, and clearing it would stampede every coalesced caller back onto a cold worklist on each flap.
 - **Any other error** — try the next endpoint in the worklist.
 
 The implementation is in `crates/tsoracle-client/src/retry.rs::issue_rpc`. The worklist starts with the cached leader (if any) followed by the configured endpoints in round-robin order; each endpoint is tried at most once per RPC. If a `FAILED_PRECONDITION` response carries a usable leader hint, that endpoint is moved to the front of the current worklist. Other gRPC statuses are recorded and the client continues through the remaining endpoints. If the worklist is exhausted without success, the last error is returned (or `ClientError::NoReachableEndpoints` if nothing was tried).


### PR DESCRIPTION
## Summary

Fixes #236.

The retry loop's `AttemptOutcome::HintRejected` arm in `crates/tsoracle-client/src/retry.rs::issue_rpc` called `pool.clear_leader()` unconditionally. But `classify_not_leader_hint` emits `HintRejected` for three **benign** cases, none of which are evidence the cached leader is wrong:

- `LeaderHintLookup::Absent` — the `FAILED_PRECONDITION` carried no `tsoracle-leader-hint-bin` trailer (the contacted peer simply can't redirect us).
- `LeaderHintLookup::Malformed` — the trailer didn't decode.
- The trailer decoded and named an endpoint, but it was dropped by the TLS-downgrade guard while the cache was still valid.

Under request coalescing, clearing the cache on every such flap forces all in-flight callers in the coalesced batch back onto a cold worklist, producing a thundering herd against every configured node on essentially every NOT_LEADER flap.

## Change

- Leave the leader cache intact in the `HintRejected` arm; the status is still preserved as `last_err` and the worklist advances (`attempt_index += 1`). The only state that should ever justify clearing — a hint that decoded, named an endpoint, was epoch-accepted, and still failed — is never produced by the current state machine.
- With its only production caller removed, `ChannelPool::clear_leader` (and its unit test) is deleted as dead code (a non-test `-D warnings` build flags it otherwise; the method lives in a private module and is not part of any public API).
- Updated the client leader-discovery docs and a now-stale integration-test comment that both described the old clear-on-NOT_LEADER behavior.

## Tests

- New `retry::tests::hint_rejected_preserves_cached_leader` drives the real `issue_rpc` loop against a loopback `TsoService` that returns `FAILED_PRECONDITION` with no trailer, seeds a cached leader, and asserts the cache survives. Written test-first: it failed on the unmodified code (`left: None` / `right: Some(endpoint)`) and passes after the fix.
- `tsoracle-client` lib tests pass; `client_e2e` integration tests pass; `clippy --all-targets` and `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets` are clean.