### PR TITLE
fix(bin): handle SIGTERM as a graceful-shutdown trigger (#245)

### DIFF
--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -140,11 +140,45 @@ async fn run_serve(args: ServeArgs) -> Result<()> {
     );
 
     server
-        .serve_with_listener(listener, async {
-            let _ = tokio::signal::ctrl_c().await;
-            tracing::info!("shutdown signal received");
-        })
+        .serve_with_listener(listener, shutdown_signal())
         .await
         .context("serve")?;
     Ok(())
+}
+
+/// Resolves when the process receives an OS request to terminate.
+///
+/// Container orchestrators (Kubernetes, `docker stop`) and systemd stop
+/// processes with SIGTERM, while an interactive Ctrl-C sends SIGINT. Both must
+/// drive tonic's graceful drain; otherwise the default SIGTERM disposition
+/// kills the process mid-flight and the supervisor SIGKILLs it after the grace
+/// period (#245). On non-unix targets only Ctrl-C is available.
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(stream) => stream,
+        Err(error) => {
+            // Installing the SIGTERM handler only fails on resource exhaustion
+            // or an invalid signal — neither expected here. Degrade to Ctrl-C
+            // rather than refuse to serve an otherwise-healthy node.
+            tracing::warn!(%error, "could not install SIGTERM handler; only Ctrl-C will trigger shutdown");
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!(signal = "SIGINT", "shutdown signal received");
+            return;
+        }
+    };
+
+    let signal_name = tokio::select! {
+        _ = tokio::signal::ctrl_c() => "SIGINT",
+        _ = sigterm.recv() => "SIGTERM",
+    };
+    tracing::info!(signal = signal_name, "shutdown signal received");
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!(signal = "SIGINT", "shutdown signal received");
 }

--- a/crates/tsoracle-bin/tests/smoke.rs
+++ b/crates/tsoracle-bin/tests/smoke.rs
@@ -101,6 +101,65 @@ async fn binary_serves_timestamps() {
     child.kill().await.unwrap();
 }
 
+/// Under Kubernetes / `docker stop` / systemd the supervisor sends SIGTERM,
+/// not SIGINT. The server must treat SIGTERM as a graceful-shutdown trigger so
+/// tonic drains in-flight requests and the process exits 0 — otherwise the
+/// default SIGTERM disposition terminates it by signal and it is SIGKILLed
+/// after the grace period (#245).
+#[cfg(unix)]
+#[tokio::test]
+async fn sigterm_triggers_graceful_shutdown() {
+    let binary_path = env!("CARGO_BIN_EXE_tsoracle");
+    let state_dir = tempdir().unwrap();
+    let listen_addr = bind_unused().await;
+
+    let mut child = Command::new(binary_path)
+        .arg("serve")
+        .arg("--listen")
+        .arg(listen_addr.to_string())
+        .arg("--state-dir")
+        .arg(state_dir.path())
+        .arg("--log")
+        .arg("warn")
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+
+    // Wait until the SIGTERM handler is live: it is registered when the
+    // shutdown future is first polled, which happens once tonic is serving —
+    // i.e. by the time the listener is accepting connections.
+    let readiness = wait_until_accepting(listen_addr, Duration::from_secs(10));
+    tokio::pin!(readiness);
+    tokio::select! {
+        result = &mut readiness => {
+            result.expect("binary did not start accepting connections");
+        }
+        child_result = child.wait() => {
+            let status = child_result.expect("wait on child failed");
+            panic!("binary exited before accepting connections: status={status}");
+        }
+    }
+
+    let pid = child.id().expect("child has a pid before exit");
+    let kill = Command::new("kill")
+        .arg("-TERM")
+        .arg(pid.to_string())
+        .status()
+        .await
+        .expect("spawn kill");
+    assert!(kill.success(), "failed to deliver SIGTERM to pid {pid}");
+
+    let status = timeout(Duration::from_secs(10), child.wait())
+        .await
+        .expect("server did not exit within the grace period after SIGTERM")
+        .expect("wait on child failed");
+
+    assert!(
+        status.success(),
+        "expected graceful exit (status 0) after SIGTERM, got {status}"
+    );
+}
+
 async fn wait_until_responsive(client: &Client, budget: Duration) -> Result<(), ClientError> {
     let deadline = Instant::now() + budget;
     let mut last_err: Option<ClientError> = None;


### PR DESCRIPTION
## Summary

Closes #245.

Shutdown was wired only to `tokio::signal::ctrl_c()` (SIGINT), so under Kubernetes, `docker stop`, or systemd the process received **SIGTERM**, never drained tonic's in-flight requests, and was SIGKILLed after the grace period.

`run_serve` now passes a dedicated `shutdown_signal()` future to `serve_with_listener`:

- On **unix**, it `select!`s over `ctrl_c()` (SIGINT) and `signal(SignalKind::terminate())` (SIGTERM); either one drives tonic's graceful drain.
- On **non-unix** targets, only Ctrl-C is available, so it waits on that alone.
- If installing the SIGTERM handler fails (resource exhaustion / invalid signal — not expected in practice), it logs a warning and degrades to Ctrl-C rather than refusing to serve an otherwise-healthy node.
- The triggering signal (`SIGINT`/`SIGTERM`) is now included in the shutdown log line.

## Test

New `#[cfg(unix)]` integration test `sigterm_triggers_graceful_shutdown` in `crates/tsoracle-bin/tests/smoke.rs`: spawns the real binary, waits until it is accepting connections (so the handler is live), sends `kill -TERM`, and asserts a graceful exit (status 0) within the grace period.

Written test-first — it failed against the old code with `got signal: 15 (SIGTERM)`, then passed after the fix.

## Verification

- `cargo test -p tsoracle --test smoke` → 2 passed
- `cargo clippy -p tsoracle --all-targets` → clean (no panic-policy lint violations)
- `cargo fmt -p tsoracle --check` → clean

## Out of scope

The `ctrl_c`-only snippets in the README / getting-started / `embedded-server` example are deliberately-minimal *library* illustrations, not the CLI binary #245 targets, so they are left unchanged.