### PR TITLE
fix(core): saturate SystemClock::now_ms instead of truncating (#249)

### DIFF
--- a/crates/tsoracle-core/src/clock.rs
+++ b/crates/tsoracle-core/src/clock.rs
@@ -27,15 +27,35 @@ pub trait Clock: Send + Sync + 'static {
 }
 
 /// Default implementation backed by `std::time::SystemTime`.
+///
+/// The conversion to `u64` milliseconds saturates at both ends rather than
+/// wrapping or panicking, so a misconfigured clock surfaces visibly instead of
+/// silently stalling window advance:
+///
+/// - A time so far in the future that the millisecond count exceeds `u64::MAX`
+///   saturates to `u64::MAX`. A bare `as u64` cast would wrap to a small value,
+///   making a far-future clock masquerade as the distant past and stall the
+///   allocator — the opposite of the truth. `u64::MAX` instead drives the
+///   allocator straight into visible window exhaustion.
+/// - A pre-Unix-epoch time saturates to `0` (the earliest representable
+///   instant). Per the module docs, a clock pinned in the past stalls new
+///   windows until wall time catches up past the persisted high-water; `0` is
+///   the faithful representation of such a clock, not a swallowed error.
 pub struct SystemClock;
 
 impl Clock for SystemClock {
     fn now_ms(&self) -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
+            .map(saturating_millis)
             .unwrap_or(0)
     }
+}
+
+/// Milliseconds in `d`, saturating to `u64::MAX` rather than truncating when
+/// the count overflows `u64`.
+fn saturating_millis(d: std::time::Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
 }
 
 #[cfg(any(test, feature = "test-clock"))]
@@ -80,6 +100,21 @@ mod tests {
         let clock = SystemClock;
         let now = clock.now_ms();
         assert!(now > 1_700_000_000_000, "current time after 2023-11");
+    }
+
+    #[test]
+    fn saturating_millis_passes_through_in_range() {
+        use std::time::Duration;
+        assert_eq!(saturating_millis(Duration::from_millis(123)), 123);
+    }
+
+    #[test]
+    fn saturating_millis_saturates_instead_of_truncating() {
+        use std::time::Duration;
+        // u64::MAX seconds is ~1000x more milliseconds than u64 can hold, so a
+        // bare `as u64` cast would wrap to a small value; saturation must pin
+        // it to u64::MAX so a far-future clock never masquerades as the past.
+        assert_eq!(saturating_millis(Duration::from_secs(u64::MAX)), u64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
Closes #249.

## Problem

`SystemClock::now_ms` converted the millisecond count with `d.as_millis() as u64`, which silently wraps the `u128` value on overflow. A clock set far enough in the future would emerge as a *small* `u64`, making the allocator perceive wall time far below the fence floor and stall window advance — with no log, metric, or error. A pre-Unix-epoch `SystemTime` similarly fell through `unwrap_or(0)`.

## Fix

- Convert with a saturating `u64::try_from(d.as_millis()).unwrap_or(u64::MAX)`, extracted into a small pure `saturating_millis` helper. A far-future clock now saturates *high*, driving the allocator into visible window exhaustion instead of masquerading as the distant past and stalling silently.
- The pre-epoch branch still maps to `0`. That is the faithful saturate-*low* value: the module already documents that a clock pinned in the past stalls new windows until wall time catches up past the persisted high-water, so `0` represents such a clock accurately rather than swallowing an error. `now_ms()` returns a bare `u64` with no error channel and sits on the performance-critical path, so the policy is documented rather than instrumented here.
- Documented the saturation behavior at both ends on `SystemClock`.

## Tests

- `saturating_millis_passes_through_in_range` — in-range durations are unchanged.
- `saturating_millis_saturates_instead_of_truncating` — `Duration::from_secs(u64::MAX)` (≈1000× more ms than `u64` holds) pins to `u64::MAX` rather than wrapping.

`cargo test -p tsoracle-core` (8 passed) and `cargo clippy -p tsoracle-core --all-targets` are clean.

## Follow-up worth considering

Surfacing a pre-epoch misconfiguration with observability (e.g. a one-time warning at clock construction) is out of scope here, since it can't be done cleanly inside the hot `now_ms()` path. Happy to file a separate issue if useful.