### PR TITLE
fix(server): carry the fencing epoch into the NOT_LEADER hint on stepdown

### DIFF
--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -194,11 +194,21 @@ impl Server {
     /// `persist_high_water`. Those in-flights will either complete cleanly
     /// (the next `try_grant` then sees `NotServing`) or fail with
     /// NotLeader/Fenced (and reach this helper themselves — it is idempotent).
-    pub(crate) fn step_down_due_to_consensus_rejection(&self, leader_endpoint: Option<String>) {
+    ///
+    /// `leader_epoch` carries the authoritative new-leader epoch when the
+    /// rejection reveals it — e.g. `ConsensusError::Fenced { current, .. }`
+    /// names the epoch that fenced us. Publishing it lets the resulting
+    /// `NotServing` hint redirect clients with an epoch to validate against;
+    /// callers with no epoch to offer (stream closure, panic) pass `None`.
+    pub(crate) fn step_down_due_to_consensus_rejection(
+        &self,
+        leader_endpoint: Option<String>,
+        leader_epoch: Option<Epoch>,
+    ) {
         self.allocator.lock().on_leadership_lost();
         let _ = self.state_tx.send(ServingState::NotServing {
             leader_endpoint,
-            leader_epoch: None,
+            leader_epoch,
         });
     }
 }
@@ -243,7 +253,7 @@ impl Server {
                     if let Err(ref _e) = result {
                         // Poison BEFORE returning so embedders who do not observe
                         // the JoinHandle still get fail-safe behavior.
-                        watch_server.step_down_due_to_consensus_rejection(None);
+                        watch_server.step_down_due_to_consensus_rejection(None, None);
                         #[cfg(feature = "tracing")]
                         tracing::error!(error = %_e, "leader-watch terminated; serving disabled");
                     }
@@ -252,7 +262,7 @@ impl Server {
                 Err(panic_payload) => {
                     // Mirror the Err branch: poison BEFORE re-raising so
                     // handle-dropping embedders still observe NotServing.
-                    watch_server.step_down_due_to_consensus_rejection(None);
+                    watch_server.step_down_due_to_consensus_rejection(None, None);
                     #[cfg(feature = "tracing")]
                     tracing::error!("leader-watch panicked; serving disabled");
                     std::panic::resume_unwind(panic_payload);

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -219,10 +219,20 @@ impl TsoServiceImpl {
             // — letting subsequent try_grant calls keep serving from a
             // fenced epoch, even briefly, is the wrong tradeoff for a TSO.
             // The step_down helper clears the allocator and publishes
-            // NotServing under the single transition API; the hint we pass
-            // back is whatever state_rx most recently knew about.
-            Err(ConsensusError::NotLeader { .. }) | Err(ConsensusError::Fenced { .. }) => {
-                self.server.step_down_due_to_consensus_rejection(None);
+            // NotServing under the single transition API; leader_hint_from
+            // then snapshots that freshly-published state for the redirect.
+            //
+            // Fenced names the epoch that fenced us as `current`; publish it
+            // so the NOT_LEADER hint carries an epoch the client can validate
+            // its next leader against. NotLeader during persist exposes no
+            // such epoch here, so its hint omits one.
+            Err(ConsensusError::Fenced { current, .. }) => {
+                self.server
+                    .step_down_due_to_consensus_rejection(None, Some(current));
+                return Err(not_leader_status(leader_hint_from(&self.server)));
+            }
+            Err(ConsensusError::NotLeader { .. }) => {
+                self.server.step_down_due_to_consensus_rejection(None, None);
                 return Err(not_leader_status(leader_hint_from(&self.server)));
             }
             // Transient driver failure: storage hiccup, peer transport flap,

--- a/crates/tsoracle-server/tests/leadership_churn.rs
+++ b/crates/tsoracle-server/tests/leadership_churn.rs
@@ -232,6 +232,10 @@ async fn extend_window_maps_not_leader_to_failed_precondition_with_hint() {
     // We did not set an endpoint, so the hint endpoint is None — but the
     // metadata itself MUST exist so clients know this is a redirectable error.
     assert!(hint.leader_endpoint.is_none());
+    // The service-layer step-down does not propagate NotLeader's `observed`
+    // epoch into the hint: the persist path that fences a stale leader returns
+    // Fenced (which does carry it), so #244 scoped epoch propagation there.
+    assert!(hint.leader_epoch.is_none());
 
     // Allocator must have been cleared (no current epoch).
     wait_until_not_serving(&mut booted.state_rx).await;
@@ -272,8 +276,18 @@ async fn extend_window_maps_fenced_to_failed_precondition_with_hint() {
         .expect_err("should fail with fenced during extension");
 
     assert_eq!(status.code(), tonic::Code::FailedPrecondition);
-    let _hint = tsoracle_server::__priv_decode_leader_hint(&status)
+    let hint = tsoracle_server::__priv_decode_leader_hint(&status)
         .expect("leader hint metadata must be present for Fenced");
+
+    // Fenced { current: Epoch(2) } names the epoch that fenced us. The hint
+    // must carry it so the client can validate its next leader against it,
+    // rather than dropping it as a bare FAILED_PRECONDITION redirect.
+    let (hi, lo) = Epoch(2).to_wire();
+    assert_eq!(
+        hint.leader_epoch,
+        Some(tsoracle_proto::v1::EpochWire { hi, lo }),
+        "Fenced hint must propagate the current (new-leader) epoch"
+    );
 
     wait_until_not_serving(&mut booted.state_rx).await;
 


### PR DESCRIPTION
Closes #244.

## Problem

When a window-extension's `persist_high_water` returned `ConsensusError::Fenced { expected, current }`, `step_down_due_to_consensus_rejection(None)` hardcoded `leader_epoch: None`. The `current` field — the authoritative epoch of the node that fenced us — was discarded, so the resulting NOT_LEADER hint carried no epoch for the client to validate its next leader against. This was the last gap in PR #234's epoch-propagation story.

## Fix

- `step_down_due_to_consensus_rejection` now takes a `leader_epoch: Option<Epoch>` and publishes it into the `NotServing` state instead of always `None`.
- The combined `NotLeader | Fenced` match arm in `service.rs` is split: the `Fenced` arm passes `Some(current)`; `leader_hint_from` then snapshots that freshly-published state, so the redirect carries the epoch.
- The two leader-watch termination callers (clean error / panic) pass `None`, since neither exposes a new-leader epoch.

## Scope

Epoch propagation is limited to the `Fenced` branch, matching the issue. This is well-founded: the paxos driver's `persist_high_water` (`driver.rs:117`) returns `Fenced` — not `NotLeader` — when fencing a stale leader, so `Fenced` is the variant that actually carries the epoch on this path. `NotLeader`'s `observed: Option<Epoch>` is left unpropagated and locked in by a test assertion.

The `fence.rs:167` branches (noted in the issue as publishing `None` "less consequentially") are out of scope here and worth a follow-up.

## Tests

- Strengthened `extend_window_maps_fenced_to_failed_precondition_with_hint` to assert the hint's `leader_epoch` equals the wire form of the injected `current` epoch.
- Added an assertion to `extend_window_maps_not_leader_to_failed_precondition_with_hint` documenting that the NotLeader hint deliberately omits an epoch.

`cargo test -p tsoracle-server --features test-support` and `cargo clippy --all-targets` both pass.