### PR TITLE
fix(driver-openraft): validate snapshot meta.last_log_id against payload.last_applied

### DIFF
--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -316,6 +316,24 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
         let payload: HighWaterStateMachineSnapshot = postcard::from_bytes(&bytes)
             .map_err(|e| io::Error::other(format!("snapshot payload decode: {e}")))?;
 
+        // `meta.last_log_id` is read back by `get_current_snapshot` while
+        // `payload.last_applied` is read back by `applied_state`. `build_snapshot`
+        // derives both from the same `last_applied`, so they always agree for an
+        // honest peer. Reject any disagreement before persisting or mutating: a
+        // mismatch would otherwise desync those two reader methods permanently
+        // and silently. Checked before `store.save` so a rejected install leaves
+        // both the store and in-memory state untouched for openraft to retry.
+        if meta.last_log_id != payload.last_applied {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "snapshot meta/payload disagree on last_log_id: \
+                     meta.last_log_id={:?}, payload.last_applied={:?}",
+                    meta.last_log_id, payload.last_applied
+                ),
+            ));
+        }
+
         let persisted = PersistedSnapshot {
             meta: meta.clone(),
             data: bytes.clone(),
@@ -679,6 +697,55 @@ mod tests {
         assert_eq!(sm2.current_value().await, 700);
         let (last, _) = sm2.applied_state().await.unwrap();
         assert_eq!(last.map(|l| l.index), Some(10));
+    }
+
+    #[tokio::test]
+    async fn install_snapshot_rejects_meta_payload_log_id_mismatch() {
+        // `meta.last_log_id` (read back by `get_current_snapshot`) and
+        // `payload.last_applied` (read back by `applied_state`) must agree —
+        // honest peers always build them from the same `last_applied`, so a
+        // disagreement signals corruption or a peer bug. Installing it anyway
+        // would silently desync the two reader methods, so the install must be
+        // rejected, leave state untouched, and persist nothing.
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        let mut sm = HighWaterStateMachine::with_store(store.clone()).expect("with_store");
+
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 123,
+            last_applied: Some(log_id(5)),
+            last_membership: StoredMem::default(),
+        };
+        let bytes = postcard::to_stdvec(&payload).expect("serialize payload");
+
+        let meta = SnapMeta {
+            last_log_id: Some(log_id(6)),
+            last_membership: payload.last_membership.clone(),
+            snapshot_id: "mismatch-1".into(),
+        };
+
+        let Err(err) = sm
+            .install_snapshot(&meta, std::io::Cursor::new(bytes))
+            .await
+        else {
+            panic!("install_snapshot must reject meta/payload last_log_id mismatch");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("last_log_id"),
+            "error should name the mismatched field: {msg}"
+        );
+
+        assert_eq!(sm.current_value().await, 0);
+        let (last, _) = sm.applied_state().await.unwrap();
+        assert_eq!(last, None);
+        assert!(
+            sm.get_current_snapshot().await.unwrap().is_none(),
+            "rejected install must not publish a current snapshot"
+        );
+        assert!(
+            store.load().expect("load").is_none(),
+            "rejected install must not persist an envelope"
+        );
     }
 
     // ---- Property tests ----


### PR DESCRIPTION
## Problem

`HighWaterStateMachine::install_snapshot` applied openraft's `meta` and the decoded snapshot payload independently. The two are consumed by *different* reader methods:

- `get_current_snapshot()` reads back `meta.last_log_id`
- `applied_state()` reads back `payload.last_applied`

`build_snapshot` derives both halves from the same `core.last_applied`, so an honest peer never produces a snapshot where they disagree. But `install_snapshot` trusted that invariant without enforcing it: if `meta.last_log_id` and `payload.last_applied` ever diverged (on-disk corruption, a buggy peer), the install would persist a desynced envelope and leave `applied_state()` and `get_current_snapshot()` reporting different log positions **permanently and silently** — exactly the kind of split identity that is very hard to debug after the fact.

Closes #261.

## Fix

Guard at the top of `install_snapshot`, right after the payload is decoded and **before** anything is persisted or mutated: if `meta.last_log_id != payload.last_applied`, return an `InvalidData` `io::Error` naming both values. Because the check precedes `store.save` and the in-memory mutation, a rejected install leaves both the store and the state machine exactly where they were, so openraft can retry cleanly.

Chosen over the `debug_assert!` alternative the issue mentioned: the desync is a production-safety hazard on a live follower, and `debug_assert!` compiles out of release builds — precisely where the loud failure is wanted. Returning an error also routes through openraft's normal install-failure/retry path rather than aborting the process.

## Testing

- New unit test `install_snapshot_rejects_meta_payload_log_id_mismatch` asserts the mismatch is rejected **and** that a rejected install mutates no state and persists no envelope (locking in the before-`save` placement).
- Existing `install_snapshot_*` tests, the `p2_snapshot_payload_round_trip` property test, and the `isolated_follower_catches_up_via_snapshot_transfer` integration test all still pass — confirming the guard never trips on an honestly-built snapshot, including over real cross-node snapshot transfer.
- `cargo fmt --check` and `cargo clippy --all-targets` clean.