### PR TITLE
fix(driver-paxos): gate submit_advance on a per-call barrier nonce (#256)

### DIFF
--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -346,23 +346,55 @@ where
     }
 
     async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
-        let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
+        // Append the Advance, then a (my_node_id, seq) barrier nonce, and
+        // wait until the apply path folds *this specific* barrier — exactly
+        // as `current_high_water` does. The barrier is appended immediately
+        // after the Advance, so a folded `Barrier { node: self, seq }`
+        // proves every earlier decided entry (this call's own Advance among
+        // them) has already been folded: the returned high-water is
+        // provably attributable to this call.
+        //
+        // A bare `new_decided > snapshot_decided && high_water() >= at_least`
+        // threshold could not make that guarantee — both halves can be
+        // satisfied by a *racing* caller's Advance before this call's own
+        // entry is applied, so the value returned would not be provably
+        // this call's. The trailing `high_water() >= at_least` guard keeps
+        // the floor postcondition (unique to `submit_advance`; a read has
+        // no floor) even in the corner where a mid-call leadership change
+        // drops this Advance while the barrier still decides under the new
+        // leader — there the floor is unmet, so we wait rather than return a
+        // sub-floor value. The outer epoch fence is the safety net that
+        // surfaces the leadership change to the caller.
         self.omnipaxos
             .lock()
             .append(HighWaterCommand::Advance { at_least })
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(AdvanceAppendError(format!("{err:?}"))))
             })?;
+        let seq = self.barrier_seq.fetch_add(1, Ordering::SeqCst) + 1;
+        self.omnipaxos
+            .lock()
+            .append(HighWaterCommand::Barrier {
+                node: self.my_node_id,
+                seq,
+            })
+            .map_err(|err| {
+                ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
+            })?;
         let notifier = self.apply_state.apply_notifier();
         tsoracle_yieldpoint::yieldpoint!(
             "standalone_host::submit_advance::after_append_before_await"
         );
         loop {
+            // Register as waiter before checking state; otherwise a
+            // notify_waiters that fires between the previous iteration's
+            // check and the next notified().await is lost.
             let notified = notifier.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            let new_decided = self.omnipaxos.lock().get_decided_idx();
-            if new_decided > snapshot_decided && self.apply_state.high_water() >= at_least {
+            if self.apply_state.applied_barrier_seq(self.my_node_id) >= seq
+                && self.apply_state.high_water() >= at_least
+            {
                 return Ok(self.apply_state.high_water());
             }
             notified.await;

--- a/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
+++ b/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
@@ -1,0 +1,102 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Regression: `submit_advance` must not return until *this call's own*
+//! proposal is provably in the decided log.
+//!
+//! The pre-fix wait was a threshold check —
+//! `new_decided > snapshot_decided && high_water() >= at_least` — which a
+//! racing caller's `Advance` can satisfy before this call's own entry is
+//! applied: both `decided_idx` moving and the floor being met can be
+//! caused by an unrelated entry, so the returned high-water was not
+//! provably attributable to this call.
+//!
+//! The fix mirrors `current_high_water`: it plants a `(my_node_id, seq)`
+//! barrier nonce immediately after the `Advance` and waits until the apply
+//! path folds *that specific* barrier. Once `submit_advance` returns, the
+//! decided log therefore contains a `Barrier` authored by this node
+//! sitting after its `Advance` — an identifiable marker the call planted
+//! and waited to commit. The pre-fix path appended no barrier at all, so
+//! this assertion fails against it.
+
+use std::time::Duration;
+
+use omnipaxos::util::LogEntry;
+use tsoracle_driver_paxos::HighWaterCommand;
+use tsoracle_driver_paxos::host::PaxosHighWaterHost;
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn submit_advance_commits_an_attributable_barrier_for_this_call() {
+    let mut cluster = common::build_mem_cluster(3);
+    cluster.start_all();
+    cluster
+        .drive_until(common::some_leader_elected(), 1_000)
+        .await;
+    let leader_id = cluster.leader();
+
+    let host_ref = cluster
+        .node(leader_id)
+        .host
+        .as_ref()
+        .expect("leader host present");
+
+    let returned = tokio::time::timeout(Duration::from_secs(5), host_ref.submit_advance(42))
+        .await
+        .expect("submit_advance must complete within 5s")
+        .expect("submit_advance must not return an error");
+    assert!(
+        returned >= 42,
+        "submit_advance must honor the requested floor (saw {returned})",
+    );
+
+    // Once submit_advance returns, the leader's decided log must contain a
+    // Barrier authored by this node, positioned after this call's
+    // Advance{at_least: 42}. That ordering is exactly the attribution
+    // guarantee: the call planted an identifiable marker right after its
+    // own Advance and only returned once that marker committed, so the
+    // returned value is provably this call's, not a racing caller's.
+    let handle = cluster.node(leader_id).omnipaxos();
+    let entries = handle
+        .lock()
+        .read_decided_suffix(0)
+        .expect("leader has a decided suffix after submit_advance returns");
+
+    let mut saw_this_calls_advance = false;
+    let mut barrier_from_this_node_after_advance = false;
+    for entry in &entries {
+        match entry {
+            LogEntry::Decided(HighWaterCommand::Advance { at_least: 42 }) => {
+                saw_this_calls_advance = true;
+            }
+            LogEntry::Decided(HighWaterCommand::Barrier { node, .. }) if *node == leader_id => {
+                if saw_this_calls_advance {
+                    barrier_from_this_node_after_advance = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        saw_this_calls_advance,
+        "this call's Advance{{42}} must be in the decided log",
+    );
+    assert!(
+        barrier_from_this_node_after_advance,
+        "a Barrier authored by this node must follow this call's Advance in the decided log",
+    );
+
+    cluster.stop_all().await;
+}


### PR DESCRIPTION
Closes #256.

## Problem

`StandaloneHost::submit_advance` waited on a threshold rather than a per-call barrier:

```rust
let new_decided = self.omnipaxos.lock().get_decided_idx();
if new_decided > snapshot_decided && self.apply_state.high_water() >= at_least {
    return Ok(self.apply_state.high_water());
}
```

Under concurrency both halves of that condition can be satisfied by a **racing caller's** `Advance` before this call's own `Advance` entry is applied: `decided_idx` moving past the snapshot and the floor being met can each be caused by an unrelated entry. The returned high-water was therefore not provably attributable to this call, and the apply-wait contract was not actually enforced — the epoch fence was the only real safety net. `current_high_water` already does this correctly with a `(node, seq)` barrier nonce.

## Fix

Mirror `current_high_water`: append a `Barrier { node: my_node_id, seq }` immediately after the `Advance` and wait until the apply path folds *that specific* barrier (`applied_barrier_seq(my_node_id) >= seq`). Because the apply task drains the decided suffix in log order, a folded barrier proves every earlier decided entry — this call's own `Advance` among them — has already been folded, so the returned value is provably this call's.

The trailing `high_water() >= at_least` guard is retained (it has no analogue in `current_high_water`, since a read has no floor). It preserves `submit_advance`'s floor postcondition in the corner where a mid-call leadership change drops this `Advance` while the barrier still decides under the new leader: there the floor is unmet, so the call waits rather than returning a sub-floor value, and the outer epoch fence surfaces the leadership change to the caller.

The barrier seq is minted from the same `barrier_seq` counter `current_high_water` uses, which is seeded at construction above this node's highest durable recovered seq — so a freshly minted seq can only be satisfied by a barrier this process actually appended, never by a stale `(self, old_seq)` replayed after restart.

## Tests

New `tests/submit_advance_attribution.rs`: after `submit_advance(42)` returns on the leader, the decided log must contain a `Barrier` authored by this node positioned *after* this call's `Advance{42}` — the direct observable of the attribution guarantee. Verified RED against the prior threshold code (it appends no barrier) and GREEN after the fix.

Full `tsoracle-driver-paxos` suite passes with and without the `yieldpoints` feature, including the existing `submit_advance` missed-notify regression and the `linearized_barrier` test. `cargo check --workspace` is clean.