### PR TITLE
fix(core): return NotLeader from try_prepare_window_extension off-leader (#251)

### DIFF
--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -229,13 +229,18 @@ impl Allocator {
     /// Returns `max(committed_high_water + 1, now_ms) + ahead_ms`. The +1 on
     /// `committed_high_water` guarantees forward progress when wall clock is
     /// behind the persisted bound (rare, but possible after a clock-step-back).
+    ///
+    /// Returns `Err(CoreError::NotLeader)` off-leader, matching every other
+    /// mutating method. A `0` sentinel here would be indistinguishable from a
+    /// legitimately prepared bound, letting a caller that skipped `is_leader()`
+    /// proceed as if preparation had succeeded.
     pub fn try_prepare_window_extension(
         &self,
         now_ms: u64,
         ahead_ms: u64,
     ) -> Result<u64, CoreError> {
         match &self.state {
-            State::NotLeader => Ok(0),
+            State::NotLeader => Err(CoreError::NotLeader),
             State::Leader {
                 committed_high_water,
                 ..
@@ -407,6 +412,17 @@ mod tests {
         assert_eq!(grant.physical_ms, 5_000);
         assert_eq!(grant.logical_start, 0);
         assert_eq!(grant.epoch, Epoch(1));
+    }
+
+    #[test]
+    fn prepare_window_extension_not_leader() {
+        // Off-leader prepare must error like every other mutating method, not
+        // return a `0` that a caller could mistake for a prepared bound.
+        let allocator = Allocator::new();
+        assert_eq!(
+            allocator.try_prepare_window_extension(1000, 3000),
+            Err(CoreError::NotLeader)
+        );
     }
 
     #[test]

--- a/crates/tsoracle-core/tests/monotonicity.rs
+++ b/crates/tsoracle-core/tests/monotonicity.rs
@@ -60,11 +60,14 @@ proptest! {
                     }
                 }
                 Op::Extend { now_ms, ahead_ms } => {
-                    let target = allocator.try_prepare_window_extension(now_ms, ahead_ms).unwrap();
-                    // Simulate the driver's monotonic-advance: the driver would
-                    // return max(stored, target). For this test we just commit target
-                    // at the allocator's current epoch (commit is no-op if NotLeader).
+                    // prepare now errors with NotLeader off-leader (matching every
+                    // other mutating method), so only attempt it on a leader. The
+                    // driver's monotonic-advance is simulated by committing target
+                    // at the allocator's current epoch.
                     if let Some(epoch) = allocator.epoch() {
+                        let target = allocator
+                            .try_prepare_window_extension(now_ms, ahead_ms)
+                            .unwrap();
                         allocator.try_commit_window_extension(target, epoch).unwrap();
                     }
                 }


### PR DESCRIPTION
Closes #251.

## Problem

Every other mutating method on `Allocator` returns `Err(CoreError::NotLeader)` for a non-leader, but `try_prepare_window_extension` returned `Ok(0)` — a value indistinguishable from a legitimately prepared bound. A caller that skipped `is_leader()` would proceed as if preparation had succeeded.

## Fix

The `NotLeader` arm now returns `Err(CoreError::NotLeader)`, restoring consistency with `try_grant` and the rest of the mutating surface.

In the server's `extend_window`, this arm was already unreachable: the allocator lock is held across both the `epoch()` pre-check and the prepare call, so an interleaving step-down cannot occur between them. Production behavior is therefore unchanged — the fix hardens the contract for any future caller that forgets to pre-check.

## Tests

- The `allocator_never_regresses` proptest was silently relying on the `Ok(0)` sentinel: it called prepare on every random `Op::Extend`, including off-leader sequences. It now gates `prepare` + `commit` behind the leader check (`if let Some(epoch) = allocator.epoch()`), which is the pre-check callers should perform anyway.
- Added `prepare_window_extension_not_leader`, mirroring the existing `try_grant_not_leader`.
- `cargo test -p tsoracle-core` (incl. proptest) and `-p tsoracle-server` pass; `cargo clippy` clean.