### PR TITLE
fix(yieldpoint): gate tokio and parking_lot behind the yieldpoints feature (#253)

### DIFF
--- a/crates/tsoracle-yieldpoint/Cargo.toml
+++ b/crates/tsoracle-yieldpoint/Cargo.toml
@@ -16,8 +16,8 @@ categories    = ["asynchronous", "development-tools::testing"]
 default     = []
 # Enables the registry + macro body. Off by default so production builds
 # carry zero overhead; `cargo test --all-features` activates it in CI.
-yieldpoints = []
+yieldpoints = ["dep:tokio", "dep:parking_lot"]
 
 [dependencies]
-parking_lot = { workspace = true }
-tokio       = { workspace = true }
+parking_lot = { workspace = true, optional = true }
+tokio       = { workspace = true, optional = true }


### PR DESCRIPTION
## Problem

`tsoracle-yieldpoint` documents a "zero overhead in production" contract: with the `yieldpoints` feature off, the `yieldpoint!` macro expands to `{}`. But `tokio` and `parking_lot` were declared as **unconditional** dependencies, so every consumer pulled the full tokio runtime into its dependency graph even when it only wanted the no-op stub. The contract held at the code level but was violated at the dependency-graph level.

Closes #253.

## Fix

Both crates are referenced only inside the feature-gated `registry` module (`#[cfg(feature = "yieldpoints")]`), so they can be made optional and activated by the feature:

```toml
yieldpoints = ["dep:tokio", "dep:parking_lot"]

parking_lot = { workspace = true, optional = true }
tokio       = { workspace = true, optional = true }
```

Using the `dep:` syntax activates the optional dependencies without leaking implicit `tokio` / `parking_lot` features on the crate's public surface.

## Verification

- **Feature off** (default): crate compiles, and `cargo tree -p tsoracle-yieldpoint` shows **neither** `tokio` nor `parking_lot` in the graph — the zero-overhead contract now holds at the dependency-graph level.
- **Feature on**: compiles, both deps reappear in the graph, doc-tests pass.
- **Consumers** (`tsoracle-server`, `tsoracle-driver-paxos`) enable this via `tsoracle-yieldpoint/yieldpoints`; that propagation transitively fires the `dep:` activations, so no consumer-side change is needed. `cargo check -p tsoracle-driver-paxos --features yieldpoints` is clean.
- `cargo check --workspace` (default features) is clean.