### PR TITLE
refactor(server): route get_ts CoreError mapping through core_status (#97)

### DIFF
--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -95,9 +95,22 @@ impl TsoService for TsoServiceImpl {
             }));
         }
 
-        // Two attempts: first one may return WindowExhausted, in which case we
-        // extend and retry once. A second WindowExhausted is a driver bug.
-        for attempt in 0..2 {
+        // At most two attempts: the first may return WindowExhausted, in which
+        // case we extend the window and retry once. Every error other than a
+        // first-attempt WindowExhausted — and NotLeader, which needs a metadata
+        // trailer core_status cannot attach — routes through the single
+        // exhaustive CoreError -> Status mapping in `core_status`, so a new
+        // variant compiles and is handled here without editing this match. A
+        // second WindowExhausted (the extension did not help — a driver bug)
+        // therefore surfaces as `core_status`'s Internal mapping.
+        //
+        // This is a divergent `loop` (no `break`, only `return`/`continue`) so
+        // it has type `!` and needs no trailing expression: the `attempt`
+        // counter bounds it to two iterations, and the second iteration's
+        // WindowExhausted falls through the guard into the `core_status` arm
+        // rather than continuing.
+        let mut attempt = 0;
+        loop {
             let outcome = {
                 let mut allocator = self.server.allocator.lock();
                 allocator.try_grant(self.server.clock.now_ms(), count)
@@ -122,27 +135,14 @@ impl TsoService for TsoServiceImpl {
                 Err(CoreError::NotLeader) => {
                     return Err(not_leader_status(leader_hint_from(&self.server)));
                 }
-                Err(CoreError::InvalidCount(c)) => {
-                    return Err(Status::invalid_argument(format!("invalid count: {c}")));
-                }
-                Err(CoreError::PhysicalMsOutOfRange(v)) => {
-                    return Err(Status::out_of_range(format!(
-                        "physical_ms {v} exceeds 46-bit timestamp field"
-                    )));
-                }
-                Err(e @ CoreError::InvalidLeadershipWindow { .. }) => {
-                    return Err(core_status(e));
-                }
                 Err(CoreError::WindowExhausted) if attempt == 0 => {
                     self.extend_window(count).await?;
+                    attempt += 1;
                     continue;
                 }
-                Err(CoreError::WindowExhausted) => {
-                    return Err(Status::internal("window still exhausted after extension"));
-                }
+                Err(other) => return Err(core_status(other)),
             }
         }
-        unreachable!("loop returns or continues exactly twice")
     }
 }
 


### PR DESCRIPTION
Closes #97.

## Problem

`get_ts`'s retry loop re-implemented the `CoreError -> Status` mapping inline for `InvalidCount`, `PhysicalMsOutOfRange`, `InvalidLeadershipWindow`, and `WindowExhausted` — duplicating `core_status`. `core_status` has an exhaustive (no-catch-all) match, so a new `CoreError` variant breaks *its* build; but `get_ts`'s inline arms were kept exhaustive only by hand, and the loop relied on a trailing `unreachable!()`.

## Change

- Collapse the inline arms into a single `Err(other) => return Err(core_status(other))`. `core_status` becomes the sole `CoreError -> Status` authority; a new variant now routes through it without editing `get_ts`.
- Keep the two arms that genuinely can't delegate:
  - `NotLeader` — must build a `LeaderHint` and attach the metadata trailer via `not_leader_status`, which `core_status` can't do.
  - `WindowExhausted if attempt == 0` — the extend-window-and-retry-once branch.
- Convert `for attempt in 0..2 { .. } unreachable!()` into a divergent `loop` with a manual `attempt` counter. With only `return`/`continue` (no `break`) the loop has type `!`, so the trailing `unreachable!()` is no longer needed — that's what lets it be removed (a `for` loop, being type `()`, always demanded a trailing expression).

## Behavior note

A second `WindowExhausted` (attempt 1 — the extension didn't help, i.e. a driver bug) previously returned the bespoke `Internal` message `"window still exhausted after extension"`. It now surfaces `core_status`'s `Internal` `"window exhausted"` — same gRPC code, less specific text, for a path that shouldn't occur in correct operation. No test depended on the old string.

## Acceptance

- [x] `unreachable!()` in `get_ts` is gone, replaced by exhaustive matching via the `core_status` catch-all.
- [x] Existing tests pass (`tsoracle-server` + `tsoracle-tests`, `--all-features`, incl. the failpoint tests that drive the `WindowExhausted` -> `extend_window` -> retry path).
- [x] A new `CoreError` variant can be added without editing `get_ts`.

## Verification

`cargo clippy --all-features` clean; full `tsoracle-server` and `tsoracle-tests` suites pass with `--all-features`.