### PR TITLE
fix(client): evict cached channel on transport-class RPC failure (#239)

### DIFF
--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -206,7 +206,22 @@ impl ChannelPool {
         accept
     }
 
-    /// Returns a tonic client for `endpoint`, opening the channel on first use.
+    /// Test-only convenience wrapper over [`Self::client_with_cell`] for the
+    /// callers that only need the client and not the cell handle. Production
+    /// code goes through `client_with_cell` so it can evict the exact channel
+    /// on a transport-class failure.
+    #[cfg(test)]
+    pub(crate) async fn client(
+        &self,
+        endpoint: &str,
+    ) -> Result<TsoServiceClient<Channel>, ClientError> {
+        self.client_with_cell(endpoint)
+            .await
+            .map(|(client, _cell)| client)
+    }
+
+    /// Returns a tonic client for `endpoint` plus the shared `OnceCell`
+    /// backing its channel, opening the channel on first use.
     ///
     /// Look up (or insert) the endpoint's shared `OnceCell` under the
     /// synchronous map lock, release the lock, then drive the dial through
@@ -216,14 +231,22 @@ impl ChannelPool {
     /// already-initialized `Channel` (itself an `Arc`-backed cheap clone).
     ///
     /// A failed dial does not stay cached: the endpoint's entry is evicted on
-    /// the error path so a stream of distinct *failing* endpoints cannot grow
-    /// the map without bound. That matters because wire-supplied leader hints
-    /// (`LeaderHint.leader_endpoint`) reach this method as arbitrary endpoint
-    /// strings, so a contacted peer handing back a fresh unparseable hint per
-    /// request would otherwise leak one uninitialized cell each time. The next
-    /// caller for the same endpoint re-inserts a fresh cell and re-dials, so
-    /// the retry semantics are unchanged — only the dead slot is reclaimed.
-    pub async fn client(&self, endpoint: &str) -> Result<TsoServiceClient<Channel>, ClientError> {
+    /// the error path (via [`Self::evict_if_current`]) so a stream of distinct
+    /// *failing* endpoints cannot grow the map without bound. That matters
+    /// because wire-supplied leader hints (`LeaderHint.leader_endpoint`) reach
+    /// this method as arbitrary endpoint strings, so a contacted peer handing
+    /// back a fresh unparseable hint per request would otherwise leak one
+    /// uninitialized cell each time. The next caller for the same endpoint
+    /// re-inserts a fresh cell and re-dials, so the retry semantics are
+    /// unchanged — only the dead slot is reclaimed.
+    ///
+    /// The returned cell handle lets the retry loop evict the *same* channel
+    /// if a later RPC over it fails with a transport error (issue #239); see
+    /// [`Self::evict_if_current`] and `crate::retry::attempt`.
+    pub(crate) async fn client_with_cell(
+        &self,
+        endpoint: &str,
+    ) -> Result<(TsoServiceClient<Channel>, Arc<OnceCell<Channel>>), ClientError> {
         let cell = {
             let mut guard = self.channels.lock();
             guard
@@ -274,23 +297,39 @@ impl ChannelPool {
                 // `OnceCell` only stores a value on a successful init, and
                 // `get_or_try_init` runs the closure at most once across every
                 // caller sharing this cell, so no concurrent caller initialized
-                // it either. Reclaim the map slot. The identity check
-                // (`Arc::ptr_eq`) ensures we only drop the entry while it still
-                // holds *this* cell: if a concurrent caller has meanwhile
-                // re-inserted a fresh cell under the same key (and may already
-                // be dialing into it), that cell is left untouched.
-                let mut guard = self.channels.lock();
-                if guard
-                    .get(endpoint)
-                    .is_some_and(|current| Arc::ptr_eq(current, &cell))
-                {
-                    guard.remove(endpoint);
-                }
+                // it either. Reclaim the map slot (the identity guard inside
+                // `evict_if_current` skips it if a concurrent caller already
+                // replaced the cell).
+                self.evict_if_current(endpoint, &cell);
                 return Err(err);
             }
         };
 
-        Ok(TsoServiceClient::new(channel.clone()))
+        Ok((TsoServiceClient::new(channel.clone()), cell))
+    }
+
+    /// Remove `endpoint`'s cached channel cell, but only while the map still
+    /// holds *this* cell. Used on two paths: a failed dial (the cell is still
+    /// uninitialized) and a transport-class RPC failure against an
+    /// already-dialed channel (issue #239 — a pod-replaced endpoint whose
+    /// cached channel and its background tonic reconnect task would otherwise
+    /// be reused indefinitely, since a static `Endpoint` resolves its address
+    /// once and never re-resolves). Eviction forces the next caller to re-dial
+    /// and re-resolve.
+    ///
+    /// The `Arc::ptr_eq` identity check ensures we only drop the entry while
+    /// it still holds the cell we were handed: if a concurrent caller has
+    /// meanwhile re-inserted a fresh cell under the same key (and may already
+    /// be dialing into it), that cell is left untouched, so a stale failure
+    /// cannot evict a freshly-redialed good channel.
+    pub(crate) fn evict_if_current(&self, endpoint: &str, cell: &Arc<OnceCell<Channel>>) {
+        let mut guard = self.channels.lock();
+        if guard
+            .get(endpoint)
+            .is_some_and(|current| Arc::ptr_eq(current, cell))
+        {
+            guard.remove(endpoint);
+        }
     }
 
     pub fn iter_round_robin(&self) -> Vec<String> {
@@ -719,6 +758,67 @@ mod tests {
             guard.len(),
             0,
             "failed dials must not be retained in the channel cache"
+        );
+    }
+
+    /// `evict_if_current` clears the endpoint's cached cell when the map
+    /// still holds *that* cell. A successful dial seats a cell; evicting it
+    /// with the same handle removes the entry, so the next caller re-dials.
+    /// This is the primitive the retry loop uses to drop a channel whose RPC
+    /// failed with a transport error.
+    #[tokio::test]
+    async fn evict_if_current_removes_the_cached_cell() {
+        let connector: Arc<crate::transport::ChannelConnector> = Arc::new(|_endpoint: &str| {
+            Box::pin(async {
+                Ok(tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy())
+            })
+        });
+        let pool = ChannelPool::new(Vec::new(), Some(connector), false, RetryPolicy::default());
+
+        let (_client, cell) = pool
+            .client_with_cell("a:1")
+            .await
+            .expect("dial against the success connector must succeed");
+        assert!(
+            pool.channels.lock().contains_key("a:1"),
+            "a successful dial must seat a cell"
+        );
+
+        pool.evict_if_current("a:1", &cell);
+        assert!(
+            !pool.channels.lock().contains_key("a:1"),
+            "evicting with the live cell must clear the entry"
+        );
+    }
+
+    /// The identity guard, mirroring the dial-failure eviction: if a
+    /// concurrent caller has replaced the endpoint's cell with a fresh one,
+    /// evicting with a *stale* handle must spare the live cell. Without it, a
+    /// transport failure observed on an old channel could evict a
+    /// freshly-redialed good channel, forcing a redundant re-dial.
+    #[tokio::test]
+    async fn evict_if_current_spares_a_replaced_cell() {
+        let connector: Arc<crate::transport::ChannelConnector> = Arc::new(|_endpoint: &str| {
+            Box::pin(async {
+                Ok(tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy())
+            })
+        });
+        let pool = ChannelPool::new(Vec::new(), Some(connector), false, RetryPolicy::default());
+
+        let (_first, cell1) = pool.client_with_cell("a:1").await.expect("first dial");
+        // Evict and re-dial so the map holds a different cell than `cell1`.
+        pool.evict_if_current("a:1", &cell1);
+        let (_second, cell2) = pool.client_with_cell("a:1").await.expect("second dial");
+        assert!(
+            !Arc::ptr_eq(&cell1, &cell2),
+            "the re-dial must seat a fresh cell"
+        );
+
+        // A stale-handle eviction must leave the live cell in place.
+        pool.evict_if_current("a:1", &cell1);
+        assert!(
+            pool.channels.lock().contains_key("a:1"),
+            "stale-cell eviction must spare the live cell"
         );
     }
 

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -46,6 +46,14 @@
 //! jittered exponential backoff. FAILED_PRECONDITION-with-hint redirects
 //! do not back off — the next endpoint is known and the redirect is
 //! part of normal discovery.
+//!
+//! A transport-class RPC failure also evicts the endpoint's cached channel
+//! ([`ChannelPool::evict_if_current`]) so the next attempt re-dials and
+//! re-resolves rather than reusing a channel pinned to a now-dead address
+//! (issue #239: a static tonic `Endpoint` resolves once and never
+//! re-resolves, so a pod-replaced endpoint would otherwise keep the dead
+//! channel and its background reconnect task forever). Application errors
+//! such as `Internal` leave the channel cached — the connection is healthy.
 
 use std::collections::{HashSet, VecDeque};
 use std::time::Duration;
@@ -56,7 +64,7 @@ use tsoracle_core::{Epoch, Timestamp};
 use crate::error::ClientError;
 use crate::leader_resolved::{ChannelPool, LeaderHintLookup, decode_leader_hint};
 use crate::response::decode_get_ts_response;
-use crate::retry_policy::{jittered_backoff, should_backoff};
+use crate::retry_policy::{is_transport_failure, jittered_backoff, should_backoff};
 
 pub(crate) async fn issue_rpc(
     pool: &ChannelPool,
@@ -211,41 +219,45 @@ async fn attempt(
     // budget — which would let one attempt run for up to `2 * budget` and
     // overrun `overall_deadline` before `max_attempts` is reached.
     let pair_deadline = Instant::now() + budget;
-    let mut client = match tokio::time::timeout(budget, pool.client(endpoint)).await {
-        Ok(Ok(client)) => client,
-        Ok(Err(err)) => {
-            #[cfg(feature = "metrics")]
-            metrics::counter!(
-                "tsoracle.client.retries.total",
-                "reason" => "connect_failure",
-            )
-            .increment(1);
-            #[cfg(feature = "tracing")]
-            tracing::debug!(
-                endpoint = %endpoint,
-                error = %err,
-                "tsoracle-client: connect failed; advancing worklist",
-            );
-            return AttemptOutcome::Err(err);
-        }
-        Err(_) => {
-            #[cfg(feature = "metrics")]
-            metrics::counter!(
-                "tsoracle.client.retries.total",
-                "reason" => "deadline_exceeded",
-            )
-            .increment(1);
-            #[cfg(feature = "tracing")]
-            tracing::debug!(
-                endpoint = %endpoint,
-                budget_ms = budget.as_millis() as u64,
-                "tsoracle-client: connect exceeded per_attempt_deadline",
-            );
-            return AttemptOutcome::Err(ClientError::Rpc(tonic::Status::deadline_exceeded(
-                format!("connect exceeded per_attempt_deadline of {budget:?}"),
-            )));
-        }
-    };
+    // Keep the channel's cell handle for the whole RPC: a transport-class
+    // failure below hands this exact cell to `evict_if_current` so the dead
+    // channel is dropped without racing a concurrent re-dial (issue #239).
+    let (mut client, cell) =
+        match tokio::time::timeout(budget, pool.client_with_cell(endpoint)).await {
+            Ok(Ok(leased)) => leased,
+            Ok(Err(err)) => {
+                #[cfg(feature = "metrics")]
+                metrics::counter!(
+                    "tsoracle.client.retries.total",
+                    "reason" => "connect_failure",
+                )
+                .increment(1);
+                #[cfg(feature = "tracing")]
+                tracing::debug!(
+                    endpoint = %endpoint,
+                    error = %err,
+                    "tsoracle-client: connect failed; advancing worklist",
+                );
+                return AttemptOutcome::Err(err);
+            }
+            Err(_) => {
+                #[cfg(feature = "metrics")]
+                metrics::counter!(
+                    "tsoracle.client.retries.total",
+                    "reason" => "deadline_exceeded",
+                )
+                .increment(1);
+                #[cfg(feature = "tracing")]
+                tracing::debug!(
+                    endpoint = %endpoint,
+                    budget_ms = budget.as_millis() as u64,
+                    "tsoracle-client: connect exceeded per_attempt_deadline",
+                );
+                return AttemptOutcome::Err(ClientError::Rpc(tonic::Status::deadline_exceeded(
+                    format!("connect exceeded per_attempt_deadline of {budget:?}"),
+                )));
+            }
+        };
     // Give `get_ts` only what the connect phase left of the pair's budget.
     // `saturating_duration_since` floors at zero, so a connect that consumed
     // the whole budget yields an immediate timeout rather than a fresh one.
@@ -278,7 +290,15 @@ async fn attempt(
                 code = ?status.code(),
                 "tsoracle-client: RPC failed; advancing worklist",
             );
-            return AttemptOutcome::Err(ClientError::Rpc(status));
+            let err = ClientError::Rpc(status);
+            // Drop the cached channel only on a transport-class failure: the
+            // connection itself looks dead (issue #239). A non-transport
+            // status (`Internal`, etc.) means the channel is healthy and the
+            // server simply returned an error, so the channel is kept.
+            if is_transport_failure(&err) {
+                pool.evict_if_current(endpoint, &cell);
+            }
+            return AttemptOutcome::Err(err);
         }
         Err(_) => {
             #[cfg(feature = "metrics")]
@@ -293,6 +313,10 @@ async fn attempt(
                 budget_ms = rpc_budget.as_millis() as u64,
                 "tsoracle-client: RPC exceeded its share of per_attempt_deadline",
             );
+            // A timed-out RPC is transport-class (`DeadlineExceeded`): the
+            // channel may be half-open and black-holing — evict so the next
+            // attempt re-dials and re-resolves the endpoint.
+            pool.evict_if_current(endpoint, &cell);
             return AttemptOutcome::Err(ClientError::Rpc(tonic::Status::deadline_exceeded(
                 format!(
                     "rpc exceeded its share of per_attempt_deadline \
@@ -424,6 +448,8 @@ fn rejects_plaintext_hint(pool: &ChannelPool, hint: &str) -> bool {
 mod tests {
     use super::*;
     use crate::RetryPolicy;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Aggressive policy used by the unit tests to keep them fast.
     /// `per_attempt_deadline` is the dominant cost — the integration
@@ -1033,6 +1059,190 @@ mod tests {
             elapsed < Duration::from_millis(450),
             "connect + get_ts must share one per_attempt_deadline (~{budget:?}); \
              took {elapsed:?} — ~2x budget means each phase got the full deadline",
+        );
+    }
+
+    /// A connector that counts its invocations and yields the channel built by
+    /// `build`. The count is the observable proxy for "did `attempt` re-dial":
+    /// an evicted channel forces a fresh `client_with_cell` cache miss (and
+    /// thus a new connector call), while a retained channel is reused without
+    /// one. Keeps the eviction tests from reaching into the pool's private
+    /// channel map.
+    fn counting_connector<F>(
+        count: Arc<AtomicUsize>,
+        build: F,
+    ) -> Arc<crate::transport::ChannelConnector>
+    where
+        F: Fn() -> tonic::transport::Channel + Send + Sync + 'static,
+    {
+        Arc::new(move |_endpoint: &str| {
+            count.fetch_add(1, Ordering::SeqCst);
+            let channel = build();
+            Box::pin(async move { Ok(channel) })
+        })
+    }
+
+    /// Issue #239: a transport-class RPC failure must evict the cached channel
+    /// so the next attempt re-dials (and re-resolves the endpoint) rather than
+    /// reusing a channel pinned to a dead address. Here a lazily-connected
+    /// channel to a closed port surfaces `Unavailable` on the first RPC; with
+    /// eviction the connector runs once per attempt (count == 2), without it
+    /// the second attempt would reuse the cached channel (count == 1).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn transport_failure_evicts_cached_channel() {
+        let connect_count = Arc::new(AtomicUsize::new(0));
+        let connector = counting_connector(connect_count.clone(), || {
+            // connect_lazy returns immediately; the first RPC over it attempts
+            // the real connect to the closed port and fails with Unavailable.
+            tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy()
+        });
+        let pool = ChannelPool::new(
+            vec!["dead:1".into()],
+            Some(connector),
+            false,
+            short_policy(),
+        );
+
+        let budget = Duration::from_millis(200);
+        let first = attempt(&pool, "dead:1", 1, budget).await;
+        assert!(
+            matches!(first, AttemptOutcome::Err(_)),
+            "a closed port must fail the RPC, got {first:?}",
+        );
+        let _second = attempt(&pool, "dead:1", 1, budget).await;
+
+        assert_eq!(
+            connect_count.load(Ordering::SeqCst),
+            2,
+            "a transport failure must evict the channel so the next attempt re-dials",
+        );
+    }
+
+    /// A non-transport application error (`Internal`) must NOT evict the
+    /// cached channel — the connection is healthy, the server merely returned
+    /// an error. The connector connects to a real server that always answers
+    /// `Internal`; the second attempt must reuse the cached channel, so the
+    /// connector runs exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn application_error_preserves_cached_channel() {
+        use tsoracle_proto::v1::tso_service_server::{TsoService, TsoServiceServer};
+
+        struct InternalServer;
+
+        #[tonic::async_trait]
+        impl TsoService for InternalServer {
+            async fn get_ts(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetTsRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetTsResponse>, tonic::Status>
+            {
+                Err(tonic::Status::internal("boom"))
+            }
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let addr = listener.local_addr().expect("local_addr");
+        let incoming = tonic::transport::server::TcpIncoming::from(listener);
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(TsoServiceServer::new(InternalServer))
+                .serve_with_incoming(incoming)
+                .await
+                .ok();
+        });
+
+        let connect_count = Arc::new(AtomicUsize::new(0));
+        let connector = counting_connector(connect_count.clone(), move || {
+            tonic::transport::Endpoint::from_shared(format!("http://{addr}"))
+                .expect("valid endpoint")
+                .connect_lazy()
+        });
+        let pool = ChannelPool::new(
+            vec!["server:1".into()],
+            Some(connector),
+            false,
+            short_policy(),
+        );
+
+        let budget = Duration::from_secs(2);
+        let first = attempt(&pool, "server:1", 1, budget).await;
+        assert!(
+            matches!(first, AttemptOutcome::Err(_)),
+            "Internal must surface as Err, got {first:?}",
+        );
+        let _second = attempt(&pool, "server:1", 1, budget).await;
+
+        assert_eq!(
+            connect_count.load(Ordering::SeqCst),
+            1,
+            "an application error must not evict the channel; it must be reused",
+        );
+    }
+
+    /// The user-selected policy evicts on timeout too: a hung RPC that exceeds
+    /// its share of the per-attempt budget surfaces `DeadlineExceeded`
+    /// (transport-class), so the channel is evicted and the next attempt
+    /// re-dials. A half-open connection to a replaced pod that black-holes
+    /// until timeout — rather than failing fast with `Unavailable` — is the
+    /// real-world case this covers.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_timeout_evicts_cached_channel() {
+        use tsoracle_proto::v1::tso_service_server::{TsoService, TsoServiceServer};
+
+        struct HangingServer;
+
+        #[tonic::async_trait]
+        impl TsoService for HangingServer {
+            async fn get_ts(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetTsRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetTsResponse>, tonic::Status>
+            {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Err(tonic::Status::internal("unreachable: should be timed out"))
+            }
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let addr = listener.local_addr().expect("local_addr");
+        let incoming = tonic::transport::server::TcpIncoming::from(listener);
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(TsoServiceServer::new(HangingServer))
+                .serve_with_incoming(incoming)
+                .await
+                .ok();
+        });
+
+        let connect_count = Arc::new(AtomicUsize::new(0));
+        let connector = counting_connector(connect_count.clone(), move || {
+            tonic::transport::Endpoint::from_shared(format!("http://{addr}"))
+                .expect("valid endpoint")
+                .connect_lazy()
+        });
+        let pool = ChannelPool::new(
+            vec!["hang:1".into()],
+            Some(connector),
+            false,
+            short_policy(),
+        );
+
+        let budget = Duration::from_millis(200);
+        let first = attempt(&pool, "hang:1", 1, budget).await;
+        assert!(
+            matches!(first, AttemptOutcome::Err(_)),
+            "a hung RPC must surface as Err, got {first:?}",
+        );
+        let _second = attempt(&pool, "hang:1", 1, budget).await;
+
+        assert_eq!(
+            connect_count.load(Ordering::SeqCst),
+            2,
+            "an RPC timeout must evict the channel so the next attempt re-dials",
         );
     }
 }

--- a/crates/tsoracle-client/src/retry_policy.rs
+++ b/crates/tsoracle-client/src/retry_policy.rs
@@ -104,14 +104,21 @@ impl Default for RetryPolicy {
     }
 }
 
-/// Decide whether to back off before the next attempt based on the
-/// last error. Returns `true` for `Unavailable` / `DeadlineExceeded`
-/// gRPC statuses, and for transport-layer errors (which are inherently
-/// "service unavailable" class — the connect itself never reached the
-/// peer). Other failures (e.g. `Internal`, `Unauthenticated`, or a
-/// user-supplied connector's own error) are treated as deterministic:
-/// the next endpoint is tried immediately without sleep.
-pub(crate) fn should_backoff(error: &crate::error::ClientError) -> bool {
+/// Classify an error as a transport-layer problem with the connection
+/// itself: the peer was unreachable (`Unavailable`), the attempt timed out
+/// (`DeadlineExceeded` — including a half-open connection that black-holes
+/// until the per-attempt deadline rather than failing fast), or the
+/// transport failed to establish (`Transport`). Deterministic failures
+/// (`Internal`, `Unauthenticated`, a user-supplied connector's own error,
+/// `DriverGone`, etc.) are not transport problems.
+///
+/// This single predicate drives two policies that happen to share the same
+/// trigger today — backing off before the next attempt
+/// ([`should_backoff`]) and evicting the cached channel after the RPC fails
+/// (`crate::retry::attempt`, issue #239). Keeping one definition means the
+/// two cannot silently drift apart; if they ever need to diverge, that must
+/// be a deliberate edit here.
+pub(crate) fn is_transport_failure(error: &crate::error::ClientError) -> bool {
     use crate::error::ClientError;
     match error {
         ClientError::Rpc(status) => matches!(
@@ -125,6 +132,16 @@ pub(crate) fn should_backoff(error: &crate::error::ClientError) -> bool {
         | ClientError::Connector(_)
         | ClientError::DriverGone => false,
     }
+}
+
+/// Decide whether to back off before the next attempt based on the last
+/// error. Backoff applies to exactly the transport-failure class (see
+/// [`is_transport_failure`]): those are the "service unavailable"-style
+/// failures where pausing before retrying de-correlates a thundering herd.
+/// Other failures are deterministic — the next endpoint is tried
+/// immediately without sleep.
+pub(crate) fn should_backoff(error: &crate::error::ClientError) -> bool {
+    is_transport_failure(error)
 }
 
 /// Jittered exponential backoff. The returned duration is uniformly


### PR DESCRIPTION
Closes #239.

## Problem

PR #290 evicts `ChannelPool` entries on a failed **dial**, but a channel that dialed successfully, got cached, then had a later **RPC fail with a transport error** was never removed. A tonic static `Endpoint` resolves its address once at connect and never re-resolves, so after pod replacement (new IP behind the same endpoint string) the cached channel's background reconnect loop hammers a dead address forever and is reused on every future resolution onto that string. The leader cache's `leader_ttl` ages out the leader *pin*, but nothing aged out the *channel* — a slow resource leak and staleness hazard in rolling-restart / pod-replacement topologies.

## Fix

`attempt` now keeps the channel's `OnceCell` handle for the duration of the RPC and, on a transport-class failure, hands that exact cell to a new `ChannelPool::evict_if_current`, dropping the dead channel (and its background reconnect task) so the next attempt re-dials and re-resolves the endpoint. It reuses the same `Arc::ptr_eq` identity guard the dial-failure path already uses, so a stale failure cannot evict a freshly-redialed good channel.

Transport class is `Unavailable`, transport errors, and `DeadlineExceeded` — the last covers a half-open connection that black-holes until the per-attempt deadline rather than failing fast, which is the real pod-replacement case. Application errors such as `Internal` leave the channel cached because the connection is healthy.

## Notes

- Backoff and channel-eviction share one trigger today, so the classification is factored into `is_transport_failure`, with `should_backoff` delegating to it; divergence would have to be a deliberate edit.
- `client` is split into `client_with_cell` (returns the cell handle for the retry loop) plus a test-only convenience wrapper.
- The leader cache is deliberately left untouched on transport failure — clearing it would stampede coalesced callers onto a cold worklist on each flap (the #236 lesson).

## Out of scope

If the outer per-attempt timeout cancels a dial mid-flight, the uninitialized cell is left in the map (an empty slot the next caller dials into — no stale channel). Not part of this issue's resource-leak class; possible follow-up.

## Tests

- `evict_if_current_removes_the_cached_cell` / `evict_if_current_spares_a_replaced_cell` — the eviction primitive and its identity guard.
- `transport_failure_evicts_cached_channel`, `rpc_timeout_evicts_cached_channel` — drive the real `attempt` path; a counting connector proves the next attempt re-dials.
- `application_error_preserves_cached_channel` — `Internal` keeps the channel cached (over-eviction guard).

All 79 client-crate tests pass; clippy clean; docs build with `-D warnings`.