### PR TITLE
refactor(driver-file): document leader_tx via #[expect] instead of #[allow(dead_code)]

### DIFF
--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -53,7 +53,14 @@ pub struct FileDriver {
     // without holding any state lock and then publish via a Release store.
     state: Arc<AtomicU64>,
     write_lock: tokio::sync::Mutex<()>,
-    #[allow(dead_code)]
+    // Held to keep the watch channel open; FileDriver never sends after the
+    // initial Leader { epoch: 0 } published at construction. Dropping it would
+    // close the channel and terminate every `WatchStream::new(leader_rx.clone())`
+    // consumer prematurely.
+    #[expect(
+        dead_code,
+        reason = "kept to hold the watch channel open for leader_rx consumers"
+    )]
     leader_tx: watch::Sender<LeaderState>,
     leader_rx: watch::Receiver<LeaderState>,
     // Holds the OS-level exclusive lock on `dir/LOCK` for the driver's


### PR DESCRIPTION
Closes #101.

## Problem

`FileDriver` holds `leader_tx: watch::Sender<LeaderState>` marked `#[allow(dead_code)]`. The sender is *not* dead — it is held to keep the watch channel open so `WatchStream::new(leader_rx.clone())` consumers don't see the stream terminate. The bare `#[allow(dead_code)]` reads as "safe to delete," misleading a future maintainer.

## Change

- Replace `#[allow(dead_code)]` with a prose comment explaining *why* the field is stored.
- Add `#[expect(dead_code, reason = "...")]` so the justification lives at the lint site.

I used `#[expect]` rather than a bare comment because the field is genuinely never read (construction-only; `derive(Debug)`'s generated read does not count toward `dead_code`), so the rustc `dead_code` lint still fires — confirmed empirically. `#[expect]` additionally re-fires if the field ever becomes truly used or removed, so a future change can't leave a stale suppression behind. MSRV is 1.88, well above the 1.81 that stabilized `#[expect]`.

## Acceptance

- The `#[allow(dead_code)]` annotation is gone.
- A reader can answer "why is this field stored?" without re-reading the file.

## Verification

- `cargo clippy -p tsoracle-driver-file --all-targets` — clean, 0 warnings (expectation fulfilled)
- `cargo fmt -p tsoracle-driver-file -- --check` — clean
- `cargo test -p tsoracle-driver-file` — all tests pass