### PR TITLE
refactor: lift the leader-hint trailer key and decoder into tsoracle-proto (#91)

### DIFF
--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -13,50 +13,24 @@
 //! Channel pool with leader-cache and NOT_LEADER redirect handling.
 
 use parking_lot::Mutex;
-use prost::Message;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 use tokio::time::Instant;
-use tonic::Status;
-use tonic::metadata::MetadataKey;
 use tonic::transport::{Channel, Endpoint};
-use tsoracle_proto::v1::LeaderHint;
 use tsoracle_proto::v1::tso_service_client::TsoServiceClient;
 
 use crate::RetryPolicy;
 use crate::error::ClientError;
 use crate::transport::apply_endpoint_config;
 
-const LEADER_HINT_KEY: &str = "tsoracle-leader-hint-bin";
-
-/// Outcome of inspecting a `Status`'s trailers for the leader-hint payload.
-///
-/// The retry loop treats the three cases differently: `Absent` is the normal
-/// "this peer doesn't know who the leader is" signal and stays silent;
-/// `Malformed` is a wire-protocol bug worth a warning + counter; `Decoded`
-/// is the followable redirect.
-pub enum LeaderHintLookup {
-    Absent,
-    Decoded(LeaderHint),
-    Malformed,
-}
-
-pub fn decode_leader_hint(status: &Status) -> LeaderHintLookup {
-    let Ok(key) = MetadataKey::from_bytes(LEADER_HINT_KEY.as_bytes()) else {
-        return LeaderHintLookup::Absent;
-    };
-    let Some(value) = status.metadata().get_bin(key) else {
-        return LeaderHintLookup::Absent;
-    };
-    let Ok(bytes) = value.to_bytes() else {
-        return LeaderHintLookup::Malformed;
-    };
-    match LeaderHint::decode(bytes.as_ref()) {
-        Ok(hint) => LeaderHintLookup::Decoded(hint),
-        Err(_) => LeaderHintLookup::Malformed,
-    }
-}
+// The leader-hint trailer key, the `LeaderHintLookup` classifier, and the
+// `decode_leader_hint` helper now live in `tsoracle-proto` as the single
+// source of truth for the wire contract (the server inserts the trailer; this
+// client decodes it). Re-exported here so the retry loop's existing
+// `crate::leader_resolved::{LeaderHintLookup, decode_leader_hint}` import path
+// is unchanged.
+pub use tsoracle_proto::v1::{LeaderHintLookup, decode_leader_hint};
 
 /// Cached pointer to the endpoint that most recently behaved like the
 /// leader, along with the epoch that confirmed it and the instant the
@@ -353,83 +327,10 @@ mod tests {
     use crate::RetryPolicy;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use tonic::Status;
-    use tonic::metadata::BinaryMetadataKey;
-    use tonic::metadata::BinaryMetadataValue;
-    use tsoracle_proto::v1::EpochWire;
 
-    /// A `Status` without a `tsoracle-leader-hint-bin` trailer must
-    /// decode to `Absent` — this is the steady-state case (every
-    /// response other than NOT_LEADER, plus NOT_LEADER from a server
-    /// that has no known leader) and must not surface as `Malformed`,
-    /// which would cause the retry loop to count it against the
-    /// wire-protocol-bug bucket.
-    #[test]
-    fn decode_leader_hint_returns_absent_when_no_trailer_present() {
-        let status = Status::failed_precondition("not leader");
-        assert!(matches!(
-            decode_leader_hint(&status),
-            LeaderHintLookup::Absent
-        ));
-    }
-
-    /// A `Status` with a `tsoracle-leader-hint-bin` trailer whose
-    /// payload is not a valid `LeaderHint` protobuf must surface as
-    /// `Malformed` — the distinction from `Absent` is what lets the
-    /// retry loop count wire-protocol bugs separately from "this peer
-    /// doesn't know the leader." Without this case the enum would be
-    /// observationally equivalent to the prior `Option<LeaderHint>` and
-    /// the type-level distinction would be lost.
-    #[test]
-    fn decode_leader_hint_returns_malformed_on_bad_protobuf() {
-        let mut status = Status::failed_precondition("not leader");
-        let key = BinaryMetadataKey::from_bytes(LEADER_HINT_KEY.as_bytes())
-            .expect("LEADER_HINT_KEY must be a valid binary metadata key");
-        // Bytes that are not a valid `LeaderHint` proto. Any sequence
-        // that doesn't decode to one or two tagged fields works; we use
-        // a wire-tag-shaped run of `0xff` so the decoder enters varint
-        // parsing and then fails.
-        let value = BinaryMetadataValue::from_bytes(&[0xff, 0xff, 0xff, 0xff]);
-        status.metadata_mut().insert_bin(key, value);
-        assert!(matches!(
-            decode_leader_hint(&status),
-            LeaderHintLookup::Malformed
-        ));
-    }
-
-    /// A well-formed trailer round-trips through `encode` ↔ `decode`
-    /// and surfaces as `Decoded(hint)` with the original payload
-    /// preserved. This is the client-side companion to the server-side
-    /// `roundtrip` test in `tsoracle-server::leader_hint`; both must
-    /// agree on the wire shape or NOT_LEADER redirects will silently
-    /// degrade.
-    #[test]
-    fn decode_leader_hint_decodes_well_formed_trailer() {
-        let mut status = Status::failed_precondition("not leader");
-        let key = BinaryMetadataKey::from_bytes(LEADER_HINT_KEY.as_bytes())
-            .expect("LEADER_HINT_KEY must be a valid binary metadata key");
-        let hint = LeaderHint {
-            leader_endpoint: Some("10.0.0.7:50551".into()),
-            leader_epoch: Some(EpochWire { hi: 0, lo: 42 }),
-        };
-        let value = BinaryMetadataValue::from_bytes(&hint.encode_to_vec());
-        status.metadata_mut().insert_bin(key, value);
-
-        match decode_leader_hint(&status) {
-            LeaderHintLookup::Decoded(decoded) => {
-                assert_eq!(decoded.leader_endpoint, hint.leader_endpoint);
-                assert_eq!(decoded.leader_epoch, hint.leader_epoch);
-            }
-            other => panic!(
-                "expected Decoded(_), got something else: {}",
-                match other {
-                    LeaderHintLookup::Absent => "Absent",
-                    LeaderHintLookup::Malformed => "Malformed",
-                    LeaderHintLookup::Decoded(_) => unreachable!(),
-                }
-            ),
-        }
-    }
+    // The `decode_leader_hint` Absent/Malformed/Decoded classification tests
+    // live alongside the helper in `tsoracle-proto`; this module covers the
+    // channel-pool and leader-cache behavior that is unique to the client.
 
     #[test]
     fn iter_starts_with_cached_leader() {

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -617,8 +617,8 @@ mod tests {
         hint.encode(&mut buf)
             .expect("LeaderHint encode is infallible");
         let mut status = tonic::Status::failed_precondition("not leader");
-        let key =
-            MetadataKey::from_bytes(b"tsoracle-leader-hint-bin").expect("static ASCII key parses");
+        let key = MetadataKey::from_bytes(tsoracle_proto::v1::LEADER_HINT_TRAILER_KEY.as_bytes())
+            .expect("static ASCII key parses");
         status
             .metadata_mut()
             .insert_bin(key, BinaryMetadataValue::from_bytes(&buf));
@@ -648,7 +648,8 @@ mod tests {
         use tonic::metadata::{BinaryMetadataValue, MetadataKey};
         let pool = ChannelPool::new(vec!["a:1".into()], None, false, RetryPolicy::default());
         let mut status = tonic::Status::failed_precondition("not leader");
-        let key = MetadataKey::from_bytes(b"tsoracle-leader-hint-bin").unwrap();
+        let key = MetadataKey::from_bytes(tsoracle_proto::v1::LEADER_HINT_TRAILER_KEY.as_bytes())
+            .unwrap();
         status.metadata_mut().insert_bin(
             key,
             BinaryMetadataValue::from_bytes(&[0xff, 0xff, 0xff, 0xff]),

--- a/crates/tsoracle-proto/src/lib.rs
+++ b/crates/tsoracle-proto/src/lib.rs
@@ -15,6 +15,52 @@
 
 pub mod v1 {
     tonic::include_proto!("tsoracle.v1");
+
+    use prost::Message;
+    use tonic::Status;
+    use tonic::metadata::MetadataKey;
+
+    /// Binary metadata trailer key carrying the [`LeaderHint`] payload on a
+    /// `NOT_LEADER` (`FAILED_PRECONDITION`) response.
+    ///
+    /// This is the single source of truth for the wire contract: the server
+    /// inserts the trailer under this key and the client decodes it from the
+    /// same key. If the two ever disagreed, the client would silently stop
+    /// following hints and degrade to round-robin, so both sides reference
+    /// this one constant rather than re-spelling the string.
+    pub const LEADER_HINT_TRAILER_KEY: &str = "tsoracle-leader-hint-bin";
+
+    /// Outcome of inspecting a `Status`'s trailers for the leader-hint payload.
+    ///
+    /// The client's retry loop treats the three cases differently: `Absent` is
+    /// the normal "this peer doesn't know who the leader is" signal and stays
+    /// silent; `Malformed` is a wire-protocol bug worth a warning + counter;
+    /// `Decoded` is the followable redirect. The server's decode path collapses
+    /// this to `Option<LeaderHint>` via a thin adapter, but the richer shape is
+    /// kept here so that distinction is not lost for callers that need it.
+    pub enum LeaderHintLookup {
+        Absent,
+        Decoded(LeaderHint),
+        Malformed,
+    }
+
+    /// Decode the [`LeaderHint`] trailer keyed by [`LEADER_HINT_TRAILER_KEY`]
+    /// from `status`, classifying the three outcomes (see [`LeaderHintLookup`]).
+    pub fn decode_leader_hint(status: &Status) -> LeaderHintLookup {
+        let Ok(key) = MetadataKey::from_bytes(LEADER_HINT_TRAILER_KEY.as_bytes()) else {
+            return LeaderHintLookup::Absent;
+        };
+        let Some(value) = status.metadata().get_bin(key) else {
+            return LeaderHintLookup::Absent;
+        };
+        let Ok(bytes) = value.to_bytes() else {
+            return LeaderHintLookup::Malformed;
+        };
+        match LeaderHint::decode(bytes.as_ref()) {
+            Ok(hint) => LeaderHintLookup::Decoded(hint),
+            Err(_) => LeaderHintLookup::Malformed,
+        }
+    }
 }
 
 /// Encoded `FileDescriptorSet` for every proto compiled by this crate.
@@ -29,6 +75,8 @@ pub const FILE_DESCRIPTOR_SET: &[u8] =
 mod tests {
     use super::v1::*;
     use prost::Message;
+    use tonic::Status;
+    use tonic::metadata::{BinaryMetadataKey, BinaryMetadataValue};
 
     #[test]
     fn message_types_exist() {
@@ -68,5 +116,70 @@ mod tests {
         };
         let decoded = LeaderHint::decode(without_epoch.encode_to_vec().as_ref()).unwrap();
         assert_eq!(decoded.leader_epoch, None);
+    }
+
+    /// A `Status` without a `tsoracle-leader-hint-bin` trailer must decode to
+    /// `Absent` — this is the steady-state case (every response other than
+    /// NOT_LEADER, plus NOT_LEADER from a server that has no known leader) and
+    /// must not surface as `Malformed`, which would cause the client's retry
+    /// loop to count it against the wire-protocol-bug bucket.
+    #[test]
+    fn decode_leader_hint_returns_absent_when_no_trailer_present() {
+        let status = Status::failed_precondition("not leader");
+        assert!(matches!(
+            decode_leader_hint(&status),
+            LeaderHintLookup::Absent
+        ));
+    }
+
+    /// A `Status` with a `tsoracle-leader-hint-bin` trailer whose payload is
+    /// not a valid `LeaderHint` protobuf must surface as `Malformed` — the
+    /// distinction from `Absent` is what lets the client's retry loop count
+    /// wire-protocol bugs separately from "this peer doesn't know the leader."
+    #[test]
+    fn decode_leader_hint_returns_malformed_on_bad_protobuf() {
+        let mut status = Status::failed_precondition("not leader");
+        let key = BinaryMetadataKey::from_bytes(LEADER_HINT_TRAILER_KEY.as_bytes())
+            .expect("LEADER_HINT_TRAILER_KEY must be a valid binary metadata key");
+        // Bytes that are not a valid `LeaderHint` proto. A wire-tag-shaped run
+        // of `0xff` makes the decoder enter varint parsing and then fail.
+        let value = BinaryMetadataValue::from_bytes(&[0xff, 0xff, 0xff, 0xff]);
+        status.metadata_mut().insert_bin(key, value);
+        assert!(matches!(
+            decode_leader_hint(&status),
+            LeaderHintLookup::Malformed
+        ));
+    }
+
+    /// A well-formed trailer round-trips through `encode` ↔ `decode` and
+    /// surfaces as `Decoded(hint)` with the original payload preserved. The
+    /// server's `not_leader_status` is the producer; both sides must agree on
+    /// the wire shape or NOT_LEADER redirects will silently degrade.
+    #[test]
+    fn decode_leader_hint_decodes_well_formed_trailer() {
+        let mut status = Status::failed_precondition("not leader");
+        let key = BinaryMetadataKey::from_bytes(LEADER_HINT_TRAILER_KEY.as_bytes())
+            .expect("LEADER_HINT_TRAILER_KEY must be a valid binary metadata key");
+        let hint = LeaderHint {
+            leader_endpoint: Some("10.0.0.7:50551".into()),
+            leader_epoch: Some(EpochWire { hi: 0, lo: 42 }),
+        };
+        let value = BinaryMetadataValue::from_bytes(&hint.encode_to_vec());
+        status.metadata_mut().insert_bin(key, value);
+
+        match decode_leader_hint(&status) {
+            LeaderHintLookup::Decoded(decoded) => {
+                assert_eq!(decoded.leader_endpoint, hint.leader_endpoint);
+                assert_eq!(decoded.leader_epoch, hint.leader_epoch);
+            }
+            other => panic!(
+                "expected Decoded(_), got something else: {}",
+                match other {
+                    LeaderHintLookup::Absent => "Absent",
+                    LeaderHintLookup::Malformed => "Malformed",
+                    LeaderHintLookup::Decoded(_) => unreachable!(),
+                }
+            ),
+        }
     }
 }

--- a/crates/tsoracle-server/src/leader_hint.rs
+++ b/crates/tsoracle-server/src/leader_hint.rs
@@ -15,20 +15,18 @@
 use prost::Message;
 use tonic::Status;
 use tonic::metadata::errors::InvalidMetadataKey;
-use tonic::metadata::{BinaryMetadataKey, BinaryMetadataValue, MetadataKey};
-use tsoracle_proto::v1::LeaderHint;
+use tonic::metadata::{BinaryMetadataKey, BinaryMetadataValue};
+use tsoracle_proto::v1::{LEADER_HINT_TRAILER_KEY, LeaderHint, LeaderHintLookup};
 
-pub const KEY: &str = "tsoracle-leader-hint-bin";
-
-/// Confirms [`KEY`] is a valid binary metadata key.
+/// Confirms [`LEADER_HINT_TRAILER_KEY`] is a valid binary metadata key.
 ///
 /// Called from [`ServerBuilder::build`](crate::server::ServerBuilder::build)
-/// so an invalid `KEY` (only reachable via developer error) surfaces as a
+/// so an invalid key (only reachable via developer error) surfaces as a
 /// startup failure rather than as a silent runtime degradation in which the
 /// `tsoracle-leader-hint-bin` trailer is dropped from every NOT_LEADER
 /// response.
 pub fn validate_key() -> Result<(), InvalidMetadataKey> {
-    BinaryMetadataKey::from_bytes(KEY.as_bytes()).map(|_| ())
+    BinaryMetadataKey::from_bytes(LEADER_HINT_TRAILER_KEY.as_bytes()).map(|_| ())
 }
 
 pub fn not_leader_status(hint: LeaderHint) -> Status {
@@ -37,7 +35,11 @@ pub fn not_leader_status(hint: LeaderHint) -> Status {
     // once per rejection regardless of which call site detected it.
     #[cfg(feature = "metrics")]
     metrics::counter!("tsoracle.not_leader.total").increment(1);
-    with_leader_hint(Status::failed_precondition("not leader"), hint, KEY)
+    with_leader_hint(
+        Status::failed_precondition("not leader"),
+        hint,
+        LEADER_HINT_TRAILER_KEY,
+    )
 }
 
 /// Inserts a [`LeaderHint`] trailer keyed by `key_str` and returns `status`.
@@ -68,11 +70,16 @@ fn with_leader_hint(mut status: Status, hint: LeaderHint, key_str: &str) -> Stat
     status
 }
 
+/// Server-side `Option` view over the shared
+/// [`tsoracle_proto::v1::decode_leader_hint`] classifier: both "no trailer"
+/// (`Absent`) and "garbage trailer" (`Malformed`) collapse to `None`, since the
+/// server's only decode caller is its own test surface, which has no use for
+/// the wire-protocol-bug distinction the client tracks.
 pub fn decode_leader_hint(status: &Status) -> Option<LeaderHint> {
-    let key = MetadataKey::from_bytes(KEY.as_bytes()).ok()?;
-    let value = status.metadata().get_bin(key)?;
-    let bytes = value.to_bytes().ok()?;
-    LeaderHint::decode(bytes.as_ref()).ok()
+    match tsoracle_proto::v1::decode_leader_hint(status) {
+        LeaderHintLookup::Decoded(hint) => Some(hint),
+        LeaderHintLookup::Absent | LeaderHintLookup::Malformed => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -30,7 +30,7 @@ use crate::service::TsoServiceImpl;
 pub enum BuildError {
     #[error("consensus_driver is required")]
     MissingConsensusDriver,
-    /// Surfaced when [`crate::leader_hint::KEY`] fails [`crate::leader_hint::validate_key`].
+    /// Surfaced when [`tsoracle_proto::v1::LEADER_HINT_TRAILER_KEY`] fails [`crate::leader_hint::validate_key`].
     /// Today the key is a valid `const &'static str`, so this variant is
     /// developer-error insurance: a future edit that breaks the key triggers
     /// a startup failure rather than silently stripping the trailer from

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -33,7 +33,7 @@ use tonic::{
 use tsoracle_client::Client;
 use tsoracle_core::Epoch;
 use tsoracle_proto::v1::{
-    GetTsRequest, GetTsResponse,
+    GetTsRequest, GetTsResponse, LEADER_HINT_TRAILER_KEY,
     tso_service_server::{TsoService, TsoServiceServer},
 };
 use tsoracle_server::test_fakes::InMemoryDriver;
@@ -41,8 +41,6 @@ use tsoracle_server::test_support::{
     boot_server, wait_for_grpc_handshake, wait_until, wait_until_serving,
 };
 use tsoracle_server::{Server, ServingState};
-
-const LEADER_HINT_TRAILER: &str = "tsoracle-leader-hint-bin";
 
 type RecordedMetric = (
     CompositeKey,
@@ -140,8 +138,8 @@ impl TsoService for MalformedHintService {
         _request: Request<GetTsRequest>,
     ) -> Result<Response<GetTsResponse>, Status> {
         let mut status = Status::failed_precondition("not leader");
-        let key =
-            MetadataKey::from_bytes(LEADER_HINT_TRAILER.as_bytes()).expect("trailer key is ascii");
+        let key = MetadataKey::from_bytes(LEADER_HINT_TRAILER_KEY.as_bytes())
+            .expect("trailer key is ascii");
         let garbage: &[u8] = &[0x0a, 0x05, b'h', b'i'];
         status
             .metadata_mut()


### PR DESCRIPTION
Closes #91.

## Problem

The leader-hint binary metadata trailer key `"tsoracle-leader-hint-bin"` was hard-coded in two production constants plus three further test literals across the workspace:

- `tsoracle-server/src/leader_hint.rs` — `pub const KEY`
- `tsoracle-client/src/leader_resolved.rs` — `const LEADER_HINT_KEY`
- `tsoracle-client/src/retry.rs` (×2) and `tsoracle-tests/tests/client_metrics.rs` — bare literals

If the key ever drifted between the server (which inserts the trailer) and the client (which decodes it), the client would silently stop following `NOT_LEADER` hints and degrade to round-robin. The `decode_leader_hint` helper was also duplicated across the server and client.

## Change

`tsoracle_proto::v1` becomes the single source of truth for the wire contract. It now owns:

- `LEADER_HINT_TRAILER_KEY` — the trailer key constant.
- `LeaderHintLookup { Absent, Decoded, Malformed }` — the three-way classifier.
- `decode_leader_hint(&Status) -> LeaderHintLookup` — the shared decoder, with its round-trip / malformed / absent tests.

Consumers:

- **Client** (`leader_resolved.rs`) deletes the local constant, enum, and decoder and re-exports the proto items, so the retry loop's `crate::leader_resolved::{LeaderHintLookup, decode_leader_hint}` import path is unchanged. The now-redundant decode tests move to the proto crate.
- **Server** (`leader_hint.rs`) drops `KEY`, points `validate_key` / `not_leader_status` at the proto constant, and keeps `decode_leader_hint -> Option<LeaderHint>` as a thin adapter over the proto helper so its test-only decode surface (`__priv_decode_leader_hint`) and the tests covering it stay unchanged.
- The remaining test literals in `retry.rs` and `client_metrics.rs` reference the proto constant.

### Note on the decode helper

The issue proposed moving the server's `decode_leader_hint -> Option<LeaderHint>`. That signature is lossy: it collapses "no trailer" and "garbage trailer" into `None`. The client's retry loop depends on distinguishing the two (`Malformed` warns and increments a wire-protocol-bug counter; `Absent` stays silent). So the richer `LeaderHintLookup` superset moves into proto instead, and the server derives its `Option` view from it via a 3-arm adapter — no behavior change on either side.

## Result

- The literal `"tsoracle-leader-hint-bin"` now appears in executable code exactly once (the proto constant); other occurrences are prose in doc comments.
- Both `tsoracle-server` and `tsoracle-client` reference `tsoracle_proto::v1::LEADER_HINT_TRAILER_KEY`.
- No behavior change on the encode (server) or three-way-classify (client) path.

## Verification

- `cargo test -p tsoracle-proto -p tsoracle-server -p tsoracle-client -p tsoracle-tests` — green (proto now runs the three migrated decode tests).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean (also enforced by the pre-commit hook).
- `cargo check --no-default-features` (server + client) — clean.