### PR TITLE
refactor(driver-openraft): narrow OpenraftHighWaterHost to a metrics-only accessor (#95)

### DIFF
--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -136,7 +136,7 @@ fn owned_leadership_stream<H: OpenraftHighWaterHost>(
     host: Arc<H>,
     peers: Arc<HashMap<<H::Config as RaftTypeConfig>::NodeId, String>>,
 ) -> impl Stream<Item = LeaderState> + Send + 'static {
-    let rx = host.raft().metrics();
+    let rx = host.metrics();
     let inner: Pin<Box<dyn Stream<Item = LeaderState> + Send>> = Box::pin(
         stream_from_receiver::<H::Config>(rx)
             .map(move |state| map_leader_state::<H::Config>(state, peers.as_ref())),

--- a/crates/tsoracle-driver-openraft/src/host.rs
+++ b/crates/tsoracle-driver-openraft/src/host.rs
@@ -19,9 +19,9 @@
 //! and route TSO commands through its existing log.
 
 use async_trait::async_trait;
-use openraft::Raft;
+use openraft::RaftMetrics;
 use openraft::RaftTypeConfig;
-use openraft::storage::RaftStateMachine;
+use openraft::type_config::alias::WatchReceiverOf;
 use tsoracle_consensus::ConsensusError;
 
 /// Host that knows how to read and advance the TSO high-water mark via openraft.
@@ -35,11 +35,15 @@ pub trait OpenraftHighWaterHost: Send + Sync + 'static {
     /// `TypeConfig` its larger raft is built on.
     type Config: RaftTypeConfig;
 
-    /// The host's state machine. Same indirection as `Config`.
-    type StateMachine: RaftStateMachine<Self::Config>;
-
-    /// The raft handle the driver reads leadership metrics from.
-    fn raft(&self) -> &Raft<Self::Config, Self::StateMachine>;
+    /// The metrics watch the driver reads leadership transitions from.
+    ///
+    /// This is the only window the driver needs onto the host's raft, so the
+    /// trait hands out the watch receiver directly rather than a
+    /// `&Raft<C, SM>`. A piggy-back host whose raft binds to its own state
+    /// machine can satisfy the trait without that state machine having to match
+    /// the standalone host's — the trait carries no `StateMachine` type. Hosts
+    /// that own a `Raft` implement this as `self.raft.metrics()`.
+    fn metrics(&self) -> WatchReceiverOf<Self::Config, RaftMetrics<Self::Config>>;
 
     /// Read the current high-water mark linearizably. Implementations are
     /// expected to issue an `ensure_linearizable` barrier before reading their
@@ -50,4 +54,62 @@ pub trait OpenraftHighWaterHost: Send + Sync + 'static {
     /// return the new high-water value after apply. The state machine must
     /// enforce monotonicity (`max(prev, at_least)`); the driver does not.
     async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::type_config::TypeConfig;
+    use openraft::RaftMetrics;
+    use openraft::type_config::TypeConfigExt;
+    use openraft::type_config::alias::WatchReceiverOf;
+
+    /// A host backed *only* by a metrics watch receiver — it owns no
+    /// `Raft<TypeConfig, HighWaterStateMachine>`. This is the piggy-back shape
+    /// the narrowed trait must admit: a larger service whose raft binds to its
+    /// own state machine can satisfy the trait because the driver only needs a
+    /// metrics watch, never a `&Raft<C, SM>`.
+    struct MetricsOnlyHost {
+        rx: WatchReceiverOf<TypeConfig, RaftMetrics<TypeConfig>>,
+    }
+
+    #[async_trait]
+    impl OpenraftHighWaterHost for MetricsOnlyHost {
+        type Config = TypeConfig;
+
+        fn metrics(&self) -> WatchReceiverOf<Self::Config, RaftMetrics<Self::Config>> {
+            self.rx.clone()
+        }
+
+        async fn current_high_water(&self) -> Result<u64, ConsensusError> {
+            Ok(0)
+        }
+
+        async fn submit_advance(&self, _at_least: u64) -> Result<u64, ConsensusError> {
+            Ok(0)
+        }
+    }
+
+    /// Compile-time proof the trait is satisfiable without a `StateMachine`
+    /// associated type or a `&Raft<C, SM>` accessor.
+    fn assert_implements_host<H: OpenraftHighWaterHost>() {}
+
+    #[tokio::test]
+    async fn metrics_only_host_satisfies_and_drives_trait() {
+        assert_implements_host::<MetricsOnlyHost>();
+
+        // The narrowed accessor yields a usable receiver built from a synthetic
+        // metrics watch — no raft cluster required.
+        let metrics: RaftMetrics<TypeConfig> = RaftMetrics::new_initial(1u64);
+        let (_tx, rx) = <TypeConfig as TypeConfigExt>::watch_channel(metrics);
+        let host = MetricsOnlyHost { rx };
+
+        // Drive every method on the trait surface, not just `metrics()`, to
+        // prove a host owning no `Raft<C, HighWaterStateMachine>` is fully
+        // usable through the trait — type-checking alone wouldn't exercise the
+        // async read/submit path.
+        let _rx = host.metrics();
+        assert!(host.current_high_water().await.is_ok());
+        assert!(host.submit_advance(7).await.is_ok());
+    }
 }

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -20,8 +20,10 @@
 
 use async_trait::async_trait;
 use openraft::Raft;
+use openraft::RaftMetrics;
 use openraft::ReadPolicy;
 use openraft::error::{ClientWriteError, LinearizableReadError, RaftError};
+use openraft::type_config::alias::WatchReceiverOf;
 use tsoracle_consensus::ConsensusError;
 
 use crate::host::OpenraftHighWaterHost;
@@ -56,10 +58,9 @@ impl StandaloneHost {
 #[async_trait]
 impl OpenraftHighWaterHost for StandaloneHost {
     type Config = TypeConfig;
-    type StateMachine = HighWaterStateMachine;
 
-    fn raft(&self) -> &Raft<Self::Config, Self::StateMachine> {
-        &self.raft
+    fn metrics(&self) -> WatchReceiverOf<Self::Config, RaftMetrics<Self::Config>> {
+        self.raft.metrics()
     }
 
     async fn current_high_water(&self) -> Result<u64, ConsensusError> {

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -26,8 +26,12 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use openraft::error::{ClientWriteError, LinearizableReadError, RaftError};
 use openraft::storage::{EntryResponder, RaftStateMachine, Snapshot};
-use openraft::type_config::alias::{LogIdOf, SnapshotMetaOf, SnapshotOf, StoredMembershipOf};
-use openraft::{EntryPayload, Raft, RaftSnapshotBuilder, ReadPolicy, StoredMembership};
+use openraft::type_config::alias::{
+    LogIdOf, SnapshotMetaOf, SnapshotOf, StoredMembershipOf, WatchReceiverOf,
+};
+use openraft::{
+    EntryPayload, Raft, RaftMetrics, RaftSnapshotBuilder, ReadPolicy, StoredMembership,
+};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use tsoracle_consensus::ConsensusError;
@@ -313,10 +317,9 @@ impl PiggybackHost {
 #[async_trait]
 impl OpenraftHighWaterHost for PiggybackHost {
     type Config = HostTypeConfig;
-    type StateMachine = HostStateMachine;
 
-    fn raft(&self) -> &Raft<Self::Config, Self::StateMachine> {
-        &self.raft
+    fn metrics(&self) -> WatchReceiverOf<Self::Config, RaftMetrics<Self::Config>> {
+        self.raft.metrics()
     }
 
     async fn current_high_water(&self) -> Result<u64, ConsensusError> {


### PR DESCRIPTION
Closes #95.

## Problem

`OpenraftHighWaterHost::raft()` handed out a full `&Raft<Self::Config, Self::StateMachine>`, but the driver's only consumer of it is `host.raft().metrics()` (`owned_leadership_stream`). The wide accessor:

- forced a `StateMachine` associated type onto the trait, and
- blocked piggy-back hosts — a host whose raft binds to its own state-machine struct cannot fit a `&Raft<C, HighWaterStateMachine>`.

It leaked a layering assumption from the standalone case onto every implementor.

## Change

Replace `raft()` (and the now-dead `StateMachine` associated type) with the narrower accessor the driver actually uses:

```rust
fn metrics(&self) -> WatchReceiverOf<Self::Config, RaftMetrics<Self::Config>>;
```

- `StandaloneHost` and the piggy-back example implement it as `self.raft.metrics()` and keep their `Raft` privately for `current_high_water` / `submit_advance`.
- `owned_leadership_stream` calls `host.metrics()` directly.
- The piggy-back example (`examples/openraft-piggyback`), whose `PiggybackHost` has its own `HostStateMachine`, is updated to the new surface — it's the concrete consumer this unblocks.

## Acceptance

- ✅ The trait no longer hands out `&Raft<C, SM>` (and no longer carries a `StateMachine` type).
- ✅ `StandaloneHost` keeps its `Raft` privately; the trait surface is narrower.
- ✅ A host with a different `StateMachine` compiles against the trait — proven two ways: a new in-crate compile test (`MetricsOnlyHost`, backed only by a metrics watch receiver, owning no `Raft<C, HighWaterStateMachine>`) and the piggy-back example's distinct `HostStateMachine`.

## Verification

- `cargo test -p tsoracle-driver-openraft` — 58 lib + all integration tests pass (new `metrics_only_host_satisfies_trait` included).
- `cargo test -p example-openraft-piggyback` — pass.
- `cargo build --workspace` and `cargo clippy --workspace --all-targets` — clean.

No wire or storage format change — pure trait-surface narrowing. The trait is pre-1.0; this is a breaking change to the `OpenraftHighWaterHost` API for external implementors, but the migration is one line (`self.raft.metrics()`).