### PR TITLE
feat(stress): detect non-overlapping cross-client real-time monotonicity (#135)

### DIFF
--- a/benchmarks/stress/src/report.rs
+++ b/benchmarks/stress/src/report.rs
@@ -264,6 +264,17 @@ fn violation_summary(v: &crate::violation::Violation) -> serde_json::Value {
                 "first_post_window_ts": first_post_window_ts.0,
             })
         }
+        ViolationKind::CrossClientRealtimeMonotonicity {
+            prior_completed_ts,
+            got,
+            ..
+        } => {
+            serde_json::json!({
+                "kind": "CrossClientRealtimeMonotonicity",
+                "prior_completed_ts": prior_completed_ts.0,
+                "got": got.0,
+            })
+        }
         ViolationKind::Liveness { incident } => {
             serde_json::json!({ "kind": "Liveness", "incident": format!("{:?}", incident.kind) })
         }
@@ -591,6 +602,14 @@ mod tests {
                 at: now,
             },
             Violation {
+                kind: ViolationKind::CrossClientRealtimeMonotonicity {
+                    prior_completed_ts: Timestamp(100),
+                    got: Timestamp(80),
+                    sample: sample.clone(),
+                },
+                at: now,
+            },
+            Violation {
                 kind: ViolationKind::Liveness {
                     incident: LivenessIncident {
                         kind: LivenessIncidentKind::DeadlineExceeded {
@@ -608,15 +627,16 @@ mod tests {
 
         let v: serde_json::Value = serde_json::from_str(&r.render_json()).unwrap();
         let arr = v["violations"].as_array().unwrap();
-        assert_eq!(arr.len(), 4);
+        assert_eq!(arr.len(), 5);
         let kinds: Vec<&str> = arr.iter().map(|v| v["kind"].as_str().unwrap()).collect();
         assert!(kinds.contains(&"Monotonicity"));
         assert!(kinds.contains(&"BatchInternalOrdering"));
         assert!(kinds.contains(&"FenceFreshness"));
+        assert!(kinds.contains(&"CrossClientRealtimeMonotonicity"));
         assert!(kinds.contains(&"Liveness"));
 
         // Also covers the text-renderer count line.
         let text = r.render_text();
-        assert!(text.contains("violations: 4"), "{text}");
+        assert!(text.contains("violations: 5"), "{text}");
     }
 }

--- a/benchmarks/stress/src/supervisor.rs
+++ b/benchmarks/stress/src/supervisor.rs
@@ -10,7 +10,10 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! Single-consumer task that checks all four invariants.
+//! Single-consumer task that checks the timestamp-oracle invariants:
+//! monotonicity (per-client, cross-client uniqueness, and non-overlapping
+//! cross-client real-time), batch internal ordering, failover-fence freshness,
+//! and liveness.
 
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -71,6 +74,13 @@ struct SupervisorState {
     /// All observed timestamps. A duplicate insert is a cross-client
     /// uniqueness violation (the TSO must never issue the same `ts` twice).
     seen_timestamps: HashSet<Timestamp>,
+    /// Highest `ts` observed so far together with the `recv_time` of the RPC
+    /// that produced it — the comparator for non-overlapping cross-client
+    /// real-time monotonicity. Distinct from `high_water` (a bare `Timestamp`
+    /// for the fence pre-window snapshot): this check needs the completion
+    /// instant to tell whether a later RPC began strictly after this one
+    /// finished. `None` until the first sample.
+    completed_high_water: Option<CompletedHighWater>,
     open_batches: HashMap<(ClientId, BatchId), OpenBatch>,
     open_windows: Vec<OpenChaosWindow>,
     /// Every applied chaos window seen so far, never pruned. Used only by
@@ -96,6 +106,7 @@ impl Default for SupervisorState {
             high_water: Timestamp(0),
             per_client_high_water: HashMap::new(),
             seen_timestamps: HashSet::new(),
+            completed_high_water: None,
             open_batches: HashMap::new(),
             open_windows: Vec::new(),
             chaos_history: Vec::new(),
@@ -110,6 +121,15 @@ impl Default for SupervisorState {
 #[derive(Debug)]
 struct OpenBatch {
     values: Vec<Timestamp>,
+}
+
+/// Highest-`ts` completed RPC seen so far, paired with the instant it
+/// completed. The cross-client real-time monotonicity check compares each new
+/// sample against this.
+#[derive(Debug, Clone, Copy)]
+struct CompletedHighWater {
+    ts: Timestamp,
+    recv_time: Instant,
 }
 
 #[derive(Debug)]
@@ -198,6 +218,12 @@ impl Supervisor {
         // in an arbitrary permutation — that is legitimate, not a TSO
         // regression. The fence-freshness check (1.5 below) is the right
         // place for "no regression across a leadership change".
+        //
+        // `monotonicity_flagged` records whether either local check fired for
+        // this sample; the cross-client real-time check (1c) is a backstop and
+        // stays quiet when a per-client regression or duplicate already named
+        // the same sample, so one root cause yields one violation.
+        let mut monotonicity_flagged = false;
         let prev = self
             .state
             .per_client_high_water
@@ -205,6 +231,7 @@ impl Supervisor {
             .copied()
             .unwrap_or(Timestamp(0));
         if sample.ts <= prev {
+            monotonicity_flagged = true;
             self.state.violations.push(Violation {
                 kind: ViolationKind::Monotonicity {
                     prev,
@@ -219,6 +246,7 @@ impl Supervisor {
                 .insert(sample.client_id, sample.ts);
         }
         if !self.state.seen_timestamps.insert(sample.ts) {
+            monotonicity_flagged = true;
             self.state.violations.push(Violation {
                 kind: ViolationKind::Monotonicity {
                     prev: sample.ts,
@@ -231,6 +259,18 @@ impl Supervisor {
         if sample.ts > self.state.high_water {
             self.state.high_water = sample.ts;
         }
+
+        // Snapshot, before the fence block mutates `open_windows`, whether a
+        // leadership-changing window still owns this sample's boundary
+        // crossing. Any window whose fence check has not yet fired and that
+        // started at or before this sample's completion covers it: the sample
+        // is either inside the window/grace or is the very first post-grace
+        // sample (which (1.5) resolves). Failpoint windows are pre-marked
+        // `fence_freshness_checked` (they don't change leadership), so they do
+        // NOT suppress (1c) — real-time monotonicity must hold across them.
+        let chaos_covered = self.state.open_windows.iter().any(|open| {
+            !open.fence_freshness_checked && sample.recv_time >= open.window.started_at
+        });
 
         // (1.5) Fence freshness — first post-window-grace sample participates.
         // We collect violations into a local buffer to keep the borrow of
@@ -262,6 +302,67 @@ impl Supervisor {
             let post_grace_at = open.window.ended_at + open.window.grace;
             sample.recv_time < post_grace_at || !open.fence_freshness_checked
         });
+
+        // (1c) Non-overlapping cross-client real-time monotonicity.
+        //
+        // (1a)/(1b) cover per-client order and global uniqueness, but they say
+        // nothing about two *different* clients whose RPCs do not overlap in
+        // real time. If client B's RPC began strictly after client A's RPC
+        // completed, then any monotonic TSO must hand B a `ts` greater than
+        // A's — a happens-before edge, not arrival-order noise. We hold the
+        // highest-`ts` completed RPC in `completed_high_water` (its `ts` and
+        // the instant it finished) and flag this sample when it began at or
+        // after that completion yet did not advance past its `ts`.
+        //
+        // This deliberately uses the per-sample `issued_at`/`recv_time` the
+        // client driver records, NOT mpsc arrival order. The rejection of
+        // cross-client arrival reordering documented at (1) therefore still
+        // holds: concurrent RPCs whose `[issued_at, recv_time]` intervals
+        // overlap never satisfy `issued_at >= prior.recv_time`, so they remain
+        // free to land at this consumer in any order without being flagged.
+        //
+        // Two exclusions keep the signal clean:
+        //   - `monotonicity_flagged`: a per-client regression or duplicate
+        //     already named this exact sample, so we do not double-report it.
+        //   - `chaos_covered`: a leadership change is in flight, where (1.5)
+        //     fence freshness is the authoritative cross-leadership check over
+        //     a tighter window; suppressing here avoids a duplicate report of
+        //     the same boundary regression.
+        if !monotonicity_flagged && !chaos_covered {
+            if let Some(prior) = self.state.completed_high_water {
+                // `issued_at >= prior.recv_time` is the happens-before test.
+                // We also require `recv_time >= prior.recv_time`: it is normally
+                // implied (recv_time >= issued_at), but the latency path already
+                // guards against an apparent backward clock, so we keep both and
+                // stay quiet if the two stamps disagree under skew.
+                if sample.issued_at >= prior.recv_time
+                    && sample.recv_time >= prior.recv_time
+                    && sample.ts <= prior.ts
+                {
+                    self.state.violations.push(Violation {
+                        kind: ViolationKind::CrossClientRealtimeMonotonicity {
+                            prior_completed_ts: prior.ts,
+                            got: sample.ts,
+                            sample: sample.clone(),
+                        },
+                        at: Instant::now(),
+                    });
+                }
+            }
+        }
+        // Advance the completed high-water on every sample (gates above only
+        // decide whether to *check*, never whether to track). Update only when
+        // `ts` strictly advances, so a stale low `ts` can neither lower the
+        // comparator nor overwrite the completion instant.
+        match self.state.completed_high_water {
+            Some(prior) if sample.ts <= prior.ts => {}
+            _ => {
+                self.state.completed_high_water = Some(CompletedHighWater {
+                    ts: sample.ts,
+                    recv_time: sample.recv_time,
+                });
+            }
+        }
 
         // (2) Batch internal ordering.
         let key = (sample.client_id, sample.batch_id);
@@ -395,6 +496,27 @@ mod tests {
         }
     }
 
+    /// Like `sample`, but with an explicit RPC interval `[issued_at, recv_time]`.
+    /// The cross-client real-time monotonicity check keys off these stamps, so
+    /// tests that exercise it must place RPCs on a shared timeline rather than
+    /// relying on `sample`'s `issued_at == recv_time == Instant::now()`.
+    fn timed_sample(
+        client: u32,
+        ts_raw: u64,
+        issued_at: Instant,
+        recv_time: Instant,
+    ) -> IssuedSample {
+        IssuedSample {
+            client_id: ClientId(client),
+            batch_id: 0,
+            batch_idx: 0,
+            is_last: true,
+            ts: Timestamp(ts_raw),
+            issued_at,
+            recv_time,
+        }
+    }
+
     #[tokio::test]
     async fn monotonicity_clean_run() {
         let (tx, rx) = mpsc::channel::<SupervisorEvent>(16);
@@ -495,13 +617,23 @@ mod tests {
         // per-client `IssuedSample`s land at the supervisor's mpsc in an
         // arbitrary permutation. That is legitimate observed behavior, not
         // a TSO regression — the supervisor must not flag it.
+        //
+        // The eight RPCs genuinely overlap: every client issues at `t0` and
+        // receives at `t0 + 10ms`, so no RPC began strictly after another
+        // completed. That keeps the cross-client real-time check quiet —
+        // arrival-order reordering of overlapping RPCs is not a violation.
         let (tx, rx) = mpsc::channel::<SupervisorEvent>(16);
         let supervisor = Supervisor::new();
         let handle = tokio::spawn(supervisor.run(rx));
+        let t0 = Instant::now();
+        let issued_at = t0;
+        let recv_time = t0 + Duration::from_millis(10);
         // Client 7's sample arrives first with the highest ts.
-        tx.send(SupervisorEvent::Issued(sample(7, 551)))
-            .await
-            .unwrap();
+        tx.send(SupervisorEvent::Issued(timed_sample(
+            7, 551, issued_at, recv_time,
+        )))
+        .await
+        .unwrap();
         // Clients 0..6 then post their (lower) samples in arbitrary order.
         for (client, ts) in [
             (3, 547),
@@ -512,10 +644,75 @@ mod tests {
             (2, 546),
             (5, 549),
         ] {
-            tx.send(SupervisorEvent::Issued(sample(client, ts)))
-                .await
-                .unwrap();
+            tx.send(SupervisorEvent::Issued(timed_sample(
+                client, ts, issued_at, recv_time,
+            )))
+            .await
+            .unwrap();
         }
+        tx.send(SupervisorEvent::End).await.unwrap();
+        drop(tx);
+        let outcome = handle.await.unwrap();
+        assert!(
+            outcome.violations.is_empty(),
+            "got: {:?}",
+            outcome.violations,
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_client_realtime_monotonicity_detects_nonoverlapping_regression() {
+        // Client A's RPC completes before client B's even begins (their
+        // intervals do not overlap), yet B receives a strictly lower ts. That
+        // is a real happens-before regression no monotonic TSO may exhibit,
+        // and it is not arrival-order reordering — the supervisor must flag
+        // exactly one CrossClientRealtimeMonotonicity violation.
+        let (tx, rx) = mpsc::channel::<SupervisorEvent>(16);
+        let supervisor = Supervisor::new();
+        let handle = tokio::spawn(supervisor.run(rx));
+        let t0 = Instant::now();
+        // A: client 0, issued [t0, t0+5ms], ts=100.
+        let a = timed_sample(0, 100, t0, t0 + Duration::from_millis(5));
+        // B: client 1, issued [t0+10ms, t0+15ms] — strictly after A finished —
+        // ts=50, a regression.
+        let b = timed_sample(
+            1,
+            50,
+            t0 + Duration::from_millis(10),
+            t0 + Duration::from_millis(15),
+        );
+        tx.send(SupervisorEvent::Issued(a)).await.unwrap();
+        tx.send(SupervisorEvent::Issued(b)).await.unwrap();
+        tx.send(SupervisorEvent::End).await.unwrap();
+        drop(tx);
+        let outcome = handle.await.unwrap();
+        assert_eq!(outcome.violations.len(), 1, "got: {:?}", outcome.violations);
+        assert!(matches!(
+            outcome.violations[0].kind,
+            ViolationKind::CrossClientRealtimeMonotonicity { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn cross_client_realtime_monotonicity_tolerates_overlapping_concurrent() {
+        // Same shape as the regression above, but B begins before A completes:
+        // the intervals overlap, so the lower ts landing later is legitimate
+        // concurrent reordering, not a happens-before violation. Nothing fires.
+        let (tx, rx) = mpsc::channel::<SupervisorEvent>(16);
+        let supervisor = Supervisor::new();
+        let handle = tokio::spawn(supervisor.run(rx));
+        let t0 = Instant::now();
+        // A: client 0, issued [t0, t0+10ms], ts=200.
+        let a = timed_sample(0, 200, t0, t0 + Duration::from_millis(10));
+        // B: client 1, issued [t0+5ms, t0+15ms] — overlaps A — ts=100.
+        let b = timed_sample(
+            1,
+            100,
+            t0 + Duration::from_millis(5),
+            t0 + Duration::from_millis(15),
+        );
+        tx.send(SupervisorEvent::Issued(a)).await.unwrap();
+        tx.send(SupervisorEvent::Issued(b)).await.unwrap();
         tx.send(SupervisorEvent::End).await.unwrap();
         drop(tx);
         let outcome = handle.await.unwrap();
@@ -688,6 +885,47 @@ mod tests {
             "expected fence violation: {:?}",
             outcome.violations
         );
+    }
+
+    #[tokio::test]
+    async fn cross_client_realtime_suppressed_under_open_chaos_window() {
+        // A leadership-changing window owns the monotonicity check across its
+        // boundary: the first post-grace sample is the fence check's job. Even
+        // though that sample (client 1) began after the pre-window sample
+        // (client 0) completed and regressed, only FenceFreshness must fire —
+        // the cross-client real-time check is suppressed while the window is
+        // still open, so the same boundary regression is reported once.
+        let (tx, rx) = mpsc::channel::<SupervisorEvent>(16);
+        let supervisor = Supervisor::new();
+        let handle = tokio::spawn(supervisor.run(rx));
+        let t0 = Instant::now();
+        // Pre-window sample completes at t0.
+        tx.send(SupervisorEvent::Issued(timed_sample(0, 500, t0, t0)))
+            .await
+            .unwrap();
+        let started = t0;
+        let ended = t0 + Duration::from_millis(50);
+        let grace = Duration::from_millis(10);
+        tx.send(SupervisorEvent::Chaos(kill_window(started, ended, grace)))
+            .await
+            .unwrap();
+        // First post-grace sample, different client, regressed ts. Its RPC
+        // began after the pre-window sample completed (issued_at > t0).
+        let after = timed_sample(
+            1,
+            450,
+            ended + grace + Duration::from_millis(1),
+            ended + grace + Duration::from_millis(1),
+        );
+        tx.send(SupervisorEvent::Issued(after)).await.unwrap();
+        tx.send(SupervisorEvent::End).await.unwrap();
+        drop(tx);
+        let outcome = handle.await.unwrap();
+        assert_eq!(outcome.violations.len(), 1, "got: {:?}", outcome.violations);
+        assert!(matches!(
+            outcome.violations[0].kind,
+            ViolationKind::FenceFreshness { .. }
+        ));
     }
 
     use crate::sample::{LivenessIncident, LivenessIncidentKind};

--- a/benchmarks/stress/src/violation.rs
+++ b/benchmarks/stress/src/violation.rs
@@ -43,6 +43,16 @@ pub enum ViolationKind {
         first_post_window_ts: Timestamp,
         window_kind: crate::chaos::ChaosKind,
     },
+    /// Non-overlapping cross-client real-time monotonicity: this sample's RPC
+    /// began strictly after another client's RPC had already completed, yet it
+    /// received a `ts` no greater than that completed RPC's. Unlike
+    /// `FenceFreshness` (scoped to a chaos window's post-grace tail), this fires
+    /// in steady state — see the comment block in `supervisor::on_issued`.
+    CrossClientRealtimeMonotonicity {
+        prior_completed_ts: Timestamp,
+        got: Timestamp,
+        sample: IssuedSample,
+    },
     Liveness {
         incident: LivenessIncident,
     },

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -623,4 +623,37 @@ mod tests {
             "stop() must complete even when a send is wedged",
         );
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tick_loop_exits_when_leader_stream_dropped() {
+        // The tick loop emits every leadership transition through the
+        // leader-event channel. Once every subscriber has dropped the stream,
+        // `LeaderEventSender::send` returns `SendError::Closed`, and the loop
+        // must exit on its own rather than spin forever emitting into a closed
+        // channel. Take the stream and drop it before starting, so the first
+        // tick's leader-event send observes the closed channel and breaks —
+        // without anyone firing the shutdown signal. This is the only path
+        // that ends the loop here, so the task finishing before we call
+        // `stop()` is proof the closed-channel arm ran.
+        let mut runner = build_runner(1);
+        let stream = runner.take_leader_stream().expect("stream");
+        drop(stream);
+        runner.start(Arc::new(NoopSink));
+
+        let exited = wait_until(Duration::from_secs(1), || {
+            runner
+                .handle
+                .as_ref()
+                .map(JoinHandle::is_finished)
+                .unwrap_or(false)
+        })
+        .await;
+        assert!(
+            exited,
+            "tick loop must exit once the leader-event stream is dropped",
+        );
+
+        // `stop()` remains safe to call after the task has already exited.
+        runner.stop().await;
+    }
 }


### PR DESCRIPTION
Closes #135.

## Problem

`benchmarks/stress/src/supervisor.rs::on_issued` enforced four monotonicity invariants — per-client monotonicity, cross-client uniqueness, per-batch internal ordering, and (only inside a chaos window's post-grace tail) fence freshness. The strictly cross-client real-time case slipped through: client A's RPC completes (we have its `recv_time`) before client B's RPC starts (we have its `issued_at`), yet B receives a `ts` no greater than A's. That is not arrival-order reordering — it is a real happens-before violation any monotonic TSO must never exhibit.

The risk is concrete: a bug that re-allocates the same physical-ms window across two epoch transitions, or fails to advance `fence_floor` past the prior leader's max-issued, surfaces as a non-overlapping cross-client regression in steady state. Fence freshness catches it only if it correlates with an `Applied` chaos window — a clean elective failover under `tsoracle-driver-openraft` would never hit a `ChaosKind::LeaderKill` window, so the regression escapes silently.

## Change

Adds a fifth invariant in `on_issued`: **non-overlapping cross-client real-time monotonicity**.

- Tracks a single supervisor-wide `completed_high_water` tuple — the highest `ts` observed plus the `recv_time` of the RPC that produced it — advanced only when `ts` strictly increases. The per-sample check is O(1).
- A sample whose `issued_at >= completed_high_water.recv_time` (its RPC began at or after that one completed) but whose `ts <= completed_high_water.ts` is flagged as the new `ViolationKind::CrossClientRealtimeMonotonicity`.
- The check keys off the per-sample `issued_at`/`recv_time` the client driver records, **not** mpsc arrival order, so the documented tolerance of concurrent arrival reordering still holds: overlapping RPCs never satisfy `issued_at >= prior.recv_time`.

Two gates keep the signal clean:
- **`monotonicity_flagged`** — a sample already named by a per-client regression or a uniqueness duplicate is not double-reported, so one root cause yields one violation.
- **`chaos_covered`** — while a leadership-changing window is open, fence freshness is the authoritative cross-leadership check over a tighter window; the new check is suppressed there to avoid a duplicate report of the same boundary regression. Failpoint windows (pre-marked `fence_freshness_checked`) do **not** suppress, since real-time monotonicity must hold across them.

`stress` emits the new kind in its JSON output, so `stress-auto-issue` deduplicates it under a distinct fingerprint key with no workflow change (the dedupe signature is data-driven off `.violations[].kind`).

## Tests

- `cross_client_realtime_monotonicity_detects_nonoverlapping_regression` — A completes before B starts, `B.ts < A.ts` → exactly one `CrossClientRealtimeMonotonicity` violation.
- `cross_client_realtime_monotonicity_tolerates_overlapping_concurrent` — same shape but overlapping intervals → clean.
- `cross_client_realtime_suppressed_under_open_chaos_window` — a regressed first-post-grace sample reports only `FenceFreshness`, not also the new kind.
- `monotonicity_tolerates_cross_client_arrival_reorder` updated: it previously used zero-duration, sequentially increasing instants that did not model the concurrency it claimed (those would read as strict happens-before regressions under the new check). It now uses genuinely overlapping intervals — a shared `issued_at` and a shared later `recv_time` — which is what "8 concurrent clients" always meant.

Verified: `cargo test -p stress` (all lib + smoke tests, including live mem/raft/process killer-loop chaos runs — no false positives under real concurrency and churn), `cargo clippy -p stress --all-targets`, `cargo fmt`.

## Related

- #79 — server: metrics emission ordering in `run_leader_watch` (sibling integrity check on the failover-fence path).