### PR TITLE
refactor(openraft-toolkit): collapse BootstrapMode::Join into a dedicated join() fn

### DIFF
--- a/crates/tsoracle-openraft-toolkit/src/lib.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lib.rs
@@ -33,7 +33,7 @@ pub mod test_fakes;
 pub use codec::{CodecError, SCHEMA_VERSION, decode, encode};
 pub use lifecycle::{
     BootstrapError, BootstrapMode, LeadershipState, MembershipError, add_learner, bootstrap,
-    change_membership, leadership_events,
+    change_membership, join, leadership_events,
 };
 
 #[cfg(feature = "rocksdb-log-store")]

--- a/crates/tsoracle-openraft-toolkit/src/lifecycle/bootstrap.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lifecycle/bootstrap.rs
@@ -18,16 +18,20 @@
 //! coverage; the compile-time signature shim in `tests/lifecycle.rs` is what
 //! catches openraft API drift inside this file.
 //!
-//! Most raft consumers need one of three startup modes:
+//! A node coming up as a voter needs one of two startup modes:
 //!
 //! - **Fresh**: first-time start; the caller knows the initial voter set.
 //! - **Reopen**: restart against existing on-disk state; do nothing special.
-//! - **Join**: start as a learner; an orchestrator will promote later.
 //!
 //! [`bootstrap`] folds these into a single async call, mapping openraft's
 //! `InitializeError::NotAllowed` (raised when the raft already has log/snapshot
 //! state) to success under `Reopen` and to a clear `BootstrapError` under
 //! `Fresh`.
+//!
+//! A node joining an existing cluster as a learner uses neither mode: it does
+//! no local initialization, so it calls [`join`] (a documented no-op on the
+//! joining side) and waits for the leader to register it via
+//! [`add_learner`](super::membership::add_learner).
 
 use std::collections::BTreeMap;
 
@@ -35,9 +39,16 @@ use openraft::error::{InitializeError, RaftError};
 use openraft::storage::RaftStateMachine;
 use openraft::{Raft, RaftTypeConfig};
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Startup mode for [`bootstrap`].
+///
+/// A learner joining an existing cluster is intentionally **not** a variant
+/// here: the joining node does no local initialization, so it calls [`join`]
+/// and waits for the leader to register it via
+/// [`add_learner`](super::membership::add_learner). Keeping it out of this enum
+/// means every arm performs a distinct local action — there is no mode whose
+/// only difference from another is the log line it emits.
 #[derive(Debug)]
 pub enum BootstrapMode<C: RaftTypeConfig> {
     /// First-time start: initialize with the given voter set.
@@ -46,8 +57,6 @@ pub enum BootstrapMode<C: RaftTypeConfig> {
     },
     /// Restart against existing on-disk state.
     Reopen,
-    /// Start as a learner; orchestrator will promote later.
-    Join,
 }
 
 /// Failure modes for [`bootstrap`].
@@ -72,8 +81,9 @@ pub enum BootstrapError {
 ///   surface as [`BootstrapError::Initialize`].
 /// - `Reopen`: does not touch the raft. The caller is expected to have opened
 ///   existing storage; openraft replays the log on its own.
-/// - `Join`: does not touch the raft. The node will sit as a learner until an
-///   orchestrator promotes it via membership change.
+///
+/// A node joining as a learner does not call [`bootstrap`] at all — see
+/// [`join`].
 pub async fn bootstrap<C, SM>(
     raft: &Raft<C, SM>,
     mode: BootstrapMode<C>,
@@ -97,9 +107,22 @@ where
             info!("tsoracle-openraft-toolkit: reopen mode; relying on existing raft state");
             Ok(())
         }
-        BootstrapMode::Join => {
-            warn!("tsoracle-openraft-toolkit: join mode; node will sit as learner until promoted");
-            Ok(())
-        }
     }
+}
+
+/// Record that this node is joining an existing cluster as a learner.
+///
+/// This is a deliberate no-op on the joining node and never touches the raft:
+/// a learner must not initialize its own membership — doing so would fork the
+/// cluster into two single-node clusters. The node simply comes up against
+/// empty or replayed storage and sits idle until it is promoted.
+///
+/// The join itself is driven from the **leader**, which registers this node by
+/// calling [`add_learner`](super::membership::add_learner). Call [`join`] only
+/// to record the startup intent in the logs; use [`bootstrap`] with
+/// [`BootstrapMode::Fresh`] or [`BootstrapMode::Reopen`] for the voter paths.
+pub fn join() {
+    info!(
+        "tsoracle-openraft-toolkit: join mode; node will sit as learner until the leader calls add_learner"
+    );
 }

--- a/crates/tsoracle-openraft-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lifecycle/mod.rs
@@ -16,6 +16,6 @@ pub mod bootstrap;
 pub mod leader;
 pub mod membership;
 
-pub use bootstrap::{BootstrapError, BootstrapMode, bootstrap};
+pub use bootstrap::{BootstrapError, BootstrapMode, bootstrap, join};
 pub use leader::{LeadershipState, leadership_events};
 pub use membership::{MembershipError, add_learner, change_membership};

--- a/crates/tsoracle-openraft-toolkit/tests/lifecycle.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/lifecycle.rs
@@ -38,7 +38,15 @@ fn bootstrap_mode_constructs_in_each_shape() {
         initial_members: members,
     };
     let _reopen: BootstrapMode<TestTypeConfig> = BootstrapMode::Reopen;
-    let _join: BootstrapMode<TestTypeConfig> = BootstrapMode::Join;
+}
+
+// `join` is the learner-side counterpart to `bootstrap`: a raft-free no-op
+// whose substance lives in its docstring (it points callers at the leader's
+// `membership::add_learner`). It takes no arguments and touches no openraft
+// API, so unlike the signature shims below it can be invoked directly.
+#[test]
+fn join_is_a_callable_no_op() {
+    tsoracle_openraft_toolkit::join();
 }
 
 // Verifies the `bootstrap` function has the expected signature.


### PR DESCRIPTION
Closes #103.

## Problem

`BootstrapMode` had three variants but only `Fresh` did real work. `Join` and `Reopen` each emitted a single log line and returned `Ok`. A caller picking `Join` over `Reopen` by name got no behavioral difference — only the log level changed (`info` vs `warn`). That is misleading API surface: the "join as learner" workflow is really the **leader's** job, via `membership::add_learner`, not anything the joining node does locally.

## Change (option (a) from the issue)

- **`BootstrapMode` shrunk to `Fresh | Reopen`.** Every remaining variant now performs a distinct local action against the raft — there is no mode whose only difference from another is the log line it emits.
- **New `lifecycle::join()`.** The learner-side intent moves into a dedicated no-op function whose docstring is the substance: a learner must not initialize its own membership (that would fork the cluster into two single-node clusters), so the joining node just comes up against empty/replayed storage and waits to be promoted. The docstring directs callers to `membership::add_learner`, invoked from the leader. Re-exported from `lifecycle` and the crate root.
- **Test updated.** Dropped the `BootstrapMode::Join` construction; added `join_is_a_callable_no_op` (it takes no args and touches no openraft API, so unlike the signature shims it runs directly).

## Acceptance criteria

- ✅ A reader of `BootstrapMode`'s docstring can now answer "what does Join do that Reopen doesn't?" without reading the bodies — the enum docstring states Join is deliberately not a variant and points to `join` / `add_learner`.
- ⚠️ The second criterion (*"Callers in `examples/openraft-standalone` and `examples/openraft-piggyback` use the simplified API"*) rests on a wrong premise: neither example ever used `BootstrapMode` / `bootstrap`. Both call `raft.initialize(...)` directly (`examples/openraft-standalone/src/main.rs:171`, `examples/openraft-piggyback/src/demo.rs:166`), so there is no caller to migrate. The only in-repo consumer was the `tests/lifecycle.rs` compile shim, which is updated here.

## Notes

- The old `Join` arm logged at `warn!`; `join()` logs at `info!`. The issue itself flagged "info vs warn" as the misleading distinction — now that `join()` is an explicit, named call, `info!` reads as a normal startup mode rather than a warning. Trivial to switch back if preferred.
- `join()` is sync and takes no `&Raft`: it does nothing async and touches no openraft API, so it needs no signature shim (there is no API to drift).

## Verification

- `cargo test -p tsoracle-openraft-toolkit --test lifecycle` → 9 passed.
- `cargo clippy -p tsoracle-openraft-toolkit --all-targets --all-features` → clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` → clean (confirms intra-doc links resolve).
- Pre-commit hook ran workspace `cargo fmt --check` + `cargo clippy` → clean.