### PR TITLE
fix(client): distinguish fanned-out transport failures from NoReachableEndpoints (#241)

### DIFF
--- a/benchmarks/minimal/src/harness.rs
+++ b/benchmarks/minimal/src/harness.rs
@@ -37,8 +37,9 @@ pub const HISTO_MAX_US: u64 = 60_000_000;
 /// Classify a `ClientError` as transient (worth retrying once) or fatal.
 ///
 /// Transient cases for a single-server, single-leader, no-real-network bench:
-/// - `Transport(_)`: typically a connection blip during server startup or
-///   graceful shutdown drain. Retry is harmless and usually quick.
+/// - `Transport(_)` / `TransportFanout(_)`: typically a connection blip during
+///   server startup or graceful shutdown drain (the latter is the same failure
+///   fanned out to a coalesced sibling waiter). Retry is harmless and usually quick.
 /// - `Rpc` with `Unavailable`/`DeadlineExceeded`/`ResourceExhausted`: the
 ///   server is up but unhealthy or backpressuring; retry.
 ///
@@ -47,7 +48,7 @@ pub const HISTO_MAX_US: u64 = 60_000_000;
 /// the run loudly.
 pub fn is_transient(err: &ClientError) -> bool {
     match err {
-        ClientError::Transport(_) => true,
+        ClientError::Transport(_) | ClientError::TransportFanout(_) => true,
         ClientError::Rpc(status) => matches!(
             status.code(),
             Code::Unavailable | Code::DeadlineExceeded | Code::ResourceExhausted

--- a/benchmarks/stress/src/loadgen.rs
+++ b/benchmarks/stress/src/loadgen.rs
@@ -22,7 +22,7 @@ use tsoracle_client::ClientError;
 
 pub fn is_transient(err: &ClientError) -> bool {
     match err {
-        ClientError::Transport(_) => true,
+        ClientError::Transport(_) | ClientError::TransportFanout(_) => true,
         ClientError::Rpc(status) => matches!(
             status.code(),
             Code::Unavailable

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -344,15 +344,20 @@ fn deliver(
 /// `ClientError` contains `tonic::Status` and `tonic::transport::Error`,
 /// neither of which is `Clone`. To fan one RPC error out across every
 /// waiter in a failed chunk we have to reconstruct an equivalent error.
-/// `Transport` collapses to `NoReachableEndpoints` because the underlying
-/// transport details aren't useful for downstream callers, and we can't
-/// duplicate the original error value.
+/// `Transport` maps to [`ClientError::TransportFanout`], carrying the
+/// original error's `Display` text: the value itself cannot be duplicated,
+/// but the failure is still a single-endpoint transport failure and must
+/// stay distinct from `NoReachableEndpoints` (whole cluster unreachable),
+/// which a coalesced waiter's tracing/alerting would otherwise misread.
 fn clone_client_error(error: &ClientError) -> ClientError {
     match error {
         ClientError::Rpc(status) => {
             ClientError::Rpc(tonic::Status::new(status.code(), status.message()))
         }
-        ClientError::Transport(_) => ClientError::NoReachableEndpoints,
+        ClientError::Transport(transport_error) => {
+            ClientError::TransportFanout(transport_error.to_string())
+        }
+        ClientError::TransportFanout(message) => ClientError::TransportFanout(message.clone()),
         ClientError::NoReachableEndpoints => ClientError::NoReachableEndpoints,
         ClientError::InvalidEndpoint(endpoint) => ClientError::InvalidEndpoint(endpoint.clone()),
         ClientError::InvalidCount(count) => ClientError::InvalidCount(*count),
@@ -561,19 +566,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clone_client_error_collapses_transport_to_no_reachable_endpoints() {
+    async fn clone_client_error_maps_transport_to_transport_fanout() {
         // Constructing a `tonic::transport::Error` directly isn't possible —
         // it has no public constructor. Trigger one by attempting to dial a
         // closed port; the resulting error is then handed to
-        // `clone_client_error` to confirm the collapse.
+        // `clone_client_error`. The fanned-out copy must be a
+        // `TransportFanout` carrying the original message — *not*
+        // `NoReachableEndpoints`, which carries the distinct meaning "the
+        // whole cluster is unreachable" and would mislead tracing/alerting
+        // on every sibling waiter in the coalesced chunk.
         let endpoint = tonic::transport::Endpoint::from_static("http://127.0.0.1:1");
         let transport_err = endpoint
             .connect()
             .await
             .expect_err("connecting to a closed port must fail");
+        let expected_message = transport_err.to_string();
         let original = ClientError::Transport(transport_err);
-        let cloned = clone_client_error(&original);
-        assert!(matches!(cloned, ClientError::NoReachableEndpoints));
+        match clone_client_error(&original) {
+            ClientError::TransportFanout(message) => {
+                assert_eq!(message, expected_message);
+            }
+            other => panic!("expected TransportFanout, got {other:?}"),
+        }
     }
 
     #[test]
@@ -596,6 +610,22 @@ mod tests {
 
         let driver_gone = clone_client_error(&ClientError::DriverGone);
         assert!(matches!(driver_gone, ClientError::DriverGone));
+    }
+
+    #[test]
+    fn clone_client_error_reclones_transport_fanout_preserving_message() {
+        // `run_chunks` fail-fast stores the *cloned* error and re-clones it
+        // for every subsequent chunk, so `clone_client_error` is called on a
+        // value it already produced. Re-cloning a `TransportFanout` must keep
+        // it a `TransportFanout` with the same message — never silently decay
+        // into `NoReachableEndpoints` on the second and later chunks.
+        let original = ClientError::TransportFanout("dial 10.0.0.7:50051 refused".into());
+        match clone_client_error(&original) {
+            ClientError::TransportFanout(message) => {
+                assert_eq!(message, "dial 10.0.0.7:50051 refused");
+            }
+            other => panic!("expected TransportFanout, got {other:?}"),
+        }
     }
 
     /// `run_chunks` fail-fast: once one chunk errors, every subsequent

--- a/crates/tsoracle-client/src/error.rs
+++ b/crates/tsoracle-client/src/error.rs
@@ -16,6 +16,15 @@ pub enum ClientError {
     NoReachableEndpoints,
     #[error("transport: {0}")]
     Transport(#[from] tonic::transport::Error),
+    /// A [`Self::Transport`] failure observed on one endpoint, fanned out to
+    /// the sibling waiters of a coalesced request chunk. `tonic::transport::Error`
+    /// is not `Clone`, so the originating value cannot be duplicated across
+    /// waiters; this variant carries its `Display` text instead. Distinct
+    /// from [`Self::NoReachableEndpoints`]: a single endpoint's transport
+    /// failed, *not* the whole cluster — collapsing the two would mislead
+    /// tracing/alerting on the receiving side.
+    #[error("transport (fanned out to coalesced waiter): {0}")]
+    TransportFanout(String),
     #[error("rpc: {0}")]
     Rpc(#[from] tonic::Status),
     #[error("invalid endpoint: {0}")]

--- a/crates/tsoracle-client/src/retry_policy.rs
+++ b/crates/tsoracle-client/src/retry_policy.rs
@@ -125,7 +125,10 @@ pub(crate) fn is_transport_failure(error: &crate::error::ClientError) -> bool {
             status.code(),
             tonic::Code::Unavailable | tonic::Code::DeadlineExceeded
         ),
-        ClientError::Transport(_) => true,
+        // `TransportFanout` is the fanned-out copy of a `Transport` failure
+        // (a coalesced sibling waiter's view), so it carries the same
+        // transport-failure semantics.
+        ClientError::Transport(_) | ClientError::TransportFanout(_) => true,
         ClientError::NoReachableEndpoints
         | ClientError::InvalidEndpoint(_)
         | ClientError::InvalidCount(_)
@@ -270,6 +273,11 @@ mod tests {
             tonic::Status::failed_precondition("fp")
         )));
         assert!(!should_backoff(&ClientError::NoReachableEndpoints));
+        // `TransportFanout` is the coalesced-waiter copy of a `Transport`
+        // failure and must stay in the transport-failure class — distinct
+        // from the `NoReachableEndpoints` case directly above, which the
+        // fanout previously collapsed into (issue #241).
+        assert!(should_backoff(&ClientError::TransportFanout("t".into())));
         assert!(!should_backoff(&ClientError::InvalidEndpoint("e".into())));
         assert!(!should_backoff(&ClientError::InvalidCount(0)));
         // `DriverGone` is deterministic: the local driver task is dead,

--- a/crates/tsoracle-tests/tests/client_tls.rs
+++ b/crates/tsoracle-tests/tests/client_tls.rs
@@ -154,10 +154,18 @@ async fn tls_handshake_fails_without_ca() {
     .expect("build does not connect")
     .get_ts()
     .await;
+    // The coalescing driver fans every per-RPC error out through
+    // `clone_client_error` (even to a lone waiter), so an eager-handshake
+    // `Transport` failure reaches the caller as `TransportFanout`, never the
+    // raw `Transport`. `NoReachableEndpoints` remains the retry-exhaustion
+    // fallback.
     match result {
         Err(tsoracle_client::ClientError::Transport(_))
+        | Err(tsoracle_client::ClientError::TransportFanout(_))
         | Err(tsoracle_client::ClientError::NoReachableEndpoints) => {}
-        other => panic!("expected Transport/NoReachableEndpoints, got {other:?}"),
+        other => {
+            panic!("expected Transport/TransportFanout/NoReachableEndpoints, got {other:?}")
+        }
     }
     booted.shutdown().await.expect("server exit");
 }
@@ -500,13 +508,17 @@ async fn mtls_handshake_fails_without_client_identity() {
     // The mTLS failure mode is tonic-version dependent: the channel may open
     // lazily and the handshake error surface during the RPC as `Rpc` with
     // code `Unknown` ("transport error"), or the retry loop may exhaust to
-    // `NoReachableEndpoints`, or the eager handshake may fail with `Transport`.
-    // All three are valid signals of "server rejected the connection."
+    // `NoReachableEndpoints`, or the eager handshake may fail with `Transport`
+    // (which the coalescing driver fans out as `TransportFanout`). All are
+    // valid signals of "server rejected the connection."
     match result {
         Err(tsoracle_client::ClientError::Transport(_))
+        | Err(tsoracle_client::ClientError::TransportFanout(_))
         | Err(tsoracle_client::ClientError::NoReachableEndpoints)
         | Err(tsoracle_client::ClientError::Rpc(_)) => {}
-        other => panic!("expected Transport/NoReachableEndpoints/Rpc, got {other:?}"),
+        other => {
+            panic!("expected Transport/TransportFanout/NoReachableEndpoints/Rpc, got {other:?}")
+        }
     }
     booted.shutdown().await.expect("server exit");
 }

--- a/examples/tls-mtls/src/main.rs
+++ b/examples/tls-mtls/src/main.rs
@@ -243,6 +243,11 @@ async fn step_mtls_misconfigured(bundle: &certs::CertBundle) -> Result<()> {
         Err(ClientError::Transport(err)) => {
             println!("  [expected] mTLS without identity -> ClientError::Transport: {err}");
         }
+        Err(ClientError::TransportFanout(message)) => {
+            println!(
+                "  [expected] mTLS without identity -> ClientError::TransportFanout: {message}"
+            );
+        }
         Err(ClientError::NoReachableEndpoints) => {
             println!("  [expected] mTLS without identity -> NoReachableEndpoints");
         }


### PR DESCRIPTION
Closes #241.

## Problem

`clone_client_error` (`crates/tsoracle-client/src/driver.rs`) fans one RPC failure out to every sibling waiter in a coalesced request chunk. Because `tonic::transport::Error` is not `Clone`, a single endpoint's `Transport` failure was reconstructed as `ClientError::NoReachableEndpoints` — a semantically distinct error meaning "the whole cluster is unreachable". Tracing/alerting on the receiving side therefore drew the wrong conclusion for every sibling waiter in the batch.

## Fix

Add a `ClientError::TransportFanout(String)` variant carrying `transport_error.to_string()`. The original error value still cannot be duplicated, but the fanned-out copy stays semantically a single-endpoint transport failure, distinct from `NoReachableEndpoints`.

- `clone_client_error` maps `Transport(e)` → `TransportFanout(e.to_string())`, and re-clones an already-fanned-out `TransportFanout` faithfully. The latter matters: `run_chunks` fail-fast stores the cloned error and re-clones it for each subsequent chunk, so the function is called on a value it previously produced.
- `is_transport_failure` groups `TransportFanout` with `Transport` (same transport-failure semantics), keeping the single source of truth shared by `should_backoff` and channel eviction honest. This is functionally moot on the happy path — the fanned-out error is terminal and never re-enters the retry loop — but the exhaustive match requires an arm, and truthful classification is the correct one.
- The two benchmark `is_transient` copies (`benchmarks/minimal`, `benchmarks/stress`) are updated identically; their exhaustive matches forced the change and the workspace build caught them.

## Tests

- `clone_client_error_maps_transport_to_transport_fanout` — rewrites the former "collapses to NoReachableEndpoints" test to pin the new mapping and message preservation.
- `clone_client_error_reclones_transport_fanout_preserving_message` — guards the multi-chunk re-clone path.
- New assertion in `should_backoff_matches_documented_status_codes` pinning `TransportFanout` to the transport-failure class, beside the `NoReachableEndpoints` case it must not collapse into.

Each test was confirmed to fail before the corresponding fix.

## Compatibility

`ClientError` is a pre-1.0 `pub` enum without `#[non_exhaustive]`, so adding a variant is a breaking change for exhaustive downstream matchers.

## Verification

- `cargo test -p tsoracle-client` → 80 pass
- `cargo test -p bench-minimal -p stress` → pass
- `cargo clippy --workspace --all-features --all-targets` → clean
- `cargo fmt --all --check` → clean