### PR TITLE
fix(proto): bump to 0.2.2 to unblock the stalled release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,11 +155,13 @@ A handful of files sit on the request-handling hot path. They carry a `// #[Perf
 
 ## Releases
 
-Releases run on [release-plz](https://release-plz.dev/). All crates share `version.workspace = true`, so a bump moves the whole workspace in lockstep. The flow is:
+Releases run on [release-plz](https://release-plz.dev/). Each crate is versioned **independently** — a change to one crate bumps only that crate (and any dependents whose `version = "..."` pin release-plz updates), not the whole workspace. The flow is:
 
-1. Land commits on `main` using [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `chore:`, etc.). The prefix determines the semver bump.
+1. Land commits on `main` using [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `chore:`, etc.). The prefix determines the semver bump, and `release_commits = "^(feat|fix|perf)"` in [`release-plz.toml`](release-plz.toml) means only `feat:`/`fix:`/`perf:` commits trigger a release for the crate they touch — `chore:`, `docs:`, `refactor:`, `style:`, `test:`, and `build:` do not.
 2. The `release-plz PR` workflow opens (or updates) a "Release PR" with the version bump and per-crate `CHANGELOG.md` diffs.
 3. Reviewing and merging that PR triggers the `release-plz release` job: it tags each crate (e.g. `tsoracle-core-v0.2.0`) and runs `cargo publish` in dependency order. A GitHub Release is created per tag.
+
+> **Adding public API to a library crate (e.g. `tsoracle-proto`) must use `feat:` or `fix:`, never `refactor:`.** The API surface is user-visible to *dependent crates* even when the gRPC wire contract (the `v1` proto package) is unchanged — a new `pub` item, re-export, or function is a release-worthy change. Because crates version independently and `refactor:` does not trigger a release, labelling such a change `refactor:` leaves the published crate behind: a dependent that already uses the new symbol then fails `cargo publish --verify` because it resolves the dependency to the stale, still-published version. Keep the proto package version (`tsoracle.v1`) and the crate version (`tsoracle-proto` on crates.io) distinct in your head — the former is the wire contract, the latter is the Rust packaging semver that dependents compile against.
 
 ### Before the first publish (one-time bootstrap)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-proto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "prost",
  "serde",

--- a/crates/tsoracle-proto/Cargo.toml
+++ b/crates/tsoracle-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-proto"
 description  = "Generated protobuf/gRPC wire types for the timestamp oracle."
-version      = "0.2.1"
+version      = "0.2.2"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Why

Release run [26369479219](https://github.com/prisma-risk/tsoracle/actions/runs/26369479219/job/77618983237) failed at `cargo publish --verify` for `tsoracle-server 0.2.3`:

```
error[E0432]: unresolved imports `tsoracle_proto::v1::LEADER_HINT_TRAILER_KEY`,
              `tsoracle_proto::v1::LeaderHintLookup`
error[E0425]: cannot find function `decode_leader_hint` in module `tsoracle_proto::v1`
error: failed to verify package tarball
```

Root cause: #295 lifted `LEADER_HINT_TRAILER_KEY`, `LeaderHintLookup`, and `decode_leader_hint` into `tsoracle_proto::v1` under a `refactor:` prefix. Crates version independently and `release_commits = "^(feat|fix|perf)"`, so `refactor:` did **not** trigger a release — proto stayed at `0.2.1`, and the published `0.2.1` (from release #233) predates and lacks those symbols. `tsoracle-server 0.2.3` already uses them, so the verify build — which strips the path dep and resolves `tsoracle-proto ^0.2.1` from the registry — got the stale crate and failed to compile.

## What

- **`tsoracle-proto` → `0.2.2`** (patch: additive, non-breaking). All consumers pin `^0.2.1`, so they resolve to `0.2.2` with no cascade. Once this lands on `main`, the `release` job publishes `proto 0.2.2` ahead of the stuck dependents (`server 0.2.3`, `client 0.2.2`, …), which then verify against a proto that has the symbols.
- **`CONTRIBUTING.md`** — document the trap (library-crate API additions must be `feat:`/`fix:`, never `refactor:`, because the API is visible to dependent crates even when the `v1` wire contract is unchanged), correct the stale "versions move in lockstep" claim (independent since #223), and spell out the `release_commits` prefix filter.

## Notes

- The `release` job publishes on a version-vs-registry diff, so the bump republishes regardless of this PR's squash prefix.
- The `release` job does not regenerate changelogs, so `tsoracle-proto`'s `CHANGELOG.md` will have a gap at `0.2.2` — left as-is rather than hand-editing it.
- Follow-up worth considering: enable `semver_check = true` so the Release PR flags "dependent uses a symbol absent from the published dep."