### PR TITLE
fix(server): sample now_ms once per get_ts to close the window-extension race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,6 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2299,6 +2328,16 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3416,18 +3455,23 @@ dependencies = [
 name = "tsoracle-tests"
 version = "0.1.4"
 dependencies = [
+ "async-stream",
  "fail",
  "futures",
+ "hyper",
+ "hyper-util",
  "metrics",
  "metrics-util 0.19.1",
  "rcgen",
  "tokio",
  "tokio-stream",
  "tonic",
+ "tower",
  "tsoracle-client",
  "tsoracle-core",
  "tsoracle-proto",
  "tsoracle-server",
+ "turmoil",
 ]
 
 [[package]]
@@ -3436,6 +3480,21 @@ version = "0.1.5"
 dependencies = [
  "parking_lot",
  "tokio",
+]
+
+[[package]]
+name = "turmoil"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0061c28f1469e94771bb8aa626ce6b29265c2fb5034115046a170b0cba2e33d2"
+dependencies = [
+ "bytes",
+ "indexmap",
+ "rand 0.9.4",
+ "rand_distr",
+ "scoped-tls",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -109,11 +109,19 @@ impl TsoService for TsoServiceImpl {
         // counter bounds it to two iterations, and the second iteration's
         // WindowExhausted falls through the guard into the `core_status` arm
         // rather than continuing.
+        // Sample the wall clock once for the whole get_ts. The retry's
+        // try_grant and the extension's would_grant / try_prepare all observe
+        // this single instant, so the would_grant recheck predicts the retry
+        // try_grant exactly. Re-reading the clock per call let it advance
+        // between the recheck and the retry, exhausting a zero-slack (small
+        // window_ahead) window — a timing race that surfaced intermittently as
+        // `Internal "window exhausted"`.
+        let now_ms = self.server.clock.now_ms();
         let mut attempt = 0;
         loop {
             let outcome = {
                 let mut allocator = self.server.allocator.lock();
-                allocator.try_grant(self.server.clock.now_ms(), count)
+                allocator.try_grant(now_ms, count)
             };
             match outcome {
                 Ok(grant) => {
@@ -136,7 +144,7 @@ impl TsoService for TsoServiceImpl {
                     return Err(not_leader_status(leader_hint_from(&self.server)));
                 }
                 Err(CoreError::WindowExhausted) if attempt == 0 => {
-                    self.extend_window(count).await?;
+                    self.extend_window(now_ms, count).await?;
                     attempt += 1;
                     continue;
                 }
@@ -157,7 +165,12 @@ impl TsoServiceImpl {
     /// request count, used so the recheck mirrors the outer loop's next
     /// `try_grant` exactly (a coarser check could skip an extension that the
     /// outer retry still actually needs).
-    async fn extend_window(&self, count: u32) -> Result<(), Status> {
+    ///
+    /// `now_ms` is the single wall-clock sample taken by `get_ts` for the whole
+    /// operation. Both the recheck and the prepare use it (rather than re-reading
+    /// the clock) so the would_grant predicate matches the retry try_grant at the
+    /// same logical instant — see the sampling comment in `get_ts`.
+    async fn extend_window(&self, now_ms: u64, count: u32) -> Result<(), Status> {
         // Single-flight gate: serialize peer extenders so consensus is hit
         // once per stampede, not once per stampeder.
         let _extension_lock = self.server.extension_lock.lock().await;
@@ -165,14 +178,9 @@ impl TsoServiceImpl {
         // Recheck-after-acquire: a peer extender may have run prepare →
         // persist → commit while we waited for the lock. If the outer
         // try_grant retry would now succeed, skip the consensus round-trip.
-        // Reading now_ms fresh inside the lock keeps the predicate aligned
-        // with what the outer loop's next try_grant will observe.
-        if self
-            .server
-            .allocator
-            .lock()
-            .would_grant(self.server.clock.now_ms(), count)
-        {
+        // Using get_ts's single `now_ms` sample keeps the predicate aligned
+        // with what the outer loop's retry try_grant will observe.
+        if self.server.allocator.lock().would_grant(now_ms, count) {
             return Ok(());
         }
 
@@ -189,9 +197,8 @@ impl TsoServiceImpl {
                 // about), not a bare FAILED_PRECONDITION without metadata.
                 return Err(not_leader_status(leader_hint_from(&self.server)));
             };
-            let now = self.server.clock.now_ms();
             let target = allocator
-                .try_prepare_window_extension(now, self.server.window_ahead.as_millis() as u64)
+                .try_prepare_window_extension(now_ms, self.server.window_ahead.as_millis() as u64)
                 .map_err(core_status)?;
             (target, epoch)
         };

--- a/crates/tsoracle-tests/Cargo.toml
+++ b/crates/tsoracle-tests/Cargo.toml
@@ -18,16 +18,22 @@ failpoints = ["tsoracle-server/failpoints", "dep:fail"]
 # Opt-in mirror of `tsoracle-client`'s `metrics` feature so `client_metrics`
 # can drive the recorder-fake test that asserts the documented client signals.
 metrics = ["tsoracle-client/metrics", "dep:metrics", "dep:metrics-util", "dep:tokio-stream"]
+dst = ["dep:turmoil", "dep:async-stream", "dep:hyper", "dep:hyper-util", "dep:tower"]
 
 [dependencies]
+async-stream    = { version = "0.3", optional = true }
 fail            = { workspace = true, optional = true }
 futures         = { workspace = true }
+hyper           = { version = "1", optional = true }
+hyper-util      = { version = "0.1", optional = true, features = ["tokio"] }
 metrics         = { workspace = true, optional = true }
 metrics-util    = { workspace = true, optional = true }
 rcgen           = { workspace = true }
 tokio           = { workspace = true, features = ["test-util"] }
 tokio-stream    = { workspace = true, optional = true, features = ["net"] }
 tonic           = { workspace = true }
+tower           = { version = "0.5", optional = true }
+turmoil         = { version = "0.7", optional = true }
 tsoracle-client = { path = "../tsoracle-client" }
 tsoracle-core   = { path = "../tsoracle-core" }
 tsoracle-proto  = { path = "../tsoracle-proto" }
@@ -55,3 +61,7 @@ name = "client_tls"
 [[test]]
 name              = "client_metrics"
 required-features = ["metrics"]
+
+[[test]]
+name              = "dst_window_race"
+required-features = ["dst"]

--- a/crates/tsoracle-tests/tests/dst_window_race.rs
+++ b/crates/tsoracle-tests/tests/dst_window_race.rs
@@ -1,0 +1,235 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Deterministic-simulation-testing (DST) trial via `turmoil`.
+//!
+//! The CI `coverage` job intermittently fails `client_backpressure`'s
+//! `first_chunk_delivers_before_slow_second_chunk_e2e` with
+//! `Status { code: Internal, message: "window exhausted" }`. That flake is a
+//! wall-clock race: with `window_ahead = 0` the committed bound has zero slack,
+//! and the server reads `now_ms()` twice per `get_ts` extend cycle (once in
+//! `extend_window`'s `would_grant` recheck, once in the retry `try_grant`). If
+//! the clock ticks between those reads, the retry exhausts. On a fast machine
+//! the gap stays sub-millisecond, so the bug is unreproducible locally — it only
+//! surfaces under the slow, contended CI runner.
+//!
+//! This test removes the dependency on real time entirely. It runs the *real*
+//! tsoracle gRPC server and a tonic client inside `turmoil`'s single-threaded,
+//! deterministic simulation, and injects a `Clock` that advances by 1ms on every
+//! read. That makes the two-read skew happen on every run from a fixed seed:
+//! "1-in-1000 on slow CI" becomes "100%, here, now".
+//!
+//! It is written as a regression test for the deterministic fix: the client
+//! asserts that `get_ts` *succeeds*. Against the current (unfixed) server it is
+//! RED — the simulation reproduces the race as a deterministic
+//! `Internal "window exhausted"`. Once the server reads `now_ms()` once per
+//! `get_ts` and reuses it, the test goes GREEN.
+//!
+//! Opt in: `cargo test -p tsoracle-tests --features dst --test dst_window_race`.
+
+use std::error::Error;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use tonic::transport::{Endpoint, Server as TonicServer};
+use tsoracle_core::{Clock, Epoch};
+use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::StallableDriver;
+use turmoil::Builder;
+use turmoil::net::TcpListener;
+
+const PORT: u16 = 9999;
+
+/// A clock that advances by 1ms on *every* read, modelling "the wall clock
+/// ticked between the server's two `now_ms()` reads" deterministically. The
+/// starting value is irrelevant; only the forward movement matters.
+struct TickingClock {
+    ms: AtomicU64,
+}
+
+impl TickingClock {
+    fn new(start_ms: u64) -> Self {
+        TickingClock {
+            ms: AtomicU64::new(start_ms),
+        }
+    }
+}
+
+impl Clock for TickingClock {
+    fn now_ms(&self) -> u64 {
+        // fetch_add returns the pre-increment value, so successive reads yield
+        // strictly increasing, distinct milliseconds.
+        self.ms.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+#[test]
+fn window_extension_race_is_deterministic_under_dst() {
+    let mut sim = Builder::new().build();
+
+    // The server host: the real tsoracle gRPC stack, served over turmoil's
+    // simulated network. `window_ahead = 0` (zero slack) + the ticking clock
+    // make the two-read skew deterministic.
+    let driver = Arc::new(StallableDriver::new());
+    sim.host("server", move || {
+        let driver = driver.clone();
+        async move {
+            let server = Server::builder()
+                .consensus_driver(driver.clone())
+                .clock(Arc::new(TickingClock::new(1_000)))
+                .window_ahead(Duration::ZERO)
+                .failover_advance(Duration::ZERO)
+                .build()
+                .expect("build server");
+
+            // `into_router` spawns the leader-watch task that seeds the
+            // allocator once the driver reports leadership.
+            let (routes, _watch) = server.into_router().expect("into_router");
+            driver.become_leader(Epoch(1));
+
+            TonicServer::builder()
+                .add_routes(routes)
+                .serve_with_incoming(async_stream::stream! {
+                    let listener =
+                        TcpListener::bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), PORT)).await?;
+                    loop {
+                        yield listener.accept().await.map(|(stream, _)| incoming::Accepted(stream));
+                    }
+                })
+                .await?;
+            Ok(())
+        }
+    });
+
+    // The client: polls `get_ts` until leadership is established, then asserts
+    // it succeeds. NOT_LEADER (FailedPrecondition) / Unavailable mean "not ready
+    // yet" — retry. An Internal reply is terminal: it is the reproduced race.
+    sim.client("client", async move {
+        let channel = Endpoint::new(format!("http://server:{PORT}"))?
+            .connect_with_connector_lazy(connector::connector());
+        let mut client = TsoServiceClient::new(channel);
+
+        for _ in 0..100 {
+            match client.get_ts(GetTsRequest { count: 1 }).await {
+                Ok(_) => return Ok(()), // GREEN: succeeds once the fix lands.
+                Err(status) => match status.code() {
+                    tonic::Code::FailedPrecondition | tonic::Code::Unavailable => {
+                        // Leadership not yet seeded / still connecting — retry.
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    _ => {
+                        // Terminal. Against the unfixed server this is the
+                        // deterministically-reproduced race.
+                        return Err(Box::<dyn Error>::from(format!(
+                            "get_ts must succeed under a forward-ticking clock with \
+                             window_ahead=0, but the window-extension race surfaced: {status:?}"
+                        )));
+                    }
+                },
+            }
+        }
+        Err(Box::<dyn Error + Send + Sync>::from(
+            "server never became leader within the poll budget",
+        ))
+    });
+
+    sim.run().expect(
+        "get_ts should succeed under deterministic simulation; \
+         the two-now_ms-read window-extension race was reproduced",
+    );
+}
+
+/// Server-side glue: wrap an accepted `turmoil` stream so tonic can treat it as
+/// a connected transport. Mirrors the upstream turmoil gRPC example.
+mod incoming {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+    use tonic::transport::server::{Connected, TcpConnectInfo};
+    use turmoil::net::TcpStream;
+
+    pub struct Accepted(pub TcpStream);
+
+    impl Connected for Accepted {
+        type ConnectInfo = TcpConnectInfo;
+
+        fn connect_info(&self) -> Self::ConnectInfo {
+            TcpConnectInfo {
+                local_addr: self.0.local_addr().ok(),
+                remote_addr: self.0.peer_addr().ok(),
+            }
+        }
+    }
+
+    impl AsyncRead for Accepted {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
+            Pin::new(&mut self.0).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for Accepted {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, std::io::Error>> {
+            Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
+            Pin::new(&mut self.0).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
+            Pin::new(&mut self.0).poll_shutdown(cx)
+        }
+    }
+}
+
+/// Client-side glue: a tower service that dials over turmoil's simulated network
+/// and hands tonic a `TokioIo`-wrapped stream. Mirrors the upstream example.
+mod connector {
+    use std::future::Future;
+    use std::pin::Pin;
+
+    use hyper::Uri;
+    use hyper_util::rt::TokioIo;
+    use tower::Service;
+    use turmoil::net::TcpStream;
+
+    type Fut = Pin<Box<dyn Future<Output = Result<TokioIo<TcpStream>, std::io::Error>> + Send>>;
+
+    pub fn connector()
+    -> impl Service<Uri, Response = TokioIo<TcpStream>, Error = std::io::Error, Future = Fut> + Clone
+    {
+        tower::service_fn(|uri: Uri| {
+            Box::pin(async move {
+                let conn = TcpStream::connect(uri.authority().unwrap().as_str()).await?;
+                Ok::<_, std::io::Error>(TokioIo::new(conn))
+            }) as Fut
+        })
+    }
+}


### PR DESCRIPTION
## Problem

`get_ts` read the wall clock multiple times per request: once in the retry `try_grant`, and again in `extend_window`'s `would_grant` recheck and `try_prepare_window_extension`. With a small (or zero) `window_ahead` the committed bound has **zero slack** above the clock, so if the clock advanced even 1ms between the `would_grant` recheck and the retry `try_grant`, the retry exhausted the window and the request failed with `Internal "window exhausted"`.

On fast hardware that inter-read gap stays sub-millisecond, so it never reproduced locally — it surfaced only as a rare flake under the slow, contended CI `coverage` runner, in `client_backpressure`'s `first_chunk_delivers_before_slow_second_chunk_e2e` (which uses `window_ahead = 0`).

## Fix

Sample `now_ms()` **once** at the top of `get_ts` and thread that single value through the retry `try_grant` and `extend_window` (`would_grant` + `try_prepare_window_extension`). The `would_grant` recheck now predicts the retry `try_grant` exactly, and the whole operation is evaluated at one logical instant. This also removes the latent production fragility for any small `window_ahead`.

No allocator changes; purely a `service.rs` clock-sampling change. Behavior is otherwise identical (timestamps remain monotonic; a single per-op sample is a valid recent reading).

## Deterministic regression test (DST trial)

Adds `crates/tsoracle-tests/tests/dst_window_race.rs` behind an opt-in `dst` feature. It runs the **real** tsoracle gRPC server and a tonic client inside [`turmoil`](https://github.com/tokio-rs/turmoil)'s single-threaded deterministic simulation, with an injected `Clock` that advances 1ms on every read — making the two-read skew happen on every run from a fixed seed.

- Before this fix: **RED** — reproduces the exact CI signature (`Internal "window exhausted"`), 100% of runs, in ~0.01s.
- After this fix: **GREEN**.

This converts a flake that was unreproducible on developer hardware (confirmed: no repro across core-count limits, fractional CPU quotas, or CPU contention) into a deterministic, instant test. The server runs unmodified over turmoil via its existing `Clock`/`ConsensusDriver` injection seams.

Run it: `cargo test -p tsoracle-tests --features dst --test dst_window_race`.

## Verification

- `cargo fmt --check`, `cargo clippy -p tsoracle-server -p tsoracle-tests --all-targets --features dst -- -D warnings`: clean.
- `tsoracle-server` lib tests (incl. `service.rs`): pass.
- Original `client_backpressure::first_chunk_delivers_before_slow_second_chunk_e2e`: passes.
- New DST test: RED before the fix, GREEN after (verified the red→green cycle).
- Note: a full `cargo test --workspace --all-features` run surfaced a failure in `tsoracle-driver-paxos` (`restart_recovers_decided_state_from_storage`) — an unrelated, pre-existing flake in a crate that does not depend on `tsoracle-server` (the `Cargo.lock` change here is additions-only), independent of this change.

## Notes

Follow-up to the timing flake surfaced during the #250 / #301 CI investigation. Branched off `origin/main` and independent of #301 (different files: `service.rs` vs `allocator.rs`).