### PR TITLE
test(server): run timing-fragile fence/churn tests under turmoil DST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,9 +3431,12 @@ dependencies = [
 name = "tsoracle-server"
 version = "0.2.3"
 dependencies = [
+ "async-stream",
  "async-trait",
  "fail",
  "futures",
+ "hyper",
+ "hyper-util",
  "metrics",
  "metrics-util 0.19.1",
  "parking_lot",
@@ -3444,29 +3447,27 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-reflection",
+ "tower",
  "tracing",
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-proto",
  "tsoracle-yieldpoint",
+ "turmoil",
 ]
 
 [[package]]
 name = "tsoracle-tests"
 version = "0.1.4"
 dependencies = [
- "async-stream",
  "fail",
  "futures",
- "hyper",
- "hyper-util",
  "metrics",
  "metrics-util 0.19.1",
  "rcgen",
  "tokio",
  "tokio-stream",
  "tonic",
- "tower",
  "tsoracle-client",
  "tsoracle-core",
  "tsoracle-proto",

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -22,6 +22,7 @@ tls-native = ["tonic/tls-native-roots"]
 tracing    = ["dep:tracing"]
 test-fakes = []
 test-support = ["test-fakes"]
+dst = ["test-support", "dep:turmoil", "dep:async-stream", "dep:hyper", "dep:hyper-util", "dep:tower"]
 reflection = ["dep:tonic-reflection", "tsoracle-proto/reflection"]
 bt         = ["tsoracle-core/bt", "tsoracle-consensus/bt"]
 
@@ -43,6 +44,11 @@ tonic              = { workspace = true }
 tonic-prost        = { workspace = true }
 tonic-reflection   = { workspace = true, optional = true }
 tracing            = { workspace = true, optional = true }
+turmoil            = { version = "0.7", optional = true }
+async-stream       = { version = "0.3", optional = true }
+hyper              = { version = "1", optional = true }
+hyper-util         = { version = "0.1", optional = true, features = ["tokio"] }
+tower              = { version = "0.5", optional = true }
 tsoracle-core      = { path = "../tsoracle-core", version = "0.2.1" }
 tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.6" }
 tsoracle-proto     = { path = "../tsoracle-proto", version = "0.2.1" }
@@ -72,6 +78,10 @@ required-features = ["test-support"]
 [[test]]
 name = "leadership_churn"
 required-features = ["test-support"]
+
+[[test]]
+name = "leadership_churn_dst"
+required-features = ["dst"]
 
 [[test]]
 name = "serve_shutdown"

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -254,3 +254,143 @@ pub async fn wait_for_grpc_handshake_tls(
         }
     }
 }
+
+/// Deterministic-simulation-testing harness: run the real gRPC server (and,
+/// optionally, a tonic client) over [`turmoil`]'s simulated network and clock,
+/// so timing-sensitive flows — window extension, fence retry/backoff,
+/// leadership churn — execute deterministically and instantly (sleeps advance
+/// simulated time). Gated behind the `dst` feature.
+///
+/// The transport glue (`Accepted` / connector) is shared so individual DST
+/// tests don't re-implement it. `into_sim_parts` spawns the leader-watch task
+/// on the calling host's executor, so the fence runs under simulated time as
+/// soon as it returns; tests then drive the in-memory driver and observe the
+/// returned `state_rx`.
+#[cfg(feature = "dst")]
+pub mod dst {
+    use std::future::Future;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+    use tokio::sync::watch;
+    use tokio::task::JoinHandle;
+    use tonic::service::Routes;
+    use tonic::transport::server::{Connected, TcpConnectInfo};
+    use tonic::transport::{Channel, Endpoint, Server as TonicServer};
+    use tsoracle_proto::v1::tso_service_client::TsoServiceClient;
+    use turmoil::net::{TcpListener, TcpStream};
+
+    use crate::{Server, ServerError, ServingState};
+
+    // Matches turmoil's `Result` error type so `?` works directly in host/client
+    // closures.
+    type BoxError = Box<dyn std::error::Error>;
+    type ConnFut = Pin<
+        Box<dyn Future<Output = Result<hyper_util::rt::TokioIo<TcpStream>, std::io::Error>> + Send>,
+    >;
+
+    /// The pieces needed to drive a server inside a turmoil host: the gRPC
+    /// `Routes` (serve them with [`serve`]), the already-spawned leader-watch
+    /// `JoinHandle`, and a clone of the observable `ServingState` channel.
+    pub struct SimParts {
+        pub routes: Routes,
+        pub watch: JoinHandle<Result<(), ServerError>>,
+        pub state_rx: watch::Receiver<ServingState>,
+    }
+
+    /// Capture a built [`Server`]'s sim parts. `into_router` spawns the
+    /// leader-watch task on the calling host's executor, so the fence begins
+    /// running under simulated time as soon as this returns.
+    pub fn into_sim_parts(server: Server) -> Result<SimParts, ServerError> {
+        let state_rx = server.state_rx.clone();
+        let (routes, watch) = server.into_router()?;
+        Ok(SimParts {
+            routes,
+            watch,
+            state_rx,
+        })
+    }
+
+    /// Serve `routes` over a `turmoil` listener on `port` until the sim ends.
+    /// Run inside a host closure (directly or via `tokio::spawn`).
+    pub async fn serve(routes: Routes, port: u16) -> Result<(), BoxError> {
+        TonicServer::builder()
+            .add_routes(routes)
+            .serve_with_incoming(async_stream::stream! {
+                let listener = TcpListener::bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), port)).await?;
+                loop {
+                    yield listener.accept().await.map(|(stream, _)| Accepted(stream));
+                }
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// A lazy tonic client that dials `host:port` over the turmoil network.
+    pub fn client(host: &str, port: u16) -> Result<TsoServiceClient<Channel>, BoxError> {
+        let channel = Endpoint::new(format!("http://{host}:{port}"))?
+            .connect_with_connector_lazy(connector());
+        Ok(TsoServiceClient::new(channel))
+    }
+
+    /// Server-side transport glue: wrap an accepted turmoil stream so tonic
+    /// treats it as a connected transport.
+    struct Accepted(TcpStream);
+
+    impl Connected for Accepted {
+        type ConnectInfo = TcpConnectInfo;
+        fn connect_info(&self) -> Self::ConnectInfo {
+            TcpConnectInfo {
+                local_addr: self.0.local_addr().ok(),
+                remote_addr: self.0.peer_addr().ok(),
+            }
+        }
+    }
+
+    impl AsyncRead for Accepted {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for Accepted {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_flush(cx)
+        }
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_shutdown(cx)
+        }
+    }
+
+    /// Client-side transport glue: dial over the turmoil network and hand tonic
+    /// a `TokioIo`-wrapped stream.
+    fn connector() -> impl tower::Service<
+        hyper::Uri,
+        Response = hyper_util::rt::TokioIo<TcpStream>,
+        Error = std::io::Error,
+        Future = ConnFut,
+    > + Clone {
+        tower::service_fn(|uri: hyper::Uri| {
+            Box::pin(async move {
+                let conn = TcpStream::connect(uri.authority().unwrap().as_str()).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(conn))
+            }) as ConnFut
+        })
+    }
+}

--- a/crates/tsoracle-server/tests/leadership_churn.rs
+++ b/crates/tsoracle-server/tests/leadership_churn.rs
@@ -12,18 +12,17 @@
 
 //! Regression tests for retry semantics during leadership churn.
 //!
-//! Two failure modes are exercised:
+//! `persist_high_water` returns `NotLeader` / `Fenced` mid-extension — the
+//! service must surface `FAILED_PRECONDITION` with a `LeaderHint`, poison server
+//! state (allocator cleared, `ServingState::NotServing` published), and remain
+//! in that state for subsequent calls. Transient and permanent driver errors
+//! must map to `UNAVAILABLE` and `INTERNAL` respectively, without poisoning
+//! state. A separate test pins that `serve_with_shutdown` exits with the watch's
+//! error when `run_leader_watch` returns `Err`.
 //!
-//! 1. `persist_high_water` returns `NotLeader` / `Fenced` mid-extension —
-//!    the service must surface `FAILED_PRECONDITION` with a `LeaderHint`,
-//!    poison server state (allocator cleared, `ServingState::NotServing`
-//!    published), and remain in that state for subsequent calls. Transient
-//!    and permanent driver errors must map to `UNAVAILABLE` and `INTERNAL`
-//!    respectively, without poisoning state.
-//!
-//! 2. `run_leader_watch` returns `Err` — `serve_with_shutdown` must exit
-//!    with the watch's error (not silently keep tonic running), and the
-//!    poisoned `NotServing` state must be visible to in-flight RPCs.
+//! The timing-fragile fence retry / sustained-churn tests live in
+//! `leadership_churn_dst.rs`, where they run deterministically under turmoil's
+//! simulated clock instead of waiting on real backoff.
 
 use core::pin::Pin;
 use futures::Stream;
@@ -34,10 +33,9 @@ use std::time::Duration;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::{Epoch, testing::MockClock};
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
-use tsoracle_server::test_fakes::{FaultKind, FaultyDriver, InMemoryDriver};
+use tsoracle_server::test_fakes::InMemoryDriver;
 use tsoracle_server::test_support::{
-    BootedServer, boot_server, wait_for_grpc_handshake, wait_until, wait_until_not_serving,
-    wait_until_serving,
+    BootedServer, boot_server, wait_for_grpc_handshake, wait_until_not_serving, wait_until_serving,
 };
 use tsoracle_server::{Server, ServerError, ServingState};
 
@@ -119,55 +117,6 @@ impl ConsensusDriver for FaultyLoadDriver {
     }
 
     async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
-        self.inner.persist_high_water(at_least, epoch).await
-    }
-}
-
-/// Returns `TransientDriver` from every `persist_high_water` call while the
-/// latch is set, modelling a driver (e.g. the paxos host) that reports
-/// leadership loss as a transient append failure rather than `NotLeader`.
-/// Leadership events and `load_high_water` delegate to the inner driver.
-struct LatchingTransientDriver {
-    inner: Arc<InMemoryDriver>,
-    fail_persists: AtomicBool,
-    persist_calls: AtomicUsize,
-}
-
-impl LatchingTransientDriver {
-    fn new(inner: Arc<InMemoryDriver>) -> Self {
-        Self {
-            inner,
-            fail_persists: AtomicBool::new(true),
-            persist_calls: AtomicUsize::new(0),
-        }
-    }
-
-    fn clear_faults(&self) {
-        self.fail_persists.store(false, Ordering::SeqCst);
-    }
-
-    fn persist_call_count(&self) -> usize {
-        self.persist_calls.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait::async_trait]
-impl ConsensusDriver for LatchingTransientDriver {
-    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
-        self.inner.leadership_events()
-    }
-
-    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
-        self.inner.load_high_water().await
-    }
-
-    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
-        self.persist_calls.fetch_add(1, Ordering::SeqCst);
-        if self.fail_persists.load(Ordering::SeqCst) {
-            return Err(ConsensusError::TransientDriver(Box::new(
-                std::io::Error::other("latched transient persist fault"),
-            )));
-        }
         self.inner.persist_high_water(at_least, epoch).await
     }
 }
@@ -393,211 +342,4 @@ async fn serve_with_shutdown_exits_when_watch_returns_error() {
         matches!(*state_rx.borrow(), ServingState::NotServing { .. }),
         "state must be poisoned to NotServing when watch terminates"
     );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn fence_recovers_after_transient_burst_exceeding_old_budget() {
-    // 10 transient persist faults is past the historical bound of 8. The fence
-    // must keep retrying — on a node that never stops being leader — until the
-    // 11th persist succeeds and the server reaches Serving. No leadership
-    // transition is ever emitted, so recovery proves the retry loop does not
-    // give up while still leader.
-    let driver = Arc::new(FaultyDriver::new());
-    driver.fail_next_persists(10, FaultKind::Transient);
-
-    let server = Server::builder()
-        .consensus_driver(driver.clone())
-        .clock(Arc::new(MockClock::new(1_000)))
-        .build()
-        .unwrap();
-    let mut booted = boot_server(server).await;
-
-    driver.become_leader(Epoch(1));
-
-    tokio::time::timeout(
-        Duration::from_secs(15),
-        wait_until_serving(&mut booted.state_rx),
-    )
-    .await
-    .expect("fence must reach Serving despite a transient burst past the old budget");
-
-    assert_eq!(
-        driver.persist_call_count(),
-        11,
-        "expected 10 failed persists + 1 success"
-    );
-
-    booted.shutdown().await.unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn sustained_leader_churn_never_exits_watch_loop() {
-    // #204: under paxos's frequent leader churn, every new election opens a
-    // volatile window where the first fence persist can fail as a transient
-    // append error (paxos reports a step-down that way, not as NotLeader). The
-    // earlier behavior exhausted the fence's retry budget and let the watch loop
-    // return Err, poisoning serving and taking the server task down with it — so
-    // the stress harness recorded zero successful client calls.
-    //
-    // `fence_observes_follower_transition_during_unbounded_transient_retry`
-    // already pins a *single* step-down observed mid-retry plus one recovery.
-    // This test pins the part #204 actually names: *sustained* oscillation. We
-    // drive several Leader -> Follower -> Leader cycles, each opening with a
-    // transient fence burst, and assert the watch task survives every cycle and
-    // re-serves each time leadership returns.
-    let driver = Arc::new(FaultyDriver::new());
-
-    let server = Server::builder()
-        .consensus_driver(driver.clone())
-        .clock(Arc::new(MockClock::new(1_000)))
-        .window_ahead(Duration::from_millis(50))
-        .failover_advance(Duration::from_millis(50))
-        .build()
-        .unwrap();
-    let mut booted = boot_server(server).await;
-
-    // A transient burst per leader window: load_high_water succeeds, then the
-    // first `BURST` persists fail transiently before one succeeds. Three is
-    // already past nothing pathological but exercises the backoff path several
-    // times per cycle.
-    const BURST: usize = 3;
-    const CYCLES: u128 = 4;
-
-    for epoch in 1..=CYCLES {
-        driver.fail_next_persists(BURST, FaultKind::Transient);
-        driver.become_leader(Epoch(epoch));
-
-        // Reaching Serving proves the fence rode through the transient burst
-        // without giving up — i.e. the watch loop is still alive and re-fenced
-        // at this epoch rather than having exited.
-        tokio::time::timeout(
-            Duration::from_secs(10),
-            wait_until_serving(&mut booted.state_rx),
-        )
-        .await
-        .unwrap_or_else(|_| panic!("fence must reach Serving on epoch {epoch} despite churn"));
-        assert!(
-            !booted.serve_handle.is_finished(),
-            "watch/serve task must stay alive while Serving on epoch {epoch}",
-        );
-
-        // Lose leadership again. The watch loop publishes NotServing and loops
-        // back to await the next event — it must not exit.
-        driver.become_follower(None);
-        tokio::time::timeout(
-            Duration::from_secs(10),
-            wait_until_not_serving(&mut booted.state_rx),
-        )
-        .await
-        .unwrap_or_else(|_| panic!("must step down to NotServing on epoch {epoch}"));
-        assert!(
-            !booted.serve_handle.is_finished(),
-            "watch/serve task must stay alive after stepping down on epoch {epoch}",
-        );
-    }
-
-    // After sustained churn the server is still alive end-to-end: win one more
-    // term and serve a real GetTs over gRPC.
-    driver.fail_next_persists(BURST, FaultKind::Transient);
-    driver.become_leader(Epoch(CYCLES + 1));
-    tokio::time::timeout(
-        Duration::from_secs(10),
-        wait_until_serving(&mut booted.state_rx),
-    )
-    .await
-    .expect("fence must reach Serving on the final term");
-    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
-        .await
-        .expect("tonic never accepted gRPC handshake");
-
-    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
-        .await
-        .unwrap();
-    let granted = client
-        .get_ts(GetTsRequest { count: 1 })
-        .await
-        .expect("GetTs must succeed after sustained churn");
-    assert_eq!(granted.into_inner().count, 1);
-
-    // The transient-fault path was actually exercised, not vacuously skipped:
-    // every cycle (plus the final term) attempted at least BURST + 1 persists.
-    assert!(
-        driver.persist_call_count() > CYCLES as u64,
-        "transient fence faults must have been exercised across cycles",
-    );
-
-    booted.shutdown().await.unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn fence_observes_follower_transition_during_unbounded_transient_retry() {
-    let inner = Arc::new(InMemoryDriver::new());
-    let driver = Arc::new(LatchingTransientDriver::new(inner.clone()));
-
-    let server = Server::builder()
-        .consensus_driver(driver.clone())
-        .clock(Arc::new(MockClock::new(1_000)))
-        .build()
-        .unwrap();
-    let mut booted = boot_server(server).await;
-
-    // Fence enters an effectively infinite transient-retry loop.
-    inner.become_leader(Epoch(1));
-
-    // Retries must climb well past the historical bound of 8 — proving the loop
-    // no longer gives up while still leader.
-    tokio::time::timeout(Duration::from_secs(15), async {
-        loop {
-            if driver.persist_call_count() >= 12 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-    })
-    .await
-    .expect("fence must keep retrying past the old budget while latched transient");
-
-    // A real leadership change arrives while the fence is mid-retry. The race
-    // against the leadership stream must observe it. The Follower handler
-    // publishes NotServing carrying the hint; the fence's own NotServing uses
-    // leader_endpoint: None, so observing Some(hint) proves the event was
-    // dispatched rather than spun past.
-    inner.become_follower(Some("10.1.2.3:50551".into()));
-
-    tokio::time::timeout(
-        Duration::from_secs(10),
-        wait_until(&mut booted.state_rx, |s| {
-            matches!(
-                s,
-                ServingState::NotServing {
-                    leader_endpoint: Some(_),
-                    ..
-                }
-            )
-        }),
-    )
-    .await
-    .expect("Follower transition during retry must be observed and published with its hint");
-
-    // Once the Follower is dispatched the loop is back on stream.next(), so no
-    // further persist attempts occur.
-    let settled = driver.persist_call_count();
-    tokio::time::sleep(Duration::from_millis(400)).await;
-    assert_eq!(
-        driver.persist_call_count(),
-        settled,
-        "no more fence persist attempts after stepping down to Follower"
-    );
-
-    // Recovery: clear the fault and re-win leadership at a new epoch.
-    driver.clear_faults();
-    inner.become_leader(Epoch(2));
-    tokio::time::timeout(
-        Duration::from_secs(10),
-        wait_until_serving(&mut booted.state_rx),
-    )
-    .await
-    .expect("fence must reach Serving after re-winning leadership");
-
-    booted.shutdown().await.unwrap();
 }

--- a/crates/tsoracle-server/tests/leadership_churn_dst.rs
+++ b/crates/tsoracle-server/tests/leadership_churn_dst.rs
@@ -1,0 +1,288 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Deterministic-simulation (turmoil) variants of the timing-fragile fence /
+//! leadership-churn tests from `leadership_churn.rs`.
+//!
+//! Those tests wait up to 10–15 seconds of *real* time for the fence to retry
+//! transient persist failures with backoff, and one races the fence's retry
+//! loop against a leadership-stream transition. Under turmoil the
+//! `tokio::time::sleep` backoff advances *simulated* time, so the same coverage
+//! runs deterministically and instantly from a fixed seed — no wall-clock waits,
+//! no flakiness. The shared transport glue lives in
+//! `tsoracle_server::test_support::dst`.
+//!
+//! The four `extend_window_maps_*` error-mapping tests stay in
+//! `leadership_churn.rs`: they use `MockClock` and assert error *codes*, so
+//! they are not timing-fragile and gain nothing from simulation.
+//!
+//! Opt in: `cargo test -p tsoracle-server --features dst --test leadership_churn_dst`.
+
+use core::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use futures::Stream;
+use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
+use tsoracle_core::{Epoch, testing::MockClock};
+use tsoracle_proto::v1::GetTsRequest;
+use tsoracle_server::test_fakes::{FaultKind, FaultyDriver, InMemoryDriver};
+use tsoracle_server::test_support::dst::{client, into_sim_parts, serve};
+use tsoracle_server::test_support::{wait_until, wait_until_not_serving, wait_until_serving};
+use tsoracle_server::{Server, ServingState};
+
+const PORT: u16 = 9_999;
+
+/// Generous virtual-time budget. Sim time is instant in wall-clock terms, so a
+/// large ceiling just guarantees the backoff retries fit without a real wait.
+fn sim() -> turmoil::Sim<'static> {
+    turmoil::Builder::new()
+        .simulation_duration(Duration::from_secs(300))
+        .build()
+}
+
+#[test]
+fn fence_recovers_after_transient_burst_exceeding_old_budget() {
+    // 10 transient persist faults is past the historical bound of 8. The fence
+    // must keep retrying — on a node that never stops being leader — until the
+    // 11th persist succeeds and the server reaches Serving. Under turmoil the
+    // backoff sleeps collapse to simulated time, so this is instant + deterministic.
+    let driver = Arc::new(FaultyDriver::new());
+    driver.fail_next_persists(10, FaultKind::Transient);
+
+    let driver_in_host = driver.clone();
+    let mut sim = sim();
+    sim.client("node", async move {
+        let server = Server::builder()
+            .consensus_driver(driver_in_host.clone())
+            .clock(Arc::new(MockClock::new(1_000)))
+            .build()
+            .unwrap();
+        // into_sim_parts spawns the leader-watch task on this host's executor,
+        // so the fence runs under simulated time.
+        let mut parts = into_sim_parts(server)?;
+        driver_in_host.become_leader(Epoch(1));
+        wait_until_serving(&mut parts.state_rx).await;
+        Ok(())
+    });
+
+    sim.run().unwrap();
+
+    assert_eq!(
+        driver.persist_call_count(),
+        11,
+        "expected 10 failed persists + 1 success"
+    );
+}
+
+#[test]
+fn fence_observes_follower_transition_during_unbounded_transient_retry() {
+    let inner = Arc::new(InMemoryDriver::new());
+    let driver = Arc::new(LatchingTransientDriver::new(inner.clone()));
+
+    let inner_in_host = inner.clone();
+    let driver_in_host = driver.clone();
+    let mut sim = sim();
+    sim.client("node", async move {
+        let server = Server::builder()
+            .consensus_driver(driver_in_host.clone())
+            .clock(Arc::new(MockClock::new(1_000)))
+            .build()
+            .unwrap();
+        let mut parts = into_sim_parts(server)?;
+
+        // Fence enters an effectively infinite transient-retry loop.
+        inner_in_host.become_leader(Epoch(1));
+
+        // Retries must climb well past the historical bound of 8, proving the
+        // loop no longer gives up while still leader. Under turmoil the backoff
+        // sleeps advance simulated time, so this poll is instant.
+        while driver_in_host.persist_call_count() < 12 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // A real leadership change arrives while the fence is mid-retry. The
+        // Follower handler publishes NotServing carrying the hint; the fence's
+        // own NotServing uses leader_endpoint: None, so observing Some(hint)
+        // proves the event was dispatched rather than spun past.
+        inner_in_host.become_follower(Some("10.1.2.3:50551".into()));
+
+        wait_until(&mut parts.state_rx, |s| {
+            matches!(
+                s,
+                ServingState::NotServing {
+                    leader_endpoint: Some(_),
+                    ..
+                }
+            )
+        })
+        .await;
+
+        // Once the Follower is dispatched the loop is back on stream.next(), so
+        // no further persist attempts occur.
+        let settled = driver_in_host.persist_call_count();
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            driver_in_host.persist_call_count(),
+            settled,
+            "no more fence persist attempts after stepping down to Follower"
+        );
+
+        // Recovery: clear the fault and re-win leadership at a new epoch.
+        driver_in_host.clear_faults();
+        inner_in_host.become_leader(Epoch(2));
+        wait_until_serving(&mut parts.state_rx).await;
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+#[test]
+fn sustained_leader_churn_never_exits_watch_loop() {
+    // #204: under paxos's frequent leader churn, every new election opens a
+    // volatile window where the first fence persist can fail as a transient
+    // append error. The earlier behavior exhausted the fence's retry budget and
+    // let the watch loop return Err, poisoning serving. This pins *sustained*
+    // oscillation: several Leader -> Follower -> Leader cycles, each opening with
+    // a transient fence burst, asserting the watch task survives every cycle.
+    const BURST: usize = 3;
+    const CYCLES: u128 = 4;
+
+    let driver = Arc::new(FaultyDriver::new());
+    let driver_in_host = driver.clone();
+    let mut sim = sim();
+
+    // Server host: drive the churn cycles (it owns state_rx + the watch handle),
+    // then serve the final term so the client host can issue a real GetTs.
+    sim.host("server", move || {
+        let driver = driver_in_host.clone();
+        async move {
+            let server = Server::builder()
+                .consensus_driver(driver.clone())
+                .clock(Arc::new(MockClock::new(1_000)))
+                .window_ahead(Duration::from_millis(50))
+                .failover_advance(Duration::from_millis(50))
+                .build()
+                .unwrap();
+            let parts = into_sim_parts(server)?;
+            let mut state_rx = parts.state_rx;
+            let watch = parts.watch;
+
+            for epoch in 1..=CYCLES {
+                driver.fail_next_persists(BURST, FaultKind::Transient);
+                driver.become_leader(Epoch(epoch));
+                // Reaching Serving proves the fence rode through the transient
+                // burst without giving up — the watch loop is still alive.
+                wait_until_serving(&mut state_rx).await;
+                assert!(
+                    !watch.is_finished(),
+                    "watch/serve task must stay alive while Serving on epoch {epoch}",
+                );
+
+                driver.become_follower(None);
+                wait_until_not_serving(&mut state_rx).await;
+                assert!(
+                    !watch.is_finished(),
+                    "watch/serve task must stay alive after stepping down on epoch {epoch}",
+                );
+            }
+
+            // Win one more term and serve it for the client.
+            driver.fail_next_persists(BURST, FaultKind::Transient);
+            driver.become_leader(Epoch(CYCLES + 1));
+            wait_until_serving(&mut state_rx).await;
+            assert!(
+                !watch.is_finished(),
+                "watch must survive into the final term"
+            );
+
+            serve(parts.routes, PORT).await?;
+            Ok(())
+        }
+    });
+
+    // Client host: poll GetTs until the server reaches its final serving term,
+    // proving the server is alive end-to-end after sustained churn.
+    sim.client("client", async move {
+        let mut grpc = client("server", PORT)?;
+        for _ in 0..200 {
+            match grpc.get_ts(GetTsRequest { count: 1 }).await {
+                Ok(resp) => {
+                    assert_eq!(resp.into_inner().count, 1);
+                    return Ok(());
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(50)).await,
+            }
+        }
+        Err("GetTs never succeeded after sustained churn".into())
+    });
+
+    sim.run().unwrap();
+
+    // The transient-fault path was actually exercised, not vacuously skipped.
+    assert!(
+        driver.persist_call_count() > CYCLES as u64,
+        "transient fence faults must have been exercised across cycles",
+    );
+}
+
+/// Returns `TransientDriver` from every `persist_high_water` while latched,
+/// modelling a driver (e.g. the paxos host) that reports leadership loss as a
+/// transient append failure rather than `NotLeader`. Leadership events and
+/// `load_high_water` delegate to the inner driver. Copied from
+/// `leadership_churn.rs` (test binaries can't share a non-`common` module).
+struct LatchingTransientDriver {
+    inner: Arc<InMemoryDriver>,
+    fail_persists: AtomicBool,
+    persist_calls: AtomicUsize,
+}
+
+impl LatchingTransientDriver {
+    fn new(inner: Arc<InMemoryDriver>) -> Self {
+        Self {
+            inner,
+            fail_persists: AtomicBool::new(true),
+            persist_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn clear_faults(&self) {
+        self.fail_persists.store(false, Ordering::SeqCst);
+    }
+
+    fn persist_call_count(&self) -> usize {
+        self.persist_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsensusDriver for LatchingTransientDriver {
+    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        self.inner.leadership_events()
+    }
+
+    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
+        self.inner.load_high_water().await
+    }
+
+    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        self.persist_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_persists.load(Ordering::SeqCst) {
+            return Err(ConsensusError::TransientDriver(Box::new(
+                std::io::Error::other("latched transient persist fault"),
+            )));
+        }
+        self.inner.persist_high_water(at_least, epoch).await
+    }
+}

--- a/crates/tsoracle-tests/Cargo.toml
+++ b/crates/tsoracle-tests/Cargo.toml
@@ -18,21 +18,17 @@ failpoints = ["tsoracle-server/failpoints", "dep:fail"]
 # Opt-in mirror of `tsoracle-client`'s `metrics` feature so `client_metrics`
 # can drive the recorder-fake test that asserts the documented client signals.
 metrics = ["tsoracle-client/metrics", "dep:metrics", "dep:metrics-util", "dep:tokio-stream"]
-dst = ["dep:turmoil", "dep:async-stream", "dep:hyper", "dep:hyper-util", "dep:tower"]
+dst = ["dep:turmoil", "tsoracle-server/dst"]
 
 [dependencies]
-async-stream    = { version = "0.3", optional = true }
 fail            = { workspace = true, optional = true }
 futures         = { workspace = true }
-hyper           = { version = "1", optional = true }
-hyper-util      = { version = "0.1", optional = true, features = ["tokio"] }
 metrics         = { workspace = true, optional = true }
 metrics-util    = { workspace = true, optional = true }
 rcgen           = { workspace = true }
 tokio           = { workspace = true, features = ["test-util"] }
 tokio-stream    = { workspace = true, optional = true, features = ["net"] }
 tonic           = { workspace = true }
-tower           = { version = "0.5", optional = true }
 turmoil         = { version = "0.7", optional = true }
 tsoracle-client = { path = "../tsoracle-client" }
 tsoracle-core   = { path = "../tsoracle-core" }

--- a/crates/tsoracle-tests/tests/dst_window_race.rs
+++ b/crates/tsoracle-tests/tests/dst_window_race.rs
@@ -10,51 +10,38 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! Deterministic-simulation-testing (DST) trial via `turmoil`.
+//! Deterministic-simulation-testing (DST) regression for the `get_ts`
+//! window-extension clock race.
 //!
-//! The CI `coverage` job intermittently fails `client_backpressure`'s
-//! `first_chunk_delivers_before_slow_second_chunk_e2e` with
-//! `Status { code: Internal, message: "window exhausted" }`. That flake is a
-//! wall-clock race: with `window_ahead = 0` the committed bound has zero slack,
-//! and the server reads `now_ms()` twice per `get_ts` extend cycle (once in
-//! `extend_window`'s `would_grant` recheck, once in the retry `try_grant`). If
-//! the clock ticks between those reads, the retry exhausts. On a fast machine
-//! the gap stays sub-millisecond, so the bug is unreproducible locally — it only
-//! surfaces under the slow, contended CI runner.
+//! With `window_ahead = 0` the committed bound has zero slack, and the server
+//! read `now_ms()` more than once per `get_ts` extend cycle; any clock tick
+//! between those reads exhausted the retry. On fast hardware the gap stays
+//! sub-millisecond, so the bug only flaked under the slow, contended CI runner.
 //!
-//! This test removes the dependency on real time entirely. It runs the *real*
-//! tsoracle gRPC server and a tonic client inside `turmoil`'s single-threaded,
-//! deterministic simulation, and injects a `Clock` that advances by 1ms on every
-//! read. That makes the two-read skew happen on every run from a fixed seed:
-//! "1-in-1000 on slow CI" becomes "100%, here, now".
-//!
-//! It is written as a regression test for the deterministic fix: the client
-//! asserts that `get_ts` *succeeds*. Against the current (unfixed) server it is
-//! RED — the simulation reproduces the race as a deterministic
-//! `Internal "window exhausted"`. Once the server reads `now_ms()` once per
-//! `get_ts` and reuses it, the test goes GREEN.
+//! This test removes real time entirely: the real tsoracle gRPC server + a tonic
+//! client run inside `turmoil`'s single-threaded simulation, with a `Clock` that
+//! advances 1ms on every read — making the two-read skew happen on every run
+//! from a fixed seed. RED before the read-once fix, GREEN after. The turmoil
+//! transport glue is shared from `tsoracle_server::test_support::dst`.
 //!
 //! Opt in: `cargo test -p tsoracle-tests --features dst --test dst_window_race`.
 
 use std::error::Error;
-use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use tonic::transport::{Endpoint, Server as TonicServer};
 use tsoracle_core::{Clock, Epoch};
-use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
+use tsoracle_proto::v1::GetTsRequest;
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::StallableDriver;
+use tsoracle_server::test_support::dst::{client, into_sim_parts, serve};
 use turmoil::Builder;
-use turmoil::net::TcpListener;
 
-const PORT: u16 = 9999;
+const PORT: u16 = 9_999;
 
 /// A clock that advances by 1ms on *every* read, modelling "the wall clock
-/// ticked between the server's two `now_ms()` reads" deterministically. The
-/// starting value is irrelevant; only the forward movement matters.
+/// ticked between the server's two `now_ms()` reads" deterministically.
 struct TickingClock {
     ms: AtomicU64,
 }
@@ -69,8 +56,6 @@ impl TickingClock {
 
 impl Clock for TickingClock {
     fn now_ms(&self) -> u64 {
-        // fetch_add returns the pre-increment value, so successive reads yield
-        // strictly increasing, distinct milliseconds.
         self.ms.fetch_add(1, Ordering::Relaxed)
     }
 }
@@ -79,9 +64,6 @@ impl Clock for TickingClock {
 fn window_extension_race_is_deterministic_under_dst() {
     let mut sim = Builder::new().build();
 
-    // The server host: the real tsoracle gRPC stack, served over turmoil's
-    // simulated network. `window_ahead = 0` (zero slack) + the ticking clock
-    // make the two-read skew deterministic.
     let driver = Arc::new(StallableDriver::new());
     sim.host("server", move || {
         let driver = driver.clone();
@@ -93,45 +75,26 @@ fn window_extension_race_is_deterministic_under_dst() {
                 .failover_advance(Duration::ZERO)
                 .build()
                 .expect("build server");
-
-            // `into_router` spawns the leader-watch task that seeds the
-            // allocator once the driver reports leadership.
-            let (routes, _watch) = server.into_router().expect("into_router");
+            let parts = into_sim_parts(server)?;
             driver.become_leader(Epoch(1));
-
-            TonicServer::builder()
-                .add_routes(routes)
-                .serve_with_incoming(async_stream::stream! {
-                    let listener =
-                        TcpListener::bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), PORT)).await?;
-                    loop {
-                        yield listener.accept().await.map(|(stream, _)| incoming::Accepted(stream));
-                    }
-                })
-                .await?;
+            serve(parts.routes, PORT).await?;
             Ok(())
         }
     });
 
-    // The client: polls `get_ts` until leadership is established, then asserts
-    // it succeeds. NOT_LEADER (FailedPrecondition) / Unavailable mean "not ready
-    // yet" — retry. An Internal reply is terminal: it is the reproduced race.
     sim.client("client", async move {
-        let channel = Endpoint::new(format!("http://server:{PORT}"))?
-            .connect_with_connector_lazy(connector::connector());
-        let mut client = TsoServiceClient::new(channel);
-
+        let mut grpc = client("server", PORT)?;
         for _ in 0..100 {
-            match client.get_ts(GetTsRequest { count: 1 }).await {
-                Ok(_) => return Ok(()), // GREEN: succeeds once the fix lands.
+            match grpc.get_ts(GetTsRequest { count: 1 }).await {
+                Ok(_) => return Ok(()), // GREEN: succeeds with the read-once fix.
                 Err(status) => match status.code() {
+                    // Leadership not yet seeded / still connecting — retry.
                     tonic::Code::FailedPrecondition | tonic::Code::Unavailable => {
-                        // Leadership not yet seeded / still connecting — retry.
                         tokio::time::sleep(Duration::from_millis(50)).await;
                     }
+                    // Terminal: against the unfixed server this is the
+                    // deterministically-reproduced race.
                     _ => {
-                        // Terminal. Against the unfixed server this is the
-                        // deterministically-reproduced race.
                         return Err(Box::<dyn Error>::from(format!(
                             "get_ts must succeed under a forward-ticking clock with \
                              window_ahead=0, but the window-extension race surfaced: {status:?}"
@@ -140,8 +103,8 @@ fn window_extension_race_is_deterministic_under_dst() {
                 },
             }
         }
-        Err(Box::<dyn Error + Send + Sync>::from(
-            "server never became leader within the poll budget",
+        Err(Box::<dyn Error>::from(
+            "server never became leader within the poll budget".to_string(),
         ))
     });
 
@@ -149,87 +112,4 @@ fn window_extension_race_is_deterministic_under_dst() {
         "get_ts should succeed under deterministic simulation; \
          the two-now_ms-read window-extension race was reproduced",
     );
-}
-
-/// Server-side glue: wrap an accepted `turmoil` stream so tonic can treat it as
-/// a connected transport. Mirrors the upstream turmoil gRPC example.
-mod incoming {
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-
-    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-    use tonic::transport::server::{Connected, TcpConnectInfo};
-    use turmoil::net::TcpStream;
-
-    pub struct Accepted(pub TcpStream);
-
-    impl Connected for Accepted {
-        type ConnectInfo = TcpConnectInfo;
-
-        fn connect_info(&self) -> Self::ConnectInfo {
-            TcpConnectInfo {
-                local_addr: self.0.local_addr().ok(),
-                remote_addr: self.0.peer_addr().ok(),
-            }
-        }
-    }
-
-    impl AsyncRead for Accepted {
-        fn poll_read(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &mut ReadBuf<'_>,
-        ) -> Poll<Result<(), std::io::Error>> {
-            Pin::new(&mut self.0).poll_read(cx, buf)
-        }
-    }
-
-    impl AsyncWrite for Accepted {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<Result<usize, std::io::Error>> {
-            Pin::new(&mut self.0).poll_write(cx, buf)
-        }
-
-        fn poll_flush(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), std::io::Error>> {
-            Pin::new(&mut self.0).poll_flush(cx)
-        }
-
-        fn poll_shutdown(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), std::io::Error>> {
-            Pin::new(&mut self.0).poll_shutdown(cx)
-        }
-    }
-}
-
-/// Client-side glue: a tower service that dials over turmoil's simulated network
-/// and hands tonic a `TokioIo`-wrapped stream. Mirrors the upstream example.
-mod connector {
-    use std::future::Future;
-    use std::pin::Pin;
-
-    use hyper::Uri;
-    use hyper_util::rt::TokioIo;
-    use tower::Service;
-    use turmoil::net::TcpStream;
-
-    type Fut = Pin<Box<dyn Future<Output = Result<TokioIo<TcpStream>, std::io::Error>> + Send>>;
-
-    pub fn connector()
-    -> impl Service<Uri, Response = TokioIo<TcpStream>, Error = std::io::Error, Future = Fut> + Clone
-    {
-        tower::service_fn(|uri: Uri| {
-            Box::pin(async move {
-                let conn = TcpStream::connect(uri.authority().unwrap().as_str()).await?;
-                Ok::<_, std::io::Error>(TokioIo::new(conn))
-            }) as Fut
-        })
-    }
 }


### PR DESCRIPTION
Tier-1 of the broader effort to put timing-fragile tests under deterministic simulation (follow-up to #303). Builds the shared turmoil harness and converts the highest-value target — the fence retry / leadership-churn tests — to it.

## Why

`leadership_churn.rs`'s fence/churn tests waited up to **10–15s of real time** for the fence to retry transient persist failures with backoff, and one raced the retry loop against the leadership stream. That's the same class of timing-only-resolves-under-specific-scheduling flake the coverage job hits. Under turmoil's simulated clock, `tokio::time::sleep` backoff advances *virtual* time, so the same coverage runs deterministically and instantly.

## What

**Shared DST harness** — `tsoracle_server::test_support::dst` (new opt-in `dst` feature):
- `Accepted`/`Connected` + connector transport glue (tonic over `turmoil::net`).
- `into_sim_parts(server)` — exposes `state_rx` (only reachable in-crate) and spawns the leader-watch task under simulated time.
- `serve(routes, port)` and `client(host, port)` helpers.
- `turmoil` is an **optional** dependency behind `dst`, so a default build of the published crate is unaffected. This lives in `tsoracle-server` (not `tsoracle-tests`) because the churn tests assert on `ServingState` transitions via `state_rx`, which only in-crate code can hand out — and it's the one spot both crates can share.

**Converted 3 timing-fragile tests** → `leadership_churn_dst.rs` (turmoil):
- `fence_recovers_after_transient_burst_exceeding_old_budget`
- `sustained_leader_churn_never_exits_watch_loop`
- `fence_observes_follower_transition_during_unbounded_transient_retry`

They run in **~0.03s total** (was 10–15s each, flake-prone) and are deterministic from a fixed seed. The flaky real-time originals are removed; the four `extend_window_maps_*` error-mapping tests and `serve_with_shutdown` stay (they use `MockClock` and assert error codes — not timing-fragile).

**De-duplicated #303**: `dst_window_race.rs` now consumes the shared harness (dropped ~120 lines of inline glue); `tsoracle-tests` sheds 4 now-unused optional deps and its `dst` feature just enables `tsoracle-server/dst`.

Net −231 lines.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean (also via pre-commit).
- `cargo test -p tsoracle-server --all-features` and `-p tsoracle-tests --all-features`: pass (exit 0).
- `cargo test --workspace --all-features --locked` (the CI test command): no failures.
- The 3 converted tests verified deterministic across repeated runs (~0.03s).

## Scope note

This is the first pass (shared module + `leadership_churn`). Remaining Tier-1 candidates (`extension_stampede`, `client_e2e`, `client_freshness`, `metrics`) and other tiers (the paxos/openraft consensus-driver flakes need madsim/lib harnesses, not turmoil) are deliberately left for follow-ups.