### PR TITLE
test(driver-paxos): deterministic step-driver for the paxos harness (+ convert the steppable tests)

### DIFF
--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use omnipaxos::OmniPaxos;
+use omnipaxos::messages::Message;
 use omnipaxos::storage::Storage;
 use parking_lot::Mutex;
 use tokio::sync::Notify;
@@ -63,6 +64,10 @@ where
     /// task is running (stop-before-start, double-stop, stop-after-exit).
     apply_shutdown: Mutex<Option<Arc<Notify>>>,
     policy: Arc<Mutex<SnapshotPolicy>>,
+    /// Decided-log cursor for the synchronous [`Self::step`] / [`Self::apply_once`]
+    /// stepping path, seeded past any recovered suffix. The async apply task
+    /// keeps its own task-local cursor; a host is driven by exactly one path.
+    step_cursor: Mutex<u64>,
 }
 
 impl<S> StandaloneHost<S>
@@ -114,6 +119,7 @@ where
             apply_handle: Mutex::new(None),
             apply_shutdown: Mutex::new(None),
             policy: Arc::new(Mutex::new(policy)),
+            step_cursor: Mutex::new(recovery_cursor),
         }
     }
 
@@ -207,6 +213,32 @@ where
     /// Used internally by `current_high_water` after a barrier decides.
     pub fn current_value(&self) -> u64 {
         self.apply_state.high_water()
+    }
+
+    /// Synchronous single step for deterministic test stepping: tick the runner
+    /// once and apply any newly-decided entries, returning the runner's outbound
+    /// messages for the caller to route. Mutually exclusive with [`Self::start`]
+    /// — a host is driven by exactly one of the two paths.
+    pub fn step(&self) -> Vec<Message<HighWaterCommand>> {
+        let outgoing = self.runner.tick_once();
+        self.apply_once();
+        outgoing
+    }
+
+    /// Apply newly-decided entries into the high-water state and snapshot per
+    /// policy, advancing the step cursor. The synchronous sibling of the async
+    /// apply task; idempotent (max over advances and per-node barrier seqs).
+    pub fn apply_once(&self) {
+        let mut cursor = self.step_cursor.lock();
+        let decided_idx = drain_decided_into(&self.omnipaxos, &mut cursor, &self.apply_state);
+        let mut policy = self.policy.lock();
+        maybe_snapshot(&self.omnipaxos, &mut policy, decided_idx);
+    }
+
+    /// Deliver an inbound message synchronously (deterministic test stepping).
+    /// Mutually exclusive with [`Self::start`]'s pump path.
+    pub fn deliver(&self, message: Message<HighWaterCommand>) {
+        self.runner.handle_incoming(message);
     }
 }
 

--- a/crates/tsoracle-driver-paxos/tests/common/mod.rs
+++ b/crates/tsoracle-driver-paxos/tests/common/mod.rs
@@ -309,6 +309,75 @@ where
             .find(|node| node.node_id == node_id)
             .expect("node id present")
     }
+
+    /// Advance the cluster by one deterministic step (no wall-clock time):
+    /// tick every running node, route its outbound messages through the
+    /// `MemNetwork`, deliver each node's queued inbound messages, then apply
+    /// newly-decided entries. A node is "running" iff it currently holds a host
+    /// and OmniPaxos handle (i.e. not between [`Self::stop_node`] and
+    /// [`Self::rebuild_rocksdb_node`]).
+    ///
+    /// Used by [`Self::step_until`]. Drive a step-mode cluster with these
+    /// instead of [`Self::start_all`] + [`Self::drive_until`] — the two models
+    /// are mutually exclusive (a stepped node must not also run its async
+    /// runner/pump tasks).
+    pub fn step(&mut self) {
+        // Phase 1: tick each running node; collect and route its outbound.
+        let mut outbound = Vec::new();
+        for node in &self.nodes {
+            if node.omnipaxos.is_none() {
+                continue;
+            }
+            if let Some(host) = node.host.as_ref() {
+                outbound.extend(host.step());
+            }
+        }
+        for message in outbound {
+            self.network.deliver_now(message);
+        }
+        // Phase 2: deliver each running node's queued inbound messages.
+        for node in &mut self.nodes {
+            if node.host.is_none() || node.omnipaxos.is_none() {
+                continue;
+            }
+            let mut inbound = Vec::new();
+            if let Some(inbox) = node.inbox.as_mut() {
+                while let Ok(message) = inbox.try_recv() {
+                    inbound.push(message);
+                }
+            }
+            let host = node.host.as_ref().expect("host present");
+            for message in inbound {
+                host.deliver(message);
+            }
+        }
+        // Phase 3: apply newly-decided entries (delivery may have advanced
+        // decided_idx).
+        for node in &self.nodes {
+            if node.omnipaxos.is_none() {
+                continue;
+            }
+            if let Some(host) = node.host.as_ref() {
+                host.apply_once();
+            }
+        }
+    }
+
+    /// Synchronous, deterministic replacement for [`Self::drive_until`]: step
+    /// the cluster until `predicate` holds, with no wall-clock sleeps. Panics
+    /// after `max_steps` steps without success.
+    pub fn step_until<F>(&mut self, mut predicate: F, max_steps: usize)
+    where
+        F: FnMut(&Self) -> bool,
+    {
+        for _ in 0..max_steps {
+            if predicate(self) {
+                return;
+            }
+            self.step();
+        }
+        panic!("predicate did not become true within {max_steps} steps");
+    }
 }
 
 /// Spawn-target: drain `inbox` into `omnipaxos.handle_incoming` until the

--- a/crates/tsoracle-driver-paxos/tests/partition_churn.rs
+++ b/crates/tsoracle-driver-paxos/tests/partition_churn.rs
@@ -10,28 +10,29 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! Partition + heal coverage.
+//! Partition + heal coverage, driven deterministically.
 //!
-//! Boots a 3-node cluster, decides an Advance, isolates the current
-//! leader via [`PartitionController::isolate`], drives until the
-//! remaining majority elects a new leader, decides a higher Advance,
-//! heals the partition, and asserts the entire cluster converges to the
-//! higher value. Confirms the driver's monotonic-advance contract under
-//! a leader churn event with no consensus regressions.
+//! Boots a 3-node cluster, decides an Advance, isolates the current leader via
+//! [`PartitionController::isolate`], drives until the remaining majority elects
+//! a new leader, decides a higher Advance, heals the partition, and asserts the
+//! entire cluster converges to the higher value. Confirms the monotonic-advance
+//! contract under a leader churn event with no consensus regressions.
+//!
+//! Driven by the deterministic step-driver (`step_until`): `step()` routes
+//! messages through the `MemNetwork`, which honors the `PartitionController`, so
+//! isolation/heal behave exactly as on the async path — but election +
+//! re-election + catch-up converge in simulated steps with no real-time budget.
 
 use tsoracle_driver_paxos::HighWaterCommand;
 
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test]
 async fn partition_then_heal_preserves_monotonic_high_water() {
     let mut cluster = common::build_mem_cluster(3);
-    cluster.start_all();
 
-    cluster
-        .drive_until(common::some_leader_elected(), 1_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 1_000);
     let original_leader = cluster.leader();
 
     cluster
@@ -42,42 +43,37 @@ async fn partition_then_heal_preserves_monotonic_high_water() {
         .expect("first append succeeds on leader");
 
     // Wait for cluster-wide convergence on 100.
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) >= 100)
-            },
-            1_500,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) >= 100)
+        },
+        1_500,
+    );
 
-    // Isolate the original leader. Outbound + inbound traffic for that
-    // node is now dropped on the shared MemNetwork.
+    // Isolate the original leader. Outbound + inbound traffic for that node is
+    // now dropped on the shared MemNetwork (step() routes via deliver_now, which
+    // consults the PartitionController).
     cluster.network.partition().isolate(original_leader);
 
     // Drive until a new leader emerges among the two reachable nodes.
-    // Election timeouts add latency under the in-memory transport, so
-    // give this plenty of headroom.
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .filter(|node| node.node_id != original_leader)
-                    .any(|node| {
-                        node.omnipaxos()
-                            .lock()
-                            .get_current_leader()
-                            .is_some_and(|leader| leader != original_leader)
-                    })
-            },
-            10_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .filter(|node| node.node_id != original_leader)
+                .any(|node| {
+                    node.omnipaxos()
+                        .lock()
+                        .get_current_leader()
+                        .is_some_and(|leader| leader != original_leader)
+                })
+        },
+        10_000,
+    );
     let new_leader = cluster
         .nodes
         .iter()
@@ -99,34 +95,30 @@ async fn partition_then_heal_preserves_monotonic_high_water() {
         .expect("second append succeeds on the new leader");
 
     // Wait for the two reachable nodes to commit the new value.
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .filter(|node| node.node_id != original_leader)
-                    .all(|node| state.high_water_on(node.node_id) >= 200)
-            },
-            10_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .filter(|node| node.node_id != original_leader)
+                .all(|node| state.high_water_on(node.node_id) >= 200)
+        },
+        10_000,
+    );
 
-    // Heal the partition. The isolated old leader rejoins the cluster
-    // and must catch up to high_water = 200.
+    // Heal the partition. The isolated old leader rejoins the cluster and must
+    // catch up to high_water = 200.
     cluster.network.partition().heal();
 
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) >= 200)
-            },
-            10_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) >= 200)
+        },
+        10_000,
+    );
 
     for node in &cluster.nodes {
         let high_water = cluster.high_water_on(node.node_id);

--- a/crates/tsoracle-driver-paxos/tests/restart_replay.rs
+++ b/crates/tsoracle-driver-paxos/tests/restart_replay.rs
@@ -10,28 +10,30 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! Restart coverage with RocksDB-backed storage.
+//! Restart coverage with RocksDB-backed storage, driven deterministically.
 //!
-//! Boots a 3-node RocksDB cluster, decides a couple of `Advance`s, stops
-//! one follower mid-flight, decides one more entry on the remaining
-//! majority, then re-opens the stopped follower's storage and rebuilds
-//! its host. The restarted node must catch up to the decided state via
-//! log replay (the runner re-asks for the missing suffix from its peers
-//! once it sees their `decided_idx > local_decided_idx`).
+//! Boots a 3-node RocksDB cluster, decides a couple of `Advance`s, stops one
+//! follower mid-flight, decides one more entry on the remaining majority, then
+//! re-opens the stopped follower's storage and rebuilds its host. The restarted
+//! node must catch up to the decided state via log replay (OmniPaxos re-asks for
+//! the missing suffix from its peers once it sees their `decided_idx >
+//! local_decided_idx`).
+//!
+//! The cluster is driven with `step_until` (synchronous, deterministic
+//! stepping) rather than async runner/pump tasks + real-time `drive_until`, so
+//! election + replication + catch-up converge in simulated steps with no
+//! wall-clock budget to overrun. Real RocksDB storage + replay stay under test.
 
 use tsoracle_driver_paxos::HighWaterCommand;
 
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test]
 async fn restart_recovers_decided_state_from_storage() {
     let mut cluster = common::build_rocksdb_cluster(3);
-    cluster.start_all();
 
-    cluster
-        .drive_until(common::some_leader_elected(), 2_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 2_000);
     let leader_id = cluster.leader();
 
     cluster
@@ -47,17 +49,15 @@ async fn restart_recovers_decided_state_from_storage() {
         .append(HighWaterCommand::Advance { at_least: 50 })
         .expect("second append succeeds on leader");
 
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) >= 50)
-            },
-            2_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) >= 50)
+        },
+        2_000,
+    );
 
     // Pick a follower to bounce.
     let follower_id = cluster
@@ -69,48 +69,43 @@ async fn restart_recovers_decided_state_from_storage() {
 
     cluster.stop_node(follower_id).await;
 
-    // Decide one more entry on the remaining majority. The stopped
-    // follower's RocksDB still has the first two entries persisted but
-    // is unreachable for this round.
+    // Decide one more entry on the remaining majority. The stopped follower's
+    // RocksDB still has the first two entries persisted but is unreachable for
+    // this round (step() skips nodes with no live host/handle).
     cluster
         .node(leader_id)
         .omnipaxos()
         .lock()
         .append(HighWaterCommand::Advance { at_least: 100 })
         .expect("third append succeeds on leader");
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .filter(|node| node.node_id != follower_id)
-                    .all(|node| state.high_water_on(node.node_id) >= 100)
-            },
-            2_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .filter(|node| node.node_id != follower_id)
+                .all(|node| state.high_water_on(node.node_id) >= 100)
+        },
+        2_000,
+    );
 
-    // Re-open the follower's storage and rebuild its host. Restart its
-    // runner + pump; the OmniPaxos handle should recover the persisted
-    // promise and replay the missing log suffix from its peers.
+    // Re-open the follower's storage and rebuild its host. The rebuilt node is
+    // immediately steppable again (no async start needed); its OmniPaxos handle
+    // recovers the persisted promise and replays the missing log suffix from
+    // its peers as the cluster steps on.
     cluster.rebuild_rocksdb_node(follower_id);
 
-    // Sanity: the recovered handle has the durably-persisted first two
-    // entries' decided_idx >= 2 (the durable decided_idx written by
-    // set_decided_idx during the original session).
+    // Sanity: the recovered handle has the durably-persisted first two entries'
+    // decided_idx >= 2 (the durable decided_idx written by set_decided_idx
+    // during the original session).
     let recovered_decided = cluster.decided_idx_on(follower_id);
     assert!(
         recovered_decided >= 2,
         "follower's recovered decided_idx must reflect the first two entries (saw {recovered_decided})",
     );
 
-    cluster.start_node(follower_id);
-
     // Catch-up: the restarted follower must converge to high_water == 100.
-    cluster
-        .drive_until(|state| state.high_water_on(follower_id) >= 100, 3_000)
-        .await;
+    cluster.step_until(|state| state.high_water_on(follower_id) >= 100, 3_000);
 
     assert_eq!(cluster.high_water_on(follower_id), 100);
 

--- a/crates/tsoracle-driver-paxos/tests/snapshot_restart.rs
+++ b/crates/tsoracle-driver-paxos/tests/snapshot_restart.rs
@@ -26,14 +26,15 @@ use tsoracle_driver_paxos::{HighWaterCommand, SnapshotPolicy};
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Driven by the deterministic step-driver (`step_until`) rather than async
+// runner/pump tasks + real-time `drive_until`, so the snapshot-policy +
+// restart-replay coverage converges in simulated steps with no wall-clock
+// budget to overrun. Real RocksDB storage + snapshot persistence stay tested.
+#[tokio::test]
 async fn snapshot_policy_persists_across_restart() {
     let mut cluster = common::build_rocksdb_cluster_with_policy(3, SnapshotPolicy::every(10));
-    cluster.start_all();
 
-    cluster
-        .drive_until(common::some_leader_elected(), 2_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 2_000);
     let leader_id = cluster.leader();
 
     // Append 20 advances: the policy must fire at least once by
@@ -47,20 +48,16 @@ async fn snapshot_policy_persists_across_restart() {
             .expect("append succeeds on leader");
     }
 
-    cluster
-        .drive_until(common::all_decided_at_least(20), 3_000)
-        .await;
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) >= 20)
-            },
-            3_000,
-        )
-        .await;
+    cluster.step_until(common::all_decided_at_least(20), 3_000);
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) >= 20)
+        },
+        3_000,
+    );
 
     // Verify the policy fired on the leader's local OmniPaxos — the
     // compacted index advances when `snapshot(idx, false)` succeeds, so
@@ -109,12 +106,9 @@ async fn snapshot_policy_persists_across_restart() {
         "compacted_idx must survive a restart cycle",
     );
 
-    cluster.start_node(follower_id);
-
-    // The restarted follower must converge to the latest high-water of 20.
-    cluster
-        .drive_until(|state| state.high_water_on(follower_id) >= 20, 3_000)
-        .await;
+    // The rebuilt follower is immediately steppable again (no async start
+    // needed); it must converge to the latest high-water of 20.
+    cluster.step_until(|state| state.high_water_on(follower_id) >= 20, 3_000);
     assert_eq!(cluster.high_water_on(follower_id), 20);
 
     cluster.stop_all().await;

--- a/crates/tsoracle-driver-paxos/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-paxos/tests/snapshot_transfer.rs
@@ -10,51 +10,49 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! Snapshot transfer to a joining node.
+//! Snapshot transfer to a joining node, driven deterministically.
 //!
-//! Boots a 3-node cluster with `SnapshotPolicy::every(10)`, isolates one
-//! node from the get-go so the other two form a quorum and decide 20
-//! Advances + trigger snapshots. The isolated node's OmniPaxos has
-//! been ticking but seeing no incoming messages, so its decided_idx
-//! stays at 0 and its log stays empty.
+//! Boots a 3-node cluster with `SnapshotPolicy::every(10)`, isolates one node
+//! from the get-go so the other two form a quorum and decide 20 Advances +
+//! trigger snapshots. The isolated node's OmniPaxos has been ticking but seeing
+//! no incoming messages, so its decided_idx stays at 0 and its log stays empty.
 //!
-//! On heal, the cluster's runners replicate to the recovering node.
-//! Because the leader's log has been trimmed past the joining node's
-//! decided_idx, the only way forward is for the leader to ship a
-//! snapshot — OmniPaxos's snapshot transfer machinery. The joining
-//! node's storage must end up with a non-empty `get_snapshot()` and
-//! the in-memory high-water must converge to the cluster's value.
+//! On heal, the cluster replicates to the recovering node. Because the leader's
+//! log has been trimmed past the joining node's decided_idx, the only way
+//! forward is for the leader to ship a snapshot — OmniPaxos's snapshot-transfer
+//! machinery. The joining node's storage must end up with a non-empty snapshot
+//! (compacted_idx advances) and the in-memory high-water must converge.
+//!
+//! Driven by the deterministic step-driver (`step_until`): isolation/heal go
+//! through the `MemNetwork`'s `PartitionController`, and the snapshot policy
+//! fires during `apply_once`, so the whole scenario converges in simulated
+//! steps with no real-time budget to overrun.
 
 use tsoracle_driver_paxos::{HighWaterCommand, SnapshotPolicy};
 
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test]
 async fn isolated_node_catches_up_via_snapshot_transfer() {
     let mut cluster = common::build_mem_cluster_with_policy(3, SnapshotPolicy::every(10));
 
-    // Isolate node 3 BEFORE start_all so it never participates in the
-    // initial election or in any of the 20 decisions.
+    // Isolate node 3 before driving so it never participates in the initial
+    // election or in any of the 20 decisions.
     let joining_id: u64 = 3;
     cluster.network.partition().isolate(joining_id);
 
-    cluster.start_all();
-
-    // Drive until a leader emerges among the reachable 2-node majority
-    // (nodes 1 and 2).
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .filter(|node| node.node_id != joining_id)
-                    .any(|node| node.omnipaxos().lock().get_current_leader().is_some())
-            },
-            3_000,
-        )
-        .await;
+    // Drive until a leader emerges among the reachable 2-node majority.
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .filter(|node| node.node_id != joining_id)
+                .any(|node| node.omnipaxos().lock().get_current_leader().is_some())
+        },
+        3_000,
+    );
     let leader_id = cluster
         .nodes
         .iter()
@@ -63,8 +61,8 @@ async fn isolated_node_catches_up_via_snapshot_transfer() {
         .expect("leader elected on the 2-node majority");
     assert_ne!(leader_id, joining_id);
 
-    // Append 20 Advances. The reachable majority decides each one and
-    // the snapshot policy fires at decided_idx >= 10 and >= 20.
+    // Append 20 Advances. The reachable majority decides each one and the
+    // snapshot policy fires at decided_idx >= 10 and >= 20.
     for n in 1..=20u64 {
         cluster
             .node(leader_id)
@@ -74,21 +72,19 @@ async fn isolated_node_catches_up_via_snapshot_transfer() {
             .expect("append succeeds on leader");
     }
 
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .filter(|node| node.node_id != joining_id)
-                    .all(|node| state.high_water_on(node.node_id) >= 20)
-            },
-            3_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .filter(|node| node.node_id != joining_id)
+                .all(|node| state.high_water_on(node.node_id) >= 20)
+        },
+        3_000,
+    );
 
-    // Sanity: the leader's log has been compacted past index 10 — there
-    // is no way to replicate the first ten entries by log replay alone.
+    // Sanity: the leader's log has been compacted past index 10 — there is no
+    // way to replicate the first ten entries by log replay alone.
     let leader_compacted = cluster
         .node(leader_id)
         .omnipaxos()
@@ -99,25 +95,22 @@ async fn isolated_node_catches_up_via_snapshot_transfer() {
         "leader's compacted_idx must reflect at least one snapshot trigger (saw {leader_compacted})",
     );
 
-    // Joining node must still be at decided_idx 0 — it heard nothing
-    // during the isolation window.
+    // Joining node must still be at decided_idx 0 — it heard nothing during the
+    // isolation window.
     let joining_decided_before_heal = cluster.decided_idx_on(joining_id);
     assert_eq!(
         joining_decided_before_heal, 0,
         "isolated node sees no decisions before heal",
     );
 
-    // Heal the partition. The leader resends to the joining node and
-    // OmniPaxos's snapshot-transfer path kicks in.
+    // Heal the partition. The leader resends to the joining node and OmniPaxos's
+    // snapshot-transfer path kicks in.
     cluster.network.partition().heal();
 
-    cluster
-        .drive_until(|state| state.high_water_on(joining_id) >= 20, 5_000)
-        .await;
+    cluster.step_until(|state| state.high_water_on(joining_id) >= 20, 5_000);
 
-    // Snapshot transfer observable: the joining node's storage now has
-    // a snapshot installed. (Plain log replay would never write the
-    // snapshot slot.)
+    // Snapshot transfer observable: the joining node's storage now has a
+    // snapshot installed. (Plain log replay would never write the snapshot slot.)
     let joining_snapshot = cluster
         .node(joining_id)
         .omnipaxos()

--- a/crates/tsoracle-driver-paxos/tests/three_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/three_node.rs
@@ -29,14 +29,14 @@ use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, encode_epoch};
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Driven by the deterministic step-driver (`step_until`). The fence-check test
+// below stays on the async path: its PaxosDriver `persist_high_water` blocks on
+// real cluster progress, which the synchronous step-driver cannot interleave.
+#[tokio::test]
 async fn three_node_quorum_advances_converge_across_replicas() {
     let mut cluster = common::build_mem_cluster(3);
-    cluster.start_all();
 
-    cluster
-        .drive_until(common::some_leader_elected(), 1_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 1_000);
     let leader_id = cluster.leader();
 
     cluster
@@ -52,22 +52,16 @@ async fn three_node_quorum_advances_converge_across_replicas() {
         .append(HighWaterCommand::Advance { at_least: 50 })
         .expect("second append succeeds on leader");
 
-    cluster
-        .drive_until(common::all_decided_at_least(2), 1_000)
-        .await;
-    // The apply task wakes on the runner's tick, so the in-memory
-    // high-water may lag the decided_idx by one or two tick intervals.
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) == 50)
-            },
-            1_000,
-        )
-        .await;
+    cluster.step_until(common::all_decided_at_least(2), 1_000);
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) == 50)
+        },
+        1_000,
+    );
 
     for node in &cluster.nodes {
         assert_eq!(

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -74,6 +74,11 @@ where
     handle: Option<JoinHandle<()>>,
     sender_handle: Option<JoinHandle<()>>,
     shutdown_tx: Option<oneshot::Sender<()>>,
+    /// Leader-observation state for the synchronous [`Self::tick_once`] stepping
+    /// path: `(last_observed_leader, leader_change_counter)`. The async
+    /// [`Self::start`] loop keeps its own task-local copy; a runner is driven by
+    /// exactly one of the two paths, so they never interleave.
+    step_leader: Mutex<(Option<u64>, u64)>,
 }
 
 impl<T, S> PaxosRunner<T, S>
@@ -104,6 +109,7 @@ where
             handle: None,
             sender_handle: None,
             shutdown_tx: None,
+            step_leader: Mutex::new((None, 0)),
         }
     }
 
@@ -261,6 +267,40 @@ where
             }
         });
         self.handle = Some(handle);
+    }
+
+    /// Synchronous single tick for deterministic test stepping.
+    ///
+    /// Ticks OmniPaxos once, emits the resulting leader transition on the
+    /// leader-event stream, and returns the outbound messages for the caller to
+    /// route (rather than the async sink path that [`Self::start`] uses).
+    /// Mutually exclusive with [`Self::start`] — drive a runner by exactly one
+    /// of the two. Intended for in-process deterministic-simulation tests.
+    pub fn tick_once(&self) -> Vec<Message<T>> {
+        let outgoing = {
+            let mut op = self.omnipaxos.lock();
+            op.tick();
+            op.outgoing_messages()
+        };
+        let leader_pid: Option<u64> = self.omnipaxos.lock().get_current_leader();
+        let mut observed = self.step_leader.lock();
+        if leader_pid != observed.0 {
+            observed.0 = leader_pid;
+            if leader_pid.is_some() {
+                observed.1 = observed.1.wrapping_add(1);
+            }
+        }
+        let epoch = leader_pid.map(|_| Epoch(u128::from(observed.1)));
+        let state =
+            LeadershipState::from_omnipaxos(self.my_node_id, leader_pid, epoch, &self.peers);
+        let _ = self.leader_sender.send(state.to_consensus());
+        outgoing
+    }
+
+    /// Deliver an inbound message synchronously (deterministic test stepping).
+    /// Mutually exclusive with [`Self::start`]'s pump path.
+    pub fn handle_incoming(&self, message: Message<T>) {
+        self.omnipaxos.lock().handle_incoming(message);
     }
 
     /// Signal shutdown and await the tick task.

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_network.rs
@@ -68,6 +68,14 @@ impl<T: Entry + Send + 'static> MemNetwork<T> {
     /// - the destination node has not been registered,
     /// - the destination's channel is full (best-effort delivery).
     pub async fn deliver(&self, message: Message<T>) {
+        self.deliver_now(message);
+    }
+
+    /// Synchronous (non-`async`) sibling of [`Self::deliver`], for deterministic
+    /// test stepping that routes messages without an executor. Delivery is
+    /// already non-blocking (`try_send`), so this shares the same routing and
+    /// drop semantics.
+    pub fn deliver_now(&self, message: Message<T>) {
         let (from, to) = endpoints(&message);
         if self.partition.is_blocked(from, to) {
             return;


### PR DESCRIPTION
Makes the flaky RocksDB/omnipaxos paxos harness tests deterministic by driving the cluster synchronously instead of with real-time-budgeted polling, then converts every cleanly-steppable test onto it.

## Why

The paxos harness tests use `drive_until(pred, max_ticks)` poll loops with fixed real-time budgets (2–10s, 1ms/tick) over a real omnipaxos + real RocksDB cluster driven by async tokio tick/pump tasks. Slow/contended CI overruns those budgets — `restart_replay` flaked during the #250 follow-up investigation, and `snapshot_restart` flaked *this PR's own* coverage run.

**madsim doesn't fit** — the tests' purpose is real RocksDB restart/replay/snapshot, and rocksdb's C++ I/O has no simulator. Since omnipaxos is tick-driven and messaging already goes through an in-memory `MemNetwork`, the right tool is a hand-rolled deterministic step-driver (FoundationDB/DST style) that keeps real RocksDB.

## What (additive — the async path is untouched)

Production stepping API:
- `PaxosRunner::tick_once() -> Vec<Message>` + `handle_incoming(msg)`.
- `StandaloneHost::step()` / `apply_once()` / `deliver()` — sync siblings of the runner tick + async apply task (host-held decided cursor seeded past recovery).
- `MemNetwork::deliver_now(msg)` — sync sibling of the async `deliver`.

Harness:
- `Cluster::step()` / `step_until()` — tick every running node, route through `MemNetwork` (honoring the `PartitionController`), deliver inbound, apply; no wall-clock sleep. A node is "running" iff it holds a host + handle, so `stop_node`..`rebuild` is naturally skipped.

Converted to `step_until` (all deterministic, 3/3, instant — ~0.02–0.05s):
- `restart_replay`, `snapshot_restart`, `snapshot_transfer` (real RocksDB + snapshot transfer still tested), `partition_churn` (isolate/heal via the PartitionController), and `three_node`'s quorum-converge test.

## Verification

- All converted tests: 3/3 deterministic.
- `cargo test -p tsoracle-driver-paxos --all-features` / `-p tsoracle-paxos-toolkit --all-features`: pass.
- `cargo fmt --check`, `cargo clippy … --all-features -- -D warnings`: clean; pre-commit workspace clippy passed.

## Residual async tests (out of scope — blocking-driver class)

Two tests can't use the synchronous step-driver because they `.await` a `PaxosDriver` call (`persist_high_water` / `current_high_water`) that **blocks on real cluster progress** — the step-driver would need to advance the cluster on the same thread that's blocked:
- `three_node`'s `fence_check_rejects_stale_epoch_and_accepts_current`
- `restart_barrier_seq` (also uses a yieldpoint-park + real-time observe dance)

These remain on the async path. **`restart_barrier_seq` is itself a pre-existing flake** (reproduced ~2/5 even locally) — independent of this change (additive; it never calls the new methods), and a candidate for a separate effort (it needs concurrency between a blocking driver call and cluster stepping, or budget/clock changes).