### PR TITLE
refactor(server): drop BuildError::InvalidLeaderHintKey runtime check

### DIFF
--- a/crates/tsoracle-server/src/leader_hint.rs
+++ b/crates/tsoracle-server/src/leader_hint.rs
@@ -14,20 +14,8 @@
 
 use prost::Message;
 use tonic::Status;
-use tonic::metadata::errors::InvalidMetadataKey;
 use tonic::metadata::{BinaryMetadataKey, BinaryMetadataValue};
 use tsoracle_proto::v1::{LEADER_HINT_TRAILER_KEY, LeaderHint, LeaderHintLookup};
-
-/// Confirms [`LEADER_HINT_TRAILER_KEY`] is a valid binary metadata key.
-///
-/// Called from [`ServerBuilder::build`](crate::server::ServerBuilder::build)
-/// so an invalid key (only reachable via developer error) surfaces as a
-/// startup failure rather than as a silent runtime degradation in which the
-/// `tsoracle-leader-hint-bin` trailer is dropped from every NOT_LEADER
-/// response.
-pub fn validate_key() -> Result<(), InvalidMetadataKey> {
-    BinaryMetadataKey::from_bytes(LEADER_HINT_TRAILER_KEY.as_bytes()).map(|_| ())
-}
 
 pub fn not_leader_status(hint: LeaderHint) -> Status {
     // Single chokepoint: every NOT_LEADER rejection in the service layer
@@ -48,9 +36,10 @@ pub fn not_leader_status(hint: LeaderHint) -> Status {
 /// returns `status` without the trailer. The client's retry path tolerates a
 /// missing trailer (it round-robins over configured endpoints instead of
 /// jumping directly to the hinted leader), so a corrupted key degrades
-/// latency rather than correctness. [`validate_key`] additionally gates this
-/// at startup so the no-trailer fallback only ever runs in a worst-case
-/// developer-error scenario.
+/// latency rather than correctness. [`LEADER_HINT_TRAILER_KEY`] is a
+/// `const &'static str`, so this fallback only ever runs in a worst-case
+/// developer-error scenario; the `validate_key_accepts_real_key` unit test
+/// proves the real key parses on every build.
 fn with_leader_hint(mut status: Status, hint: LeaderHint, key_str: &str) -> Status {
     match BinaryMetadataKey::from_bytes(key_str.as_bytes()) {
         Ok(key) => {
@@ -101,7 +90,11 @@ mod tests {
 
     #[test]
     fn validate_key_accepts_real_key() {
-        validate_key().expect("KEY is a valid binary metadata key");
+        // The build-time guard that LEADER_HINT_TRAILER_KEY is a valid binary
+        // metadata key. If a future edit breaks the const, this test fails
+        // rather than letting `with_leader_hint` silently drop the trailer.
+        BinaryMetadataKey::from_bytes(LEADER_HINT_TRAILER_KEY.as_bytes())
+            .expect("LEADER_HINT_TRAILER_KEY is a valid binary metadata key");
     }
 
     #[test]

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -30,13 +30,6 @@ use crate::service::TsoServiceImpl;
 pub enum BuildError {
     #[error("consensus_driver is required")]
     MissingConsensusDriver,
-    /// Surfaced when [`tsoracle_proto::v1::LEADER_HINT_TRAILER_KEY`] fails [`crate::leader_hint::validate_key`].
-    /// Today the key is a valid `const &'static str`, so this variant is
-    /// developer-error insurance: a future edit that breaks the key triggers
-    /// a startup failure rather than silently stripping the trailer from
-    /// every NOT_LEADER response.
-    #[error("invalid leader-hint metadata key: {0}")]
-    InvalidLeaderHintKey(#[from] tonic::metadata::errors::InvalidMetadataKey),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -132,7 +125,6 @@ impl ServerBuilder {
     }
 
     pub fn build(self) -> Result<Server, BuildError> {
-        crate::leader_hint::validate_key()?;
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
         let (state_tx, state_rx) = watch::channel(ServingState::NotServing {


### PR DESCRIPTION
Closes #100.

## Problem

`ServerBuilder::build` called `crate::leader_hint::validate_key()?`, which checked that `tsoracle_proto::v1::LEADER_HINT_TRAILER_KEY` parses as a binary metadata key. But `LEADER_HINT_TRAILER_KEY` is a `const &'static str`, so that check could only fail on a developer error that any passing build already rules out. It duplicated what the `validate_key_accepts_real_key` unit test proves on every build, while pulling a runtime error variant — `BuildError::InvalidLeaderHintKey` — onto the public build API for a condition that cannot occur in practice.

## Change

- Delete `BuildError::InvalidLeaderHintKey` and its `#[from] InvalidMetadataKey` conversion.
- Delete `leader_hint::validate_key()`, its now-unused `InvalidMetadataKey` import, and the call site in `ServerBuilder::build`.
- Keep `validate_key_accepts_real_key` as the real guard — it now asserts the const parses as a `BinaryMetadataKey` directly, so a future edit that breaks the key still fails the build.
- Reword `with_leader_hint`'s doc comment to drop the stale `validate_key` reference (it would otherwise become a broken intra-doc link).

No behavior change for any valid build; `BuildError` is one variant shorter. Nothing across the workspace referenced the removed symbols, so this lands as `refactor:`.

## Verification

- `cargo test -p tsoracle-server validate_key` passes (the guard test remains).
- `cargo test --workspace` passes (the sole failure was the timing-flaky `partition_then_heal_preserves_monotonic_high_water` paxos test, which passes on isolated re-run in 0.08s — a CPU-contention timeout under full-suite parallelism, unrelated to this change).
- `cargo clippy` and `cargo fmt --check` clean workspace-wide.

## Acceptance (from the issue)

- [x] `BuildError` is one variant shorter.
- [x] `cargo test -p tsoracle-server validate_key` still passes.
- [x] `ServerBuilder::build` no longer mentions the leader-hint key.