### PR TITLE
fix(client): drop unused async-trait dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,7 +3269,6 @@ dependencies = [
 name = "tsoracle-client"
 version = "0.2.2"
 dependencies = [
- "async-trait",
  "futures",
  "metrics",
  "metrics-util 0.19.1",

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -25,7 +25,6 @@ features       = ["tls-rustls", "tracing", "metrics"]
 rustdoc-args   = ["--cfg", "docsrs"]
 
 [dependencies]
-async-trait    = { workspace = true }
 futures        = { workspace = true }
 metrics        = { workspace = true, optional = true }
 parking_lot    = { workspace = true }


### PR DESCRIPTION
## Summary

`tsoracle-client` declared `async-trait` under `[dependencies]` but never used it. The crate's only async-trait-style attribute is `#[tonic::async_trait]` (in `retry.rs` test modules), which is re-exported by **tonic** — not the `async-trait` crate. No `async_trait::` import exists anywhere in the crate, so the direct dependency was dead weight on the published dependency graph and compile time.

## Workspace audit

The issue asked to check whether other crates have the same unused declaration. They don't — every other crate declaring `async-trait` imports it in reachable code (`use async_trait::async_trait` or bare `#[async_trait::async_trait]`). `tsoracle-bin`'s declaration is already a `[dev-dependency]` legitimately used by `examples/custom-driver.rs`. So `tsoracle-client` was the only offender.

## Change

- Remove `async-trait = { workspace = true }` from `crates/tsoracle-client/Cargo.toml`.
- `Cargo.lock` drops only the `tsoracle-client → async-trait` edge; the `async-trait` package (0.1.89) is retained for its ~14 other consumers, and the `[workspace.dependencies]` entry is untouched.

## Verification

- `cargo test -p tsoracle-client --all-features` — 77 tests + 1 doctest pass without the dependency, proving it was unused.
- `cargo build --workspace --all-targets` — green; nothing transitively relied on the client pulling `async-trait` in.
- Pre-commit `cargo fmt --check` and `cargo clippy` pass.

Closes #242