### PR TITLE
docs(server): document extension_lock/extension_gate lock-ordering at the fence site

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -120,6 +120,20 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                     // can be classified below.
                     let attempt: Result<(), ServerError> = async {
                         // Drain in-flight extensions from the prior epoch.
+                        //
+                        // Lock-ordering invariant: the fence takes ONLY
+                        // `extension_gate.write()` here and intentionally does
+                        // NOT acquire `extension_lock`. Extenders acquire in the
+                        // order `extension_lock` → `extension_gate.read()` (see
+                        // `service::extend_window`), so the safe global order is
+                        // `extension_lock` before `extension_gate`. The fence
+                        // holds no `extension_lock`, so it cannot close a cycle:
+                        // it just waits for in-flight readers to drain. A future
+                        // path that took these in the opposite order — grabbing
+                        // `extension_gate.write()` and then `extension_lock` —
+                        // would deadlock against an extender holding
+                        // `extension_lock` and waiting on `read()`. Keep the
+                        // fence `extension_lock`-free.
                         let drain_guard = server.extension_gate.write().await;
 
                         // Linearized load of the durably-persisted high-water.


### PR DESCRIPTION
## Summary

Closes #247.

The `extension_lock` / `extension_gate` lock-ordering invariant was documented only at the lock definitions (`server.rs`) and at the `step_down_due_to_consensus_rejection` helper — but **not** at the actual `extension_gate.write()` site in `fence.rs:123`, which is exactly where a future maintainer is most likely to be tempted to also grab `extension_lock`.

This PR adds a comment at the fence site stating:

- The fence takes **only** `extension_gate.write()` and intentionally does **not** acquire `extension_lock`.
- The safe global order is `extension_lock` → `extension_gate` (the order extenders use in `service::extend_window`).
- Why it is deadlock-free today: the fence holds no `extension_lock`, so it cannot close a cycle — it just waits for in-flight readers to drain.
- The concrete deadlock that an opposite-order path (`extension_gate.write()` then `extension_lock`) would create against an extender holding `extension_lock` and waiting on `read()`.

## Scope

Documentation only. No behavior change, so no tests apply. `cargo check -p tsoracle-server` passes and the pre-commit fmt + clippy hook is green.