### PR TITLE
feat(server): add Server::subscribe() and demote state_rx to pub(crate)

### DIFF
--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -154,7 +154,7 @@ pub struct Server {
     pub(crate) failover_advance: Duration,
     pub(crate) allocator: Arc<Mutex<Allocator>>,
     pub(crate) state_tx: watch::Sender<ServingState>,
-    pub state_rx: watch::Receiver<ServingState>,
+    pub(crate) state_rx: watch::Receiver<ServingState>,
     /// Serializes window extensions so a stampeding burst of `WindowExhausted`
     /// requests resolves to a single `persist_high_water` round-trip. Acquired
     /// before `extension_gate`; combined with a recheck-after-acquire inside
@@ -174,6 +174,21 @@ pub struct Server {
 impl Server {
     pub fn builder() -> ServerBuilder {
         ServerBuilder::default()
+    }
+
+    /// Subscribe to serving-state transitions.
+    ///
+    /// Returns a fresh `watch::Receiver` observing the same `ServingState`
+    /// the server publishes as leadership comes and goes. Embedders use this
+    /// to gate their own startup on `ServingState::Serving` (see the
+    /// `embedded_router` and piggyback examples). Because `into_router`
+    /// consumes the `Server`, capture the receiver before mounting.
+    ///
+    /// This method is the stable observation API: the underlying field is
+    /// `pub(crate)`, so the receiver's type can evolve (e.g. a future newtype
+    /// around `ServingState`) without breaking embedders that go through it.
+    pub fn subscribe(&self) -> watch::Receiver<ServingState> {
+        self.state_rx.clone()
     }
 
     /// Single transition API used in response to evidence that the current

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -95,7 +95,7 @@ pub async fn boot_server(server: Server) -> BootedServer {
     let addr = listener
         .local_addr()
         .expect("local_addr on freshly bound listener");
-    let state_rx = server.state_rx.clone();
+    let state_rx = server.subscribe();
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let serve_handle = tokio::spawn(async move {
         server
@@ -304,7 +304,7 @@ pub mod dst {
     /// leader-watch task on the calling host's executor, so the fence begins
     /// running under simulated time as soon as this returns.
     pub fn into_sim_parts(server: Server) -> Result<SimParts, ServerError> {
-        let state_rx = server.state_rx.clone();
+        let state_rx = server.subscribe();
         let (routes, watch) = server.into_router()?;
         Ok(SimParts {
             routes,

--- a/crates/tsoracle-server/tests/embedded_router.rs
+++ b/crates/tsoracle-server/tests/embedded_router.rs
@@ -33,7 +33,7 @@ async fn embedded_router_serves_via_caller_owned_listener() {
         .unwrap();
 
     // Clone state_rx before into_router consumes the Server.
-    let mut state_rx = tsoracle.state_rx.clone();
+    let mut state_rx = tsoracle.subscribe();
     let (router, _leader_watch) = tsoracle
         .into_router()
         .expect("into_router is infallible without the reflection feature");
@@ -85,7 +85,7 @@ async fn embedded_router_poisons_when_leadership_stream_closes() {
 
     let tsoracle = Server::builder().consensus_driver(driver).build().unwrap();
 
-    let mut state_rx = tsoracle.state_rx.clone();
+    let mut state_rx = tsoracle.subscribe();
     let (router, leader_watch) = tsoracle
         .into_router()
         .expect("into_router is infallible without the reflection feature");

--- a/crates/tsoracle-server/tests/fence_yieldpoint.rs
+++ b/crates/tsoracle-server/tests/fence_yieldpoint.rs
@@ -52,7 +52,7 @@ async fn fence_parks_at_after_load_yieldpoint_until_released() {
             .build()
             .unwrap(),
     );
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
 
     // Arm the yield point BEFORE spawning the watch task so the first
     // Leader iteration is guaranteed to park.

--- a/crates/tsoracle-server/tests/leader_watch.rs
+++ b/crates/tsoracle-server/tests/leader_watch.rs
@@ -56,7 +56,7 @@ async fn leader_watch_persists_fence_before_serving() {
     driver.become_leader(Epoch(1));
 
     // Wait until serving = true.
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     wait_until_serving(&mut state_rx).await;
 
     // max(prior_max + 1 = 5_001, now = 10_000) + failover_advance = 2_000 = 12_000.
@@ -107,7 +107,7 @@ async fn fence_strictly_above_prior_high_water_when_prior_exceeds_now() {
 
     driver.become_leader(Epoch(1));
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     wait_until_serving(&mut state_rx).await;
 
     let persisted = driver.current_high_water();
@@ -162,7 +162,7 @@ async fn first_grant_strictly_above_prior_high_water_when_prior_exceeds_now() {
 
     driver.become_leader(Epoch(1));
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     wait_until_serving(&mut state_rx).await;
 
     let grant = server
@@ -209,7 +209,7 @@ async fn fence_retries_transient_persist_error_then_serves() {
 
     driver.become_leader(Epoch(1));
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     timeout(Duration::from_secs(5), wait_until_serving(&mut state_rx))
         .await
         .expect("fence must recover from a transient persist error and reach Serving");
@@ -267,7 +267,7 @@ async fn fence_steps_down_on_not_leader_then_serves_next_election() {
 
     // Re-won leadership: the fence must now complete and serve.
     driver.become_leader(Epoch(2));
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     timeout(Duration::from_secs(5), wait_until_serving(&mut state_rx))
         .await
         .expect("fence must serve after re-winning leadership");
@@ -327,7 +327,7 @@ async fn leader_watch_propagates_follower_epoch_into_serving_state() {
 
     driver.become_follower_with_epoch(Some("http://leader:9000".into()), Some(Epoch(7)));
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let snapshot = timeout(Duration::from_secs(1), async {
         loop {
             let current = state_rx.borrow_and_update().clone();

--- a/crates/tsoracle-tests/tests/server_failpoints.rs
+++ b/crates/tsoracle-tests/tests/server_failpoints.rs
@@ -41,7 +41,7 @@ async fn fence_recovers_after_transient_load_error() {
         .consensus_driver(driver.clone())
         .build()
         .unwrap();
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let (_routes, watch_handle) = server
         .into_router()
         .expect("into_router is infallible without the reflection feature");
@@ -213,7 +213,7 @@ async fn before_allocate_sleep_delays_get_ts() {
         .consensus_driver(driver.clone())
         .build()
         .unwrap();
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let (routes, _watch_handle) = server
         .into_router()
         .expect("into_router is infallible without the reflection feature");
@@ -273,7 +273,7 @@ async fn extension_gate_held_sleep_delays_get_ts() {
         .failover_advance(Duration::from_millis(1))
         .build()
         .unwrap();
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let (routes, _watch_handle) = server
         .into_router()
         .expect("into_router is infallible without the reflection feature");

--- a/examples/failover-demo/src/main.rs
+++ b/examples/failover-demo/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
     let server = Server::builder().consensus_driver(driver.clone()).build()?;
 
     // Capture state_rx BEFORE consuming server via into_router.
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let (router, _watch_handle) = server.into_router()?;
 
     let addr = bind_unused().await;

--- a/examples/openraft-piggyback/src/demo.rs
+++ b/examples/openraft-piggyback/src/demo.rs
@@ -126,7 +126,7 @@ async fn build_cluster() -> anyhow::Result<(Vec<Node>, Arc<MemNetwork<HostTypeCo
         let host = PiggybackHost::new(raft.clone(), sm_for_host.clone());
         let driver = OpenraftDriver::new(host);
         let server = TsoServer::builder().consensus_driver(driver).build()?;
-        let serving_state_rx = server.state_rx.clone();
+        let serving_state_rx = server.subscribe();
 
         // Bind on port 0 so the OS assigns a free port, avoiding conflicts when
         // the smoke test runs alongside other services or in parallel CI jobs.

--- a/examples/paxos-piggyback/src/demo.rs
+++ b/examples/paxos-piggyback/src/demo.rs
@@ -206,7 +206,7 @@ async fn build_node(
     let host = PiggybackHost::new(omnipaxos.clone(), state.clone(), id);
     let driver = Arc::new(PaxosDriver::new(host, leader_stream));
     let server = TsoServer::builder().consensus_driver(driver).build()?;
-    let serving_state_rx = server.state_rx.clone();
+    let serving_state_rx = server.subscribe();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let tso_port = listener.local_addr()?.port();

--- a/examples/tls-mtls/src/main.rs
+++ b/examples/tls-mtls/src/main.rs
@@ -67,7 +67,7 @@ async fn step_plain_tls(bundle: &certs::CertBundle) -> Result<()> {
         .tls_config(ServerTlsConfig::new().identity(server_identity(bundle)))
         .build()?;
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let server_handle = tokio::spawn(async move {
         server
             .serve_with_listener(listener, futures::future::pending())
@@ -112,7 +112,7 @@ async fn step_mtls(bundle: &certs::CertBundle) -> Result<()> {
         )
         .build()?;
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let server_handle = tokio::spawn(async move {
         server
             .serve_with_listener(listener, futures::future::pending())
@@ -161,7 +161,7 @@ async fn step_custom_connector_against_mtls(bundle: &certs::CertBundle) -> Resul
         )
         .build()?;
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let server_handle = tokio::spawn(async move {
         server
             .serve_with_listener(listener, futures::future::pending())
@@ -222,7 +222,7 @@ async fn step_mtls_misconfigured(bundle: &certs::CertBundle) -> Result<()> {
         )
         .build()?;
 
-    let mut state_rx = server.state_rx.clone();
+    let mut state_rx = server.subscribe();
     let server_handle = tokio::spawn(async move {
         server
             .serve_with_listener(listener, futures::future::pending())


### PR DESCRIPTION
## Summary

`Server.state_rx` was the only `pub` field among the eight on `Server` — the other seven are `pub(crate)`. Exposing the `watch::Receiver<ServingState>` as a bare public field pinned the serving-state observation API to a concrete field type: a future newtype around `ServingState`, or any change to the receiver's type, would be a breaking change to a public field rather than to a method.

This change introduces a method-based observation API and demotes the field:

- Add `pub fn subscribe(&self) -> watch::Receiver<ServingState>` to `impl Server`, documented as the stable observation API.
- Demote `state_rx` from `pub` to `pub(crate)`. Embedders that switch to `subscribe()` are insulated from future representation changes (non-breaking for them).
- Migrate every out-of-crate consumer from `state_rx.clone()` to `subscribe()`: the `tls-mtls`, `paxos-piggyback`, `openraft-piggyback`, and `failover-demo` examples; the `leader_watch`, `fence_yieldpoint`, and `embedded_router` integration tests; and `tsoracle-tests/server_failpoints`.
- Dogfood `subscribe()` from the in-crate `test_support` helpers, so the new public method is the single way to obtain a receiver everywhere except the in-crate service hot path, which keeps its direct `state_rx.borrow()`.

Labeled `feat` rather than `refactor` because it adds a public method to a published library crate, so the version must bump for any future dependent on `subscribe()` to resolve against the registry.

Closes #246

## Test Plan

- [x] `cargo build --workspace --all-targets` — green (catches the API change at every call site, including the aliased `embedded_router` binding)
- [x] `cargo test --workspace` — green except one isolated, pre-existing timing flake in `tsoracle-driver-paxos` (`three_node_quorum_advances_converge_across_replicas`) that passes on isolated re-run and is unrelated to this change
- [x] pre-commit `cargo fmt --check` + `cargo clippy` — green