### PR TITLE
test(driver-paxos): convert the blocking-driver harness tests to deterministic stepping

### DIFF
--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -225,6 +225,15 @@ where
         outgoing
     }
 
+    /// Tick the runner once *without* applying decided entries, returning its
+    /// outbound messages. Lets a deterministic test hold a node's apply "parked"
+    /// (decided_idx advances via consensus, but the high-water / barrier ledger
+    /// does not fold) — the synchronous analogue of pausing the async apply task
+    /// at its yield point. Pair with an explicit [`Self::apply_once`] to release.
+    pub fn tick_only(&self) -> Vec<Message<HighWaterCommand>> {
+        self.runner.tick_once()
+    }
+
     /// Apply newly-decided entries into the high-water state and snapshot per
     /// policy, advancing the step cursor. The synchronous sibling of the async
     /// apply task; idempotent (max over advances and per-node barrier seqs).

--- a/crates/tsoracle-driver-paxos/tests/common/mod.rs
+++ b/crates/tsoracle-driver-paxos/tests/common/mod.rs
@@ -378,6 +378,26 @@ where
         }
         panic!("predicate did not become true within {max_steps} steps");
     }
+
+    /// Drain a node's inbox synchronously, returning its queued inbound
+    /// messages. For tests that drive a node "by hand" — e.g. after taking its
+    /// host out of the cluster (`node.host.take()`) to poll a blocking driver
+    /// call against it — and route the messages themselves while `step()` drives
+    /// the rest of the cluster (which skips the host-less node).
+    pub fn drain_inbox(&mut self, node_id: u64) -> Vec<Message<HighWaterCommand>> {
+        let node = self
+            .nodes
+            .iter_mut()
+            .find(|node| node.node_id == node_id)
+            .expect("node id present");
+        let mut drained = Vec::new();
+        if let Some(inbox) = node.inbox.as_mut() {
+            while let Ok(message) = inbox.try_recv() {
+                drained.push(message);
+            }
+        }
+        drained
+    }
 }
 
 /// Spawn-target: drain `inbox` into `omnipaxos.handle_incoming` until the

--- a/crates/tsoracle-driver-paxos/tests/restart_barrier_seq.rs
+++ b/crates/tsoracle-driver-paxos/tests/restart_barrier_seq.rs
@@ -10,56 +10,37 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 //
-//! Regression: a process restart resets `StandaloneHost::barrier_seq` to
-//! 0, but the `applied_barriers` ledger is restored from durable state
-//! (decided-log replay + snapshot transfer). `current_high_water` returns
-//! once `applied_barrier_seq(self) >= minted_seq`. If the freshly minted
-//! seq is not lifted above the recovered ledger, a `(self, old_seq)` entry
-//! from a PRIOR process lifetime satisfies the predicate immediately, so
-//! the read returns the stale `high_water()` before its own barrier is
-//! applied — exactly the failover hazard the per-node nonce was meant to
-//! close, reopened across a restart.
+//! Regression: a process restart resets `StandaloneHost::barrier_seq` to 0, but
+//! the `applied_barriers` ledger is restored from durable state (decided-log
+//! replay + snapshot transfer). `current_high_water` returns once
+//! `applied_barrier_seq(self) >= minted_seq`. If the freshly minted seq is not
+//! lifted above the recovered ledger, a `(self, old_seq)` entry from a PRIOR
+//! lifetime satisfies the predicate immediately, so the read returns the stale
+//! `high_water()` before its own barrier is applied — the failover hazard the
+//! per-node nonce closes, reopened across a restart.
 //!
-//! This test reproduces the interleaving with RocksDB-backed storage and
-//! yield-point gating:
-//!   1. Durably record seven barriers attributed to a follower plus an
-//!      Advance(100); the follower folds them, so its recovered ledger is
-//!      `reader -> 7` and its recovered high-water is 100.
-//!   2. Stop the follower, decide Advance(500) on the surviving majority
-//!      (durable, but absent from the follower's recovered log), then
-//!      rebuild the follower from disk — its `barrier_seq` is back to 0.
-//!   3. Pause every apply task so the recovered suffix folds (ledger=7,
-//!      hw=100) but the caught-up Advance(500) stays unfolded.
-//!   4. Issue `current_high_water` on the follower, parked between its
-//!      `append(Barrier)` and its wait, and let the barrier decide.
-//!
-//! Pre-fix the follower mints seq=1, the recovered `reader -> 7` satisfies
-//! `7 >= 1` the instant the reader is released, and it returns the stale
-//! 100. With the fix the minting counter resumes at 7, the read mints
-//! seq=8, `7 >= 8` is false, so it waits until its own barrier folds and
-//! returns the linearized 500.
+//! Driven deterministically with the step-driver rather than yield-point
+//! parking and real-time sleeps. The reader's host is taken out of the cluster
+//! and driven by hand with its apply held "parked" so that its decided_idx
+//! advances via consensus while its high-water and barrier ledger do not fold;
+//! an explicit `apply_once` then releases it. This gives exact, instant control
+//! over the interleaving the original reproduced with `tokio::time::sleep`.
 
-#![cfg(all(feature = "rocksdb-storage", feature = "yieldpoints"))]
+#![cfg(feature = "rocksdb-storage")]
 
-use std::time::Duration;
+use std::future::Future;
+use std::task::{Context, Poll};
 
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_driver_paxos::host::PaxosHighWaterHost;
-use tsoracle_yieldpoint as yieldpoint;
 
 #[path = "common/mod.rs"]
 mod common;
 
-const APPLY_TASK_YIELD: &str = "standalone_host::apply_task::between_iterations";
-const CURRENT_HW_YIELD: &str = "standalone_host::current_high_water::after_append_before_await";
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test]
 async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() {
     let mut cluster = common::build_rocksdb_cluster(3);
-    cluster.start_all();
-    cluster
-        .drive_until(common::some_leader_elected(), 2_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 2_000);
     let leader_id = cluster.leader();
     let reader_id = cluster
         .nodes
@@ -68,10 +49,9 @@ async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() 
         .find(|id| *id != leader_id)
         .expect("at least one follower");
 
-    // Phase A: durably record seven barriers attributed to `reader_id`
-    // plus Advance(100). Injecting via the leader keeps the follower out
-    // of election churn — the `node` field is what keys the ledger, not
-    // which node appended the entry.
+    // Phase A: durably record seven barriers attributed to `reader_id` plus
+    // Advance(100). The `node` field keys the ledger, not which node appended,
+    // so injecting via the leader keeps the follower out of election churn.
     {
         let leader = cluster.node(leader_id).omnipaxos();
         let mut handle = leader.lock();
@@ -87,40 +67,38 @@ async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() 
             .append(HighWaterCommand::Advance { at_least: 100 })
             .expect("append advance on leader");
     }
-    cluster
-        .drive_until(|state| state.high_water_on(reader_id) >= 100, 3_000)
-        .await;
-    cluster
-        .drive_until(common::all_decided_at_least(8), 3_000)
-        .await;
+    cluster.step_until(|state| state.high_water_on(reader_id) >= 100, 3_000);
+    cluster.step_until(common::all_decided_at_least(8), 3_000);
     let reader_decided_before = cluster.decided_idx_on(reader_id);
     assert!(reader_decided_before >= 8);
 
-    // Phase B: stop the follower and rebuild it from disk so its
-    // barrier_seq resets to 0 while its durable ledger (reader -> 7) and
-    // high-water (100) survive. Pause every apply task BEFORE the follower
-    // starts so that, once started, it folds its recovered suffix
-    // (ledger=7, hw=100) on the first drain and then parks.
+    // Phase B: stop the follower and rebuild it from disk. Its `barrier_seq`
+    // resets to 0 in construction, but `new()` folds the recovered suffix and
+    // resumes the counter to the durable ledger's `reader -> 7`; the recovered
+    // high-water is 100. Stepping the cluster lets the rebuilt node fold.
     cluster.stop_node(reader_id).await;
-    let apply_gate = yieldpoint::cfg(APPLY_TASK_YIELD);
     cluster.rebuild_rocksdb_node(reader_id);
-    let reader_recovered_decided = cluster.decided_idx_on(reader_id);
     assert_eq!(
-        reader_recovered_decided, reader_decided_before,
+        cluster.decided_idx_on(reader_id),
+        reader_decided_before,
         "recovered decided_idx must reflect exactly the durable pre-stop suffix",
     );
-    cluster.start_node(reader_id);
-    cluster
-        .drive_until(|state| state.high_water_on(reader_id) >= 100, 5_000)
-        .await;
-    // Beat to let the apply task fold the recovered suffix and park at the
-    // yield point before any further entries decide.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    cluster.step_until(|state| state.high_water_on(reader_id) >= 100, 5_000);
 
-    // Decide Advance(500) AFTER the follower's apply task is parked. The
-    // follower learns it through consensus (decided_idx advances) but, with
-    // apply parked, never folds it — so its high_water stays the recovered
-    // 100. This is the entry a correct linearized read must reflect.
+    // Take the reader's host out of the cluster so we can drive it by hand with
+    // apply held parked. `step()` now skips it (host-less); we route its
+    // messages manually through the shared MemNetwork.
+    let reader_host = cluster
+        .node_mut(reader_id)
+        .host
+        .take()
+        .expect("reader host present");
+    let reader_recovered_decided = reader_host.omnipaxos_handle().lock().get_decided_idx();
+
+    // Decide Advance(500) on the surviving majority, then drive the reader to
+    // DECIDE it (its decided_idx advances) without applying — so its high-water
+    // stays the recovered 100. This is the entry a correct linearized read must
+    // reflect.
     {
         let leader = cluster.node(leader_id).omnipaxos();
         leader
@@ -128,63 +106,68 @@ async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() 
             .append(HighWaterCommand::Advance { at_least: 500 })
             .expect("append advance(500) on leader");
     }
-    cluster
-        .drive_until(
-            |state| state.decided_idx_on(reader_id) > reader_recovered_decided,
-            5_000,
-        )
-        .await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    for _ in 0..5_000 {
+        for message in reader_host.tick_only() {
+            cluster.network.deliver_now(message);
+        }
+        for message in cluster.drain_inbox(reader_id) {
+            reader_host.deliver(message);
+        }
+        cluster.step();
+        if reader_host.omnipaxos_handle().lock().get_decided_idx() > reader_recovered_decided {
+            break;
+        }
+    }
     assert_eq!(
-        cluster.high_water_on(reader_id),
+        reader_host.current_value(),
         100,
         "apply parked: Advance(500) decided + replicated to the follower but not yet folded",
     );
 
-    // Phase C: parked read on the recovered follower.
-    let reader_park_gate = yieldpoint::cfg(CURRENT_HW_YIELD);
-    let observed = {
-        let host_ref = cluster
-            .node(reader_id)
-            .host
-            .as_ref()
-            .expect("reader host present");
-        let mut read_future = Box::pin(host_ref.current_high_water());
+    // Phase C: parked read on the recovered follower. It mints seq = 8
+    // (barrier_seq resumed to 7), appends its Barrier, and must WAIT — the
+    // recovered `reader -> 7` ledger must NOT satisfy `7 >= 8`.
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut read_future = Box::pin(reader_host.current_high_water());
 
-        // Drive the reader to its park; the appended barrier is forwarded
-        // to the leader, decided, and replicated back to the follower
-        // (its decided_idx advances) while apply stays parked. The reader
-        // must not return during this window.
-        tokio::select! {
-            _ = tokio::time::sleep(Duration::from_millis(300)) => {}
-            _ = &mut read_future => panic!("read returned before yieldpoint was released"),
+    // First poll mints the seq, appends the Barrier, and parks on the apply
+    // notifier (applied_barrier_seq(reader) == 7 < 8).
+    assert!(
+        matches!(read_future.as_mut().poll(&mut cx), Poll::Pending),
+        "read must park after appending its barrier",
+    );
+    let barrier_decided = reader_host.omnipaxos_handle().lock().get_decided_idx() + 1;
+
+    // Drive the reader's barrier through consensus to decided WITHOUT applying
+    // it. The read must stay pending throughout: the recovered ledger (7) does
+    // not short-circuit the fresh seq (8).
+    for _ in 0..5_000 {
+        for message in reader_host.tick_only() {
+            cluster.network.deliver_now(message);
         }
+        for message in cluster.drain_inbox(reader_id) {
+            reader_host.deliver(message);
+        }
+        cluster.step();
+        assert!(
+            matches!(read_future.as_mut().poll(&mut cx), Poll::Pending),
+            "read must not return while its own barrier is decided-but-unfolded",
+        );
+        if reader_host.omnipaxos_handle().lock().get_decided_idx() >= barrier_decided {
+            break;
+        }
+    }
 
-        // Release the parked reader. Pre-fix the next loop iteration sees
-        // the recovered `reader -> 7` ledger satisfy `7 >= 1` and returns
-        // the stale `high_water()` (100). With the fix the minted seq is 8,
-        // so `7 >= 8` is false and the reader keeps waiting.
-        reader_park_gate.notify_one();
-
-        // Release the apply tasks shortly after so a correct (waiting)
-        // reader can make progress: its own barrier and the Advance(500)
-        // fold, and the read returns 500. Disarm the yield point BEFORE
-        // notifying: the apply loop re-checks the registry on every hit,
-        // so notifying first would let a woken task re-park before remove()
-        // lands and never fold the reader's barrier.
-        let apply_release_gate = apply_gate.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            yieldpoint::remove(APPLY_TASK_YIELD);
-            apply_release_gate.notify_waiters();
-        });
-
-        tokio::time::timeout(Duration::from_secs(5), &mut read_future)
-            .await
-            .expect("current_high_water must complete")
-            .expect("current_high_water must not error")
+    // Release: apply the reader. It folds Advance(500) + its own Barrier(seq 8),
+    // lifting applied_barrier_seq(reader) to 8 and high-water to 500; the apply
+    // notifier wakes the read, which now observes 8 >= 8 and returns 500.
+    let observed = loop {
+        match read_future.as_mut().poll(&mut cx) {
+            Poll::Ready(result) => break result.expect("current_high_water must not error"),
+            Poll::Pending => reader_host.apply_once(),
+        }
     };
-
     assert_eq!(
         observed, 500,
         "post-restart read must wait for its own barrier (seq resumed above the recovered \
@@ -192,6 +175,9 @@ async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() 
          the stale 100",
     );
 
-    yieldpoint::remove(CURRENT_HW_YIELD);
+    // Drop the read future (it borrows `reader_host`) before returning the host
+    // to the cluster for graceful teardown.
+    drop(read_future);
+    cluster.node_mut(reader_id).host = Some(reader_host);
     cluster.stop_all().await;
 }

--- a/crates/tsoracle-driver-paxos/tests/three_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/three_node.rs
@@ -22,6 +22,9 @@
 //!    fabricated stale epoch — the fence rejects with
 //!    [`ConsensusError::Fenced`].
 
+use std::future::Future;
+use std::task::{Context, Poll};
+
 use tsoracle_consensus::{ConsensusDriver, ConsensusError};
 use tsoracle_core::Epoch;
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, encode_epoch};
@@ -29,9 +32,7 @@ use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, encode_epoch};
 #[path = "common/mod.rs"]
 mod common;
 
-// Driven by the deterministic step-driver (`step_until`). The fence-check test
-// below stays on the async path: its PaxosDriver `persist_high_water` blocks on
-// real cluster progress, which the synchronous step-driver cannot interleave.
+// Driven by the deterministic step-driver (`step_until`).
 #[tokio::test]
 async fn three_node_quorum_advances_converge_across_replicas() {
     let mut cluster = common::build_mem_cluster(3);
@@ -75,14 +76,16 @@ async fn three_node_quorum_advances_converge_across_replicas() {
     cluster.stop_all().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Driven by the deterministic step-driver. Path A (stale epoch) is rejected by
+// the fence check before any cluster progress, so it completes immediately;
+// Path B's blocking `persist_high_water` is polled by hand while `step()` drives
+// the cluster (the proxy shares the follower's OmniPaxos by Arc, so there is no
+// borrow conflict with stepping).
+#[tokio::test]
 async fn fence_check_rejects_stale_epoch_and_accepts_current() {
     let mut cluster = common::build_mem_cluster(3);
-    cluster.start_all();
 
-    cluster
-        .drive_until(common::some_leader_elected(), 1_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 1_000);
     let leader_id = cluster.leader();
 
     // Pick a follower deterministically.
@@ -102,17 +105,14 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
     // Wait for the follower's encoded promise to match the leader's
     // before sampling so the assertion against the driver's fence-check
     // observation is race-free.
-    cluster
-        .drive_until(
-            |c| {
-                let leader_epoch = encode_epoch(c.node(leader_id).omnipaxos().lock().get_promise());
-                let follower_epoch =
-                    encode_epoch(c.node(follower_id).omnipaxos().lock().get_promise());
-                leader_epoch != Epoch(0) && leader_epoch == follower_epoch
-            },
-            1_000,
-        )
-        .await;
+    cluster.step_until(
+        |c| {
+            let leader_epoch = encode_epoch(c.node(leader_id).omnipaxos().lock().get_promise());
+            let follower_epoch = encode_epoch(c.node(follower_id).omnipaxos().lock().get_promise());
+            leader_epoch != Epoch(0) && leader_epoch == follower_epoch
+        },
+        1_000,
+    );
     let current_epoch = {
         let handle = cluster.node(follower_id).omnipaxos();
         let promise = handle.lock().get_promise();
@@ -145,13 +145,19 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
         other => panic!("expected Fenced, got {other:?}"),
     }
 
-    // Path B: current epoch passes the fence and the proposal commits.
-    // The follower-proxy host appends directly to OmniPaxos and waits for
-    // the cluster to decide.
-    let returned = driver
-        .persist_high_water(75, current_epoch)
-        .await
-        .expect("current epoch passes the fence");
+    // Path B: current epoch passes the fence and the proposal commits. The proxy
+    // appends to the shared OmniPaxos and waits for the cluster to decide; poll
+    // it by hand (noop waker) while stepping the cluster forward.
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut persist = Box::pin(driver.persist_high_water(75, current_epoch));
+    let returned = loop {
+        match persist.as_mut().poll(&mut cx) {
+            Poll::Ready(result) => break result.expect("current epoch passes the fence"),
+            Poll::Pending => cluster.step(),
+        }
+    };
+    drop(persist);
     assert_eq!(
         returned, 75,
         "the apply state reflects the proposed high-water"
@@ -160,17 +166,15 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
     // Wait for every node's in-memory high-water to converge — submit_advance
     // returned the proxy's view, but the cluster's other nodes may still be
     // catching up.
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) >= 75)
-            },
-            1_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) >= 75)
+        },
+        1_000,
+    );
 
     cluster.stop_all().await;
 }
@@ -185,7 +189,6 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
 use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
 
 use async_trait::async_trait;
 use omnipaxos::OmniPaxos;
@@ -239,7 +242,9 @@ impl PaxosHighWaterHost for FollowerProxyHost {
             })?;
 
         for _ in 0..2_000 {
-            tokio::time::sleep(Duration::from_millis(1)).await;
+            // yield_now (not a real-time sleep) so a hand-polled caller can
+            // interleave cluster steps between re-polls without wall-clock waits.
+            tokio::task::yield_now().await;
             let new_decided = self.omnipaxos.lock().get_decided_idx();
             if new_decided > snapshot_decided {
                 self.last_known_high_water.store(at_least, Ordering::SeqCst);


### PR DESCRIPTION
Follows #312 (merged): converts the two remaining paxos harness tests that #312 left on the async path — both blocking-driver cases — completing the deterministic migration. **No real-time waits remain in the paxos-driver harness tests.**

## The blocking-driver problem

Both tests `.await` a `PaxosDriver` call that **blocks on real cluster progress**: `current_high_water` / `submit_advance` append an entry and wait for the cluster to decide it. A synchronous step-driver can't drive that directly — the test thread is the one that must `step()`. The async versions forced the interleaving with yield-point parking + `tokio::time::sleep`, which is what flaked (`restart_barrier_seq` was ~2/5 even locally).

## Technique: hand-poll the blocking call between steps

Poll the blocking future manually (`futures::task::noop_waker`) and `cluster.step()` between polls — no spawn, no real time:

**`restart_barrier_seq`** — the read borrows a node's host. Take that host *out* of the cluster (`step()` then skips it), route its messages by hand (`tick_only` → `network.deliver_now`; `drain_inbox` → `deliver`), and hold its apply **parked** (withhold `apply_once`) so `Advance(500)` + the read's own `Barrier(seq 8)` decide but don't fold — proving the recovered ledger (`reader -> 7`) doesn't short-circuit the fresh seq 8. Release with `apply_once` (which notifies the apply waiter); the read wakes and returns the linearized 500.

**`three_node` fence-check** — simpler: the `FollowerProxyHost` shares the follower's OmniPaxos by `Arc`, so no take-host-out and no borrow conflict. Path A (stale epoch → `Fenced`) completes before any cluster progress (direct await); Path B (current epoch) is hand-polled while `step()` drives its appended `Advance` to decide. The proxy's `submit_advance` now `yield_now`s instead of sleeping so re-polls interleave with steps.

## Additive helpers (driver-paxos)

- `StandaloneHost::tick_only()` — tick without applying (hold apply parked).
- `Cluster::drain_inbox(node_id)` — drain a node's inbox for hand-routing.

## Verification

- `restart_barrier_seq`: 8/8 (was ~2/5); `three_node` (both tests): 5/5.
- `cargo test -p tsoracle-driver-paxos --all-features` / `-p tsoracle-paxos-toolkit --all-features`: pass.
- `cargo fmt --check`, `cargo clippy … --all-features -- -D warnings`: clean; pre-commit passed.