### PR TITLE
test(driver-openraft): run the harness tests under tokio virtual time

### DIFF
--- a/crates/tsoracle-driver-openraft/tests/partition_churn.rs
+++ b/crates/tsoracle-driver-openraft/tests/partition_churn.rs
@@ -64,7 +64,7 @@ async fn find_leader_excluding(cluster: &TestCluster, exclude_idx: usize) -> usi
     .expect("a new leader (excluding old) was elected within 10s")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn partition_then_heal_converges_monotonically() {
     let cluster = build_three_node().await;
     let partitions = cluster

--- a/crates/tsoracle-driver-openraft/tests/restart_replay.rs
+++ b/crates/tsoracle-driver-openraft/tests/restart_replay.rs
@@ -29,7 +29,7 @@ use tsoracle_core::Epoch;
 
 use common::{TestCluster, build_single_node, eventually_eq, reopen_node};
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn restart_replays_high_water_from_rocksdb_log() {
     let cluster = build_single_node().await;
     let TestCluster {

--- a/crates/tsoracle-driver-openraft/tests/single_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/single_node.rs
@@ -27,7 +27,7 @@ use tsoracle_consensus::{ConsensusDriver, LeaderState};
 
 use common::build_single_node;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn single_node_leader_persists_high_water() {
     let cluster = build_single_node().await;
     let driver = &cluster.drivers[0];
@@ -64,7 +64,7 @@ async fn single_node_leader_persists_high_water() {
     assert_eq!(driver.load_high_water().await.unwrap(), 200);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn leader_state_epoch_matches_raft_term() {
     let cluster = build_single_node().await;
     let driver = &cluster.drivers[0];
@@ -94,7 +94,7 @@ async fn leader_state_epoch_matches_raft_term() {
     assert_eq!(epoch.0, u128::from(term));
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn leadership_stream_outlives_driver_drop() {
     let cluster = build_single_node().await;
 
@@ -109,7 +109,7 @@ async fn leadership_stream_outlives_driver_drop() {
         .expect("event stream alive");
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn persist_high_water_ignores_epoch_arg() {
     use tsoracle_core::Epoch;
 

--- a/crates/tsoracle-driver-openraft/tests/snapshot_restart.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_restart.rs
@@ -61,7 +61,7 @@ fn aggressive_snapshot_config() -> Arc<Config> {
     )
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn snapshot_persists_across_restart_when_log_is_purged() {
     let cluster = build_single_node_with_config(aggressive_snapshot_config()).await;
     let TestCluster {

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -98,7 +98,7 @@ async fn find_leader_idx(nodes: &[SnapshotNode]) -> usize {
     .expect("a leader elected within 10s")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn isolated_follower_catches_up_via_snapshot_transfer() {
     let net = MemNetwork::<TypeConfig>::new();
     let cfg = snapshot_aggressive_config();

--- a/crates/tsoracle-driver-openraft/tests/three_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/three_node.rs
@@ -46,7 +46,7 @@ async fn find_leader_idx(cluster: &TestCluster) -> usize {
     .expect("some node became leader within 10s")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn three_node_leader_persists_and_followers_converge() {
     let cluster = build_three_node().await;
 
@@ -76,7 +76,7 @@ async fn three_node_leader_persists_and_followers_converge() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn three_node_follower_returns_not_leader() {
     let cluster = build_three_node().await;
 


### PR DESCRIPTION
Makes the openraft driver harness tests deterministic — the last untouched flake family after the paxos harness migration.

## Why a different approach than the paxos step-driver

The openraft tests waited on real wall-clock budgets — `timeout(5–10s)` for leader election, `tokio::time::sleep(500ms)` past `election_timeout`, `eventually_eq` poll loops — over openraft's internally-driven `RaftCore` (heartbeat 50ms, election 150–300ms). Slow CI overran those budgets (same flake class as the paxos harness).

But openraft is **not** manually tick-driven like omnipaxos — `RaftCore` runs its own async loop on tokio timers, so there's no `tick()` to step. And every test is **RocksDB-backed**, ruling out madsim. The right tool is **tokio virtual time**: switch each test from `#[tokio::test(flavor = "multi_thread")]` to `#[tokio::test(start_paused = true)]`. The paused clock auto-advances when the runtime is idle, so openraft's election/heartbeat timers and the tests' own sleeps/timeouts fire in *simulated* time — instantly, without wall-clock variance — while real RocksDB storage, `MemNetwork`, partition isolate/heal, and snapshot transfer all stay under test.

`★ Insight ─────────────────────────────────────`
Two consensus families, two opposite techniques. omnipaxos is externally tick-driven, so determinism comes from *replacing* its driver with a synchronous step loop (#312/#318). openraft drives *itself* on timers, so determinism comes from *replacing the clock* underneath it (paused virtual time) and letting it run. Both avoid madsim (rocksdb), and both turn multi-second real-time waits into instant simulated ones — but the lever is the driver in one case and the clock in the other.
`─────────────────────────────────────────────────`

## Scope

Test-attribute-only — no production changes. Converts all openraft integration tests: `single_node` (×4), `three_node` (×2), `partition_churn`, `restart_replay`, `snapshot_restart`, `snapshot_transfer`.

## Verification

- Every integration test now runs in ~0.1–0.2s (was 5–10s real-time budgets).
- Deterministic: 5/5 across repeats (incl. partition isolate/heal and snapshot transfer).
- `cargo test -p tsoracle-driver-openraft --all-features`: pass (58 unit + all integration).
- `cargo fmt --check`, `cargo clippy -p tsoracle-driver-openraft --all-targets --all-features -- -D warnings`: clean; pre-commit workspace clippy passed.