### PR TITLE
ci: bump rust-cache to v2.9.1 and actions/cache to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - name: system deps
         timeout-minutes: 5
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: cross-platform-driver-file-${{ matrix.os }}
       - name: build
@@ -129,7 +129,7 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac  # v2
         with:
           tool: cargo-llvm-cov
@@ -156,7 +156,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - name: system deps
         timeout-minutes: 5
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0

--- a/.github/workflows/leak-nightly.yml
+++ b/.github/workflows/leak-nightly.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: nightly-2026-03-31
           components: rust-src, llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           # Sanitizer builds compile a separate copy of libstd into a custom
           # target dir; isolate the cache key so it does not collide with

--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -18,7 +18,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry and og-image build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Cache cargo registry and og-image build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - name: system deps
         timeout-minutes: 5
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
@@ -75,7 +75,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - name: system deps
         timeout-minutes: 5
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0

--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: steps.filter.outputs.skip != 'true'
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         if: steps.filter.outputs.skip != 'true'
 
       - name: system deps


### PR DESCRIPTION
## Why

GitHub is forcing JavaScript actions off the deprecated **Node 20** runtime starting **June 2, 2026**. The nightly `stress` run surfaced this as a warning on `actions/cache/restore@0057852…`, which is pulled in **transitively** by `Swatinem/rust-cache` (the 2.8.x line bundles `actions/cache` v4/Node 20).

## What

- Pin all 8 `Swatinem/rust-cache` uses to `c1937114…` (**v2.9.1**, the "Update to node24" release, which bundles `actions/cache` v5):
  - `ci.yml` ×4, `release-plz.yml` ×2, `leak-nightly.yml`, `stress-nightly.yml`
- Bump the 2 direct `actions/cache@v4` uses to `@v5` (Node 24): `pages.yml`, `pages-build-check.yml`

`fuzz-pr.yml` / `fuzz-nightly.yml` already use `actions/cache/*@v5`, so they were left untouched.

## Notes

The moving `@v2` tag still resolves to the old `e18b497…` (pre-Node-24 2.8.x) commit, so a `@v2 → @v2` bump would have been a no-op — pinning to the 2.9.1 commit is what actually swaps the bundled cache action to the Node-24 v5. This also normalizes the previously-bare `@v2` references to the SHA-pin + version-comment convention already used elsewhere in these workflows.

The pre-commit `cargo fmt`/`clippy` hook passed locally.