### PR TITLE
feat(consensus): unify HighWaterCommand advance naming across backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ version = "0.1.6"
 dependencies = [
  "async-trait",
  "futures",
+ "postcard",
  "serde",
  "thiserror",
  "tsoracle-core",

--- a/crates/tsoracle-consensus/Cargo.toml
+++ b/crates/tsoracle-consensus/Cargo.toml
@@ -27,3 +27,6 @@ futures        = { workspace = true }
 thiserror      = { workspace = true }
 tsoracle-core  = { path = "../tsoracle-core", version = "0.2.1" }
 serde          = { workspace = true, optional = true }
+
+[dev-dependencies]
+postcard       = { workspace = true }

--- a/crates/tsoracle-consensus/src/lib.rs
+++ b/crates/tsoracle-consensus/src/lib.rs
@@ -21,6 +21,24 @@ use core::pin::Pin;
 use futures::Stream;
 use tsoracle_core::Epoch;
 
+/// The payload of an "advance the high-water to at least `at_least`" command,
+/// shared by every consensus backend's replicated log entry.
+///
+/// Each backend's `HighWaterCommand` newtype-wraps this in its `Advance`
+/// variant, so the "advance" semantics carry one name and one field across
+/// backends. Apply semantics are `current = max(current, at_least)`, which
+/// makes the command idempotent under retries and monotone under reordering —
+/// matching the [`ConsensusDriver::persist_high_water`] "advance to at least"
+/// contract.
+///
+/// `serde` is feature-gated to match the crate's optional-serde design; the
+/// drivers that persist this enable `tsoracle-consensus`'s `serde` feature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AdvancePayload {
+    pub at_least: u64,
+}
+
 /// Leadership state surfaced to the server's leader-watch task.
 ///
 /// `PartialEq`/`Eq` allow drivers to implement payload-aware debounce on a
@@ -192,6 +210,30 @@ mod tests {
         // Debug round-trips through the derive (covers the derive impl).
         let rendered = format!("{l1:?}");
         assert!(rendered.contains("Leader"));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn advance_payload_postcard_pins_at_least_varint() {
+        // Both backends embed this payload after their `Advance` variant tag,
+        // so its on-the-wire shape is a cross-backend contract: a bare varint
+        // of `at_least`, with no struct framing of its own.
+        let payload = AdvancePayload { at_least: 5 };
+        let bytes = postcard::to_stdvec(&payload).expect("serialize");
+        assert_eq!(bytes, vec![5]);
+        let back: AdvancePayload = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, payload);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn advance_payload_postcard_round_trips_extremes() {
+        for at_least in [0u64, 1, u64::MAX] {
+            let payload = AdvancePayload { at_least };
+            let bytes = postcard::to_stdvec(&payload).expect("serialize");
+            let back: AdvancePayload = postcard::from_bytes(&bytes).expect("deserialize");
+            assert_eq!(back, payload);
+        }
     }
 
     #[test]

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -41,7 +41,7 @@ thiserror          = { workspace = true }
 tokio              = { workspace = true }
 tokio-stream       = { workspace = true }
 tracing            = { workspace = true }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.6" }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.6", features = ["serde"] }
 tsoracle-core      = { path = "../tsoracle-core", version = "0.2.1" }
 
 [dev-dependencies]

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -31,4 +31,7 @@ pub use snapshot_store::RocksdbSnapshotStore;
 pub use snapshot_store::{InMemorySnapshotStore, SnapshotStore};
 pub use standalone::StandaloneHost;
 pub use state_machine::{HighWaterStateMachine, HighWaterStateMachineSnapshot};
+/// Re-export of the cross-backend advance payload that [`HighWaterCommand::Advance`]
+/// wraps, so consumers can build commands without depending on `tsoracle-consensus`.
+pub use tsoracle_consensus::AdvancePayload;
 pub use type_config::{HighWaterApplied, OpenraftPeer, TypeConfig};

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -14,14 +14,18 @@
 //! Log entries replicated by the openraft cluster.
 //!
 //! The driver replicates a single command: advance the high-water mark to at
-//! least `target`. The state machine treats this as `current = max(current,
-//! target)`, which makes the operation idempotent under retries and monotone
-//! under reordering — matching the [`tsoracle_consensus::ConsensusDriver`]
-//! "advance to at least" contract.
+//! least [`AdvancePayload::at_least`]. The state machine treats this as
+//! `current = max(current, at_least)`, which makes the operation idempotent
+//! under retries and monotone under reordering — matching the
+//! [`tsoracle_consensus::ConsensusDriver`] "advance to at least" contract. The
+//! payload is the cross-backend [`tsoracle_consensus::AdvancePayload`], shared
+//! with the paxos driver so the "advance" command carries one name and one
+//! field across backends.
 
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
+use tsoracle_consensus::AdvancePayload;
 
 /// Commands the state machine knows how to apply.
 ///
@@ -29,14 +33,16 @@ use serde::{Deserialize, Serialize};
 /// (used in the `Entry`'s human-readable summary).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HighWaterCommand {
-    /// Advance the high-water mark to at least `target`. Idempotent.
-    Bump { target: u64 },
+    /// Advance the high-water mark to at least `at_least`. Idempotent.
+    Advance(AdvancePayload),
 }
 
 impl fmt::Display for HighWaterCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HighWaterCommand::Bump { target } => write!(f, "Bump {{ target: {target} }}"),
+            HighWaterCommand::Advance(AdvancePayload { at_least }) => {
+                write!(f, "Advance {{ at_least: {at_least} }}")
+            }
         }
     }
 }
@@ -46,22 +52,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn display_renders_bump() {
-        let cmd = HighWaterCommand::Bump { target: 42 };
-        assert_eq!(format!("{cmd}"), "Bump { target: 42 }");
+    fn display_renders_advance() {
+        let cmd = HighWaterCommand::Advance(AdvancePayload { at_least: 42 });
+        assert_eq!(format!("{cmd}"), "Advance { at_least: 42 }");
     }
 
     #[test]
-    fn display_renders_zero_target() {
-        let cmd = HighWaterCommand::Bump { target: 0 };
-        assert_eq!(format!("{cmd}"), "Bump { target: 0 }");
+    fn display_renders_zero_at_least() {
+        let cmd = HighWaterCommand::Advance(AdvancePayload { at_least: 0 });
+        assert_eq!(format!("{cmd}"), "Advance { at_least: 0 }");
     }
 
     #[test]
-    fn postcard_round_trip_bump() {
-        let cmd = HighWaterCommand::Bump {
-            target: 1_234_567_890,
-        };
+    fn postcard_round_trip_advance() {
+        let cmd = HighWaterCommand::Advance(AdvancePayload {
+            at_least: 1_234_567_890,
+        });
         let bytes = postcard::to_stdvec(&cmd).expect("serialize");
         let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, cmd);
@@ -69,7 +75,7 @@ mod tests {
 
     #[test]
     fn postcard_round_trip_zero() {
-        let cmd = HighWaterCommand::Bump { target: 0 };
+        let cmd = HighWaterCommand::Advance(AdvancePayload { at_least: 0 });
         let bytes = postcard::to_stdvec(&cmd).expect("serialize");
         let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, cmd);
@@ -77,7 +83,7 @@ mod tests {
 
     #[test]
     fn postcard_round_trip_max() {
-        let cmd = HighWaterCommand::Bump { target: u64::MAX };
+        let cmd = HighWaterCommand::Advance(AdvancePayload { at_least: u64::MAX });
         let bytes = postcard::to_stdvec(&cmd).expect("serialize");
         let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, cmd);

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -30,6 +30,7 @@ use crate::host::OpenraftHighWaterHost;
 use crate::log_entry::HighWaterCommand;
 use crate::state_machine::HighWaterStateMachine;
 use crate::type_config::TypeConfig;
+use tsoracle_consensus::AdvancePayload;
 
 /// `OpenraftHighWaterHost` that owns its own raft cluster + state machine.
 ///
@@ -79,7 +80,7 @@ impl OpenraftHighWaterHost for StandaloneHost {
     async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
         match self
             .raft
-            .client_write(HighWaterCommand::Bump { target: at_least })
+            .client_write(HighWaterCommand::Advance(AdvancePayload { at_least }))
             .await
         {
             Ok(resp) => Ok(resp.data.value),

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -51,6 +51,7 @@ use tsoracle_openraft_toolkit::{SCHEMA_VERSION, decode, encode};
 use crate::log_entry::HighWaterCommand;
 use crate::snapshot_store::{InMemorySnapshotStore, SnapshotStore};
 use crate::type_config::{HighWaterApplied, TypeConfig};
+use tsoracle_consensus::AdvancePayload;
 
 type LogId = LogIdOf<TypeConfig>;
 type SnapMeta = SnapshotMetaOf<TypeConfig>;
@@ -294,10 +295,10 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                     }
                 }
                 EntryPayload::Normal(cmd) => {
-                    let HighWaterCommand::Bump { target } = cmd;
+                    let HighWaterCommand::Advance(AdvancePayload { at_least }) = cmd;
                     let mut core = self.core.lock();
-                    if *target > core.current_value {
-                        core.current_value = *target;
+                    if *at_least > core.current_value {
+                        core.current_value = *at_least;
                     }
                     core.last_applied = Some(log_id);
                     HighWaterApplied {
@@ -402,6 +403,7 @@ mod tests {
 
     use crate::log_entry::HighWaterCommand;
     use crate::type_config::TypeConfig;
+    use tsoracle_consensus::AdvancePayload;
 
     // --- Test helpers ---
 
@@ -450,7 +452,7 @@ mod tests {
         apply_one(
             &mut sm,
             1,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 100 })),
         )
         .await;
         assert_eq!(sm.current_value().await, 100);
@@ -462,13 +464,13 @@ mod tests {
         apply_one(
             &mut sm,
             1,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 100 })),
         )
         .await;
         apply_one(
             &mut sm,
             2,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 50 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 50 })),
         )
         .await;
         assert_eq!(sm.current_value().await, 100);
@@ -480,13 +482,13 @@ mod tests {
         apply_one(
             &mut sm,
             1,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 100 })),
         )
         .await;
         apply_one(
             &mut sm,
             2,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 100 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 100 })),
         )
         .await;
         assert_eq!(sm.current_value().await, 100);
@@ -498,7 +500,7 @@ mod tests {
         apply_one(
             &mut sm,
             1,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 42 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 42 })),
         )
         .await;
         let mem = openraft::Membership::new_with_defaults(vec![BTreeSet::from([1u64])], [1u64]);
@@ -516,7 +518,7 @@ mod tests {
         apply_one(
             &mut sm,
             1,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 500 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 500 })),
         )
         .await;
 
@@ -535,7 +537,7 @@ mod tests {
         apply_one(
             &mut sm,
             1,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 7 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 7 })),
         )
         .await;
 
@@ -601,7 +603,7 @@ mod tests {
         apply_one(
             &mut sm,
             1,
-            EntryPayload::Normal(HighWaterCommand::Bump { target: 42 }),
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 42 })),
         )
         .await;
         sm.build_snapshot().await.expect("build_snapshot");
@@ -619,7 +621,7 @@ mod tests {
             apply_one(
                 &mut sm,
                 1,
-                EntryPayload::Normal(HighWaterCommand::Bump { target: 99 }),
+                EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 99 })),
             )
             .await;
             sm.build_snapshot().await.expect("build_snapshot");
@@ -791,8 +793,8 @@ mod tests {
     }
 
     proptest! {
-        /// Monotonicity invariant: applying an arbitrary sequence of `Bump`
-        /// targets leaves the state machine at `max(0, max(targets))`, and
+        /// Monotonicity invariant: applying an arbitrary sequence of `Advance`
+        /// values leaves the state machine at `max(0, max(at_leasts))`, and
         /// `current_value` is non-decreasing at every intermediate step.
         #[test]
         fn p1_monotonicity_under_arbitrary_bumps(
@@ -807,7 +809,7 @@ mod tests {
                     apply_one(
                         &mut sm,
                         idx,
-                        EntryPayload::Normal(HighWaterCommand::Bump { target: *t }),
+                        EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: *t })),
                     )
                     .await;
                     let now = sm.current_value().await;
@@ -835,7 +837,7 @@ mod tests {
                     apply_one(
                         &mut sm,
                         idx,
-                        EntryPayload::Normal(HighWaterCommand::Bump { target: *t }),
+                        EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: *t })),
                     )
                     .await;
                 }
@@ -881,13 +883,15 @@ mod tests {
     #[test]
     fn log_entry_pins_v1_layout() {
         // The bytes RocksdbLogStore<TypeConfig> persists per entry: the v1
-        // frame around a Normal entry carrying Bump { target: 5 } at log id
-        // (term 1, node 1, index 1). Body [1,1,1,1,0,5] = leader (term 1,
-        // node 1), index 1, EntryPayload::Normal tag (1), Bump variant (0),
-        // target 5.
+        // frame around a Normal entry carrying Advance(AdvancePayload { at_least: 5 })
+        // at log id (term 1, node 1, index 1). Body [1,1,1,1,0,5] = leader
+        // (term 1, node 1), index 1, EntryPayload::Normal tag (1), Advance
+        // variant (0), at_least 5 — byte-identical to the pre-newtype layout.
         let lid = openraft::testing::log_id::<TypeConfig>(1, 1, 1);
-        let entry: EntryOf<TypeConfig> =
-            EntryOf::<TypeConfig>::new_normal(lid, HighWaterCommand::Bump { target: 5 });
+        let entry: EntryOf<TypeConfig> = EntryOf::<TypeConfig>::new_normal(
+            lid,
+            HighWaterCommand::Advance(AdvancePayload { at_least: 5 }),
+        );
         let framed =
             tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &entry)
                 .expect("encode");

--- a/crates/tsoracle-driver-openraft/tests/generate_fuzz_seeds.rs
+++ b/crates/tsoracle-driver-openraft/tests/generate_fuzz_seeds.rs
@@ -25,6 +25,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use openraft::type_config::alias::StoredMembershipOf;
+use tsoracle_driver_openraft::AdvancePayload;
 use tsoracle_driver_openraft::{HighWaterCommand, HighWaterStateMachineSnapshot, TypeConfig};
 
 fn fuzz_corpus_dir(target: &str) -> PathBuf {
@@ -43,16 +44,16 @@ fn generate_log_entry_decode_seeds() {
     let target = "log_entry_decode";
     // Empty input — exercises the postcard "unexpected EOF" branch.
     write_seed(target, "seed_empty", &[]);
-    // Three boundary `Bump` targets mirror the existing hand-written
+    // Three boundary `Advance` values mirror the existing hand-written
     // roundtrip tests in `log_entry.rs::tests`.
     for (name, target_value) in [
         ("seed_bump_zero", 0u64),
         ("seed_bump_one", 1u64),
         ("seed_bump_max", u64::MAX),
     ] {
-        let bytes = postcard::to_stdvec(&HighWaterCommand::Bump {
-            target: target_value,
-        })
+        let bytes = postcard::to_stdvec(&HighWaterCommand::Advance(AdvancePayload {
+            at_least: target_value,
+        }))
         .expect("serialize HighWaterCommand");
         write_seed(target, name, &bytes);
     }

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -35,6 +35,7 @@ use openraft::{Config, Raft, SnapshotPolicy};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tempfile::TempDir;
 use tokio::time::timeout;
+use tsoracle_driver_openraft::AdvancePayload;
 use tsoracle_driver_openraft::{HighWaterCommand, HighWaterStateMachine, OpenraftPeer, TypeConfig};
 use tsoracle_openraft_toolkit::test_fakes::MemNetwork;
 use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
@@ -146,7 +147,7 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     // follower — converge so we know the test's starting state.
     nodes[leader_idx]
         .raft
-        .client_write(HighWaterCommand::Bump { target: 10 })
+        .client_write(HighWaterCommand::Advance(AdvancePayload { at_least: 10 }))
         .await
         .expect("baseline bump");
     for node in &nodes {
@@ -163,15 +164,15 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     // quorum so writes succeed.
     net.partitions().isolate(follower_id);
 
-    // Apply enough Bumps to comfortably cross LogsSinceLast(4) and grow the
+    // Apply enough Advances to comfortably cross LogsSinceLast(4) and grow the
     // committed-log distance between the leader and the trailing follower.
     let final_target = 80u64;
     for next_target in [20u64, 30, 40, 50, 60, 70, final_target] {
         nodes[leader_idx]
             .raft
-            .client_write(HighWaterCommand::Bump {
-                target: next_target,
-            })
+            .client_write(HighWaterCommand::Advance(AdvancePayload {
+                at_least: next_target,
+            }))
             .await
             .expect("partition-side bump");
     }

--- a/crates/tsoracle-driver-paxos/Cargo.toml
+++ b/crates/tsoracle-driver-paxos/Cargo.toml
@@ -25,7 +25,7 @@ thiserror            = { workspace = true }
 tokio                = { workspace = true }
 tokio-stream         = { workspace = true }
 tracing              = { workspace = true }
-tsoracle-consensus   = { path = "../tsoracle-consensus", version = "0.1.6" }
+tsoracle-consensus   = { path = "../tsoracle-consensus", version = "0.1.6", features = ["serde"] }
 tsoracle-core        = { path = "../tsoracle-core", version = "0.2.1" }
 tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "0.2.2", default-features = false }
 tsoracle-yieldpoint  = { workspace = true }

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -27,4 +27,7 @@ pub use log_entry::{HighWaterCommand, HighWaterSnapshot};
 pub use snapshot_policy::SnapshotPolicy;
 pub use standalone::{BuilderError, StandaloneHost, StandaloneHostBuilder};
 pub use state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
+/// Re-export of the cross-backend advance payload that [`HighWaterCommand::Advance`]
+/// wraps, so consumers can build commands without depending on `tsoracle-consensus`.
+pub use tsoracle_consensus::AdvancePayload;
 pub use type_config::{PaxosPeer, decode_epoch, encode_epoch};

--- a/crates/tsoracle-driver-paxos/src/log_entry.rs
+++ b/crates/tsoracle-driver-paxos/src/log_entry.rs
@@ -13,8 +13,11 @@
 //! The single command type replicated through the OmniPaxos log.
 //!
 //! Two variants:
-//! - [`Advance`](HighWaterCommand::Advance) — bump the high-water to at least
-//!   the given value. Apply is `max(prev, at_least)`.
+//! - [`Advance`](HighWaterCommand::Advance) — advance the high-water to at least
+//!   the [`AdvancePayload::at_least`] value. Apply is `max(prev, at_least)`. The
+//!   payload is the cross-backend [`tsoracle_consensus::AdvancePayload`], shared
+//!   with the openraft driver so the "advance" command carries one name and one
+//!   field across backends.
 //! - [`Barrier`](HighWaterCommand::Barrier) — identified no-op used to
 //!   linearize reads. `current_high_water` mints a `(node, seq)` nonce,
 //!   appends `Barrier { node, seq }`, and waits until the apply path
@@ -27,10 +30,11 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use tsoracle_consensus::AdvancePayload;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum HighWaterCommand {
-    Advance { at_least: u64 },
+    Advance(AdvancePayload),
     Barrier { node: u64, seq: u64 },
 }
 
@@ -56,7 +60,7 @@ impl omnipaxos::storage::Snapshot<HighWaterCommand> for HighWaterSnapshot {
         let mut applied_barriers: HashMap<u64, u64> = HashMap::new();
         for command in entries {
             match command {
-                HighWaterCommand::Advance { at_least } => {
+                HighWaterCommand::Advance(AdvancePayload { at_least }) => {
                     if *at_least > value {
                         value = *at_least;
                     }
@@ -98,10 +102,10 @@ mod tests {
     #[test]
     fn snapshot_create_picks_max_advance() {
         let entries = vec![
-            HighWaterCommand::Advance { at_least: 10 },
+            HighWaterCommand::Advance(AdvancePayload { at_least: 10 }),
             HighWaterCommand::Barrier { node: 1, seq: 1 },
-            HighWaterCommand::Advance { at_least: 30 },
-            HighWaterCommand::Advance { at_least: 20 },
+            HighWaterCommand::Advance(AdvancePayload { at_least: 30 }),
+            HighWaterCommand::Advance(AdvancePayload { at_least: 20 }),
         ];
         let snap = HighWaterSnapshot::create(&entries);
         assert_eq!(snap.value, 30);
@@ -151,7 +155,7 @@ mod tests {
     fn snapshot_create_folds_barriers_into_ledger() {
         let entries = vec![
             HighWaterCommand::Barrier { node: 1, seq: 3 },
-            HighWaterCommand::Advance { at_least: 100 },
+            HighWaterCommand::Advance(AdvancePayload { at_least: 100 }),
             HighWaterCommand::Barrier { node: 1, seq: 5 },
             HighWaterCommand::Barrier { node: 2, seq: 9 },
         ];

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -31,7 +31,7 @@ use parking_lot::Mutex;
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tracing::warn;
-use tsoracle_consensus::ConsensusError;
+use tsoracle_consensus::{AdvancePayload, ConsensusError};
 use tsoracle_paxos_toolkit::lifecycle::{LeaderEventStream, MessageSink, PaxosRunner, Peer};
 
 use crate::host::PaxosHighWaterHost;
@@ -399,7 +399,7 @@ where
         // surfaces the leadership change to the caller.
         self.omnipaxos
             .lock()
-            .append(HighWaterCommand::Advance { at_least })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least }))
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(AdvanceAppendError(format!("{err:?}"))))
             })?;

--- a/crates/tsoracle-driver-paxos/src/state_machine.rs
+++ b/crates/tsoracle-driver-paxos/src/state_machine.rs
@@ -40,6 +40,7 @@ use tracing::trace;
 
 use crate::log_entry::HighWaterCommand;
 use crate::snapshot_policy::SnapshotPolicy;
+use tsoracle_consensus::AdvancePayload;
 
 /// Shared apply-task state.
 ///
@@ -125,7 +126,7 @@ where
     if let Some(entries) = entries {
         for entry in &entries {
             match entry {
-                LogEntry::Decided(HighWaterCommand::Advance { at_least }) => {
+                LogEntry::Decided(HighWaterCommand::Advance(AdvancePayload { at_least })) => {
                     let prev = state.high_water.load(Ordering::SeqCst);
                     if *at_least > prev {
                         state.high_water.store(*at_least, Ordering::SeqCst);
@@ -361,7 +362,7 @@ mod drain_tests {
 
         leader_handle(&cluster)
             .lock()
-            .append(HighWaterCommand::Advance { at_least: 42 })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: 42 }))
             .expect("append succeeds on leader");
 
         drive_until(
@@ -394,13 +395,13 @@ mod drain_tests {
             let leader = leader_handle(&cluster);
             let mut handle = leader.lock();
             handle
-                .append(HighWaterCommand::Advance { at_least: 10 })
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 10 }))
                 .expect("append");
             handle
-                .append(HighWaterCommand::Advance { at_least: 50 })
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 50 }))
                 .expect("append");
             handle
-                .append(HighWaterCommand::Advance { at_least: 30 })
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 30 }))
                 .expect("append");
         }
 
@@ -436,7 +437,7 @@ mod drain_tests {
             let leader = leader_handle(&cluster);
             let mut handle = leader.lock();
             handle
-                .append(HighWaterCommand::Advance { at_least: 17 })
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 17 }))
                 .expect("append");
             handle
                 .append(HighWaterCommand::Barrier { node: 1, seq: 1 })
@@ -532,7 +533,7 @@ mod drain_tests {
 
         leader_handle(&cluster)
             .lock()
-            .append(HighWaterCommand::Advance { at_least: 7 })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: 7 }))
             .expect("append");
 
         drive_until(
@@ -572,7 +573,7 @@ mod drain_tests {
 
         leader_handle(&cluster)
             .lock()
-            .append(HighWaterCommand::Advance { at_least: 1 })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: 1 }))
             .expect("append");
 
         drive_until(

--- a/crates/tsoracle-driver-paxos/tests/codec_fixture.rs
+++ b/crates/tsoracle-driver-paxos/tests/codec_fixture.rs
@@ -14,13 +14,16 @@
 //! exact bytes `RocksdbStorage` persists per entry. A layout change trips this
 //! and forces a `SCHEMA_VERSION` bump.
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_paxos_toolkit::codec::{SCHEMA_VERSION, encode};
 
 #[test]
 fn log_entry_pins_v1_layout() {
-    // Body [0,5] = HighWaterCommand::Advance variant (0) + at_least 5.
-    let cmd = HighWaterCommand::Advance { at_least: 5 };
+    // Body [0,5] = HighWaterCommand::Advance variant tag (0) + the wrapped
+    // AdvancePayload, which postcard encodes as a bare `at_least` varint (5) —
+    // byte-for-byte identical to the pre-newtype struct-variant layout.
+    let cmd = HighWaterCommand::Advance(AdvancePayload { at_least: 5 });
     let framed = encode(SCHEMA_VERSION, &cmd).expect("encode");
     assert_eq!(framed, vec![1, 0, 5]);
 }

--- a/crates/tsoracle-driver-paxos/tests/generate_fuzz_seeds.rs
+++ b/crates/tsoracle-driver-paxos/tests/generate_fuzz_seeds.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::{HighWaterCommand, HighWaterSnapshot};
 
 fn fuzz_corpus_dir(target: &str) -> PathBuf {
@@ -51,7 +52,7 @@ fn generate_paxos_log_entry_decode_seeds() {
         ("seed_advance_one", 1u64),
         ("seed_advance_max", u64::MAX),
     ] {
-        let bytes = postcard::to_stdvec(&HighWaterCommand::Advance { at_least })
+        let bytes = postcard::to_stdvec(&HighWaterCommand::Advance(AdvancePayload { at_least }))
             .expect("serialize Advance");
         write_seed(target, name, &bytes);
     }

--- a/crates/tsoracle-driver-paxos/tests/linearized_barrier.rs
+++ b/crates/tsoracle-driver-paxos/tests/linearized_barrier.rs
@@ -35,6 +35,7 @@
 
 use std::time::Duration;
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_driver_paxos::host::PaxosHighWaterHost;
 use tsoracle_yieldpoint as yieldpoint;
@@ -68,7 +69,7 @@ async fn current_high_water_returns_value_advanced_before_call_under_paused_appl
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 500 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 500 }))
         .expect("append Advance on leader");
     cluster
         .drive_until(common::all_decided_at_least(1), 1_000)

--- a/crates/tsoracle-driver-paxos/tests/partition_churn.rs
+++ b/crates/tsoracle-driver-paxos/tests/partition_churn.rs
@@ -23,6 +23,7 @@
 //! isolation/heal behave exactly as on the async path — but election +
 //! re-election + catch-up converge in simulated steps with no real-time budget.
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 
 #[path = "common/mod.rs"]
@@ -39,7 +40,7 @@ async fn partition_then_heal_preserves_monotonic_high_water() {
         .node(original_leader)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 100 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 100 }))
         .expect("first append succeeds on leader");
 
     // Wait for cluster-wide convergence on 100.
@@ -91,7 +92,7 @@ async fn partition_then_heal_preserves_monotonic_high_water() {
         .node(new_leader)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 200 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 200 }))
         .expect("second append succeeds on the new leader");
 
     // Wait for the two reachable nodes to commit the new value.

--- a/crates/tsoracle-driver-paxos/tests/reconfiguration.rs
+++ b/crates/tsoracle-driver-paxos/tests/reconfiguration.rs
@@ -32,6 +32,7 @@
 //! intra-config behavior verified here is the load-bearing contract
 //! for the stopsign path.
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 
 use omnipaxos::ClusterConfig;
@@ -55,13 +56,13 @@ async fn stopsign_decides_and_seals_old_configuration() {
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 5 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 5 }))
         .expect("pre-stopsign append succeeds");
     cluster
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 17 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 17 }))
         .expect("pre-stopsign append succeeds");
     cluster
         .drive_until(
@@ -145,7 +146,7 @@ async fn stopsign_decides_and_seals_old_configuration() {
         let result = node
             .omnipaxos()
             .lock()
-            .append(HighWaterCommand::Advance { at_least: 99 });
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: 99 }));
         assert!(
             result.is_err(),
             "append on node {} after stopsign must be rejected",

--- a/crates/tsoracle-driver-paxos/tests/restart_barrier_seq.rs
+++ b/crates/tsoracle-driver-paxos/tests/restart_barrier_seq.rs
@@ -43,6 +43,7 @@
 
 use std::time::Duration;
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_driver_paxos::host::PaxosHighWaterHost;
 use tsoracle_yieldpoint as yieldpoint;
@@ -84,7 +85,7 @@ async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() 
                 .expect("append barrier on leader");
         }
         handle
-            .append(HighWaterCommand::Advance { at_least: 100 })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: 100 }))
             .expect("append advance on leader");
     }
     cluster
@@ -125,7 +126,7 @@ async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() 
         let leader = cluster.node(leader_id).omnipaxos();
         leader
             .lock()
-            .append(HighWaterCommand::Advance { at_least: 500 })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: 500 }))
             .expect("append advance(500) on leader");
     }
     cluster

--- a/crates/tsoracle-driver-paxos/tests/restart_replay.rs
+++ b/crates/tsoracle-driver-paxos/tests/restart_replay.rs
@@ -24,6 +24,7 @@
 //! election + replication + catch-up converge in simulated steps with no
 //! wall-clock budget to overrun. Real RocksDB storage + replay stay under test.
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 
 #[path = "common/mod.rs"]
@@ -40,13 +41,13 @@ async fn restart_recovers_decided_state_from_storage() {
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 10 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 10 }))
         .expect("first append succeeds on leader");
     cluster
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 50 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 50 }))
         .expect("second append succeeds on leader");
 
     cluster.step_until(
@@ -76,7 +77,7 @@ async fn restart_recovers_decided_state_from_storage() {
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 100 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 100 }))
         .expect("third append succeeds on leader");
     cluster.step_until(
         |state| {

--- a/crates/tsoracle-driver-paxos/tests/single_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/single_node.rs
@@ -22,6 +22,7 @@
 
 use std::time::Duration;
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 
 #[path = "common/mod.rs"]
@@ -74,7 +75,7 @@ async fn three_runners_advance_then_converge() {
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 25 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 25 }))
         .expect("append succeeds on leader");
 
     cluster

--- a/crates/tsoracle-driver-paxos/tests/snapshot_restart.rs
+++ b/crates/tsoracle-driver-paxos/tests/snapshot_restart.rs
@@ -21,6 +21,7 @@
 //! plus any missing entries replicated from peers bring the node back
 //! to the latest decided state.
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::{HighWaterCommand, SnapshotPolicy};
 
 #[path = "common/mod.rs"]
@@ -44,7 +45,7 @@ async fn snapshot_policy_persists_across_restart() {
             .node(leader_id)
             .omnipaxos()
             .lock()
-            .append(HighWaterCommand::Advance { at_least: n })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: n }))
             .expect("append succeeds on leader");
     }
 

--- a/crates/tsoracle-driver-paxos/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-paxos/tests/snapshot_transfer.rs
@@ -28,6 +28,7 @@
 //! fires during `apply_once`, so the whole scenario converges in simulated
 //! steps with no real-time budget to overrun.
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::{HighWaterCommand, SnapshotPolicy};
 
 #[path = "common/mod.rs"]
@@ -68,7 +69,7 @@ async fn isolated_node_catches_up_via_snapshot_transfer() {
             .node(leader_id)
             .omnipaxos()
             .lock()
-            .append(HighWaterCommand::Advance { at_least: n })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least: n }))
             .expect("append succeeds on leader");
     }
 

--- a/crates/tsoracle-driver-paxos/tests/standalone_stale_permit.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_stale_permit.rs
@@ -22,6 +22,7 @@
 //! loop immediately — so decided entries are never drained into the in-memory
 //! high-water, and reads that wait on the apply notifier hang forever.
 
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 
 #[path = "common/mod.rs"]
@@ -51,7 +52,7 @@ async fn stop_before_start_does_not_poison_apply_task() {
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 25 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 25 }))
         .expect("append succeeds on leader");
 
     cluster

--- a/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
+++ b/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
@@ -31,6 +31,7 @@
 use std::time::Duration;
 
 use omnipaxos::util::LogEntry;
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_driver_paxos::host::PaxosHighWaterHost;
 
@@ -77,7 +78,7 @@ async fn submit_advance_commits_an_attributable_barrier_for_this_call() {
     let mut barrier_from_this_node_after_advance = false;
     for entry in &entries {
         match entry {
-            LogEntry::Decided(HighWaterCommand::Advance { at_least: 42 }) => {
+            LogEntry::Decided(HighWaterCommand::Advance(AdvancePayload { at_least: 42 })) => {
                 saw_this_calls_advance = true;
             }
             LogEntry::Decided(HighWaterCommand::Barrier { node, .. }) if *node == leader_id => {

--- a/crates/tsoracle-driver-paxos/tests/three_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/three_node.rs
@@ -24,6 +24,7 @@
 
 use tsoracle_consensus::{ConsensusDriver, ConsensusError};
 use tsoracle_core::Epoch;
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, encode_epoch};
 
 #[path = "common/mod.rs"]
@@ -43,13 +44,13 @@ async fn three_node_quorum_advances_converge_across_replicas() {
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 10 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 10 }))
         .expect("first append succeeds on leader");
     cluster
         .node(leader_id)
         .omnipaxos()
         .lock()
-        .append(HighWaterCommand::Advance { at_least: 50 })
+        .append(HighWaterCommand::Advance(AdvancePayload { at_least: 50 }))
         .expect("second append succeeds on leader");
 
     cluster.step_until(common::all_decided_at_least(2), 1_000);
@@ -233,7 +234,7 @@ impl PaxosHighWaterHost for FollowerProxyHost {
         let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
         self.omnipaxos
             .lock()
-            .append(HighWaterCommand::Advance { at_least })
+            .append(HighWaterCommand::Advance(AdvancePayload { at_least }))
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(ProxyAppendError(format!("{err:?}"))))
             })?;

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -35,7 +35,7 @@ use openraft::{
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use tsoracle_consensus::ConsensusError;
-use tsoracle_driver_openraft::{HighWaterCommand, OpenraftHighWaterHost};
+use tsoracle_driver_openraft::{AdvancePayload, HighWaterCommand, OpenraftHighWaterHost};
 use tsoracle_openraft_toolkit::declare_raft_types_ext;
 
 // ---------- Envelope shape ----------
@@ -227,10 +227,12 @@ impl RaftStateMachine<HostTypeConfig> for HostStateMachine {
                         tso: None,
                     }
                 }
-                EntryPayload::Normal(HostCommand::Tso(HighWaterCommand::Bump { target })) => {
+                EntryPayload::Normal(HostCommand::Tso(HighWaterCommand::Advance(
+                    AdvancePayload { at_least },
+                ))) => {
                     let mut core = self.core.lock();
-                    if *target > core.high_water {
-                        core.high_water = *target;
+                    if *at_least > core.high_water {
+                        core.high_water = *at_least;
                     }
                     core.last_applied = Some(log_id);
                     HostApplied {
@@ -298,7 +300,7 @@ impl RaftStateMachine<HostTypeConfig> for HostStateMachine {
 // ---------- OpenraftHighWaterHost impl ----------
 
 /// The integration: 30-ish lines. Owns a clone of the host's raft handle and
-/// the state machine; wraps `HighWaterCommand::Bump` in `HostCommand::Tso`
+/// the state machine; wraps `HighWaterCommand::Advance` in `HostCommand::Tso`
 /// for `submit_advance`.
 pub struct PiggybackHost {
     raft: Raft<HostTypeConfig, HostStateMachine>,
@@ -341,7 +343,7 @@ impl OpenraftHighWaterHost for PiggybackHost {
     async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
         // Envelope: wrap the driver's HighWaterCommand into HostCommand::Tso
         // so it rides the same log entries as the host's KV writes.
-        let cmd = HostCommand::Tso(HighWaterCommand::Bump { target: at_least });
+        let cmd = HostCommand::Tso(HighWaterCommand::Advance(AdvancePayload { at_least }));
         match self.raft.client_write(cmd).await {
             Ok(resp) => Ok(resp
                 .data

--- a/examples/paxos-piggyback/src/host_service.rs
+++ b/examples/paxos-piggyback/src/host_service.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
 use tracing::trace;
 use tsoracle_consensus::ConsensusError;
+use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_driver_paxos::host::PaxosHighWaterHost;
 use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
@@ -107,7 +108,7 @@ fn apply_into_snapshot(entry: &MyAppCommand, snap: &mut MyAppSnap) {
         MyAppCommand::Kv(KvOp::Delete { key }) => {
             snap.kv.remove(key);
         }
-        MyAppCommand::HighWater(HighWaterCommand::Advance { at_least }) => {
+        MyAppCommand::HighWater(HighWaterCommand::Advance(AdvancePayload { at_least })) => {
             if *at_least > snap.high_water {
                 snap.high_water = *at_least;
             }
@@ -198,7 +199,7 @@ pub fn apply_decided_into(cmd: &MyAppCommand, state: &HostState) {
         MyAppCommand::Kv(KvOp::Delete { key }) => {
             state.kv.lock().remove(key);
         }
-        MyAppCommand::HighWater(HighWaterCommand::Advance { at_least }) => {
+        MyAppCommand::HighWater(HighWaterCommand::Advance(AdvancePayload { at_least })) => {
             let prev = state.high_water.load(Ordering::SeqCst);
             if *at_least > prev {
                 state.high_water.store(*at_least, Ordering::SeqCst);
@@ -371,9 +372,9 @@ impl PaxosHighWaterHost for PiggybackHost {
         let snapshot_decided = self.omnipaxos.lock().get_decided_idx();
         self.omnipaxos
             .lock()
-            .append(MyAppCommand::HighWater(HighWaterCommand::Advance {
-                at_least,
-            }))
+            .append(MyAppCommand::HighWater(HighWaterCommand::Advance(
+                AdvancePayload { at_least },
+            )))
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(PiggybackAppendError(format!("{err:?}"))))
             })?;
@@ -412,7 +413,7 @@ mod tests {
     }
 
     fn advance(at_least: u64) -> MyAppCommand {
-        MyAppCommand::HighWater(HighWaterCommand::Advance { at_least })
+        MyAppCommand::HighWater(HighWaterCommand::Advance(AdvancePayload { at_least }))
     }
 
     fn barrier(node: u64, seq: u64) -> MyAppCommand {
@@ -423,9 +424,10 @@ mod tests {
 
     #[test]
     fn from_highwatercommand_wraps_into_envelope() {
-        let wrapped: MyAppCommand = HighWaterCommand::Advance { at_least: 5 }.into();
+        let wrapped: MyAppCommand =
+            HighWaterCommand::Advance(AdvancePayload { at_least: 5 }).into();
         match wrapped {
-            MyAppCommand::HighWater(HighWaterCommand::Advance { at_least }) => {
+            MyAppCommand::HighWater(HighWaterCommand::Advance(AdvancePayload { at_least })) => {
                 assert_eq!(at_least, 5);
             }
             other => panic!("expected envelope wrap, got {other:?}"),


### PR DESCRIPTION
## Summary

Closes #267.

Both consensus backends carried the same "advance the high-water to at least N" command under divergent names — paxos `HighWaterCommand::Advance { at_least }` vs openraft `HighWaterCommand::Bump { target }` — forcing a context switch when reading across drivers.

- New shared `AdvancePayload { at_least: u64 }` in `tsoracle-consensus`. Both drivers newtype-wrap it as `HighWaterCommand::Advance(AdvancePayload)`.
- Paxos keeps its Paxos-only `Barrier` variant; openraft's `Bump`/`target` is renamed to `Advance`/`at_least`, with its `Display` impl updated to match.
- Each driver re-exports `AdvancePayload` at its crate root, so consumers build commands without depending on `tsoracle-consensus` directly.
- The shared type's serde derives are gated behind the crate's existing optional `serde` feature, which both drivers now enable.

Lands as `feat(consensus):` rather than `refactor:`: it adds a public symbol to the published `tsoracle-consensus` library that the drivers consume, and a `refactor:` commit would be excluded from the release filter, breaking the release run's `cargo publish --verify` against a stale registry.

## Wire compatibility

This is wire-compatible — these are persisted log entries. postcard encodes the newtype variant `Advance(AdvancePayload { at_least })` byte-for-byte identically to the former struct variants (variant tag followed by the `at_least` varint), so **no `SCHEMA_VERSION` bump** is needed.

- New serialization test in `tsoracle-consensus` pins `AdvancePayload { at_least: 5 }` to its bare varint `[5]`.
- Both per-backend on-disk frame fixtures continue to pin their exact bytes: paxos `[1, 0, 5]`, openraft `[1, 1, 1, 1, 0, 5]`.

## Test plan

- [x] `cargo test --workspace` — green
- [x] `cargo build --workspace --all-targets` — green (includes all examples)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] Confirmed the serde-gated shared serialization test actually runs (not skipped) and both codec-byte fixtures pass