### PR TITLE
feat: extract the version-prefixed postcard codec into a shared tsoracle-codec crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,6 +3285,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tsoracle-codec"
+version = "0.1.0"
+dependencies = [
+ "postcard",
+ "proptest",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "tsoracle-consensus"
 version = "0.1.6"
 dependencies = [
@@ -3396,6 +3406,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tsoracle-codec",
  "tsoracle-failpoint",
 ]
 
@@ -3408,8 +3419,6 @@ dependencies = [
  "omnipaxos",
  "parking_lot",
  "pastey",
- "postcard",
- "proptest",
  "rocksdb",
  "serde",
  "tempfile",
@@ -3417,6 +3426,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tsoracle-codec",
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-failpoint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members  = [
     "crates/tsoracle-tests",
     "crates/tsoracle-yieldpoint",
     "crates/tsoracle-failpoint",
+    "crates/tsoracle-codec",
     "examples/embedded-server",
     "examples/failover-demo",
     "examples/metrics-prometheus",
@@ -45,6 +46,7 @@ default-members = [
     "crates/tsoracle-paxos-toolkit",
     "crates/tsoracle-yieldpoint",
     "crates/tsoracle-failpoint",
+    "crates/tsoracle-codec",
 ]
 
 [workspace.package]
@@ -90,6 +92,7 @@ tokio              = { version = "1", features = ["macros", "rt-multi-thread", "
 tokio-stream       = { version = "0.1", features = ["sync"] }
 tsoracle-yieldpoint = { path = "crates/tsoracle-yieldpoint", version = "0.1.5" }
 tsoracle-failpoint = { path = "crates/tsoracle-failpoint", version = "0.1.0" }
+tsoracle-codec = { path = "crates/tsoracle-codec", version = "0.1.0" }
 tonic              = "0.14"
 tonic-prost        = "0.14"
 tonic-prost-build  = "0.14"

--- a/crates/tsoracle-codec/Cargo.toml
+++ b/crates/tsoracle-codec/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name         = "tsoracle-codec"
+description  = "Shared version-prefixed postcard codec: one `[version_byte | postcard(value)]` framing re-used across the tsoracle toolkits so an on-disk layout change fails loudly instead of misdecoding"
+version      = "0.1.0"
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+homepage.workspace     = true
+readme.workspace       = true
+authors.workspace      = true
+documentation = "https://docs.rs/tsoracle-codec"
+keywords      = ["serialization", "postcard", "versioning", "codec", "storage"]
+categories    = ["encoding", "database-implementations"]
+
+[dependencies]
+postcard  = { workspace = true }
+serde     = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/tsoracle-codec/README.md
+++ b/crates/tsoracle-codec/README.md
@@ -1,0 +1,38 @@
+# tsoracle-codec
+
+The one version-prefixed `postcard` codec shared across [tsoracle](https://github.com/prisma-risk/tsoracle) — every persisted blob is framed as `[version_byte | postcard(value)]` so an on-disk layout change fails loudly instead of misdecoding.
+
+## Why it exists
+
+Both consensus toolkits (`tsoracle-paxos-toolkit`, `tsoracle-openraft-toolkit`) carried a near-identical `encode`/`decode`/`CodecError` copy of this framing. Every persisted struct — a `Ballot`, a `HighWaterCommand` log entry, a snapshot, a Raft log record — is stamped with a leading schema-version byte; a node upgraded mid-flight that reads prior-version bytes hits a structured version mismatch rather than silently parsing them against a new struct layout. This crate is the single home for that framing.
+
+## What's in the box
+
+- `encode(version, value)` — serializes `value` with `postcard` and prepends `version`, yielding `[version | postcard(value)]`.
+- `decode(expected_version, bytes)` — checks the leading byte against `expected_version` (returning `CodecError::Version` on mismatch) before deserializing the body.
+- `CodecError` — `Empty`, `Version { expected, actual }`, `Encode(postcard::Error)`, `Decode(postcard::Error)`. Encode and decode failures are kept distinct, and the underlying `postcard::Error` is carried as the error source (no `From` conversion) so a stray `?` never silently becomes a `CodecError`.
+
+The schema-version *number* is deliberately **not** owned here. `version` is a parameter, so each consumer keeps its own `SCHEMA_VERSION` constant and evolves its on-disk format independently of the others.
+
+## Quick reference
+
+```toml
+# consumer Cargo.toml
+[dependencies]
+tsoracle-codec = { workspace = true }
+```
+
+```rust,ignore
+// Each consumer owns its own schema version.
+pub const SCHEMA_VERSION: u8 = 1;
+
+let framed = tsoracle_codec::encode(SCHEMA_VERSION, &value)?;
+let value: MyType = tsoracle_codec::decode(SCHEMA_VERSION, &framed)?;
+```
+
+Bump the consumer's `SCHEMA_VERSION` when a persisted struct's `postcard` layout changes in a backward-incompatible way (field reorder/insert/remove); a stale reader then fails with `CodecError::Version` instead of misdecoding.
+
+## Related
+
+- [`postcard`](https://crates.io/crates/postcard) — the compact `serde` wire format this frames.
+- `tsoracle-failpoint`, `tsoracle-yieldpoint` — the other shared micro-crates that exist so a single behavior is not duplicated across the workspace.

--- a/crates/tsoracle-codec/src/lib.rs
+++ b/crates/tsoracle-codec/src/lib.rs
@@ -1,0 +1,174 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+#![doc = include_str!("../README.md")]
+
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Failure modes of the version-prefixed postcard codec.
+///
+/// `Encode` and `Decode` are kept distinct so a caller can tell which
+/// direction failed; both carry the underlying [`postcard::Error`] as the
+/// error source rather than via a `From` conversion, so a stray `?` on a
+/// `postcard` result never silently becomes a `CodecError`.
+#[derive(Debug, thiserror::Error)]
+pub enum CodecError {
+    /// The payload had no leading version byte (it was empty).
+    #[error("payload empty")]
+    Empty,
+    /// The leading version byte did not match the version the reader expected.
+    /// A stale reader hits this instead of misdecoding old bytes against a new
+    /// struct layout.
+    #[error("version mismatch: expected {expected}, got {actual}")]
+    Version { expected: u8, actual: u8 },
+    /// `postcard` failed to serialize the value.
+    #[error("encode failed: {0}")]
+    Encode(#[source] postcard::Error),
+    /// `postcard` failed to deserialize the framed body.
+    #[error("decode failed: {0}")]
+    Decode(#[source] postcard::Error),
+}
+
+/// Encode `value` as `[version | postcard(value)]`.
+///
+/// The leading byte lets the on-disk/wire format evolve without a silent
+/// misdecode: see [`decode`], which rejects a foreign version. The `version`
+/// is a parameter rather than a constant so each consumer owns its own schema
+/// version and can evolve it independently.
+pub fn encode<T: Serialize>(version: u8, value: &T) -> Result<Vec<u8>, CodecError> {
+    let body = postcard::to_stdvec(value).map_err(CodecError::Encode)?;
+    let mut out = Vec::with_capacity(1 + body.len());
+    out.push(version);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Decode a payload produced by [`encode`], rejecting a version mismatch.
+///
+/// Returns [`CodecError::Version`] when the leading byte differs from
+/// `expected_version` — a stale reader fails loudly instead of parsing old
+/// bytes against a new struct layout.
+pub fn decode<T: DeserializeOwned>(expected_version: u8, bytes: &[u8]) -> Result<T, CodecError> {
+    let (first, rest) = bytes.split_first().ok_or(CodecError::Empty)?;
+    if *first != expected_version {
+        return Err(CodecError::Version {
+            expected: expected_version,
+            actual: *first,
+        });
+    }
+    postcard::from_bytes(rest).map_err(CodecError::Decode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Sample {
+        idx: u64,
+        name: String,
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let original = Sample {
+            idx: 42,
+            name: "tsoracle".into(),
+        };
+        let bytes = encode(1, &original).expect("encode");
+        assert_eq!(bytes[0], 1);
+        let decoded: Sample = decode(1, &bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_version() {
+        let bytes = encode(
+            2,
+            &Sample {
+                idx: 1,
+                name: "x".into(),
+            },
+        )
+        .expect("encode");
+        let err = decode::<Sample>(1, &bytes).expect_err("must reject");
+        assert!(matches!(
+            err,
+            CodecError::Version {
+                expected: 1,
+                actual: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_empty() {
+        let err = decode::<Sample>(1, &[]).expect_err("must reject");
+        assert!(matches!(err, CodecError::Empty));
+    }
+
+    #[test]
+    fn decode_rejects_truncated_input() {
+        let original = Sample {
+            idx: u64::MAX,
+            name: "hello-world-storage-roundtrip".into(),
+        };
+        let bytes = encode(1, &original).expect("encode");
+        assert!(bytes.len() >= 16, "payload should be non-trivial");
+        let truncated = &bytes[..bytes.len() / 2];
+        assert!(matches!(
+            decode::<Sample>(1, truncated),
+            Err(CodecError::Decode(_))
+        ));
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        // Roundtrip: encode then decode at the same version returns the
+        // original value, for any (version, payload).
+        #[test]
+        fn encode_decode_roundtrip_any(
+            version in any::<u8>(),
+            idx in any::<u64>(),
+            name in any::<String>(),
+        ) {
+            let s = Sample { idx, name };
+            let bytes = encode(version, &s).unwrap();
+            prop_assert_eq!(bytes[0], version);
+            let back: Sample = decode(version, &bytes).unwrap();
+            prop_assert_eq!(s, back);
+        }
+
+        // Version-mismatch detection: decoding with the wrong expected version
+        // returns CodecError::Version carrying the exact values, for any pair
+        // (encoded, expected) where the two differ.
+        #[test]
+        fn decode_rejects_any_version_mismatch(
+            encoded in any::<u8>(),
+            expected in any::<u8>(),
+            idx in any::<u64>(),
+            name in any::<String>(),
+        ) {
+            prop_assume!(encoded != expected);
+            let bytes = encode(encoded, &Sample { idx, name }).unwrap();
+            match decode::<Sample>(expected, &bytes) {
+                Err(CodecError::Version { expected: e, actual: a }) => {
+                    prop_assert_eq!(e, expected);
+                    prop_assert_eq!(a, encoded);
+                }
+                other => prop_assert!(false, "expected Version mismatch; got {other:?}"),
+            }
+        }
+    }
+}

--- a/crates/tsoracle-openraft-toolkit/Cargo.toml
+++ b/crates/tsoracle-openraft-toolkit/Cargo.toml
@@ -35,6 +35,7 @@ thiserror        = { workspace = true }
 tokio            = { workspace = true }
 tokio-stream     = { workspace = true }
 tracing          = { workspace = true }
+tsoracle-codec     = { workspace = true }
 tsoracle-failpoint = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -15,9 +15,12 @@
 //! Every payload is encoded as `[version_byte | postcard(value)]`. The leading
 //! byte lets us evolve the wire format without an explicit migration when both
 //! sides of an upgrade run mixed versions briefly.
+//!
+//! The framing itself lives in the shared [`tsoracle_codec`] crate, re-used
+//! verbatim by the paxos toolkit. Only [`SCHEMA_VERSION`] is owned here, so
+//! this toolkit's wire/on-disk format versions independently of the others.
 
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
+pub use tsoracle_codec::{CodecError, decode, encode};
 
 /// On-disk/wire schema version stamped as the leading byte of every framed
 /// snapshot, log entry, and storage record produced by this toolkit. Bump
@@ -25,128 +28,3 @@ use thiserror::Error;
 /// backward-incompatible way (field reorder/insert/remove); a stale reader
 /// then fails loudly with [`CodecError::Version`] instead of misdecoding.
 pub const SCHEMA_VERSION: u8 = 1;
-
-#[derive(Debug, Error)]
-pub enum CodecError {
-    #[error("payload empty")]
-    Empty,
-    #[error("version mismatch: expected {expected}, got {actual}")]
-    Version { expected: u8, actual: u8 },
-    #[error("decode failed: {0}")]
-    Decode(#[from] postcard::Error),
-}
-
-/// Encode `value` as `[version | postcard(value)]`.
-pub fn encode<T: Serialize>(version: u8, value: &T) -> Result<Vec<u8>, CodecError> {
-    let body = postcard::to_stdvec(value)?;
-    let mut out = Vec::with_capacity(1 + body.len());
-    out.push(version);
-    out.extend_from_slice(&body);
-    Ok(out)
-}
-
-/// Decode a payload previously produced by [`encode`], rejecting any version mismatch.
-pub fn decode<T: for<'de> Deserialize<'de>>(
-    expected_version: u8,
-    bytes: &[u8],
-) -> Result<T, CodecError> {
-    let (first, rest) = bytes.split_first().ok_or(CodecError::Empty)?;
-    if *first != expected_version {
-        return Err(CodecError::Version {
-            expected: expected_version,
-            actual: *first,
-        });
-    }
-    Ok(postcard::from_bytes(rest)?)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct Payload {
-        a: u64,
-        b: String,
-    }
-
-    #[test]
-    fn roundtrip_preserves_payload() {
-        let p = Payload {
-            a: 42,
-            b: "hello".into(),
-        };
-        let bytes = encode(1, &p).unwrap();
-        assert_eq!(bytes[0], 1);
-        let back: Payload = decode(1, &bytes).unwrap();
-        assert_eq!(p, back);
-    }
-
-    #[test]
-    fn decode_rejects_wrong_version() {
-        let p = Payload {
-            a: 1,
-            b: "x".into(),
-        };
-        let bytes = encode(2, &p).unwrap();
-        let err = decode::<Payload>(1, &bytes).unwrap_err();
-        assert!(matches!(
-            err,
-            CodecError::Version {
-                expected: 1,
-                actual: 2
-            }
-        ));
-    }
-
-    #[test]
-    fn decode_rejects_empty() {
-        let err = decode::<Payload>(1, &[]).unwrap_err();
-        assert!(matches!(err, CodecError::Empty));
-    }
-
-    use proptest::prelude::*;
-
-    proptest! {
-        // Roundtrip: encode then decode at the same version must return the
-        // original value, for any (version, payload). The Payload's two fields
-        // give us coverage of an integer + an arbitrary UTF-8 string body.
-        #[test]
-        fn encode_decode_roundtrip(
-            version in any::<u8>(),
-            a in any::<u64>(),
-            b in any::<String>(),
-        ) {
-            let p = Payload { a, b };
-            let bytes = encode(version, &p).unwrap();
-            prop_assert_eq!(bytes[0], version);
-            let back: Payload = decode(version, &bytes).unwrap();
-            prop_assert_eq!(p, back);
-        }
-
-        // Version-mismatch detection: decoding with the wrong expected version
-        // must return CodecError::Version{ expected, actual } carrying the
-        // exact values, for any pair (encoded_version, expected_version) where
-        // the two differ.
-        #[test]
-        fn decode_rejects_any_version_mismatch(
-            encoded in any::<u8>(),
-            expected in any::<u8>(),
-            a in any::<u64>(),
-            b in any::<String>(),
-        ) {
-            prop_assume!(encoded != expected);
-            let bytes = encode(encoded, &Payload { a, b }).unwrap();
-            match decode::<Payload>(expected, &bytes) {
-                Err(CodecError::Version { expected: e, actual: c }) => {
-                    prop_assert_eq!(e, expected);
-                    prop_assert_eq!(c, encoded);
-                }
-                other => prop_assert!(
-                    false,
-                    "expected Version mismatch error; got {other:?}",
-                ),
-            }
-        }
-    }
-}

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -29,19 +29,18 @@ futures            = { workspace = true }
 omnipaxos          = { workspace = true, features = ["serde"] }
 parking_lot        = { workspace = true }
 pastey             = { workspace = true }
-postcard           = { workspace = true }
 rocksdb            = { workspace = true, optional = true, features = ["multi-threaded-cf"] }
 serde              = { workspace = true }
 thiserror          = { workspace = true }
 tokio              = { workspace = true }
 tokio-stream       = { workspace = true }
 tracing            = { workspace = true }
+tsoracle-codec     = { workspace = true }
 tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.6" }
 tsoracle-core      = { path = "../tsoracle-core", version = "0.2.1" }
 tsoracle-failpoint = { workspace = true }
 
 [dev-dependencies]
-proptest           = { workspace = true }
 rocksdb            = { workspace = true }
 tempfile           = { workspace = true }
 tokio              = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/tsoracle-paxos-toolkit/src/codec.rs
+++ b/crates/tsoracle-paxos-toolkit/src/codec.rs
@@ -14,145 +14,15 @@
 //! OmniPaxos state. Every payload is encoded as `[version_byte |
 //! postcard(value)]`; the leading byte lets the on-disk format evolve without
 //! a silent misdecode — a stale reader hits [`CodecError::Version`] instead of
-//! parsing old bytes against a new struct layout. Centralizing it also gives
-//! one place to swap formats later and to attach diagnostic context to errors.
+//! parsing old bytes against a new struct layout.
+//!
+//! The framing itself lives in the shared [`tsoracle_codec`] crate, re-used
+//! verbatim by the openraft toolkit. Only [`SCHEMA_VERSION`] is owned here, so
+//! this toolkit's on-disk format versions independently of the others.
 
-use serde::{Serialize, de::DeserializeOwned};
-
-#[derive(Debug, thiserror::Error)]
-pub enum CodecError {
-    #[error("payload empty")]
-    Empty,
-    #[error("version mismatch: expected {expected}, got {actual}")]
-    Version { expected: u8, actual: u8 },
-    #[error("encode failed: {0}")]
-    Encode(#[source] postcard::Error),
-    #[error("decode failed: {0}")]
-    Decode(#[source] postcard::Error),
-}
+pub use tsoracle_codec::{CodecError, decode, encode};
 
 /// On-disk schema version stamped as the leading byte of every framed ballot,
 /// stopsign, snapshot, and log entry. Bump when a persisted struct's postcard
 /// layout changes incompatibly so a stale reader fails loudly.
 pub const SCHEMA_VERSION: u8 = 1;
-
-/// Encode `value` as `[version | postcard(value)]`.
-pub fn encode<T: Serialize>(version: u8, value: &T) -> Result<Vec<u8>, CodecError> {
-    let body = postcard::to_stdvec(value).map_err(CodecError::Encode)?;
-    let mut out = Vec::with_capacity(1 + body.len());
-    out.push(version);
-    out.extend_from_slice(&body);
-    Ok(out)
-}
-
-/// Decode a payload produced by [`encode`], rejecting a version mismatch.
-pub fn decode<T: DeserializeOwned>(expected_version: u8, bytes: &[u8]) -> Result<T, CodecError> {
-    let (first, rest) = bytes.split_first().ok_or(CodecError::Empty)?;
-    if *first != expected_version {
-        return Err(CodecError::Version {
-            expected: expected_version,
-            actual: *first,
-        });
-    }
-    postcard::from_bytes(rest).map_err(CodecError::Decode)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct Sample {
-        idx: u64,
-        name: String,
-    }
-
-    #[test]
-    fn encode_decode_roundtrip() {
-        let original = Sample {
-            idx: 42,
-            name: "paxos".into(),
-        };
-        let bytes = encode(SCHEMA_VERSION, &original).expect("encode");
-        assert_eq!(bytes[0], SCHEMA_VERSION);
-        let decoded: Sample = decode(SCHEMA_VERSION, &bytes).expect("decode");
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    fn decode_rejects_wrong_version() {
-        let bytes = encode(
-            2,
-            &Sample {
-                idx: 1,
-                name: "x".into(),
-            },
-        )
-        .expect("encode");
-        let err = decode::<Sample>(1, &bytes).expect_err("must reject");
-        assert!(matches!(
-            err,
-            CodecError::Version {
-                expected: 1,
-                actual: 2
-            }
-        ));
-    }
-
-    #[test]
-    fn decode_rejects_empty() {
-        let err = decode::<Sample>(1, &[]).expect_err("must reject");
-        assert!(matches!(err, CodecError::Empty));
-    }
-
-    #[test]
-    fn decode_rejects_truncated_input() {
-        let original = Sample {
-            idx: u64::MAX,
-            name: "hello-world-paxos-storage-roundtrip".into(),
-        };
-        let bytes = encode(SCHEMA_VERSION, &original).expect("encode");
-        assert!(bytes.len() >= 16, "payload should be non-trivial");
-        let truncated = &bytes[..bytes.len() / 2];
-        assert!(matches!(
-            decode::<Sample>(SCHEMA_VERSION, truncated),
-            Err(CodecError::Decode(_))
-        ));
-    }
-
-    use proptest::prelude::*;
-
-    proptest! {
-        #[test]
-        fn encode_decode_roundtrip_any(
-            version in any::<u8>(),
-            idx in any::<u64>(),
-            name in any::<String>(),
-        ) {
-            let s = Sample { idx, name };
-            let bytes = encode(version, &s).unwrap();
-            prop_assert_eq!(bytes[0], version);
-            let back: Sample = decode(version, &bytes).unwrap();
-            prop_assert_eq!(s, back);
-        }
-
-        #[test]
-        fn decode_rejects_any_version_mismatch(
-            encoded in any::<u8>(),
-            expected in any::<u8>(),
-            idx in any::<u64>(),
-            name in any::<String>(),
-        ) {
-            prop_assume!(encoded != expected);
-            let bytes = encode(encoded, &Sample { idx, name }).unwrap();
-            match decode::<Sample>(expected, &bytes) {
-                Err(CodecError::Version { expected: e, actual: a }) => {
-                    prop_assert_eq!(e, expected);
-                    prop_assert_eq!(a, encoded);
-                }
-                other => prop_assert!(false, "expected Version mismatch; got {other:?}"),
-            }
-        }
-    }
-}


### PR DESCRIPTION
## Summary

Closes #265. The issue's primary ask (a version byte in the Paxos codec) already shipped in #291; this completes its remaining parenthetical — *"ideally a shared codec crate"* — by deduplicating the framing.

- New `tsoracle-codec` micro-crate (mirrors `tsoracle-failpoint` / `tsoracle-yieldpoint`) owns the `[version_byte | postcard(value)]` framing: `encode`, `decode`, and `CodecError`. Both toolkits' `codec.rs` become thin re-export shims.
- **`SCHEMA_VERSION` stays per-toolkit.** `version` is a function parameter, so each toolkit keeps its own constant and evolves its on-disk format independently — a layout change in one can't trigger a false version mismatch in the other.
- The shared `CodecError` adopts the richer paxos shape (distinct `Encode`/`Decode` variants carrying the `postcard::Error` as `#[source]`), a safe widening for the one external openraft consumer (it matches `Version` plus a catch-all).
- On-disk byte format unchanged (golden-byte fixtures pass) and each toolkit's public codec surface preserved → no downstream consumer changes. `tsoracle-paxos-toolkit` drops its now-unused direct `postcard` dependency (it reaches `postcard` transitively via `tsoracle-codec`).
- Lands as `feat:` so the new crate publishes before the toolkits that depend on it.

## Test plan

- [x] `cargo test -p tsoracle-codec` — 6 unit/property tests green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — all codec-exercising tests pass; `codec_fixture::log_entry_pins_v1_layout` confirms the `[1, 0, 5]` frame is byte-identical
- [x] `cargo tree -i postcard -p tsoracle-paxos-toolkit` — `postcard` reaches paxos only via `tsoracle-codec`

## Notes

This PR does not touch the driver-paxos harness. The not-yet-deterministic real-time yield-point tests there (e.g. `linearized_barrier`) can flake under full-suite CPU contention; they pass reliably in isolation and are unrelated to this change.