### PR TITLE
feat(core): lift a shared TsoPeer type into tsoracle-core (#266)

### DIFF
--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -44,7 +44,7 @@ use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Instant, sleep};
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
-use tsoracle_paxos_toolkit::lifecycle::{MessageSink, Peer};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, TsoPeer};
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 use tsoracle_paxos_toolkit::test_fakes::partition::PartitionController;
@@ -259,10 +259,10 @@ impl PaxosTopology {
             });
 
             // ---- StandaloneHost ----
-            let toolkit_peers: Vec<Peer> = tso_endpoints
+            let toolkit_peers: Vec<TsoPeer> = tso_endpoints
                 .iter()
                 .filter(|(peer_id, _)| *peer_id != id)
-                .map(|(peer_id, peer_addr)| Peer {
+                .map(|(peer_id, peer_addr)| TsoPeer {
                     node_id: *peer_id,
                     endpoint: format!("http://{peer_addr}"),
                 })

--- a/crates/tsoracle-core/Cargo.toml
+++ b/crates/tsoracle-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-core"
-description  = "Sync algorithm core for tsoracle: window allocator, 46/18-bit timestamp packing, monotonicity invariants."
+description  = "Sync algorithm core for tsoracle: window allocator, 46/18-bit timestamp packing, monotonicity invariants, and the shared cluster peer type."
 version      = "0.2.1"
 edition.workspace      = true
 rust-version.workspace = true

--- a/crates/tsoracle-core/src/lib.rs
+++ b/crates/tsoracle-core/src/lib.rs
@@ -19,6 +19,7 @@ mod allocator;
 mod bt;
 mod clock;
 mod epoch;
+mod peer;
 mod timestamp;
 
 pub mod docs;
@@ -27,6 +28,7 @@ pub use allocator::{Allocator, CoreError, WindowGrant};
 pub use bt::Bt;
 pub use clock::{Clock, SystemClock};
 pub use epoch::Epoch;
+pub use peer::TsoPeer;
 pub use timestamp::{LOGICAL_MAX, PHYSICAL_MS_MAX, Timestamp, TimestampError};
 
 #[cfg(any(test, feature = "test-clock"))]

--- a/crates/tsoracle-core/src/peer.rs
+++ b/crates/tsoracle-core/src/peer.rs
@@ -1,0 +1,79 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! A consensus peer and the tsoracle service endpoint it advertises.
+
+/// A known peer node and the network endpoint where its TSO service can be
+/// reached for follower-redirect hints.
+///
+/// `node_id` is the consensus node identity (the OmniPaxos `NodeId`/pid or the
+/// openraft `NodeId`). `endpoint` is the advertised tsoracle service address
+/// surfaced via `LeaderState::Follower::leader_endpoint` when this peer is the
+/// elected leader. This is the cross-backend shape consensus drivers share so
+/// the `leader_endpoint` derivation reads the same regardless of the engine
+/// underneath.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TsoPeer {
+    pub node_id: u64,
+    pub endpoint: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn carries_node_id_and_endpoint() {
+        let peer = TsoPeer {
+            node_id: 2,
+            endpoint: "http://node-2:50051".to_string(),
+        };
+        assert_eq!(peer.node_id, 2);
+        assert_eq!(peer.endpoint, "http://node-2:50051");
+    }
+
+    #[test]
+    fn equality_is_by_node_id_and_endpoint() {
+        let left = TsoPeer {
+            node_id: 1,
+            endpoint: "http://a".to_string(),
+        };
+        let same = TsoPeer {
+            node_id: 1,
+            endpoint: "http://a".to_string(),
+        };
+        let different_endpoint = TsoPeer {
+            node_id: 1,
+            endpoint: "http://b".to_string(),
+        };
+        assert_eq!(left, same);
+        assert_ne!(left, different_endpoint);
+    }
+
+    #[test]
+    fn is_usable_as_a_hash_set_member() {
+        use std::collections::HashSet;
+
+        let mut peers = HashSet::new();
+        peers.insert(TsoPeer {
+            node_id: 1,
+            endpoint: "http://a".to_string(),
+        });
+        let duplicate = peers.insert(TsoPeer {
+            node_id: 1,
+            endpoint: "http://a".to_string(),
+        });
+        assert!(!duplicate, "an equal peer must hash to the same bucket");
+        assert_eq!(peers.len(), 1);
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -37,7 +37,7 @@ use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 use openraft::RaftTypeConfig;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, TsoPeer};
 use tsoracle_openraft_toolkit::LeadershipState;
 use tsoracle_openraft_toolkit::leadership_events_from_metrics;
 
@@ -60,35 +60,42 @@ impl<H: OpenraftHighWaterHost> OpenraftDriver<H> {
     /// Build a driver from a host value with no endpoint resolution. Follower
     /// hints carry `leader_endpoint: None`; use [`Self::with_peers`] to resolve.
     pub fn new(host: H) -> Arc<Self> {
-        Self::with_peers(host, HashMap::new())
-    }
-
-    /// Build a driver from a host value and a `NodeId -> tsoracle-service-addr`
-    /// map. The map is consulted on the follower branch to resolve the elected
-    /// leader's advertised endpoint for `LeaderHint` redirects.
-    pub fn with_peers(
-        host: H,
-        peers: HashMap<<H::Config as RaftTypeConfig>::NodeId, String>,
-    ) -> Arc<Self> {
         Arc::new(Self {
             host: Arc::new(host),
-            peers: Arc::new(peers),
+            peers: Arc::new(HashMap::new()),
+        })
+    }
+
+    /// Build a driver from a host value and the cluster's [`TsoPeer`] topology.
+    /// The peers are consulted on the follower branch to resolve the elected
+    /// leader's advertised endpoint for `LeaderHint` redirects.
+    pub fn with_peers(host: H, peers: impl IntoIterator<Item = TsoPeer>) -> Arc<Self>
+    where
+        <H::Config as RaftTypeConfig>::NodeId: From<u64>,
+    {
+        Arc::new(Self {
+            host: Arc::new(host),
+            peers: Arc::new(endpoint_map_from_peers::<H::Config>(peers)),
         })
     }
 
     /// Build a driver from a pre-shared `Arc<H>` with no endpoint resolution.
     pub fn from_arc(host: Arc<H>) -> Arc<Self> {
-        Self::from_arc_with_peers(host, HashMap::new())
-    }
-
-    /// Build a driver from a pre-shared `Arc<H>` and a peer map.
-    pub fn from_arc_with_peers(
-        host: Arc<H>,
-        peers: HashMap<<H::Config as RaftTypeConfig>::NodeId, String>,
-    ) -> Arc<Self> {
         Arc::new(Self {
             host,
-            peers: Arc::new(peers),
+            peers: Arc::new(HashMap::new()),
+        })
+    }
+
+    /// Build a driver from a pre-shared `Arc<H>` and the cluster's [`TsoPeer`]
+    /// topology.
+    pub fn from_arc_with_peers(host: Arc<H>, peers: impl IntoIterator<Item = TsoPeer>) -> Arc<Self>
+    where
+        <H::Config as RaftTypeConfig>::NodeId: From<u64>,
+    {
+        Arc::new(Self {
+            host,
+            peers: Arc::new(endpoint_map_from_peers::<H::Config>(peers)),
         })
     }
 }
@@ -165,6 +172,25 @@ impl<H: OpenraftHighWaterHost> Stream for KeepAlive<H> {
     }
 }
 
+/// Build a `NodeId -> tsoracle-service-endpoint` map from a [`TsoPeer`] list.
+///
+/// Each peer's `node_id` (a `u64`) is widened into the config's `NodeId` via
+/// `From<u64>` — the identity for every real config, which keys nodes by `u64`.
+/// The resulting map is what the follower branch consults to resolve the
+/// elected leader's advertised endpoint for `LeaderHint` redirects. A repeated
+/// `node_id` keeps the last endpoint, as a misconfigured topology would.
+fn endpoint_map_from_peers<C: RaftTypeConfig>(
+    peers: impl IntoIterator<Item = TsoPeer>,
+) -> HashMap<C::NodeId, String>
+where
+    C::NodeId: From<u64>,
+{
+    peers
+        .into_iter()
+        .map(|peer| (C::NodeId::from(peer.node_id), peer.endpoint))
+        .collect()
+}
+
 /// Project a toolkit [`LeadershipState`] into a tsoracle-consensus
 /// [`LeaderState`].
 ///
@@ -192,12 +218,58 @@ fn map_leader_state<C: RaftTypeConfig>(
 
 #[cfg(test)]
 mod tests {
-    use super::map_leader_state;
+    use super::{endpoint_map_from_peers, map_leader_state};
     use crate::type_config::TypeConfig;
     use std::collections::HashMap;
     use tsoracle_consensus::LeaderState;
-    use tsoracle_core::Epoch;
+    use tsoracle_core::{Epoch, TsoPeer};
     use tsoracle_openraft_toolkit::LeadershipState;
+
+    #[test]
+    fn endpoint_map_from_peers_keys_each_endpoint_by_node_id() {
+        let map = endpoint_map_from_peers::<TypeConfig>([
+            TsoPeer {
+                node_id: 2,
+                endpoint: "http://node-2:50051".to_string(),
+            },
+            TsoPeer {
+                node_id: 3,
+                endpoint: "http://node-3:50051".to_string(),
+            },
+        ]);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&2), Some(&"http://node-2:50051".to_string()));
+        assert_eq!(map.get(&3), Some(&"http://node-3:50051".to_string()));
+    }
+
+    #[test]
+    fn endpoint_map_from_peers_then_resolves_follower_endpoint() {
+        // The map a TsoPeer list builds must drive the same follower-redirect
+        // resolution as a hand-built NodeId->endpoint map.
+        let peers = endpoint_map_from_peers::<TypeConfig>([TsoPeer {
+            node_id: 2,
+            endpoint: "http://node-2:50051".to_string(),
+        }]);
+        let state = map_leader_state::<TypeConfig>(
+            LeadershipState::Follower {
+                term: 4,
+                leader: Some((
+                    2u64,
+                    crate::type_config::OpenraftPeer {
+                        addr: "raft-addr".into(),
+                    },
+                )),
+            },
+            &peers,
+        );
+        assert_eq!(
+            state,
+            LeaderState::Follower {
+                leader_endpoint: Some("http://node-2:50051".into()),
+                leader_epoch: Some(Epoch(4)),
+            }
+        );
+    }
 
     #[test]
     fn leader_maps_to_leader_with_epoch() {

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -34,4 +34,5 @@ pub use state_machine::{HighWaterStateMachine, HighWaterStateMachineSnapshot};
 /// Re-export of the cross-backend advance payload that [`HighWaterCommand::Advance`]
 /// wraps, so consumers can build commands without depending on `tsoracle-consensus`.
 pub use tsoracle_consensus::AdvancePayload;
+pub use tsoracle_core::TsoPeer;
 pub use type_config::{HighWaterApplied, OpenraftPeer, TypeConfig};

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -30,4 +30,4 @@ pub use state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
 /// Re-export of the cross-backend advance payload that [`HighWaterCommand::Advance`]
 /// wraps, so consumers can build commands without depending on `tsoracle-consensus`.
 pub use tsoracle_consensus::AdvancePayload;
-pub use type_config::{PaxosPeer, decode_epoch, encode_epoch};
+pub use type_config::{decode_epoch, encode_epoch};

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -32,7 +32,7 @@ use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tracing::warn;
 use tsoracle_consensus::{AdvancePayload, ConsensusError};
-use tsoracle_paxos_toolkit::lifecycle::{LeaderEventStream, MessageSink, PaxosRunner, Peer};
+use tsoracle_paxos_toolkit::lifecycle::{LeaderEventStream, MessageSink, PaxosRunner, TsoPeer};
 
 use crate::host::PaxosHighWaterHost;
 use crate::log_entry::HighWaterCommand;
@@ -83,7 +83,7 @@ where
     pub fn new(
         omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
         my_node_id: u64,
-        peers: Vec<Peer>,
+        peers: Vec<TsoPeer>,
         tick_interval: Duration,
         policy: SnapshotPolicy,
     ) -> Self {
@@ -258,7 +258,7 @@ where
 {
     omnipaxos: Option<Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>>,
     my_node_id: Option<u64>,
-    peers: Vec<Peer>,
+    peers: Vec<TsoPeer>,
     tick_interval: Duration,
     policy: SnapshotPolicy,
 }
@@ -293,7 +293,7 @@ where
         self
     }
 
-    pub fn peers(mut self, peers: Vec<Peer>) -> Self {
+    pub fn peers(mut self, peers: Vec<TsoPeer>) -> Self {
         self.peers = peers;
         self
     }

--- a/crates/tsoracle-driver-paxos/src/type_config.rs
+++ b/crates/tsoracle-driver-paxos/src/type_config.rs
@@ -20,14 +20,6 @@
 use omnipaxos::ballot_leader_election::Ballot;
 use tsoracle_core::Epoch;
 
-/// A peer node in the paxos cluster, with the endpoint used to populate
-/// `LeaderState::Follower::leader_endpoint` for follower-redirect hints.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PaxosPeer {
-    pub node_id: u64,
-    pub endpoint: String,
-}
-
 /// Pack a Ballot into the 128-bit Epoch space.
 ///
 /// Layout (high bits to low):

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -16,7 +16,8 @@ pub mod events;
 pub mod state;
 
 pub use events::{LeaderEventSender, LeaderEventStream, SendError, leader_event_channel};
-pub use state::{LeadershipState, Peer};
+pub use state::LeadershipState;
+pub use tsoracle_core::TsoPeer;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -66,7 +67,7 @@ where
 {
     omnipaxos: Arc<Mutex<OmniPaxos<T, S>>>,
     my_node_id: u64,
-    peers: Vec<Peer>,
+    peers: Vec<TsoPeer>,
     tick_interval: Duration,
     leader_sender: LeaderEventSender,
     leader_stream: Option<LeaderEventStream>,
@@ -94,7 +95,7 @@ where
     pub fn new(
         omnipaxos: Arc<Mutex<OmniPaxos<T, S>>>,
         my_node_id: u64,
-        peers: Vec<Peer>,
+        peers: Vec<TsoPeer>,
         tick_interval: Duration,
     ) -> Self {
         let (leader_sender, leader_stream) = leader_event_channel();

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
@@ -13,20 +13,7 @@
 //! Maps OmniPaxos leadership observations to `tsoracle_consensus::LeaderState`.
 
 use tsoracle_consensus::LeaderState;
-use tsoracle_core::Epoch;
-
-/// A known peer node and the network endpoint where its TSO service can be
-/// reached for follower-redirect hints.
-///
-/// `node_id` is the OmniPaxos `NodeId` (pid) of the peer. `endpoint` is the
-/// advertised tsoracle service address surfaced via
-/// `tsoracle_consensus::LeaderState::Follower::leader_endpoint` when this
-/// peer becomes the elected leader.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Peer {
-    pub node_id: u64,
-    pub endpoint: String,
-}
+use tsoracle_core::{Epoch, TsoPeer};
 
 /// Internal leadership observation, mappable to
 /// [`tsoracle_consensus::LeaderState`] via [`Self::to_consensus`].
@@ -63,7 +50,7 @@ impl LeadershipState {
         my_node_id: u64,
         current_leader: Option<u64>,
         epoch: Option<Epoch>,
-        peers: &[Peer],
+        peers: &[TsoPeer],
     ) -> Self {
         match current_leader {
             Some(leader) if leader == my_node_id => match epoch {
@@ -123,7 +110,7 @@ mod tests {
 
     #[test]
     fn leader_is_other_emits_follower_with_endpoint() {
-        let peers = vec![Peer {
+        let peers = vec![TsoPeer {
             node_id: 2,
             endpoint: "http://node-2:50051".into(),
         }];

--- a/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
@@ -23,7 +23,7 @@ use common::{TestCommand, build_mem_cluster};
 use futures::StreamExt;
 use omnipaxos::messages::Message;
 use tsoracle_consensus::LeaderState;
-use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PaxosRunner, Peer};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PaxosRunner, TsoPeer};
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 
 struct NetworkSink {
@@ -51,7 +51,7 @@ async fn runners_emit_leader_or_follower_event_after_election() {
             .nodes
             .iter()
             .filter(|peer_node| peer_node.node_id != node.node_id)
-            .map(|peer_node| Peer {
+            .map(|peer_node| TsoPeer {
                 node_id: peer_node.node_id,
                 endpoint: format!("mem://{}", peer_node.node_id),
             })

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -31,7 +31,7 @@ use openraft::{Config, Raft};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tsoracle_driver_openraft::{
     HighWaterStateMachine, OpenraftDriver, OpenraftPeer, RocksdbSnapshotStore, SnapshotStore,
-    StandaloneHost, TypeConfig,
+    StandaloneHost, TsoPeer, TypeConfig,
 };
 use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
 use tsoracle_server::Server as TsoServer;
@@ -211,7 +211,10 @@ async fn main() -> anyhow::Result<()> {
     // `--tso-peers` is the NodeId -> tsoracle-service-addr map; the driver
     // consults it to populate LeaderHint follower-redirects.
     let host = StandaloneHost::new(raft.clone(), state_machine_for_host);
-    let driver = OpenraftDriver::with_peers(host, tso_addrs);
+    let tso_peers = tso_addrs
+        .into_iter()
+        .map(|(node_id, endpoint)| TsoPeer { node_id, endpoint });
+    let driver = OpenraftDriver::with_peers(host, tso_peers);
 
     // ---- Tsoracle gRPC server ----
     let tso = TsoServer::builder().consensus_driver(driver).build()?;

--- a/examples/paxos-embedded/src/main.rs
+++ b/examples/paxos-embedded/src/main.rs
@@ -32,7 +32,7 @@ use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
 use parking_lot::Mutex;
 use tokio::sync::{mpsc, oneshot};
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
-use tsoracle_paxos_toolkit::lifecycle::{MessageSink, Peer};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, TsoPeer};
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
 use tsoracle_server::Server as TsoServer;
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
         flexible_quorum: None,
     };
 
-    // Build a `Peer` list of TSO endpoints so each node's StandaloneHost can
+    // Build a `TsoPeer` list of TSO endpoints so each node's StandaloneHost can
     // populate `LeaderHint` follower-redirect with the leader's address.
     let tso_endpoints: Vec<(u64, SocketAddr)> = node_ids
         .iter()
@@ -112,10 +112,10 @@ async fn main() -> anyhow::Result<()> {
         });
 
         // ---- StandaloneHost ----
-        let toolkit_peers: Vec<Peer> = tso_endpoints
+        let toolkit_peers: Vec<TsoPeer> = tso_endpoints
             .iter()
             .filter(|(peer_id, _)| *peer_id != id)
-            .map(|(peer_id, addr)| Peer {
+            .map(|(peer_id, addr)| TsoPeer {
                 node_id: *peer_id,
                 endpoint: format!("http://{addr}"),
             })

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -34,7 +34,7 @@ use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
 use parking_lot::Mutex;
 use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
-use tsoracle_paxos_toolkit::lifecycle::Peer;
+use tsoracle_paxos_toolkit::lifecycle::TsoPeer;
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 use tsoracle_server::Server as TsoServer;
 
@@ -169,10 +169,10 @@ async fn main() -> anyhow::Result<()> {
     // toolkit's `LeadershipState::from_omnipaxos` consults this list when a
     // peer is elected so `LeaderState::Follower::leader_endpoint` points at
     // the leader's tsoracle gRPC address.
-    let toolkit_peers: Vec<Peer> = tso_addrs
+    let toolkit_peers: Vec<TsoPeer> = tso_addrs
         .iter()
         .filter(|(id, _)| **id != cli.node_id)
-        .map(|(id, endpoint)| Peer {
+        .map(|(id, endpoint)| TsoPeer {
             node_id: *id,
             endpoint: format!("http://{endpoint}"),
         })


### PR DESCRIPTION
## Summary

Closes #266. Both consensus backends encoded "a consensus node id + its advertised tsoracle endpoint" as separate structs (paxos toolkit's `Peer`, and the dead `PaxosPeer` in driver-paxos). This lifts the concept into one shared type.

- **`tsoracle-core`**: new `TsoPeer { node_id: u64, endpoint: String }` (`Clone`/`Debug`/`Eq`/`Hash` + optional `serde`, matching the `Epoch`/`Timestamp` convention).
- **`tsoracle-paxos-toolkit`**: local `Peer` replaced by `TsoPeer`; `from_omnipaxos` takes `&[TsoPeer]`; re-exported from the `lifecycle` module.
- **`tsoracle-driver-paxos`**: deleted the unused `PaxosPeer` and its re-export.
- **`tsoracle-driver-openraft`**: `with_peers`/`from_arc_with_peers` now ingest `impl IntoIterator<Item = TsoPeer>` (bounded `NodeId: From<u64>`) via a new tested `endpoint_map_from_peers` helper; `new`/`from_arc` stay bound-free; the internal `HashMap<NodeId, String>` field and `map_leader_state` are unchanged.
- Updated consumers: paxos-standalone, paxos-embedded, openraft-standalone examples, and the stress benchmark.

### Scope note

The issue also named `OpenraftPeer { addr }`, but it is deliberately **left untouched**: it is openraft's `Node` type persisted in membership log entries (the raft transport address), a distinct concept from the tso advertised endpoint. The openraft driver already resolves leader endpoints from a separate node-id → endpoint map, never from `OpenraftPeer`. Replacing it would change the persisted membership wire format and conflate two different addresses.

Lands as `feat:` (not `refactor:`) so the new `tsoracle-core` symbol publishes ahead of the dependent driver crates.

## Test Plan

- [x] `cargo build --workspace --all-targets` — exit 0
- [x] `cargo test --workspace` — 0 failures (incl. new core `TsoPeer` tests and openraft `endpoint_map_from_peers` tests)
- [x] `cargo clippy --workspace --all-targets` — no warnings
- [x] `cargo fmt --check` — clean