### PR TITLE
test: make the remaining real-time consensus-harness tests deterministic

### DIFF
--- a/crates/tsoracle-driver-paxos/tests/blocking_reads_missed_notify.rs
+++ b/crates/tsoracle-driver-paxos/tests/blocking_reads_missed_notify.rs
@@ -37,6 +37,16 @@
 //! with the fix in place, the recheck after `enable()` returns the value
 //! immediately. Without the fix the reader hangs and the test panics on
 //! the `tokio::time::timeout`.
+//!
+//! Both tests run under tokio virtual time (`start_paused`): the runner's
+//! `interval` ticks, the apply task's `notify_waiters`, the `spawn_release`
+//! delay, and the `timeout(2s)` guard all advance in simulated time the
+//! moment the runtime goes idle. The async apply task — the very thing
+//! whose drain-before-register the reader must not miss — still runs as a
+//! real task, so the race is preserved; only the wall-clock variance is
+//! removed. The paused clock guarantees the releaser's delay outlasts the
+//! apply drain without a real-time gamble. `start_paused` implies the
+//! current-thread runtime.
 
 #![cfg(feature = "yieldpoints")]
 
@@ -66,7 +76,7 @@ fn spawn_release(
     })
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn current_high_water_returns_when_apply_drained_before_register() {
     let mut cluster = common::build_mem_cluster(3);
     cluster.start_all();
@@ -102,7 +112,7 @@ async fn current_high_water_returns_when_apply_drained_before_register() {
     cluster.stop_all().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn submit_advance_returns_when_apply_drained_before_register() {
     let mut cluster = common::build_mem_cluster(3);
     cluster.start_all();

--- a/crates/tsoracle-driver-paxos/tests/linearized_barrier.rs
+++ b/crates/tsoracle-driver-paxos/tests/linearized_barrier.rs
@@ -30,6 +30,16 @@
 //! returns the stale `high_water` (0) the moment `decided_idx` advances;
 //! with the fix it waits until the apply task folds its own barrier and
 //! returns the correct post-fold value (500).
+//!
+//! Runs under tokio virtual time (`start_paused`). The interleaving this
+//! regression needs — apply tasks parked at their yield point while an
+//! `Advance` decides beneath an as-yet-unfolded `Barrier`, then a paced
+//! release — is built from `tokio::time::sleep` delays, which under a
+//! paused clock define a deterministic ordering instead of racing the
+//! wall clock. The apply tasks and the reader future remain real async
+//! tasks, so the yield-point gating still exercises the missed-fold path;
+//! only the timing nondeterminism is removed. `start_paused` implies the
+//! current-thread runtime.
 
 #![cfg(feature = "yieldpoints")]
 
@@ -46,7 +56,7 @@ mod common;
 const APPLY_TASK_YIELD: &str = "standalone_host::apply_task::between_iterations";
 const CURRENT_HW_YIELD: &str = "standalone_host::current_high_water::after_append_before_await";
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn current_high_water_returns_value_advanced_before_call_under_paused_apply() {
     let mut cluster = common::build_mem_cluster(3);
     cluster.start_all();

--- a/crates/tsoracle-driver-paxos/tests/reconfiguration.rs
+++ b/crates/tsoracle-driver-paxos/tests/reconfiguration.rs
@@ -41,14 +41,12 @@ use omnipaxos::util::LogEntry;
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Driven by the deterministic step-driver (`step_until`).
+#[tokio::test]
 async fn stopsign_decides_and_seals_old_configuration() {
     let mut cluster = common::build_mem_cluster(3);
-    cluster.start_all();
 
-    cluster
-        .drive_until(common::some_leader_elected(), 2_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 2_000);
     let leader_id = cluster.leader();
 
     // Decide a few Advances under the original 3-node config.
@@ -64,17 +62,15 @@ async fn stopsign_decides_and_seals_old_configuration() {
         .lock()
         .append(HighWaterCommand::Advance(AdvancePayload { at_least: 17 }))
         .expect("pre-stopsign append succeeds");
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) >= 17)
-            },
-            2_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) >= 17)
+        },
+        2_000,
+    );
 
     // Issue the reconfiguration. The new 5-node config takes effect once
     // the stopsign is decided cluster-wide.
@@ -91,17 +87,15 @@ async fn stopsign_decides_and_seals_old_configuration() {
         .expect("reconfigure submits a stopsign proposal");
 
     // Drive until every node has decided the stopsign.
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| node.omnipaxos().lock().is_reconfigured().is_some())
-            },
-            3_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| node.omnipaxos().lock().is_reconfigured().is_some())
+        },
+        3_000,
+    );
 
     // Every node must agree on the next configuration's metadata.
     for node in &cluster.nodes {

--- a/crates/tsoracle-driver-paxos/tests/single_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/single_node.rs
@@ -17,10 +17,12 @@
 //! ticking. Without quorum the runner cannot elect a leader, cannot decide
 //! anything, and must not panic — this test confirms it stays inert.
 //!
-//! Then the same node count under `start_all` reaches a stable leader,
-//! decides an `Advance`, and converges across all replicas.
-
-use std::time::Duration;
+//! Then the full 3-node cluster reaches a stable leader, decides an
+//! `Advance`, and converges across all replicas.
+//!
+//! Both tests use the deterministic step-driver (`step` / `step_until`)
+//! instead of async runner/pump tasks + real-time `drive_until`, so the
+//! liveness contracts are exercised without wall-clock variance.
 
 use tsoracle_driver_paxos::AdvancePayload;
 use tsoracle_driver_paxos::HighWaterCommand;
@@ -28,24 +30,27 @@ use tsoracle_driver_paxos::HighWaterCommand;
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test]
 async fn single_started_runner_stays_inert_without_quorum() {
     let mut cluster = common::build_mem_cluster(3);
 
-    // Start only node 1's runner + pump. Nodes 2 and 3 exist in the
-    // ClusterConfig but never tick, so no quorum is reachable.
-    let sink = std::sync::Arc::new(common::MeshSink::new(cluster.network.clone()));
-    let host = cluster.node_mut(1).host.as_mut().expect("host present");
-    host.start(sink);
+    // Take nodes 2 and 3's hosts out so only node 1 steps. They remain in
+    // the ClusterConfig but never tick (the step-driver skips host-less
+    // nodes), so no quorum is reachable and node 1's prepares go
+    // unanswered.
+    cluster.node_mut(2).host.take();
+    cluster.node_mut(3).host.take();
 
-    // Give the single runner a healthy window to flap around. Without peer
+    // Step the lone node well past an election timeout. Without peer
     // responses no entry can be decided and `decided_idx` stays at 0; the
     // apply state machine never observes a folded `Advance`. OmniPaxos's
     // BLE may unilaterally observe itself as a leader candidate before a
     // remote promise lands, so we do NOT assert leadership is absent —
     // the contract under test is "runner stays in a sane state, nothing
     // decides, no panic."
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    for _ in 0..200 {
+        cluster.step();
+    }
 
     assert_eq!(cluster.decided_idx_on(1), 0, "decided_idx stays at 0");
     assert_eq!(
@@ -53,24 +58,17 @@ async fn single_started_runner_stays_inert_without_quorum() {
         0,
         "the apply state never observes a decided entry"
     );
-
-    // Tear down the lone running host without touching the others.
-    let mut host = cluster.node_mut(1).host.take().expect("host present");
-    host.stop().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test]
 async fn three_runners_advance_then_converge() {
     let mut cluster = common::build_mem_cluster(3);
-    cluster.start_all();
 
-    cluster
-        .drive_until(common::some_leader_elected(), 1_000)
-        .await;
+    cluster.step_until(common::some_leader_elected(), 1_000);
     let leader_id = cluster.leader();
 
-    // Append directly on the leader's OmniPaxos handle. The harness's
-    // apply task picks it up via `apply_notify` after the runner ticks.
+    // Append directly on the leader's OmniPaxos handle. `step` folds it via
+    // `apply_once` once consensus decides it.
     cluster
         .node(leader_id)
         .omnipaxos()
@@ -78,25 +76,17 @@ async fn three_runners_advance_then_converge() {
         .append(HighWaterCommand::Advance(AdvancePayload { at_least: 25 }))
         .expect("append succeeds on leader");
 
-    cluster
-        .drive_until(common::all_decided_at_least(1), 1_000)
-        .await;
+    cluster.step_until(common::all_decided_at_least(1), 1_000);
 
-    // Give every apply task a couple of ticks to drain (the apply task
-    // wakes on the runner's tick — not on the decided-idx transition
-    // directly — so a one-tick window after decided_idx advances is
-    // enough for the in-memory state to catch up on every node).
-    cluster
-        .drive_until(
-            |state| {
-                state
-                    .nodes
-                    .iter()
-                    .all(|node| state.high_water_on(node.node_id) >= 25)
-            },
-            1_000,
-        )
-        .await;
+    cluster.step_until(
+        |state| {
+            state
+                .nodes
+                .iter()
+                .all(|node| state.high_water_on(node.node_id) >= 25)
+        },
+        1_000,
+    );
 
     for node in &cluster.nodes {
         assert_eq!(
@@ -106,6 +96,4 @@ async fn three_runners_advance_then_converge() {
             node.node_id
         );
     }
-
-    cluster.stop_all().await;
 }

--- a/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
@@ -76,7 +76,12 @@ fn build_host() -> StandaloneHost<MemStorage<HighWaterCommand>> {
         .expect("build standalone host")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Runs under tokio virtual time (`start_paused`). The livelock this regression
+// guards is in the async apply task, so the test keeps the real `start` /
+// `stop` machinery and only removes wall-clock variance: the runner's
+// `interval` ticks, the coordinating `sleep`s, and the `timeout` guard all
+// advance in simulated time. `start_paused` implies the current-thread runtime.
+#[tokio::test(start_paused = true)]
 async fn stop_delivers_shutdown_when_apply_task_is_mid_iteration() {
     // Arm the yield point. The apply task will await this Notify
     // between iterations of its `apply_notify` branch — yielding its
@@ -109,13 +114,12 @@ async fn stop_delivers_shutdown_when_apply_task_is_mid_iteration() {
 
     // Liveness guard, not a latency assertion. Once the gate releases, the
     // apply task consumes the stored `apply_shutdown` permit on its next
-    // `select!` turn and `stop()` returns in microseconds. The pre-fix
-    // `notify_waiters` regression livelocked here *forever*, so any generous
-    // finite bound distinguishes "fixed" from "regressed". The bound is wide
-    // (10s) because the `coverage` CI job runs the whole instrumented suite
-    // in parallel: a tighter 2s budget expired intermittently from pure
-    // scheduler starvation — this task simply not getting a worker in time —
-    // not from a lost wakeup.
+    // `select!` turn and `stop()` returns. The pre-fix `notify_waiters`
+    // regression livelocked here *forever*; under virtual time the runner
+    // ticks pace that livelock, so the runtime still goes idle between ticks
+    // and the paused clock advances to this (simulated) deadline, tripping the
+    // timeout. Any finite bound distinguishes "fixed" from "regressed"; the
+    // duration is sim-time, so it costs no wall clock.
     tokio::time::timeout(Duration::from_secs(10), stop_handle)
         .await
         .expect("host.stop() must complete after yield-point release (shutdown livelock?)")

--- a/crates/tsoracle-driver-paxos/tests/standalone_stale_permit.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_stale_permit.rs
@@ -28,7 +28,15 @@ use tsoracle_driver_paxos::HighWaterCommand;
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Runs under tokio virtual time (`start_paused`). The poison this regression
+// guards lives in the async apply task spawned by `start` (a stale permit
+// makes it exit on its first `select!` turn), so the test keeps `start_all` +
+// `drive_until` rather than the synchronous step-driver, which would apply via
+// `apply_once` and never spawn the task under test. Virtual time only removes
+// the wall-clock variance: the runner ticks, the apply drain, and the
+// `drive_until` polls all advance in simulated time. `start_paused` implies the
+// current-thread runtime.
+#[tokio::test(start_paused = true)]
 async fn stop_before_start_does_not_poison_apply_task() {
     let mut cluster = common::build_mem_cluster(3);
 

--- a/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
+++ b/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
@@ -38,7 +38,13 @@ use tsoracle_driver_paxos::host::PaxosHighWaterHost;
 #[path = "common/mod.rs"]
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Runs under tokio virtual time (`start_paused`): the runner's `interval`
+// ticks, the apply task's `notified()`, the test's `drive_until` polls, and
+// the `timeout(5s)` guard all advance in simulated time the moment the
+// runtime goes idle — so the async apply task that folds the attributable
+// barrier still runs (the regression lives in that path), but without
+// wall-clock variance. `start_paused` implies the current-thread runtime.
+#[tokio::test(start_paused = true)]
 async fn submit_advance_commits_an_attributable_barrier_for_this_call() {
     let mut cluster = common::build_mem_cluster(3);
     cluster.start_all();

--- a/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
@@ -173,7 +173,7 @@ impl RaftStateMachine<SmokeConfig> for SmokeStateMachine {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn three_node_mem_network_elects_and_replicates() {
     use rocksdb::{ColumnFamilyDescriptor, DB, Options};
     use tempfile::TempDir;
@@ -273,7 +273,7 @@ async fn three_node_mem_network_elects_and_replicates() {
 /// moved incidentally (if an automatic election timer happened to re-elect the
 /// target). This test pins that the RPC now delivers and the chosen target takes
 /// over.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(start_paused = true)]
 async fn transfer_leader_moves_leadership_to_target() {
     use rocksdb::{ColumnFamilyDescriptor, DB, Options};
     use tempfile::TempDir;

--- a/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
@@ -37,7 +37,12 @@ impl MessageSink<TestCommand> for NetworkSink {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// Runs under tokio virtual time (`start_paused`): the runners' `interval`
+// ticks, the leader-stream `next()` awaits, and the `timeout(3s)` guard all
+// advance in simulated time once the runtime goes idle, so the election still
+// runs through the real async runner tasks but without wall-clock variance.
+// `start_paused` implies the current-thread runtime.
+#[tokio::test(start_paused = true)]
 async fn runners_emit_leader_or_follower_event_after_election() {
     let cluster = build_mem_cluster(3);
     let sink = Arc::new(NetworkSink {


### PR DESCRIPTION
## What

Converts the last wall-clock-dependent tests across the paxos and openraft test harnesses to deterministic execution, removing their timing flakiness. **No production changes — test-harness only.**

This completes the consensus-harness deterministic sweep (the paxos step-driver and openraft virtual-time work landed in earlier PRs; this picks up the stragglers across all three harness crates).

## Two techniques, chosen by where each test's regression lives

**Synchronous step-driver (`step` / `step_until`)** — for tests whose contract is pure consensus progression, where the step-driver's `apply_once` faithfully stands in for the async apply task:

- `driver-paxos/tests/reconfiguration.rs` — stopsign decide/seal
- `driver-paxos/tests/single_node.rs` — the inert case takes the peer hosts out so only one node steps (the step-driver skips host-less nodes), so no quorum is reachable; the converge case uses `step_until`

**Tokio virtual time (`start_paused`)** — where the regression lives *in* the async apply task or a yield-point race that the step-driver's synchronous `apply_once` would bypass. These keep the real runner/apply machinery and yield-point gating, so the race is preserved; only wall-clock variance is removed:

- `driver-paxos/tests/blocking_reads_missed_notify.rs` — missed `notify_waiters` race (×2)
- `driver-paxos/tests/linearized_barrier.rs` — apply-task-paused barrier fold
- `driver-paxos/tests/submit_advance_attribution.rs` — attributable-barrier commit
- `driver-paxos/tests/standalone_stale_permit.rs` — stale-permit apply-task poison
- `driver-paxos/tests/standalone_shutdown.rs` — shutdown-vs-livelock (the obsolete "CI scheduler starvation" rationale on the timeout was rewritten)
- `paxos-toolkit/tests/lifecycle.rs` — raw `PaxosRunner` election liveness
- `openraft-toolkit/tests/mem_network_smoke.rs` — election + leader transfer (×2)

The deciding factor per test was whether its bug lives in the async apply task: if so, the step-driver would silently bypass it, so virtual time is the honest fit (keep the task real, kill the clock).

## Verification

- `cargo test -p tsoracle-driver-paxos --all-features`: 56 passed, 0 failed (15 binaries)
- `paxos-toolkit` `lifecycle` + `openraft-toolkit` `mem_network_smoke` (`--features test-fakes`): pass
- **Red-green under `start_paused`**: reintroduced the `current_high_water` bug → `linearized_barrier` failed (got 0, expected 500); reverted → passes. Virtual time preserves the race detection — the converted tests still fail when the bug returns.
- Determinism: 5/5 clean across the converted driver-paxos tests
- `cargo fmt --check` clean; `cargo clippy --all-features --all-targets` clean

Each converted `start_paused` test went from a multi-second budget to ~0.00–0.10s.