### PR TITLE
refactor(driver-paxos): extract ApplyEngine + ApplyTask from StandaloneHost

### DIFF
--- a/crates/tsoracle-driver-paxos/src/apply.rs
+++ b/crates/tsoracle-driver-paxos/src/apply.rs
@@ -1,0 +1,219 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Apply pipeline for the standalone host.
+//!
+//! [`ApplyEngine`] bundles the apply state, the snapshot policy, and the
+//! single drain-and-snapshot step they drive. [`ApplyTask`] owns the
+//! lifecycle of the spawned async apply task. [`crate::StandaloneHost`]
+//! holds exactly one engine and at most one task.
+//!
+//! [`ApplyEngine::apply_step`] is the one drain+snapshot step shared by the
+//! host's synchronous stepping path ([`crate::StandaloneHost::apply_once`])
+//! and the async apply task spawned by [`ApplyEngine::spawn`]. A host is
+//! driven by exactly one of those two paths, so the two never run together.
+//!
+//! These types are keyed on [`HighWaterCommand`] and are internal to the
+//! standalone host: a piggyback host replicating a wider envelope entry
+//! cannot reuse them and instead builds its own pipeline directly on the
+//! public [`crate::state_machine`] primitives.
+
+use std::sync::Arc;
+
+use omnipaxos::OmniPaxos;
+use omnipaxos::storage::Storage;
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+use crate::log_entry::HighWaterCommand;
+use crate::snapshot_policy::SnapshotPolicy;
+use crate::state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
+
+/// Apply state + snapshot policy + the drain/snapshot step.
+///
+/// Cheap to clone (Arc-wrapped fields). [`ApplyEngine::spawn`] moves a clone
+/// into the async apply task; the host keeps its own copy for the synchronous
+/// stepping path and the barrier-linearized reads.
+#[derive(Clone)]
+pub(crate) struct ApplyEngine {
+    apply_state: ApplyState,
+    policy: Arc<Mutex<SnapshotPolicy>>,
+}
+
+impl ApplyEngine {
+    pub(crate) fn new(policy: SnapshotPolicy) -> Self {
+        Self {
+            apply_state: ApplyState::new(),
+            policy: Arc::new(Mutex::new(policy)),
+        }
+    }
+
+    /// Fold the decided suffix from `*cursor` into the apply state *without*
+    /// snapshotting, advancing the cursor. Used once at host construction to
+    /// seed the in-memory high-water and the barrier ledger from recovered
+    /// storage. Recovery deliberately skips compaction — a node that just
+    /// recovered should not immediately re-snapshot — which is why this is
+    /// distinct from [`Self::apply_step`].
+    pub(crate) fn recover<S>(
+        &self,
+        omnipaxos: &Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+        cursor: &mut u64,
+    ) where
+        S: Storage<HighWaterCommand> + Send + 'static,
+    {
+        drain_decided_into(omnipaxos, cursor, &self.apply_state);
+    }
+
+    /// Drain newly-decided entries from `*cursor` into the apply state, then
+    /// snapshot per policy, advancing the cursor. The single step shared by
+    /// the host's synchronous `apply_once` and the async apply task body;
+    /// idempotent (max over advances and per-node barrier seqs).
+    pub(crate) fn apply_step<S>(
+        &self,
+        omnipaxos: &Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+        cursor: &mut u64,
+    ) where
+        S: Storage<HighWaterCommand> + Send + 'static,
+    {
+        let decided_idx = drain_decided_into(omnipaxos, cursor, &self.apply_state);
+        let mut policy = self.policy.lock();
+        maybe_snapshot(omnipaxos, &mut policy, decided_idx);
+    }
+
+    /// Current in-memory high-water value (no consensus round-trip).
+    pub(crate) fn high_water(&self) -> u64 {
+        self.apply_state.high_water()
+    }
+
+    /// Latest applied barrier sequence the apply path has folded for `node`.
+    pub(crate) fn applied_barrier_seq(&self, node: u64) -> u64 {
+        self.apply_state.applied_barrier_seq(node)
+    }
+
+    /// Notifier the host's blocking-read methods loop on. Edge-triggered,
+    /// all-waiters-wake; callers MUST loop and re-check their condition.
+    pub(crate) fn apply_notifier(&self) -> Arc<Notify> {
+        self.apply_state.apply_notifier()
+    }
+
+    /// Spawn the async apply task and return its [`ApplyTask`] handle.
+    ///
+    /// On each `apply_notify` wake the task drains and snapshots via
+    /// [`Self::apply_step`] over a task-local cursor seeded at 0; the fold is
+    /// idempotent, so re-draining a recovered suffix is harmless. The task
+    /// runs until the returned [`ApplyTask`] is stopped.
+    ///
+    /// A fresh shutdown `Notify` is minted per spawn rather than reused across
+    /// the host's lifetime: `stop` signals with `notify_one`, which stores a
+    /// permit when no task is parked on `notified()`; a reused `Notify` would
+    /// carry that stale permit into the next task, which would consume it and
+    /// exit immediately. Confining each `Notify` to the task it was minted for
+    /// keeps every permit scoped to its own task.
+    pub(crate) fn spawn<S>(
+        &self,
+        apply_notify: Arc<Notify>,
+        omnipaxos: Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+    ) -> ApplyTask
+    where
+        S: Storage<HighWaterCommand> + Send + 'static,
+        <HighWaterCommand as omnipaxos::storage::Entry>::Snapshot: Send,
+    {
+        let shutdown = Arc::new(Notify::new());
+        let task_shutdown = shutdown.clone();
+        let engine = self.clone();
+        let handle = tokio::spawn(async move {
+            let mut cursor: u64 = 0;
+            loop {
+                tokio::select! {
+                    _ = apply_notify.notified() => {
+                        engine.apply_step(&omnipaxos, &mut cursor);
+                        tsoracle_yieldpoint::yieldpoint!(
+                            "standalone_host::apply_task::between_iterations"
+                        );
+                    }
+                    _ = task_shutdown.notified() => {
+                        break;
+                    }
+                }
+            }
+        });
+        ApplyTask { handle, shutdown }
+    }
+}
+
+/// Lifecycle handle for the spawned apply task.
+///
+/// Bundling the join handle and the per-spawn shutdown `Notify` in one value
+/// lets the host represent "running" as a single `Option<ApplyTask>` — the
+/// apply task cannot be left half-installed (handle without shutdown, or vice
+/// versa).
+pub(crate) struct ApplyTask {
+    handle: JoinHandle<()>,
+    shutdown: Arc<Notify>,
+}
+
+impl ApplyTask {
+    /// Signal shutdown and await the task, surfacing a `tracing::warn!` if it
+    /// terminated abnormally.
+    ///
+    /// `notify_one` (not `notify_waiters`): the task may be mid-drain rather
+    /// than parked on `notified()` when this fires; the stored permit is then
+    /// consumed on its next `select!` turn instead of being lost and
+    /// livelocking against the runner's per-tick `apply_notify`. Consuming
+    /// `self` makes double-stop unrepresentable.
+    pub(crate) async fn stop(self) {
+        self.shutdown.notify_one();
+        if let Err(err) = self.handle.await {
+            warn!(error = ?err, "paxos driver apply task terminated abnormally");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_engine_starts_at_zero_high_water() {
+        let engine = ApplyEngine::new(SnapshotPolicy::disabled());
+        assert_eq!(engine.high_water(), 0);
+    }
+
+    #[test]
+    fn applied_barrier_seq_is_zero_for_unseen_node() {
+        let engine = ApplyEngine::new(SnapshotPolicy::disabled());
+        assert_eq!(engine.applied_barrier_seq(7), 0);
+    }
+
+    #[test]
+    fn apply_notifier_is_stable_across_calls() {
+        let engine = ApplyEngine::new(SnapshotPolicy::disabled());
+        assert!(Arc::ptr_eq(
+            &engine.apply_notifier(),
+            &engine.apply_notifier()
+        ));
+    }
+
+    #[test]
+    fn clone_shares_apply_state() {
+        // The spawned task gets a clone; it must observe the same notifier the
+        // host's blocking reads loop on, or wakeups would never reach them.
+        let engine = ApplyEngine::new(SnapshotPolicy::disabled());
+        let clone = engine.clone();
+        assert!(Arc::ptr_eq(
+            &engine.apply_notifier(),
+            &clone.apply_notifier()
+        ));
+    }
+}

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -14,6 +14,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
+mod apply;
 pub mod driver;
 pub mod host;
 pub mod log_entry;

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -28,16 +28,13 @@ use omnipaxos::OmniPaxos;
 use omnipaxos::messages::Message;
 use omnipaxos::storage::Storage;
 use parking_lot::Mutex;
-use tokio::sync::Notify;
-use tokio::task::JoinHandle;
-use tracing::warn;
 use tsoracle_consensus::{AdvancePayload, ConsensusError};
 use tsoracle_paxos_toolkit::lifecycle::{LeaderEventStream, MessageSink, PaxosRunner, TsoPeer};
 
+use crate::apply::{ApplyEngine, ApplyTask};
 use crate::host::PaxosHighWaterHost;
 use crate::log_entry::HighWaterCommand;
 use crate::snapshot_policy::SnapshotPolicy;
-use crate::state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
 
 /// Standalone host owning its own paxos cluster + apply pipeline.
 pub struct StandaloneHost<S>
@@ -48,22 +45,17 @@ where
     my_node_id: u64,
     barrier_seq: AtomicU64,
     runner: PaxosRunner<HighWaterCommand, S>,
-    apply_state: ApplyState,
     leader_stream: Mutex<Option<LeaderEventStream>>,
-    apply_handle: Mutex<Option<JoinHandle<()>>>,
-    /// Shutdown handle for the *currently running* apply task, installed by
-    /// `start` and taken by `stop`. `None` whenever no apply task is live.
-    ///
-    /// Each `start` mints a fresh `Notify` rather than reusing one across the
-    /// host's lifetime. `stop` signals shutdown with `notify_one`, which
-    /// stores a permit when no task is parked on `notified()`; a reused
-    /// `Notify` would carry such a stale permit into the next `start`, where
-    /// the newly spawned apply task would consume it and exit immediately. A
-    /// per-`start` `Notify` confines every permit to the task it was minted
-    /// for, and the `Option` lets `stop` skip signalling entirely when no
-    /// task is running (stop-before-start, double-stop, stop-after-exit).
-    apply_shutdown: Mutex<Option<Arc<Notify>>>,
-    policy: Arc<Mutex<SnapshotPolicy>>,
+    /// Apply state + snapshot policy + the drain/snapshot step. Drives the
+    /// synchronous stepping path and the barrier-linearized reads directly,
+    /// and the async apply path via a clone moved into the spawned task.
+    engine: ApplyEngine,
+    /// The running apply task, or `None` when no task is live. `start`
+    /// installs one; `stop` takes and consumes it. A single `Option` makes
+    /// "running" structural — the apply task cannot be half-installed — and
+    /// needs no `Mutex` because `start`/`stop` take `&mut self`. `None`
+    /// covers stop-before-start, double-stop, and stop-after-exit.
+    task: Option<ApplyTask>,
     /// Decided-log cursor for the synchronous [`Self::step`] / [`Self::apply_once`]
     /// stepping path, seeded past any recovered suffix. The async apply task
     /// keeps its own task-local cursor; a host is driven by exactly one path.
@@ -104,21 +96,19 @@ where
         // this lifetime's own barrier. The apply task re-drains from its own
         // cursor on start; the fold is idempotent (max over advances and
         // per-node seqs), so seeding the shared state early is safe.
-        let apply_state = ApplyState::new();
+        let engine = ApplyEngine::new(policy);
         let mut recovery_cursor = 0u64;
-        drain_decided_into(&omnipaxos, &mut recovery_cursor, &apply_state);
-        let recovered_seq = apply_state.applied_barrier_seq(my_node_id);
+        engine.recover(&omnipaxos, &mut recovery_cursor);
+        let recovered_seq = engine.applied_barrier_seq(my_node_id);
 
         Self {
             omnipaxos,
             my_node_id,
             barrier_seq: AtomicU64::new(recovered_seq),
             runner,
-            apply_state,
             leader_stream: Mutex::new(leader_stream),
-            apply_handle: Mutex::new(None),
-            apply_shutdown: Mutex::new(None),
-            policy: Arc::new(Mutex::new(policy)),
+            engine,
+            task: None,
             step_cursor: Mutex::new(recovery_cursor),
         }
     }
@@ -147,42 +137,14 @@ where
     /// apply task orphaned.
     pub fn start<Sink: MessageSink<HighWaterCommand>>(&mut self, sink: Arc<Sink>) {
         debug_assert!(
-            self.apply_handle.lock().is_none(),
+            self.task.is_none(),
             "StandaloneHost::start called while already running",
         );
 
-        let omnipaxos = self.omnipaxos.clone();
-        let apply_notify = self.runner.apply_notify();
-        let apply_state = self.apply_state.clone();
-        let policy = self.policy.clone();
-        // Mint a fresh shutdown Notify for this apply task and publish it for
-        // stop(). A per-start Notify cannot carry a stale permit from an
-        // earlier stop() into this task's select! loop.
-        let shutdown = Arc::new(Notify::new());
-        *self.apply_shutdown.lock() = Some(shutdown.clone());
-
-        let handle = tokio::spawn(async move {
-            let mut cursor: u64 = 0;
-            loop {
-                tokio::select! {
-                    _ = apply_notify.notified() => {
-                        let decided_idx = drain_decided_into(&omnipaxos, &mut cursor, &apply_state);
-                        {
-                            let mut policy = policy.lock();
-                            maybe_snapshot(&omnipaxos, &mut policy, decided_idx);
-                        }
-                        tsoracle_yieldpoint::yieldpoint!(
-                            "standalone_host::apply_task::between_iterations"
-                        );
-                    }
-                    _ = shutdown.notified() => {
-                        break;
-                    }
-                }
-            }
-        });
-        *self.apply_handle.lock() = Some(handle);
-
+        self.task = Some(
+            self.engine
+                .spawn(self.runner.apply_notify(), self.omnipaxos.clone()),
+        );
         self.runner.start(sink);
     }
 
@@ -190,21 +152,11 @@ where
     /// apply task. Surfaces a `tracing::warn!` if the apply task
     /// terminated abnormally.
     pub async fn stop(&mut self) {
-        // Signal only the apply task that start() installed. notify_one (not
-        // notify_waiters) is required because the apply task may be mid-drain
-        // rather than parked on notified() when stop() fires; the stored
-        // permit is consumed on its next select! turn instead of being lost
-        // and livelocking against the runner's per-tick apply_notify. Taking
-        // the Option means a stop() with no running task signals nothing, so
-        // no permit can survive to poison a later start().
-        if let Some(shutdown) = self.apply_shutdown.lock().take() {
-            shutdown.notify_one();
-        }
-        let handle = self.apply_handle.lock().take();
-        if let Some(handle) = handle {
-            if let Err(err) = handle.await {
-                warn!(error = ?err, "paxos driver apply task terminated abnormally");
-            }
+        // Taking the Option means a stop() with no running task does nothing,
+        // so no shutdown permit can survive to poison a later start(). The
+        // notify_one / mid-drain reasoning lives on ApplyTask::stop.
+        if let Some(task) = self.task.take() {
+            task.stop().await;
         }
         self.runner.stop().await;
     }
@@ -212,7 +164,7 @@ where
     /// Current in-memory high-water value (no consensus round-trip).
     /// Used internally by `current_high_water` after a barrier decides.
     pub fn current_value(&self) -> u64 {
-        self.apply_state.high_water()
+        self.engine.high_water()
     }
 
     /// Synchronous single step for deterministic test stepping: tick the runner
@@ -239,9 +191,7 @@ where
     /// apply task; idempotent (max over advances and per-node barrier seqs).
     pub fn apply_once(&self) {
         let mut cursor = self.step_cursor.lock();
-        let decided_idx = drain_decided_into(&self.omnipaxos, &mut cursor, &self.apply_state);
-        let mut policy = self.policy.lock();
-        maybe_snapshot(&self.omnipaxos, &mut policy, decided_idx);
+        self.engine.apply_step(&self.omnipaxos, &mut cursor);
     }
 
     /// Deliver an inbound message synchronously (deterministic test stepping).
@@ -368,7 +318,7 @@ where
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
             })?;
-        let notifier = self.apply_state.apply_notifier();
+        let notifier = self.engine.apply_notifier();
         tsoracle_yieldpoint::yieldpoint!(
             "standalone_host::current_high_water::after_append_before_await"
         );
@@ -379,8 +329,8 @@ where
             let notified = notifier.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            if self.apply_state.applied_barrier_seq(self.my_node_id) >= seq {
-                return Ok(self.apply_state.high_water());
+            if self.engine.applied_barrier_seq(self.my_node_id) >= seq {
+                return Ok(self.engine.high_water());
             }
             notified.await;
         }
@@ -422,7 +372,7 @@ where
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
             })?;
-        let notifier = self.apply_state.apply_notifier();
+        let notifier = self.engine.apply_notifier();
         tsoracle_yieldpoint::yieldpoint!(
             "standalone_host::submit_advance::after_append_before_await"
         );
@@ -433,10 +383,10 @@ where
             let notified = notifier.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            if self.apply_state.applied_barrier_seq(self.my_node_id) >= seq
-                && self.apply_state.high_water() >= at_least
+            if self.engine.applied_barrier_seq(self.my_node_id) >= seq
+                && self.engine.high_water() >= at_least
             {
-                return Ok(self.apply_state.high_water());
+                return Ok(self.engine.high_water());
             }
             notified.await;
         }


### PR DESCRIPTION
Closes #259.

## Problem

`StandaloneHost` carried eight-ish responsibilities inline: the OmniPaxos handle, the toolkit `PaxosRunner`, the spawned apply task, barrier-seq linearization, write submission, leader-event passthrough, the synchronous test-stepping path, and snapshot policy — an 11-field struct. Two concrete smells:

1. `start()`'s spawned task closure duplicated `apply_once()`'s `drain_decided_into` + `maybe_snapshot` four lines.
2. `apply_handle` + `apply_shutdown` were two separate `Mutex<Option<…>>` kept in lockstep (both `Some` while running, both `None` otherwise) only by convention.

The asymmetry with the ~50-line openraft sibling is structural, not sloppiness: openraft pulls the state machine *into* the library behind `RaftStateMachine` (absorbing apply + snapshotting), whereas OmniPaxos hands the application a decided log, so the paxos driver must own the apply pipeline. This change relocates and groups it.

## Change

New `pub(crate)` `apply` module:

- **`ApplyEngine`** bundles `apply_state` + snapshot `policy` and owns the single drain+snapshot step (`apply_step`) shared by the synchronous stepping path and the async apply task, a drain-only `recover()` for construction (recovery stays snapshot-free), and the accessors the barrier-linearized reads use.
- **`ApplyTask`** owns the join handle + per-spawn shutdown `Notify`; `stop(self)` consumes it, making double-stop unrepresentable.

`StandaloneHost` drops 11 → 8 fields: `apply_state` + `policy` collapse into one `engine`, and `apply_handle` + `apply_shutdown` collapse into one `Option<ApplyTask>` (no `Mutex` — `start`/`stop` take `&mut self`), so a half-installed apply task is structurally impossible. The public method surface and the `PaxosHighWaterHost` impl are unchanged; every method is now a thin delegator.

## Why `refactor:`

`ApplyEngine`/`ApplyTask` are `pub(crate)` — no public API change, nothing external depends on a removed symbol, so there is no publish-ordering concern. The public extension primitives in `state_machine.rs` (`ApplyState`, `drain_decided_into`, `maybe_snapshot`) are untouched.

## Behavior preservation

- **Recovery stays snapshot-free.** `new()` folds the recovered suffix via the drain-only `recover()`, not `apply_step`, so a node restarting with `policy = every(N)` and `decided_idx >= N` does not compact at construction (unchanged from before).
- **The apply-task yieldpoint label is verbatim**, so the `yieldpoints`-gated shutdown/livelock regressions still intercept it.

## Verification

- `cargo test --workspace --all-features` — 722 passed, 0 failed.
- `cargo test -p tsoracle-driver-paxos --all-features` — passes, including the three `yieldpoints`-gated regressions (`standalone_shutdown`, `standalone_stale_permit`, `blocking_reads_missed_notify`) that a default-feature `--workspace` run silently skips.
- `cargo build --workspace --all-targets --all-features`, `cargo clippy --all-features --all-targets`, `cargo fmt --check` — all clean.
- Added four `ApplyEngine` accessor unit tests (zero-init high-water, unseen-node barrier seq, notifier stability, clone-shares-state). The fold-and-snapshot behavior of `apply_step` is already covered end-to-end by `state_machine`'s `drain_tests` and every `three_node`/`single_node` integration test.