### PR TITLE
refactor(server): emit leader-transition counter after state changes in run_leader_watch

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -77,11 +77,14 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                 None => break,
             },
         };
-        // Every state change (Leader, Follower, Unknown) counts as a transition
-        // observed from the driver: the total counter answers "how often is
-        // leadership churning".
-        #[cfg(feature = "metrics")]
-        metrics::counter!("tsoracle.leader_transition.total").increment(1);
+        // `tsoracle.leader_transition.total` is emitted per-arm *after* that
+        // arm's safety state change (clear/publish), never here before the
+        // `match`. The counter answers "how often is leadership churning"; one
+        // increment per observed event (Leader, Follower, Unknown), same as a
+        // pre-`match` emission, but ordered so a (contract-violating) blocking
+        // recorder cannot delay the safety-critical transition. The `metrics`
+        // crate's de facto contract is non-blocking O(1); this placement keeps
+        // the "safety before metrics" invariant structural, not conventional.
         match evt {
             LeaderState::Leader { epoch } => {
                 // Time the full fence: drain-barrier wait, durable persist, and
@@ -97,6 +100,15 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                     leader_epoch: None,
                 });
                 server.allocator.lock().on_leadership_lost();
+
+                // Count the transition after the clear above, not on the fence's
+                // success path below: a Leader event is "observed" the moment we
+                // begin handling it, so it must increment once even if the fence
+                // then steps down (NotLeader/Fenced) or faults — matching the
+                // prior pre-`match` placement exactly. Emitting after the clear
+                // (not before) keeps a blocking recorder from delaying it.
+                #[cfg(feature = "metrics")]
+                metrics::counter!("tsoracle.leader_transition.total").increment(1);
 
                 // Fence with retry. A consensus error here is not automatically
                 // fatal: the post-election window is volatile and `ConsensusError`
@@ -267,6 +279,10 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                     leader_endpoint,
                     leader_epoch,
                 });
+                // Emit after the NotServing publish so a blocking recorder
+                // cannot delay the safety state change.
+                #[cfg(feature = "metrics")]
+                metrics::counter!("tsoracle.leader_transition.total").increment(1);
             }
             LeaderState::Unknown => {
                 server.allocator.lock().on_leadership_lost();
@@ -274,6 +290,10 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                     leader_endpoint: None,
                     leader_epoch: None,
                 });
+                // Emit after the NotServing publish so a blocking recorder
+                // cannot delay the safety state change.
+                #[cfg(feature = "metrics")]
+                metrics::counter!("tsoracle.leader_transition.total").increment(1);
             }
         }
     }


### PR DESCRIPTION
Closes #79.

## Summary

In `crates/tsoracle-server/src/fence.rs`, the `tsoracle.leader_transition.total` counter was incremented *before* the `match evt` in `run_leader_watch`, so every branch (Leader/Follower/Unknown) waited behind the metric emission before clearing the allocator and publishing the new `ServingState`. Under the `metrics` crate's de facto non-blocking O(1) recorder contract this is unobservable, but the placement made "metrics latency = correctness latency" a *structural* property: a recorder with a blocking `increment` would delay safety-critical leadership transitions. This moves the right ordering to the only ordering.

## What changed

- Removed the single pre-`match` counter increment.
- Emit `tsoracle.leader_transition.total` once per arm, *after* that arm's safety state change:
  - **Leader arm** — after the up-front clear-to-`NotServing` + `on_leadership_lost()`, *before* the fence retry loop. A Leader event is "observed" the moment we begin handling it, so it increments exactly once even if the fence then steps down (`NotLeader`/`Fenced`) or faults — matching the prior pre-`match` behavior exactly.
  - **Follower / Unknown arms** — after their `state_tx.send(NotServing)`.
- The `fence_latency` histogram is **unchanged**: it already records inside the `Ok` arm after `Serving` is published, which its "fence-start to Serving" semantic requires.
- Added comments at each emission site documenting the "safety state change first, recorder expected non-blocking O(1)" invariant so the inverted ordering can't be re-introduced.

## Note on the issue's proposed snippet

The issue's example bundled the Leader-arm counter *after* `Serving` is published. That would have stopped counting Leader events whose fence steps down or faults — silently contradicting the issue's own acceptance criterion ("increments once per observed event, same as today"). The counter is instead placed after the guaranteed up-front clear, preserving exact parity. The existing `>=`-based metrics test would not have caught that regression.

## Acceptance criteria

- [x] Every metrics emission in `run_leader_watch` happens after the state transition in its branch.
- [x] `tsoracle.leader_transition.total` increments once per observed event, same as before (verified for all Leader exit paths, not just the success path).
- [x] `tsoracle.leader_transition.fence_latency` records once per successful fence-to-`Serving` transition, unchanged.
- [x] Existing tests pass without modification.
- [x] Comments at the emission sites document the invariant.

No behavior change under any standard `metrics` recorder; `examples/metrics-prometheus` is unaffected.

## Verification

| Check | Result |
|---|---|
| `cargo test -p tsoracle-server --features test-support,metrics --test metrics` | 1 passed |
| `cargo build -p tsoracle-server` (default — `metrics` off, cfg gating) | clean |
| `cargo test -p tsoracle-server --features test-support --test leader_watch --test leadership_churn` | 12 passed |
| `cargo test -p tsoracle-server --features yieldpoints,test-fakes --test fence_yieldpoint` | 1 passed |
| `cargo clippy` + `cargo fmt --check` (workspace, via pre-commit hook) | clean |

## Related

- #72, #77 — sibling integrity issues in the leadership-event pipeline.