### PR TITLE
feat(client): expose Client::cached_leader() and drop the dead pool field

### DIFF
--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -154,7 +154,6 @@ impl ClientBuilder {
 }
 
 pub struct Client {
-    #[allow(dead_code)]
     pool: Arc<ChannelPool>,
     driver: driver::Driver,
 }
@@ -162,6 +161,19 @@ pub struct Client {
 impl Client {
     pub async fn connect(endpoints: Vec<String>) -> Result<Self, ClientError> {
         ClientBuilder::endpoints(endpoints).build().await
+    }
+
+    /// The endpoint the client currently believes is the leader, or `None`
+    /// if no leader has been observed yet or the cached entry has aged past
+    /// the configured `leader_ttl`.
+    ///
+    /// Read-only diagnostic surface for ops dashboards and integration tests
+    /// asserting that a client has converged to the expected leader. It
+    /// reflects the cache as last updated by a completed RPC — it neither
+    /// triggers nor waits on any network round-trip, and the TTL check is
+    /// lazy (an expired entry reads as `None`).
+    pub fn cached_leader(&self) -> Option<String> {
+        self.pool.cached_leader()
     }
 
     pub async fn get_ts(&self) -> Result<Timestamp, ClientError> {
@@ -179,6 +191,19 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn cached_leader_is_none_before_any_rpc() {
+        // A freshly built client has issued no RPC, so the channel pool's
+        // leader cache is empty and `cached_leader()` reports `None`. This
+        // pins the "nothing observed yet" branch of the diagnostic accessor
+        // without needing a server; the post-RPC `Some(addr)` case is covered
+        // end-to-end in `tsoracle-tests`.
+        let client = Client::connect(vec!["http://127.0.0.1:1".into()])
+            .await
+            .expect("build with a non-empty endpoint list must succeed");
+        assert_eq!(client.cached_leader(), None);
+    }
 
     #[tokio::test]
     async fn build_rejects_empty_endpoint_list() {

--- a/crates/tsoracle-tests/Cargo.toml
+++ b/crates/tsoracle-tests/Cargo.toml
@@ -49,6 +49,9 @@ name = "server_serve_with_listener"
 name = "client_tls"
 
 [[test]]
+name = "client_cached_leader"
+
+[[test]]
 name              = "client_metrics"
 required-features = ["metrics"]
 

--- a/crates/tsoracle-tests/tests/client_cached_leader.rs
+++ b/crates/tsoracle-tests/tests/client_cached_leader.rs
@@ -1,0 +1,83 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! End-to-end coverage for `Client::cached_leader`, the read-only diagnostic
+//! accessor onto the channel pool's leader cache (issue #96). The pool-level
+//! cache mechanics are unit-tested in `tsoracle-client`; this test pins the
+//! observable client-facing contract through the real gRPC stack: the cache
+//! is empty until a `GetTs` completes, and a successful round-trip seats the
+//! endpoint that served it.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tsoracle_client::Client;
+use tsoracle_core::Epoch;
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{boot_server, wait_until_serving};
+
+/// A single successful `get_ts` is the only proof that every layer (tonic
+/// accept loop, gRPC handshake, leader fence, allocator) is live; the early
+/// attempts may race server readiness, so retry within a bounded budget.
+async fn first_successful_get_ts(client: &Client, budget: Duration) {
+    let deadline = Instant::now() + budget;
+    loop {
+        if client.get_ts().await.is_ok() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("server never became responsive within {budget:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// `cached_leader()` reports `None` before any RPC and converges to the
+/// endpoint that served a successful `GetTs`. With a single configured
+/// endpoint pointing at the booted leader, the dialed endpoint and the
+/// cached leader are the same string (`record_success` caches the worklist
+/// entry the client dialed), so we can assert the exact address.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cached_leader_converges_to_the_server_after_a_successful_rpc() {
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .build()
+        .unwrap();
+    let mut booted = boot_server(server).await;
+    driver.become_leader(Epoch(1));
+    wait_until_serving(&mut booted.state_rx).await;
+
+    let endpoint = booted.addr.to_string();
+    let client = Client::connect(vec![endpoint.clone()])
+        .await
+        .expect("connect with a non-empty endpoint list must succeed");
+
+    // No RPC has been issued yet, so the leader cache is empty.
+    assert_eq!(
+        client.cached_leader(),
+        None,
+        "a freshly connected client has observed no leader"
+    );
+
+    first_successful_get_ts(&client, Duration::from_secs(5)).await;
+
+    // The completed round-trip seated the endpoint that served it.
+    assert_eq!(
+        client.cached_leader().as_deref(),
+        Some(endpoint.as_str()),
+        "a successful GetTs must cache the serving endpoint as the leader"
+    );
+
+    booted.shutdown().await.expect("server shutdown");
+}


### PR DESCRIPTION
## Summary

Resolves #96 (option **(b)**).

`Client` held `pool: Arc<ChannelPool>` marked `#[allow(dead_code)]` — the driver closure captures its own `Arc<ChannelPool>` clone, so the field on `Client` was never read.

Rather than delete it, this makes the field **live** by exposing the channel pool's existing leader-cache accessor:

```rust
/// The endpoint the client currently believes is the leader, or `None`
/// if no leader has been observed yet or the cached entry has aged past
/// the configured `leader_ttl`.
pub fn cached_leader(&self) -> Option<String>
```

It's a read-only diagnostic surface for ops dashboards and integration tests that want to assert a client has converged to the expected leader. It reflects the cache as last updated by a completed RPC — it neither triggers nor waits on a round-trip, and the TTL check is lazy (an expired entry reads as `None`).

`endpoints()` was deliberately **not** added (YAGNI — callers already own the configured endpoint list they passed to the builder; `cached_leader()` is the dynamic state they cannot otherwise observe).

## Why `feat:` and not `refactor:`

Despite the issue's `refactor`/`tech debt` labels, this adds public API to a library crate. Under the repo's release rule (`release_commits = "^(feat|fix|perf)"`), a public-API add under `refactor:` would skip the version bump and break `cargo publish --verify` for any dependent of the new symbol. A public-surface add is a `feat`.

## Acceptance criteria

- [x] No `#[allow(dead_code)]` on the public `Client` type.
- [x] At least one test exercises `cached_leader()` post-RPC and asserts the expected leader.

## Tests

- **In-crate unit test** (`tsoracle-client`): a freshly connected client reports `None` before any RPC — pins the "nothing observed yet" branch without a server.
- **End-to-end test** (`tsoracle-tests/tests/client_cached_leader.rs`): boots a real server, asserts `cached_leader()` is `None` before any RPC, then `Some(addr)` after a successful `GetTs` over the real gRPC stack. The two-assertion shape rules out a trivially-passing implementation.

## Verification

- `cargo test --workspace` → 105 test groups, 0 failures
- `cargo clippy --workspace --all-targets` → clean
- `cargo fmt --all --check` → clean