### PR TITLE
fix(consensus): reject out-of-range high-water advance before persisting

### DIFF
--- a/crates/tsoracle-consensus/src/lib.rs
+++ b/crates/tsoracle-consensus/src/lib.rs
@@ -94,6 +94,43 @@ pub enum ConsensusError {
     PermanentDriver(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
+/// The error carried by a rejected out-of-range high-water advance. See
+/// [`reject_out_of_range_advance`].
+#[derive(Debug, thiserror::Error)]
+#[error("high-water advance {0} exceeds the 46-bit physical_ms maximum")]
+pub struct AdvanceOutOfRange(pub u64);
+
+/// Reject a high-water advance whose `physical_ms` value exceeds
+/// `tsoracle_core::PHYSICAL_MS_MAX`, before it is durably persisted.
+///
+/// `persist_high_water` carries a value in the `physical_ms` domain, which must
+/// fit the 46-bit timestamp layout. A value above the cap is a *poison*: once
+/// durably committed it can never be served — every subsequent leadership gain
+/// reloads it and the allocator's `try_on_leadership_gained` rejects it
+/// (`CoreError::PhysicalMsOutOfRange`), so the new leader can never serve. The
+/// high-water only ratchets up, so it cannot self-heal.
+///
+/// Every `ConsensusDriver::persist_high_water` MUST call this before appending
+/// the advance to durable storage (the consensus log, the on-disk record), so
+/// an out-of-range value is rejected at the propose boundary and never
+/// persisted. The single-node `FileDriver` already guards at persist time; this
+/// is the shared check that keeps the consensus backends — which append through
+/// a replicated log and apply with an unchecked `max` — from drifting away from
+/// that contract.
+///
+/// Classified [`ConsensusError::PermanentDriver`]: an out-of-range advance
+/// signals a saturated or misconfigured clock (`SystemClock::now_ms` saturates
+/// to `u64::MAX` to surface a far-future clock visibly), not a transient
+/// condition, so the server must surface `INTERNAL` rather than silently retry.
+pub fn reject_out_of_range_advance(at_least: u64) -> Result<(), ConsensusError> {
+    if at_least > tsoracle_core::PHYSICAL_MS_MAX {
+        return Err(ConsensusError::PermanentDriver(Box::new(
+            AdvanceOutOfRange(at_least),
+        )));
+    }
+    Ok(())
+}
+
 /// The single injection point for HA and durable persistence.
 ///
 /// Implementations own leadership election, peer transport, durable storage,
@@ -281,5 +318,31 @@ mod tests {
         let permanent = ConsensusError::PermanentDriver(Box::new(std::io::Error::other("corrupt")));
         assert!(permanent.to_string().contains("permanent"));
         assert!(permanent.to_string().contains("corrupt"));
+    }
+
+    #[test]
+    fn reject_out_of_range_advance_accepts_up_to_the_cap() {
+        // The cap itself is a valid physical_ms; only values strictly above it
+        // are rejected.
+        reject_out_of_range_advance(0).expect("zero is in range");
+        reject_out_of_range_advance(tsoracle_core::PHYSICAL_MS_MAX)
+            .expect("the maximum physical_ms is in range");
+    }
+
+    #[test]
+    fn reject_out_of_range_advance_rejects_above_the_cap_as_permanent() {
+        for at_least in [tsoracle_core::PHYSICAL_MS_MAX + 1, u64::MAX] {
+            let err = reject_out_of_range_advance(at_least)
+                .expect_err("a value above the cap must be rejected");
+            match err {
+                ConsensusError::PermanentDriver(source) => {
+                    let downcast = source
+                        .downcast_ref::<AdvanceOutOfRange>()
+                        .expect("permanent driver error must carry AdvanceOutOfRange");
+                    assert_eq!(downcast.0, at_least);
+                }
+                other => panic!("expected PermanentDriver, got {other:?}"),
+            }
+        }
     }
 }

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -265,11 +265,9 @@ impl ConsensusDriver for FileDriver {
         at_least: u64,
         _epoch: Epoch,
     ) -> Result<u64, ConsensusError> {
-        if at_least > PHYSICAL_MS_MAX {
-            return Err(ConsensusError::PermanentDriver(Box::new(
-                FileDriverError::PhysicalMsOutOfRange(at_least),
-            )));
-        }
+        // Shared with the consensus backends so every driver rejects an
+        // out-of-range advance at the same bound before persisting it.
+        tsoracle_consensus::reject_out_of_range_advance(at_least)?;
 
         // `write_lock` serializes writers — no two `persist_high_water` calls
         // can race the disk write or the publish step below.

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -132,6 +132,10 @@ impl<H: OpenraftHighWaterHost> ConsensusDriver for OpenraftDriver<H> {
         at_least: u64,
         _epoch: Epoch,
     ) -> Result<u64, ConsensusError> {
+        // Reject an out-of-range value before it enters the replicated log:
+        // the apply path computes an unchecked `max(prev, at_least)`, so a
+        // committed poison value can never be served and cannot self-heal.
+        tsoracle_consensus::reject_out_of_range_advance(at_least)?;
         self.host.submit_advance(at_least).await
     }
 }
@@ -394,5 +398,80 @@ mod tests {
         let peers = HashMap::new();
         let s = map_leader_state::<TypeConfig>(LeadershipState::Shutdown, &peers);
         assert_eq!(s, LeaderState::Unknown);
+    }
+
+    /// A host whose `submit_advance` echoes the requested value back as the
+    /// persisted high-water. It owns only a metrics watch (the piggy-back
+    /// shape), so it boots without a raft cluster. The echo lets a
+    /// `persist_high_water` test distinguish "the range guard rejected the
+    /// value before submission" from "the value was submitted and persisted":
+    /// an out-of-range value that reaches `submit_advance` comes back as
+    /// `Ok(at_least)`, so an `Err` proves the guard fired first.
+    struct EchoHost {
+        rx: openraft::type_config::alias::WatchReceiverOf<
+            TypeConfig,
+            openraft::RaftMetrics<TypeConfig>,
+        >,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::host::OpenraftHighWaterHost for EchoHost {
+        type Config = TypeConfig;
+
+        fn metrics(
+            &self,
+        ) -> openraft::type_config::alias::WatchReceiverOf<
+            Self::Config,
+            openraft::RaftMetrics<Self::Config>,
+        > {
+            self.rx.clone()
+        }
+
+        async fn current_high_water(&self) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Ok(0)
+        }
+
+        async fn submit_advance(
+            &self,
+            at_least: u64,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Ok(at_least)
+        }
+    }
+
+    fn echo_driver() -> std::sync::Arc<super::OpenraftDriver<EchoHost>> {
+        use openraft::type_config::TypeConfigExt;
+        let metrics = openraft::RaftMetrics::<TypeConfig>::new_initial(1u64);
+        let (_tx, rx) = <TypeConfig as TypeConfigExt>::watch_channel(metrics);
+        super::OpenraftDriver::new(EchoHost { rx })
+    }
+
+    #[tokio::test]
+    async fn persist_high_water_rejects_out_of_range_before_submit() {
+        use tsoracle_consensus::ConsensusDriver;
+        use tsoracle_core::PHYSICAL_MS_MAX;
+
+        let driver = echo_driver();
+
+        // Out-of-range: the guard must reject *before* the value reaches the
+        // host's log, so the poison is never durably committed.
+        let err = driver
+            .persist_high_water(PHYSICAL_MS_MAX + 1, Epoch::ZERO)
+            .await
+            .expect_err("an out-of-range advance must be rejected, not persisted");
+        assert!(
+            matches!(err, tsoracle_consensus::ConsensusError::PermanentDriver(_)),
+            "out-of-range advance must classify as PermanentDriver, got {err:?}"
+        );
+
+        // The boundary value is in range and still delegates to the host,
+        // which echoes it back — the guard rejects only what exceeds the cap.
+        assert_eq!(
+            driver
+                .persist_high_water(PHYSICAL_MS_MAX, Epoch::ZERO)
+                .await
+                .expect("the maximum in-range value must persist"),
+            PHYSICAL_MS_MAX
+        );
     }
 }

--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -102,6 +102,13 @@ where
     }
 
     async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        // Reject an out-of-range value before the Advance is appended: the
+        // apply path computes an unchecked `max(prev, at_least)`, so a decided
+        // poison value can never be served and cannot self-heal. This is
+        // value-intrinsic, so it precedes the epoch fence — an out-of-range
+        // request is permanently bad regardless of which epoch issued it.
+        tsoracle_consensus::reject_out_of_range_advance(at_least)?;
+
         // Fence: reject the call if the supplied epoch does not match
         // the host's current ballot-derived epoch. The check + append
         // are NOT atomic across the OmniPaxos handle, but a stale leader
@@ -199,6 +206,40 @@ mod tests {
             }
             other => panic!("expected Fenced, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn persist_rejects_out_of_range_before_append() {
+        use tsoracle_core::PHYSICAL_MS_MAX;
+
+        let host = StubHost::new();
+        let current_ballot = host.omnipaxos().lock().get_promise();
+        let current_epoch = encode_epoch(current_ballot);
+
+        let (_sender, stream) = leader_event_channel();
+        let driver = PaxosDriver::new(host, stream);
+
+        // The range guard must run before the Advance is appended to the log,
+        // so an out-of-range fence value is never durably committed. StubHost's
+        // submit_advance echoes Ok(at_least), so a returned Err proves the
+        // value was rejected before it reached the append path.
+        let err = driver
+            .persist_high_water(PHYSICAL_MS_MAX + 1, current_epoch)
+            .await
+            .expect_err("an out-of-range advance must be rejected, not appended");
+        assert!(
+            matches!(err, ConsensusError::PermanentDriver(_)),
+            "out-of-range advance must classify as PermanentDriver, got {err:?}"
+        );
+
+        // The boundary value is in range and still reaches the host.
+        assert_eq!(
+            driver
+                .persist_high_water(PHYSICAL_MS_MAX, current_epoch)
+                .await
+                .expect("the maximum in-range value must persist"),
+            PHYSICAL_MS_MAX
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #353. An out-of-range `physical_ms` value (`> PHYSICAL_MS_MAX`) handed to `persist_high_water` was durably committed by both consensus backends **before** any range check. The single-node `FileDriver` guarded at persist time, but the openraft and paxos drivers appended the `Advance` to the replicated log and applied it with an unchecked `max(prev, at_least)`.

A committed out-of-range value is a **poison**: on every subsequent leadership gain `load_high_water` returns it, the allocator's `try_on_leadership_gained` rejects it (`PhysicalMsOutOfRange`), and the new leader can never serve — and because the high-water only ratchets up, it cannot self-heal. The most plausible trigger is a saturated clock, since `SystemClock::now_ms` saturates to `u64::MAX` (#249) to surface a far-future clock visibly; that saturated value would be persisted before rejection.

## Change

- **`tsoracle-consensus`**: new `reject_out_of_range_advance(at_least) -> Result<(), ConsensusError>` (with `AdvanceOutOfRange` error), classified `PermanentDriver`. Single source of truth for the bound.
- **`tsoracle-driver-openraft`** / **`tsoracle-driver-paxos`**: call the guard at the propose boundary of `persist_high_water`, so an out-of-range value is rejected **before** it is appended to the log and never reaches the unchecked apply-time `max`. In paxos the guard precedes the epoch fence (an out-of-range request is permanently bad regardless of which epoch issued it).
- **`tsoracle-driver-file`**: migrate the inline persist-time check onto the shared helper so the bound cannot drift across backends. (`PermanentDriver` classification is unchanged, so existing `FileDriver` tests still hold.)

`PermanentDriver` (→ `INTERNAL`) is the right classification: an out-of-range advance signals a saturated/misconfigured clock, not a transient condition, so the server must not silently retry. This matches `FileDriver`'s existing behavior.

### Scope

Propose-time prevention only — the cure for *new* poison. Apply-time/recovery validation (and the unified `AdvancePayload::merge` from #348) are deliberately out of scope; raft apply must stay deterministic/infallible, and a propose-time reject keeps any value this code proposes out of the log entirely.

## Tests

- `tsoracle-consensus`: unit tests for the helper (accepts up to and including `PHYSICAL_MS_MAX`; rejects above as `PermanentDriver` carrying `AdvanceOutOfRange`).
- `tsoracle-driver-openraft` / `tsoracle-driver-paxos`: regression tests (RED→GREEN) proving `persist_high_water(PHYSICAL_MS_MAX + 1)` returns `PermanentDriver` and is rejected before submission (echo-host / stub-host `submit_advance` would otherwise return `Ok`), while the boundary `PHYSICAL_MS_MAX` still persists.

Verified: `cargo test` across the four crates, `cargo clippy --workspace --all-targets`, and `cargo fmt --all --check` all green.