### PR TITLE
fix(core): make WindowGrant valid-by-construction so first/last can't panic

### DIFF
--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -15,18 +15,91 @@
 
 use crate::{Epoch, LOGICAL_MAX, PHYSICAL_MS_MAX, Timestamp};
 
+/// A contiguous block of `count` timestamps starting at
+/// `(physical_ms, logical_start)`, all sharing one leadership `epoch`.
+///
+/// Fields are private and the only public constructor is
+/// [`try_new`](Self::try_new), which validates that every timestamp the grant
+/// covers fits the packed 46-bit physical / 18-bit logical layout. A value of
+/// this type is therefore proof that [`first`](Self::first) and
+/// [`last`](Self::last) can pack without panicking — the in-range invariant is
+/// guaranteed by the type, not by the one constructor that happens to build it.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct WindowGrant {
-    pub physical_ms: u64,
-    pub logical_start: u32,
-    pub count: u32,
-    pub epoch: Epoch,
+    physical_ms: u64,
+    logical_start: u32,
+    count: u32,
+    epoch: Epoch,
 }
 
 impl WindowGrant {
+    /// Construct a grant, checking that every timestamp it covers packs
+    /// cleanly. This is the only way to build a `WindowGrant` outside this
+    /// module, so a constructed value witnesses that `first`/`last` are
+    /// infallible.
+    ///
+    /// Rejects `count == 0` (a grant covers at least one timestamp, and
+    /// `last`'s `logical_start + count - 1` would underflow). The range check
+    /// defers to [`Timestamp::try_pack`] on the *last* logical the grant emits:
+    /// it is the single source of truth for the bit layout, and since
+    /// `logical_start <= last_logical <= LOGICAL_MAX` validating the last
+    /// boundary validates the first by implication.
+    pub fn try_new(
+        physical_ms: u64,
+        logical_start: u32,
+        count: u32,
+        epoch: Epoch,
+    ) -> Result<Self, CoreError> {
+        if count == 0 {
+            return Err(CoreError::InvalidCount(0));
+        }
+        let last_logical =
+            logical_start
+                .checked_add(count - 1)
+                .ok_or(CoreError::LogicalRangeOutOfRange {
+                    logical_start,
+                    count,
+                })?;
+        Timestamp::try_pack(physical_ms, last_logical).map_err(|err| match err {
+            crate::TimestampError::PhysicalMsOutOfRange { physical_ms, .. } => {
+                CoreError::PhysicalMsOutOfRange(physical_ms)
+            }
+            crate::TimestampError::LogicalOutOfRange { .. } => CoreError::LogicalRangeOutOfRange {
+                logical_start,
+                count,
+            },
+        })?;
+        Ok(WindowGrant {
+            physical_ms,
+            logical_start,
+            count,
+            epoch,
+        })
+    }
+
+    pub fn physical_ms(&self) -> u64 {
+        self.physical_ms
+    }
+    pub fn logical_start(&self) -> u32 {
+        self.logical_start
+    }
+    pub fn count(&self) -> u32 {
+        self.count
+    }
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    /// The first timestamp in the grant. Infallible: [`try_new`](Self::try_new)
+    /// validated `(physical_ms, logical_start)` is in range, so `pack` cannot
+    /// trip its `assert!`.
     pub fn first(&self) -> Timestamp {
         Timestamp::pack(self.physical_ms, self.logical_start)
     }
+    /// The last timestamp in the grant. Infallible: [`try_new`](Self::try_new)
+    /// validated `(physical_ms, logical_start + count - 1)` is in range (and
+    /// `count >= 1`, so the subtraction cannot underflow), so `pack` cannot
+    /// trip its `assert!`.
     pub fn last(&self) -> Timestamp {
         Timestamp::pack(self.physical_ms, self.logical_start + self.count - 1)
     }
@@ -42,6 +115,8 @@ pub enum CoreError {
     InvalidCount(u32),
     #[error("physical_ms {0} exceeds 46-bit maximum")]
     PhysicalMsOutOfRange(u64),
+    #[error("logical range [{logical_start}, +{count}) exceeds the 18-bit logical field")]
+    LogicalRangeOutOfRange { logical_start: u32, count: u32 },
     #[error(
         "invalid leadership window: fence_floor {fence_floor} exceeds committed_ceiling {committed_ceiling}"
     )]
@@ -210,12 +285,12 @@ impl Allocator {
             count,
         )?;
 
-        let grant = WindowGrant {
-            physical_ms,
-            logical_start,
-            count,
-            epoch: *epoch,
-        };
+        // project_grant already guarantees physical_ms and the logical range
+        // are in bounds, so this construction never fails in practice — but
+        // routing through the checked constructor propagates a CoreError rather
+        // than panicking should that invariant ever be violated, and keeps this
+        // path free of the unwrap/expect the crate's panic policy bans.
+        let grant = WindowGrant::try_new(physical_ms, logical_start, count, *epoch)?;
         *next_physical_ms = physical_ms;
         *next_logical = logical_start + count;
         Ok(grant)
@@ -684,5 +759,67 @@ mod tests {
         let second = allocator.try_grant(1, 1).unwrap();
         assert_eq!(second.physical_ms, 2);
         assert_eq!(second.logical_start, 0);
+    }
+
+    #[test]
+    fn try_new_accepts_valid_grant_and_packs_boundaries() {
+        // A checked grant exposes its fields through accessors and its
+        // boundary timestamps pack without panicking — first() at
+        // logical_start, last() at logical_start + count - 1.
+        let grant = WindowGrant::try_new(1_000, 5, 3, Epoch(7)).unwrap();
+        assert_eq!(grant.physical_ms(), 1_000);
+        assert_eq!(grant.logical_start(), 5);
+        assert_eq!(grant.count(), 3);
+        assert_eq!(grant.epoch(), Epoch(7));
+        assert_eq!(grant.first(), Timestamp::pack(1_000, 5));
+        assert_eq!(grant.last(), Timestamp::pack(1_000, 7));
+    }
+
+    #[test]
+    fn try_new_accepts_max_logical_boundary() {
+        // logical_start + count - 1 == LOGICAL_MAX is the widest in-range grant.
+        let grant = WindowGrant::try_new(1_000, 0, LOGICAL_MAX + 1, Epoch(1)).unwrap();
+        assert_eq!(grant.last(), Timestamp::pack(1_000, LOGICAL_MAX));
+    }
+
+    #[test]
+    fn try_new_rejects_zero_count() {
+        // count == 0 would underflow logical_start + count - 1 in last().
+        assert_eq!(
+            WindowGrant::try_new(1_000, 0, 0, Epoch(1)),
+            Err(CoreError::InvalidCount(0))
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_out_of_range_physical_ms() {
+        assert_eq!(
+            WindowGrant::try_new(PHYSICAL_MS_MAX + 1, 0, 1, Epoch(1)),
+            Err(CoreError::PhysicalMsOutOfRange(PHYSICAL_MS_MAX + 1))
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_logical_range_overflow() {
+        // last logical (logical_start + count - 1) exceeds the 18-bit field.
+        assert_eq!(
+            WindowGrant::try_new(1_000, LOGICAL_MAX, 2, Epoch(1)),
+            Err(CoreError::LogicalRangeOutOfRange {
+                logical_start: LOGICAL_MAX,
+                count: 2
+            })
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_logical_count_u32_overflow() {
+        // logical_start + (count - 1) overflows u32 before any range check.
+        assert_eq!(
+            WindowGrant::try_new(1_000, u32::MAX, 2, Epoch(1)),
+            Err(CoreError::LogicalRangeOutOfRange {
+                logical_start: u32::MAX,
+                count: 2
+            })
+        );
     }
 }

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -61,6 +61,12 @@ fn core_status(error: CoreError) -> Status {
         CoreError::PhysicalMsOutOfRange(physical_ms) => Status::out_of_range(format!(
             "physical_ms {physical_ms} exceeds 46-bit timestamp field"
         )),
+        CoreError::LogicalRangeOutOfRange {
+            logical_start,
+            count,
+        } => Status::out_of_range(format!(
+            "logical range [{logical_start}, +{count}) exceeds 18-bit timestamp field"
+        )),
         CoreError::InvalidLeadershipWindow {
             fence_floor,
             committed_ceiling,
@@ -129,13 +135,13 @@ impl TsoService for TsoServiceImpl {
                     {
                         metrics::counter!("tsoracle.get_ts.total").increment(1);
                         metrics::counter!("tsoracle.get_ts.timestamps_issued")
-                            .increment(u64::from(grant.count));
+                            .increment(u64::from(grant.count()));
                     }
-                    let (epoch_hi, epoch_lo) = grant.epoch.to_wire();
+                    let (epoch_hi, epoch_lo) = grant.epoch().to_wire();
                     return Ok(Response::new(GetTsResponse {
-                        physical_ms: grant.physical_ms,
-                        logical_start: grant.logical_start,
-                        count: grant.count,
+                        physical_ms: grant.physical_ms(),
+                        logical_start: grant.logical_start(),
+                        count: grant.count(),
                         epoch_hi,
                         epoch_lo,
                     }));

--- a/crates/tsoracle-server/tests/leader_watch.rs
+++ b/crates/tsoracle-server/tests/leader_watch.rs
@@ -174,8 +174,8 @@ async fn first_grant_strictly_above_prior_high_water_when_prior_exceeds_now() {
         grant.first() > prior_leader_max_ts,
         "first grant = (physical_ms={}, logical={}); prior leader could have issued up to \
          (physical_ms={}, logical={}). New leader's first timestamp must be strictly greater.",
-        grant.physical_ms,
-        grant.logical_start,
+        grant.physical_ms(),
+        grant.logical_start(),
         prior_max,
         LOGICAL_MAX,
     );


### PR DESCRIPTION
Closes #347.

## Problem

`WindowGrant` (`crates/tsoracle-core/src/allocator.rs`) is a `pub` `Copy` struct with `pub` fields. Its `first()`/`last()` accessors call `Timestamp::pack`, which `assert!`-panics on out-of-range input. It's safe *today* only because `project_grant` validates the fields before the one constructor (`try_grant`) builds a grant — but the invariant lives in that constructor, not in the type. Any caller (server, tests) can build a `WindowGrant` with arbitrary field values and call `.last()` to panic, bypassing the crate's panic-policy lint (`lib.rs:16`, which bans `unwrap`/`expect` on non-test paths). `pack`'s `assert!` is the sanctioned back door.

## Fix

Make the in-range invariant a *type* guarantee.

- **Private fields + accessors.** `WindowGrant`'s four fields are now private; added `physical_ms()`, `logical_start()`, `count()`, `epoch()` getters for readers.
- **Checked constructor `try_new(physical_ms, logical_start, count, epoch) -> Result<Self, CoreError>`** — the only way to build a grant outside the module. Rejects `count == 0` (`InvalidCount(0)`; `last()` would underflow `logical_start + count - 1`), guards the u32 overflow of `logical_start + (count - 1)` with `checked_add`, and validates the range with a single `Timestamp::try_pack` on the *last* logical the grant emits. Since `logical_start <= last_logical <= LOGICAL_MAX` and both boundaries share `physical_ms`, validating the last boundary proves `first()` is in range too — so the constructor defers to the canonical packer once rather than re-deriving bounds that could drift from `pack`.
- **`first()`/`last()` stay** (still call the infallible `pack`) and are now documented as infallible *because* `try_new` validated the range.
- **`try_grant`** builds through `WindowGrant::try_new(..)?`. `project_grant` already guarantees in-range, so this never fails in practice — but it propagates a `CoreError` instead of panicking and keeps the hot path free of `unwrap`/`expect`. State write-back still happens only after a successful build.
- **`CoreError::LogicalRangeOutOfRange { logical_start, count }`** added, with its `core_status` arm in `tsoracle-server` mapping to `Status::out_of_range(...)` (mirrors `PhysicalMsOutOfRange`; the exhaustive match forces the arm).

Cross-crate readers (`service.rs`, the `leader_watch` integration test) move to the new accessors; the allocator's own unit tests keep direct field access via Rust's child-module privacy.

No wire/proto change.

## Tests

Five new `tsoracle-core` unit tests for `try_new`: valid grant + boundary packing, max-logical boundary, `count == 0`, out-of-range `physical_ms`, logical-range overflow, and the u32-overflow case.

## Verification

- `cargo build --workspace --all-targets` — clean, no warnings
- `cargo test --workspace` — all pass
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets` — clean