### PR TITLE
fix(driver-paxos): bound StandaloneHost barrier waits with a deadline and apply-task liveness

### DIFF
--- a/crates/tsoracle-driver-paxos/src/apply.rs
+++ b/crates/tsoracle-driver-paxos/src/apply.rs
@@ -28,6 +28,7 @@
 //! public [`crate::state_machine`] primitives.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use omnipaxos::OmniPaxos;
 use omnipaxos::storage::Storage;
@@ -40,6 +41,15 @@ use crate::log_entry::HighWaterCommand;
 use crate::snapshot_policy::SnapshotPolicy;
 use crate::state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
 
+/// Liveness of the async apply task, tracked so a barrier waiter can tell
+/// "no task has ever been spawned" (the synchronous stepping path drives
+/// `apply_once` itself) from "a task was spawned and has since died" (a panic
+/// or shutdown — the barrier can never be folded, so the waiter must fail
+/// fast rather than park).
+const APPLY_NEVER_SPAWNED: u8 = 0;
+const APPLY_ALIVE: u8 = 1;
+const APPLY_DEAD: u8 = 2;
+
 /// Apply state + snapshot policy + the drain/snapshot step.
 ///
 /// Cheap to clone (Arc-wrapped fields). [`ApplyEngine::spawn`] moves a clone
@@ -49,6 +59,11 @@ use crate::state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
 pub(crate) struct ApplyEngine {
     apply_state: ApplyState,
     policy: Arc<Mutex<SnapshotPolicy>>,
+    /// Shared liveness of the spawned apply task — see the `APPLY_*` constants.
+    /// `spawn` flips it to `APPLY_ALIVE`; the task's death-guard flips it to
+    /// `APPLY_DEAD` on any exit. Read by the host's barrier waits via
+    /// [`Self::apply_task_died`].
+    apply_liveness: Arc<AtomicU8>,
 }
 
 impl ApplyEngine {
@@ -56,7 +71,18 @@ impl ApplyEngine {
         Self {
             apply_state: ApplyState::new(),
             policy: Arc::new(Mutex::new(policy)),
+            apply_liveness: Arc::new(AtomicU8::new(APPLY_NEVER_SPAWNED)),
         }
+    }
+
+    /// Whether a spawned apply task has died (panicked or been shut down).
+    ///
+    /// `false` while no task has ever been spawned — the synchronous stepping
+    /// path ([`crate::StandaloneHost::apply_once`]) folds barriers itself, so
+    /// "never spawned" must not be mistaken for "dead". A barrier waiter uses
+    /// this to fail fast once the task that would fold its barrier is gone.
+    pub(crate) fn apply_task_died(&self) -> bool {
+        self.apply_liveness.load(Ordering::Acquire) == APPLY_DEAD
     }
 
     /// Fold the decided suffix from `*cursor` into the apply state *without*
@@ -137,7 +163,22 @@ impl ApplyEngine {
         let shutdown = Arc::new(Notify::new());
         let task_shutdown = shutdown.clone();
         let engine = self.clone();
+
+        // Mark the task live *before* spawning so a `start()` caller that
+        // immediately issues a barrier read observes `APPLY_ALIVE`, never a
+        // transient `APPLY_NEVER_SPAWNED`. The death-guard, moved into the
+        // task, flips it back to `APPLY_DEAD` on any exit — the shutdown
+        // break, a panic in `apply_step`, or the task being aborted/dropped —
+        // and wakes parked barrier readers on the apply-state notifier so they
+        // fail fast instead of hanging on a task that will never fold again.
+        self.apply_liveness.store(APPLY_ALIVE, Ordering::Release);
+        let death_guard = ApplyDeathGuard {
+            liveness: self.apply_liveness.clone(),
+            waiters: self.apply_notifier(),
+        };
+
         let handle = tokio::spawn(async move {
+            let _death_guard = death_guard;
             loop {
                 tokio::select! {
                     _ = apply_notify.notified() => {
@@ -159,6 +200,25 @@ impl ApplyEngine {
             }
         });
         ApplyTask { handle, shutdown }
+    }
+}
+
+/// Drop-guard moved into the spawned apply task. On the task's exit — by any
+/// path, including a panic unwind or an abort — it marks the apply path dead
+/// and wakes parked barrier readers so they observe the death and fail fast.
+///
+/// `store(DEAD)` happens *before* `notify_waiters` so a reader woken by the
+/// notify always observes `APPLY_DEAD` on its re-check, never a stale
+/// `APPLY_ALIVE`.
+struct ApplyDeathGuard {
+    liveness: Arc<AtomicU8>,
+    waiters: Arc<Notify>,
+}
+
+impl Drop for ApplyDeathGuard {
+    fn drop(&mut self) {
+        self.liveness.store(APPLY_DEAD, Ordering::Release);
+        self.waiters.notify_waiters();
     }
 }
 

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -69,7 +69,20 @@ where
     /// every startup (the two paths can no longer disagree on where recovery
     /// left off).
     apply_cursor: Arc<Mutex<u64>>,
+    /// Upper bound on how long a barrier-linearized read/advance
+    /// ([`Self::current_high_water`], [`Self::submit_advance`]) waits for its
+    /// barrier to be folded before giving up with a retryable
+    /// [`ConsensusError::TransientDriver`]. A backstop against an
+    /// indefinite park when the barrier never decides (quorum loss, lost
+    /// leadership) — not a tight SLA. Apply-task death is surfaced faster than
+    /// this via the engine's liveness signal.
+    barrier_timeout: Duration,
 }
+
+/// Default barrier-wait deadline. Generous relative to the tick cadence
+/// (consensus normally folds a barrier in a handful of ticks), so it fires
+/// only when the barrier genuinely cannot make progress.
+pub const DEFAULT_BARRIER_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl<S> StandaloneHost<S>
 where
@@ -87,6 +100,7 @@ where
         peers: Vec<TsoPeer>,
         tick_interval: Duration,
         policy: SnapshotPolicy,
+        barrier_timeout: Duration,
     ) -> Self {
         let mut runner = PaxosRunner::new(omnipaxos.clone(), my_node_id, peers, tick_interval);
         let leader_stream = runner.take_leader_stream();
@@ -125,6 +139,7 @@ where
             engine,
             task: None,
             apply_cursor: Arc::new(Mutex::new(recovery_cursor)),
+            barrier_timeout,
         }
     }
 
@@ -219,6 +234,56 @@ where
     pub fn deliver(&self, message: Message<HighWaterCommand>) {
         self.runner.handle_incoming(message);
     }
+
+    /// Wait for this node's barrier nonce `seq` to be folded by the apply path,
+    /// then return the resulting high-water. `floor`, when set, additionally
+    /// requires `high_water >= floor` (the `submit_advance` postcondition; a
+    /// read passes `None`).
+    ///
+    /// Bounded three ways so the wait can never park forever (#354):
+    /// - the barrier is folded and the floor (if any) is met — success;
+    /// - the apply task that would fold the barrier has died — fail fast with a
+    ///   non-retryable [`ConsensusError::PermanentDriver`];
+    /// - `barrier_timeout` elapses without progress (quorum loss, lost
+    ///   leadership) — give up with a retryable
+    ///   [`ConsensusError::TransientDriver`] so the caller can react.
+    async fn await_barrier(&self, seq: u64, floor: Option<u64>) -> Result<u64, ConsensusError> {
+        let notifier = self.engine.apply_notifier();
+        let wait = async {
+            loop {
+                // Register as waiter before checking state; otherwise a
+                // notify_waiters that fires between this check and the next
+                // notified().await is lost.
+                let notified = notifier.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+
+                let folded = self.engine.applied_barrier_seq(self.my_node_id) >= seq;
+                let floor_met = match floor {
+                    Some(at_least) => self.engine.high_water() >= at_least,
+                    None => true,
+                };
+                if folded && floor_met {
+                    return Ok(self.engine.high_water());
+                }
+                // The apply task that folds barriers is gone, so no further
+                // progress is possible — fail fast instead of waiting out the
+                // whole deadline. A host driven by the synchronous stepping
+                // path never spawns one, so "never spawned" is not death.
+                if self.engine.apply_task_died() {
+                    return Err(ConsensusError::PermanentDriver(Box::new(ApplyTaskGone)));
+                }
+                notified.await;
+            }
+        };
+
+        match tokio::time::timeout(self.barrier_timeout, wait).await {
+            Ok(result) => result,
+            Err(_elapsed) => Err(ConsensusError::TransientDriver(Box::new(
+                BarrierWaitTimeout(self.barrier_timeout),
+            ))),
+        }
+    }
 }
 
 /// Builder for [`StandaloneHost`].
@@ -231,6 +296,7 @@ where
     peers: Vec<TsoPeer>,
     tick_interval: Duration,
     policy: SnapshotPolicy,
+    barrier_timeout: Duration,
 }
 
 impl<S> Default for StandaloneHostBuilder<S>
@@ -244,6 +310,7 @@ where
             peers: Vec::new(),
             tick_interval: Duration::from_millis(20),
             policy: SnapshotPolicy::disabled(),
+            barrier_timeout: DEFAULT_BARRIER_TIMEOUT,
         }
     }
 }
@@ -278,6 +345,13 @@ where
         self
     }
 
+    /// Override the barrier-wait deadline (default [`DEFAULT_BARRIER_TIMEOUT`]).
+    /// See [`StandaloneHost::current_high_water`] / [`StandaloneHost::submit_advance`].
+    pub fn barrier_timeout(mut self, barrier_timeout: Duration) -> Self {
+        self.barrier_timeout = barrier_timeout;
+        self
+    }
+
     pub fn build(self) -> Result<StandaloneHost<S>, BuilderError> {
         let omnipaxos = self.omnipaxos.ok_or(BuilderError::MissingOmnipaxos)?;
         let my_node_id = self.my_node_id.ok_or(BuilderError::MissingNodeId)?;
@@ -287,6 +361,7 @@ where
             self.peers,
             self.tick_interval,
             self.policy,
+            self.barrier_timeout,
         ))
     }
 }
@@ -338,22 +413,12 @@ where
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
             })?;
-        let notifier = self.engine.apply_notifier();
         tsoracle_yieldpoint::yieldpoint!(
             "standalone_host::current_high_water::after_append_before_await"
         );
-        loop {
-            // Register as waiter before checking state; otherwise a
-            // notify_waiters that fires between the previous iteration's
-            // check and the next notified().await is lost.
-            let notified = notifier.notified();
-            tokio::pin!(notified);
-            notified.as_mut().enable();
-            if self.engine.applied_barrier_seq(self.my_node_id) >= seq {
-                return Ok(self.engine.high_water());
-            }
-            notified.await;
-        }
+        // A read has no floor — any folded value attributable to this barrier
+        // is correct.
+        self.await_barrier(seq, None).await
     }
 
     async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError> {
@@ -392,30 +457,34 @@ where
             .map_err(|err| {
                 ConsensusError::TransientDriver(Box::new(BarrierAppendError(format!("{err:?}"))))
             })?;
-        let notifier = self.engine.apply_notifier();
         tsoracle_yieldpoint::yieldpoint!(
             "standalone_host::submit_advance::after_append_before_await"
         );
-        loop {
-            // Register as waiter before checking state; otherwise a
-            // notify_waiters that fires between the previous iteration's
-            // check and the next notified().await is lost.
-            let notified = notifier.notified();
-            tokio::pin!(notified);
-            notified.as_mut().enable();
-            if self.engine.applied_barrier_seq(self.my_node_id) >= seq
-                && self.engine.high_water() >= at_least
-            {
-                return Ok(self.engine.high_water());
-            }
-            notified.await;
-        }
+        // Keep the floor postcondition (unique to submit_advance) even in the
+        // corner where a mid-call leadership change drops this Advance while
+        // the barrier still decides under the new leader: there the floor is
+        // unmet, so we keep waiting rather than return a sub-floor value.
+        self.await_barrier(seq, Some(at_least)).await
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 #[error("barrier append failed: {0}")]
 struct BarrierAppendError(String);
+
+/// The barrier did not fold within `barrier_timeout`. Retryable: the most
+/// likely cause is transient (quorum loss, a leadership change in flight), and
+/// the caller's epoch fence surfaces a genuine leadership loss separately.
+#[derive(Debug, thiserror::Error)]
+#[error("barrier wait timed out after {0:?}")]
+struct BarrierWaitTimeout(Duration);
+
+/// The apply task that folds barriers has died, so the barrier can never be
+/// folded. Non-retryable: a panicked/stopped apply task does not recover by
+/// retrying the same call.
+#[derive(Debug, thiserror::Error)]
+#[error("apply task is gone; barrier can never be folded")]
+struct ApplyTaskGone;
 
 #[derive(Debug, thiserror::Error)]
 #[error("advance append failed: {0}")]
@@ -554,6 +623,7 @@ mod tests {
             Vec::new(),
             Duration::from_millis(2),
             SnapshotPolicy::disabled(),
+            DEFAULT_BARRIER_TIMEOUT,
         );
 
         assert_eq!(

--- a/crates/tsoracle-driver-paxos/tests/barrier_wait_liveness.rs
+++ b/crates/tsoracle-driver-paxos/tests/barrier_wait_liveness.rs
@@ -1,0 +1,98 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! `StandaloneHost` barrier waits must not park forever (#354).
+//!
+//! `current_high_water` / `submit_advance` append a Barrier and wait for the
+//! apply path to fold it. Two failure modes used to hang indefinitely: the
+//! barrier never decides (quorum loss / lost leadership), and the apply task
+//! dies (panic). Both must now end in a classified error instead of parking.
+//!
+//! Both tests run under tokio virtual time (`start_paused`): the deadline test
+//! relies on the runtime auto-advancing the virtual clock to the barrier
+//! timeout once no task can make progress, so it is instant and deterministic.
+
+use std::time::Duration;
+
+use tsoracle_consensus::ConsensusError;
+use tsoracle_driver_paxos::host::PaxosHighWaterHost;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{build_mem_cluster, build_mem_cluster_with_barrier_timeout, some_leader_elected};
+
+/// A barrier that never decides or applies must end at the deadline as a
+/// retryable `TransientDriver`, not park forever.
+#[tokio::test(start_paused = true)]
+async fn submit_advance_times_out_when_barrier_never_applies() {
+    // Elect a leader by deterministic stepping so the Advance append succeeds,
+    // then stop stepping. With no further steps the barrier is never decided
+    // or applied, and a stepped cluster has no async apply task to fold it, so
+    // the only way the wait can end is the deadline.
+    let mut cluster = build_mem_cluster_with_barrier_timeout(3, Duration::from_millis(50));
+    cluster.step_until(some_leader_elected(), 10_000);
+    let leader = cluster.leader();
+    let host = cluster
+        .node(leader)
+        .host
+        .as_ref()
+        .expect("leader host present");
+
+    let err = host
+        .submit_advance(42)
+        .await
+        .expect_err("a barrier that never applies must end at the deadline");
+    assert!(
+        matches!(err, ConsensusError::TransientDriver(_)),
+        "the deadline must classify as TransientDriver, got {err:?}",
+    );
+    assert!(
+        err.to_string().contains("timed out"),
+        "the error must be the barrier-wait timeout, not an append failure: {err}",
+    );
+}
+
+/// Once the apply task is gone, a barrier read can never be folded, so it must
+/// fail fast as `PermanentDriver` rather than wait out the whole deadline.
+#[tokio::test(start_paused = true)]
+async fn current_high_water_fails_fast_when_apply_task_dies() {
+    let mut cluster = build_mem_cluster(3);
+    cluster.start_all();
+    cluster.drive_until(some_leader_elected(), 10_000).await;
+    let leader = cluster.leader();
+
+    // Take the leader's host out and stop it: ApplyTask shutdown drops the
+    // apply task, whose death-guard marks the apply path dead and wakes any
+    // parked barrier readers.
+    let mut host = cluster
+        .node_mut(leader)
+        .host
+        .take()
+        .expect("leader host present");
+    host.stop().await;
+
+    let err = host
+        .current_high_water()
+        .await
+        .expect_err("a barrier read after the apply task is gone must fail");
+    assert!(
+        matches!(err, ConsensusError::PermanentDriver(_)),
+        "apply-task death must classify as PermanentDriver, got {err:?}",
+    );
+    assert!(
+        err.to_string().contains("apply task"),
+        "the error must name the gone apply task: {err}",
+    );
+
+    cluster.stop_all().await;
+}

--- a/crates/tsoracle-driver-paxos/tests/common/mod.rs
+++ b/crates/tsoracle-driver-paxos/tests/common/mod.rs
@@ -438,6 +438,28 @@ pub fn build_mem_cluster(node_count: usize) -> MemCluster {
 }
 
 pub fn build_mem_cluster_with_policy(node_count: usize, policy: SnapshotPolicy) -> MemCluster {
+    build_mem_cluster_inner(node_count, policy, None)
+}
+
+/// Build a cluster with an explicit barrier-wait timeout (default snapshot
+/// policy). Lets the barrier-liveness tests force the deadline path on a short,
+/// virtual-time-friendly timeout instead of the host's multi-second default.
+pub fn build_mem_cluster_with_barrier_timeout(
+    node_count: usize,
+    barrier_timeout: Duration,
+) -> MemCluster {
+    build_mem_cluster_inner(
+        node_count,
+        SnapshotPolicy::disabled(),
+        Some(barrier_timeout),
+    )
+}
+
+fn build_mem_cluster_inner(
+    node_count: usize,
+    policy: SnapshotPolicy,
+    barrier_timeout: Option<Duration>,
+) -> MemCluster {
     assert!(
         node_count >= 3,
         "omnipaxos 0.2 rejects ClusterConfig with fewer than 3 nodes"
@@ -469,14 +491,16 @@ pub fn build_mem_cluster_with_policy(node_count: usize, policy: SnapshotPolicy) 
         let shared_omnipaxos = Arc::new(Mutex::new(omnipaxos));
         let inbox = network.register(node_id);
 
-        let host = StandaloneHost::builder()
+        let mut builder = StandaloneHost::builder()
             .omnipaxos(shared_omnipaxos.clone())
             .my_node_id(node_id)
             .peers(Vec::new())
             .tick_interval(DEFAULT_TICK_INTERVAL)
-            .snapshot_policy(policy)
-            .build()
-            .expect("build standalone host");
+            .snapshot_policy(policy);
+        if let Some(barrier_timeout) = barrier_timeout {
+            builder = builder.barrier_timeout(barrier_timeout);
+        }
+        let host = builder.build().expect("build standalone host");
         let leader_stream = host.take_leader_stream();
         nodes.push(NodeHandle {
             node_id,


### PR DESCRIPTION
## Summary

Fixes #354. `StandaloneHost::current_high_water` and `submit_advance` appended a `Barrier` and then looped on the apply-state notifier with **no deadline, cancellation, or liveness check**. If the apply task died (panic) or the barrier never decided (quorum loss / lost leadership), the `await` parked **forever**. The server's fence and window-extension paths call these through the driver, so a stalled barrier surfaced as a stuck server rather than a clean, retryable error.

## Change

Both waits now route through a shared `await_barrier(seq, floor)` bounded three ways:

- **Deadline.** A configurable `barrier_timeout` (`StandaloneHostBuilder::barrier_timeout`, default `DEFAULT_BARRIER_TIMEOUT` = **5 s**) wraps the wait; on elapse it returns a retryable `ConsensusError::TransientDriver`. The default is generous relative to the tick cadence, so it fires only when the barrier genuinely cannot make progress — it's a backstop against an indefinite park, not a tight SLA.
- **Apply-task liveness.** `ApplyEngine` carries a tri-state signal `NeverSpawned → Alive → Dead`. `spawn` marks it `Alive` and installs a **drop-guard in the task** that flips it to `Dead` and wakes parked waiters on *any* exit (shutdown break, panic unwind, or abort). A waiter that observes `Dead` fails fast with a non-retryable `ConsensusError::PermanentDriver` instead of waiting out the whole deadline.
- **Sync path preserved.** `NeverSpawned` is deliberately *not* treated as death, so the synchronous stepping path (`apply_once`, no spawned task) is unaffected.

### Error classification

Follows the `ConsensusError` contract (chosen deliberately): a stalled barrier is most likely transient — the caller's epoch fence surfaces a genuine leadership loss separately — so the deadline maps to `TransientDriver`; a dead apply task will not recover by retrying, so it maps to `PermanentDriver`.

### Scope

Paxos-only. The openraft host's `submit_advance` goes through raft's own `client_write` timeouts. The `debug_assert!` double-start (#355) and a leadership-loss→`Fenced` mapping are intentionally out of scope.

## Tests

New `barrier_wait_liveness.rs`, deterministic under tokio virtual time (`start_paused`):
- a barrier that never applies times out as `TransientDriver` (asserts the timeout error, not an append failure);
- a barrier read after the apply task is stopped fails fast as `PermanentDriver`.

**Mutation-verified:** disabling the death fast-fail makes the death test observe `TransientDriver(BarrierWaitTimeout(5s))` instead — proving both the liveness fast-fail and the timeout backstop fire.

All 17 existing paxos test binaries pass with `--all-features` (the sync-path `restart_barrier_seq` and the yield-point barrier tests included). Verified: `cargo test --workspace`, `cargo build --workspace --all-targets`, `cargo clippy --all-features --all-targets`, `cargo fmt --all --check` — all green.