### PR TITLE
feat(paxos): surface snapshot and async-persistence failures as health metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
+ "metrics",
+ "metrics-util 0.19.1",
  "omnipaxos",
  "parking_lot",
  "postcard",
@@ -3417,6 +3419,8 @@ version = "0.2.2"
 dependencies = [
  "async-trait",
  "futures",
+ "metrics",
+ "metrics-util 0.19.1",
  "omnipaxos",
  "parking_lot",
  "pastey",

--- a/crates/tsoracle-driver-paxos/Cargo.toml
+++ b/crates/tsoracle-driver-paxos/Cargo.toml
@@ -13,10 +13,12 @@ authors.workspace      = true
 default          = ["rocksdb-storage"]
 rocksdb-storage  = ["tsoracle-paxos-toolkit/rocksdb-storage"]
 yieldpoints      = ["tsoracle-yieldpoint/yieldpoints"]
+metrics          = ["dep:metrics", "tsoracle-paxos-toolkit/metrics"]
 
 [dependencies]
 async-trait          = { workspace = true }
 futures              = { workspace = true }
+metrics              = { workspace = true, optional = true }
 omnipaxos            = { workspace = true, features = ["serde"] }
 parking_lot          = { workspace = true }
 postcard             = { workspace = true }
@@ -32,6 +34,7 @@ tsoracle-yieldpoint  = { workspace = true }
 
 [dev-dependencies]
 anyhow           = { workspace = true }
+metrics-util     = { workspace = true }
 proptest         = { workspace = true }
 rocksdb          = { workspace = true }
 tempfile         = { workspace = true }

--- a/crates/tsoracle-driver-paxos/src/state_machine.rs
+++ b/crates/tsoracle-driver-paxos/src/state_machine.rs
@@ -184,12 +184,28 @@ pub fn maybe_snapshot<S>(
     S: Storage<HighWaterCommand> + Send + 'static,
 {
     if policy.should_snapshot(decided_idx) {
+        // Count every attempt so the success rate is recoverable as
+        // `snapshot.total - snapshot.failures.total`.
+        #[cfg(feature = "metrics")]
+        metrics::counter!("tsoracle.paxos.snapshot.total").increment(1);
+
         let mut handle = omnipaxos.lock();
         // local_only=false: best-effort cluster-wide snapshot. Errors
         // are logged but not propagated; snapshot failure is not fatal
-        // for liveness.
-        if let Err(err) = handle.snapshot(Some(decided_idx), false) {
-            tracing::warn!(?err, "snapshot trigger failed");
+        // for liveness. A persistent failure would otherwise stay hidden
+        // behind log lines, so it is also counted as a health signal.
+        match handle.snapshot(Some(decided_idx), false) {
+            Ok(()) => {
+                // The last successfully-snapshotted index. Operators alert on
+                // this gauge ceasing to advance.
+                #[cfg(feature = "metrics")]
+                metrics::gauge!("tsoracle.paxos.snapshot.last_index").set(decided_idx as f64);
+            }
+            Err(err) => {
+                #[cfg(feature = "metrics")]
+                metrics::counter!("tsoracle.paxos.snapshot.failures.total").increment(1);
+                tracing::warn!(?err, "snapshot trigger failed");
+            }
         }
     }
 }
@@ -606,5 +622,142 @@ mod drain_tests {
         let mut policy = SnapshotPolicy::disabled();
         maybe_snapshot(&leader_handle(&cluster), &mut policy, 0);
         assert!(!policy.should_snapshot(u64::MAX));
+    }
+
+    #[cfg(feature = "metrics")]
+    mod snapshot_health_metrics {
+        //! `maybe_snapshot` must surface snapshot health as metrics: every
+        //! attempt bumps `tsoracle.paxos.snapshot.total`, a success sets the
+        //! `tsoracle.paxos.snapshot.last_index` gauge, and a failure bumps
+        //! `tsoracle.paxos.snapshot.failures.total` (instead of only logging).
+        //! A thread-local recorder captures real emission, not a mock.
+
+        use super::*;
+        use metrics_util::{
+            MetricKind,
+            debugging::{DebugValue, DebuggingRecorder},
+        };
+
+        type RecordedMetric = (
+            metrics_util::CompositeKey,
+            Option<metrics::Unit>,
+            Option<metrics::SharedString>,
+            DebugValue,
+        );
+
+        fn counter(snapshot: &[RecordedMetric], name: &str) -> u64 {
+            for (composite, _u, _d, value) in snapshot {
+                if composite.kind() == MetricKind::Counter && composite.key().name() == name {
+                    if let DebugValue::Counter(n) = value {
+                        return *n;
+                    }
+                }
+            }
+            0
+        }
+
+        fn gauge(snapshot: &[RecordedMetric], name: &str) -> Option<f64> {
+            for (composite, _u, _d, value) in snapshot {
+                if composite.kind() == MetricKind::Gauge && composite.key().name() == name {
+                    if let DebugValue::Gauge(g) = value {
+                        return Some(g.into_inner());
+                    }
+                }
+            }
+            None
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn successful_snapshot_emits_attempt_and_last_index_gauge() {
+            let mut cluster = build_cluster(3);
+            drive_to_leader_election(&mut cluster).await;
+
+            leader_handle(&cluster)
+                .lock()
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 1 }))
+                .expect("append");
+            drive_until(
+                &mut cluster,
+                |state| {
+                    state
+                        .nodes
+                        .iter()
+                        .all(|node| node.omnipaxos.lock().get_decided_idx() >= 1)
+                },
+                500,
+            )
+            .await;
+
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            let handle = leader_handle(&cluster);
+            let mut policy = SnapshotPolicy::every(1);
+            metrics::with_local_recorder(&recorder, || maybe_snapshot(&handle, &mut policy, 1));
+
+            let snapshot = snapshotter.snapshot().into_vec();
+            assert_eq!(
+                counter(&snapshot, "tsoracle.paxos.snapshot.total"),
+                1,
+                "a fired snapshot attempt must be counted",
+            );
+            assert_eq!(
+                gauge(&snapshot, "tsoracle.paxos.snapshot.last_index"),
+                Some(1.0),
+                "a successful snapshot must publish its decided index as the health gauge",
+            );
+            assert_eq!(
+                counter(&snapshot, "tsoracle.paxos.snapshot.failures.total"),
+                0,
+                "a successful snapshot must not be counted as a failure",
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn failed_snapshot_increments_failure_counter() {
+            let mut cluster = build_cluster(3);
+            drive_to_leader_election(&mut cluster).await;
+
+            leader_handle(&cluster)
+                .lock()
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 1 }))
+                .expect("append");
+            drive_until(
+                &mut cluster,
+                |state| {
+                    state
+                        .nodes
+                        .iter()
+                        .all(|node| node.omnipaxos.lock().get_decided_idx() >= 1)
+                },
+                500,
+            )
+            .await;
+
+            // Request a snapshot far beyond the decided index. OmniPaxos rejects
+            // compaction past what has been decided, so the snapshot fails — the
+            // failure path `maybe_snapshot` previously only logged.
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            let handle = leader_handle(&cluster);
+            let mut policy = SnapshotPolicy::every(1);
+            metrics::with_local_recorder(&recorder, || maybe_snapshot(&handle, &mut policy, 999));
+
+            let snapshot = snapshotter.snapshot().into_vec();
+            assert_eq!(
+                counter(&snapshot, "tsoracle.paxos.snapshot.total"),
+                1,
+                "the rejected snapshot is still an attempt",
+            );
+            assert_eq!(
+                counter(&snapshot, "tsoracle.paxos.snapshot.failures.total"),
+                1,
+                "a rejected snapshot must increment the failure counter",
+            );
+            assert_eq!(
+                gauge(&snapshot, "tsoracle.paxos.snapshot.last_index"),
+                None,
+                "a failed snapshot must not advance the last-index health gauge",
+            );
+        }
     }
 }

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -22,10 +22,12 @@ default            = ["rocksdb-storage"]
 rocksdb-storage    = ["dep:rocksdb"]
 test-fakes         = []
 failpoints         = ["tsoracle-failpoint/failpoints"]
+metrics            = ["dep:metrics"]
 
 [dependencies]
 async-trait        = { workspace = true }
 futures            = { workspace = true }
+metrics            = { workspace = true, optional = true }
 omnipaxos          = { workspace = true, features = ["serde"] }
 parking_lot        = { workspace = true }
 pastey             = { workspace = true }
@@ -41,6 +43,7 @@ tsoracle-core      = { path = "../tsoracle-core", version = "0.2.1" }
 tsoracle-failpoint = { workspace = true }
 
 [dev-dependencies]
+metrics-util       = { workspace = true }
 rocksdb            = { workspace = true }
 tempfile           = { workspace = true }
 tokio              = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
@@ -132,15 +132,38 @@ impl<T: Entry> RocksdbStorage<T> {
         Ok(())
     }
 
-    pub(crate) fn batch_async<F>(&self, f: F) -> Result<(), StorageError>
+    /// Run a non-synced batch write, tagged with the OmniPaxos storage
+    /// operation `op` driving it (`set_decided_idx`, `set_compacted_idx`,
+    /// `trim`, `set_snapshot`, `set_stopsign`). On failure, the error is
+    /// counted under `tsoracle.paxos.storage.async_write_failures.total`
+    /// (labelled by `op`) before being returned, so a recurring async-write
+    /// fault surfaces as an operational signal instead of only flowing up as a
+    /// `StorageResult` the caller may swallow. The counter lives on the error
+    /// path, so the hot apply-path write pays only a branch.
+    pub(crate) fn batch_async<F>(&self, op: &'static str, f: F) -> Result<(), StorageError>
     where
         F: FnOnce(Arc<BoundColumnFamily<'_>>, &mut WriteBatch) -> Result<(), StorageError>,
     {
-        let cf = self.cf()?;
-        let mut batch = WriteBatch::default();
-        f(cf, &mut batch)?;
-        self.db.write_opt(batch, &Self::write_async_opts())?;
-        Ok(())
+        // `op` is read only by the failpoint message and the failure counter;
+        // keep it live when both of those are compiled out.
+        #[cfg(not(any(feature = "metrics", feature = "failpoints")))]
+        let _ = op;
+        let result = (|| {
+            tsoracle_failpoint::failpoint!("paxos_toolkit::storage::async_write", |_| Err(
+                StorageError::LogIntegrity(format!("async_write failpoint armed for {op}"))
+            ));
+            let cf = self.cf()?;
+            let mut batch = WriteBatch::default();
+            f(cf, &mut batch)?;
+            self.db.write_opt(batch, &Self::write_async_opts())?;
+            Ok(())
+        })();
+        #[cfg(feature = "metrics")]
+        if result.is_err() {
+            metrics::counter!("tsoracle.paxos.storage.async_write_failures.total", "op" => op)
+                .increment(1);
+        }
+        result
     }
 }
 
@@ -275,7 +298,7 @@ where
         use crate::storage::key_space::meta_decided_idx_key;
         use crate::storage::meta::encode_u64;
         let bytes = encode_u64(ld);
-        self.batch_async(|cf, batch| {
+        self.batch_async("set_decided_idx", |cf, batch| {
             batch.put_cf(&cf, meta_decided_idx_key(), bytes);
             Ok(())
         })
@@ -418,14 +441,14 @@ where
         match stopsign {
             Some(inner) => {
                 let bytes = encode_postcard(&inner).map_err(box_err)?;
-                self.batch_async(|cf, batch| {
+                self.batch_async("set_stopsign", |cf, batch| {
                     batch.put_cf(&cf, meta_stopsign_key(), bytes);
                     Ok(())
                 })
                 .map_err(box_err)?;
             }
             None => {
-                self.batch_async(|cf, batch| {
+                self.batch_async("set_stopsign", |cf, batch| {
                     batch.delete_cf(&cf, meta_stopsign_key());
                     Ok(())
                 })
@@ -449,7 +472,7 @@ where
 
     fn trim(&mut self, idx: u64) -> omnipaxos::storage::StorageResult<()> {
         use crate::storage::key_space::log_key;
-        self.batch_async(|cf, batch| {
+        self.batch_async("trim", |cf, batch| {
             let lower = log_key(0);
             let upper = log_key(idx);
             batch.delete_range_cf(&cf, &lower, &upper);
@@ -463,7 +486,7 @@ where
         use crate::storage::key_space::meta_compacted_idx_key;
         use crate::storage::meta::encode_u64;
         let bytes = encode_u64(idx);
-        self.batch_async(|cf, batch| {
+        self.batch_async("set_compacted_idx", |cf, batch| {
             batch.put_cf(&cf, meta_compacted_idx_key(), bytes);
             Ok(())
         })
@@ -484,14 +507,14 @@ where
         match snapshot {
             Some(snap) => {
                 let bytes = encode_postcard(&snap).map_err(box_err)?;
-                self.batch_async(|cf, batch| {
+                self.batch_async("set_snapshot", |cf, batch| {
                     batch.put_cf(&cf, meta_snapshot_key(), bytes);
                     Ok(())
                 })
                 .map_err(box_err)?;
             }
             None => {
-                self.batch_async(|cf, batch| {
+                self.batch_async("set_snapshot", |cf, batch| {
                     batch.delete_cf(&cf, meta_snapshot_key());
                     Ok(())
                 })
@@ -886,6 +909,218 @@ mod decided_compacted_tests {
         let single = storage.get_entries(4, 5).unwrap();
         assert_eq!(single.len(), 1);
         assert_eq!(single[0].value, 88);
+    }
+}
+
+#[cfg(all(test, feature = "rocksdb-storage"))]
+mod crash_recovery_conformance {
+    //! Crash-conformance for the snapshot/compaction sequence
+    //! (`set_snapshot` / `trim` / `set_compacted_idx`).
+    //!
+    //! These writes are non-synced (`batch_async`), so a crash can lose a
+    //! suffix of them. RocksDB's WAL is append-only and recovery replays a
+    //! *prefix* of the issued writes — a crash can drop the tail but never
+    //! resurrect an earlier write while losing a later one. Because OmniPaxos
+    //! (and this crate's own pairing tests) issue `trim(idx)` before
+    //! `set_compacted_idx(idx)`, the realistic partial-crash state is "trim
+    //! persisted, compacted-index update lost", which the failpoint test below
+    //! reproduces faithfully.
+    //!
+    //! fsync itself is not in-process observable (a clean drop + reopen flushes
+    //! everything), so a lost write is modeled by making that specific write
+    //! fail, not by toggling the sync flag.
+
+    use super::open_in_tests::{TestEntry, TestSnapshot, open_db};
+    use super::*;
+    use omnipaxos::storage::Storage;
+    use tempfile::TempDir;
+
+    #[test]
+    fn full_ordered_compaction_sequence_survives_reopen() {
+        // set_snapshot -> trim -> set_compacted_idx, all persisted, then reopen.
+        // The snapshot, the compacted offset, and the surviving suffix must all
+        // recover consistently, and the next append must continue past them.
+        let dir = TempDir::new().unwrap();
+        {
+            let db = open_db(&dir, "tso_paxos");
+            let mut storage: RocksdbStorage<TestEntry> =
+                RocksdbStorage::open_in(db, "tso_paxos").unwrap();
+            storage
+                .append_entries(vec![
+                    TestEntry { value: 10 },
+                    TestEntry { value: 20 },
+                    TestEntry { value: 30 },
+                    TestEntry { value: 40 },
+                ])
+                .unwrap();
+            storage
+                .set_snapshot(Some(TestSnapshot { value: 30 }))
+                .unwrap();
+            storage.trim(3).unwrap();
+            storage.set_compacted_idx(3).unwrap();
+        }
+
+        let db = open_db(&dir, "tso_paxos");
+        let mut storage: RocksdbStorage<TestEntry> =
+            RocksdbStorage::open_in(db, "tso_paxos").unwrap();
+        assert_eq!(storage.get_compacted_idx().unwrap(), 3);
+        assert_eq!(storage.get_snapshot().unwrap().expect("snapshot").value, 30);
+        let suffix = storage.get_suffix(3).unwrap();
+        assert_eq!(suffix.len(), 1);
+        assert_eq!(
+            suffix[0].value, 40,
+            "the single surviving entry lives at idx 3"
+        );
+
+        let new_len = storage.append_entry(TestEntry { value: 99 }).unwrap();
+        assert_eq!(new_len, 2, "physical remaining = (4+1) - 3");
+        let single = storage.get_entries(4, 5).unwrap();
+        assert_eq!(single.len(), 1);
+        assert_eq!(
+            single[0].value, 99,
+            "next append continues at absolute idx 4"
+        );
+    }
+
+    #[cfg(feature = "failpoints")]
+    #[test]
+    fn lost_compacted_index_after_trim_recovers_forward_only() {
+        // Realistic crash: trim persists, then the set_compacted_idx write is
+        // lost (the WAL tail is truncated past trim). On reopen the compacted
+        // offset is stale-low, but recovery must stay forward-only — surviving
+        // entries remain readable at their absolute indices, no phantom entry
+        // appears at a low index, and the next append lands past the survivors
+        // rather than overwriting one.
+        let dir = TempDir::new().unwrap();
+        {
+            let db = open_db(&dir, "tso_paxos");
+            let mut storage: RocksdbStorage<TestEntry> =
+                RocksdbStorage::open_in(db, "tso_paxos").unwrap();
+            storage
+                .append_entries(vec![
+                    TestEntry { value: 1 },
+                    TestEntry { value: 2 },
+                    TestEntry { value: 3 },
+                    TestEntry { value: 4 },
+                ])
+                .unwrap();
+            // trim persists (deletes physical keys 0,1).
+            storage.trim(2).unwrap();
+            // The paired compacted-index update is lost in the crash.
+            tsoracle_failpoint::fail::cfg("paxos_toolkit::storage::async_write", "return").unwrap();
+            let lost = storage.set_compacted_idx(2);
+            tsoracle_failpoint::fail::remove("paxos_toolkit::storage::async_write");
+            assert!(
+                lost.is_err(),
+                "the failpoint must drop the compacted-index write"
+            );
+        }
+
+        let db = open_db(&dir, "tso_paxos");
+        let mut storage: RocksdbStorage<TestEntry> =
+            RocksdbStorage::open_in(db, "tso_paxos").unwrap();
+        assert_eq!(
+            storage.get_compacted_idx().unwrap(),
+            0,
+            "the lost compacted-index update leaves the offset stale-low",
+        );
+        // The trimmed-but-uncompacted entries are still readable at their
+        // absolute indices; the trimmed-away keys 0,1 do NOT reappear.
+        let suffix = storage.get_suffix(0).unwrap();
+        assert_eq!(suffix.len(), 2, "only the untrimmed entries survive");
+        assert_eq!(suffix[0].value, 3);
+        assert_eq!(suffix[1].value, 4);
+
+        // Forward-only: the next append lands at idx 4 (past the survivors at
+        // 2,3), never overwriting a survivor or planting a phantom at idx 0.
+        storage.append_entry(TestEntry { value: 99 }).unwrap();
+        let single = storage.get_entries(4, 5).unwrap();
+        assert_eq!(single.len(), 1);
+        assert_eq!(single[0].value, 99);
+        let suffix = storage.get_suffix(2).unwrap();
+        assert_eq!(suffix.len(), 3);
+        assert_eq!(suffix[2].value, 99);
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "metrics",
+    feature = "failpoints",
+    feature = "rocksdb-storage"
+))]
+mod async_write_metrics_tests {
+    //! A failing async (non-synced) write must increment
+    //! `tsoracle.paxos.storage.async_write_failures.total`, labelled with the
+    //! storage operation that failed. The `async_write` failpoint forces the
+    //! `batch_async` body to return an error; a thread-local recorder captures
+    //! the emitted counter so the assertion observes real emission, not a mock.
+
+    use super::log_tests::fresh_storage;
+    use metrics_util::{
+        MetricKind,
+        debugging::{DebugValue, DebuggingRecorder},
+    };
+    use omnipaxos::storage::Storage;
+    use tempfile::TempDir;
+
+    const ASYNC_WRITE_FP: &str = "paxos_toolkit::storage::async_write";
+
+    /// Counter value for `name` whose label set contains `op = <expected_op>`.
+    fn counter_with_op(
+        snapshot: &[(
+            metrics_util::CompositeKey,
+            Option<metrics::Unit>,
+            Option<metrics::SharedString>,
+            DebugValue,
+        )],
+        name: &str,
+        expected_op: &str,
+    ) -> u64 {
+        for (composite, _unit, _desc, value) in snapshot {
+            if composite.kind() != MetricKind::Counter || composite.key().name() != name {
+                continue;
+            }
+            let has_op = composite
+                .key()
+                .labels()
+                .any(|label| label.key() == "op" && label.value() == expected_op);
+            if has_op {
+                if let DebugValue::Counter(n) = value {
+                    return *n;
+                }
+            }
+        }
+        0
+    }
+
+    #[test]
+    fn failed_async_write_increments_labelled_failure_counter() {
+        let dir = TempDir::new().unwrap();
+        let mut storage = fresh_storage(&dir);
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        tsoracle_failpoint::fail::cfg(ASYNC_WRITE_FP, "return").unwrap();
+        let result = metrics::with_local_recorder(&recorder, || storage.set_compacted_idx(5));
+        tsoracle_failpoint::fail::remove(ASYNC_WRITE_FP);
+
+        assert!(
+            result.is_err(),
+            "armed failpoint must surface a write error"
+        );
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert_eq!(
+            counter_with_op(
+                &snapshot,
+                "tsoracle.paxos.storage.async_write_failures.total",
+                "set_compacted_idx",
+            ),
+            1,
+            "a failed set_compacted_idx must increment the op-labelled failure counter once",
+        );
     }
 }
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,7 +14,7 @@ Default is 1 second. On leadership gain, the new leader first computes `serving_
 
 ## Monitoring hooks
 
-Both `tsoracle-server` and `tsoracle-client` emit signals through the [`metrics`](https://docs.rs/metrics) crate facade. Emission is gated behind the `metrics` Cargo feature on each crate (off by default so the dependency stays opt-in for embedders who do not want it). The client additionally emits structured events through the [`tracing`](https://docs.rs/tracing) crate; `tracing` is on by default for `tsoracle-client` (matching `tsoracle-server`).
+`tsoracle-server`, `tsoracle-client`, and the OmniPaxos backend (`tsoracle-driver-paxos` / `tsoracle-paxos-toolkit`) emit signals through the [`metrics`](https://docs.rs/metrics) crate facade. Emission is gated behind the `metrics` Cargo feature on each crate (off by default so the dependency stays opt-in for embedders who do not want it); enabling the feature on `tsoracle-driver-paxos` also turns it on for the toolkit it depends on. The client additionally emits structured events through the [`tracing`](https://docs.rs/tracing) crate; `tracing` is on by default for `tsoracle-client` (matching `tsoracle-server`).
 
 **Server signals**
 
@@ -26,6 +26,13 @@ Both `tsoracle-server` and `tsoracle-client` emit signals through the [`metrics`
 - `tsoracle.leader_transition.fence_latency` — duration of the failover fence (histogram, seconds)
 - `tsoracle.leader_transition.fence_transient_retries.total` — fence retried a transient consensus error during failover (counter)
 - `tsoracle.not_leader.total` — RPCs rejected with `NOT_LEADER` (counter)
+
+**Paxos consensus signals** (emitted by `tsoracle-driver-paxos` / `tsoracle-paxos-toolkit` when their `metrics` feature is enabled)
+
+- `tsoracle.paxos.snapshot.total` — snapshot attempts triggered by the snapshot policy after a successful apply (counter)
+- `tsoracle.paxos.snapshot.failures.total` — snapshot attempts the OmniPaxos handle rejected (counter). Snapshot failure is non-fatal for liveness, so the success rate is `total - failures`; a sustained non-zero rate points at a degrading snapshot/compaction path.
+- `tsoracle.paxos.snapshot.last_index` — decided index of the last snapshot that succeeded (gauge). This should keep advancing under load; a stall while `snapshot.total` keeps climbing means snapshots are firing but failing.
+- `tsoracle.paxos.storage.async_write_failures.total{op}` — non-synced RocksDB storage writes that failed (counter). `op` is one of `set_decided_idx`, `set_compacted_idx`, `trim`, `set_snapshot`, `set_stopsign`. These writes are recoverable after a crash, so a failure is not immediately fatal, but a recurring rate signals disk pressure or storage faults that would otherwise stay hidden in logs.
 
 **Client signals**
 


### PR DESCRIPTION
Closes #359.

## Problem

Two failure classes in the OmniPaxos backend were visible only as log lines:

- **Snapshot-trigger failures** — `maybe_snapshot` (`crates/tsoracle-driver-paxos/src/state_machine.rs`) logged `warn!("snapshot trigger failed")` and continued. A repeatedly-failing snapshot stayed hidden until it surfaced as slow recovery or disk pressure.
- **Async-persistence write failures** — every non-fsync'd write (`set_decided_idx`, `set_compacted_idx`, `trim`, `set_snapshot`, `set_stopsign`) flows through `RocksdbStorage::batch_async`. Errors propagated up as `StorageResult` but were never counted.

This is an observability gap, not a correctness bug. No behavior changes beyond emitting metrics.

## Changes

New `metrics`-crate signals (namespace `tsoracle.paxos.*`), gated behind an optional `metrics` feature on each crate (off by default, matching the `tsoracle-server` / `tsoracle-client` convention; enabling it on `tsoracle-driver-paxos` also enables the toolkit's):

| Metric | Type | Meaning |
|---|---|---|
| `tsoracle.paxos.snapshot.total` | counter | snapshot attempts |
| `tsoracle.paxos.snapshot.failures.total` | counter | rejected attempts (success rate = total − failures) |
| `tsoracle.paxos.snapshot.last_index` | gauge | last successfully-snapshotted decided index; should keep advancing |
| `tsoracle.paxos.storage.async_write_failures.total{op}` | counter | non-synced write failures, labelled by storage op |

`batch_async` gains an `op` tag and emits the failure counter on its error arm only, so the hot apply-path write pays just a branch. `batch_sync` (the fsync'd, safety-critical path) is intentionally untouched — out of scope for this issue.

`docs/operations.md` documents the new signals under a "Paxos consensus signals" subsection.

## Tests

All counter work was done test-first (red → green):

- **`failed_async_write_increments_labelled_failure_counter`** — a new `paxos_toolkit::storage::async_write` failpoint forces a `set_compacted_idx` write to fail; asserts the op-labelled counter via a thread-local `DebuggingRecorder` (real emission, not a mock).
- **`successful_snapshot_emits_attempt_and_last_index_gauge`** / **`failed_snapshot_increments_failure_counter`** — drive a real OmniPaxos snapshot (success) and a real `CompactionErr` (requesting a snapshot past the decided index) for the failure arm.
- **Crash-conformance** — `full_ordered_compaction_sequence_survives_reopen` plus `lost_compacted_index_after_trim_recovers_forward_only`. The latter models the realistic suffix-truncation crash (trim persisted, `set_compacted_idx` lost) via the new failpoint and asserts recovery stays forward-only with no phantom writes. fsync is not in-process observable, so a lost write is modeled by making that write fail rather than toggling the sync flag.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked` — green
- Builds warning-free with `metrics` off and across all `metrics`/`failpoints` feature combos

## Out of scope / follow-ups

- Instrumenting the synchronous (fsync'd) write path.
- Wiring the `metrics` feature into example binaries — operators opt in like they do for the server/client features.
- An exhaustive partial-persistence crash matrix across every survival subset of the compaction sequence.