### PR TITLE
feat(consensus): give the high-water advance rule a single home via AdvancePayload::merge

### DIFF
--- a/crates/tsoracle-consensus/src/advance.rs
+++ b/crates/tsoracle-consensus/src/advance.rs
@@ -34,6 +34,21 @@ pub struct AdvancePayload {
     pub at_least: u64,
 }
 
+impl AdvancePayload {
+    /// Apply this advance to a `current` high-water, returning the new value.
+    ///
+    /// This is the single home for the monotonic apply rule — `max(current,
+    /// at_least)` — that every backend's state machine runs when it applies a
+    /// decided `Advance`. Folding the rule into one named method (rather than
+    /// re-spelling the `if at_least > current` comparison at each apply site)
+    /// gives the "advance only ratchets up" invariant one test and one place to
+    /// reason about its idempotence and reorder-independence.
+    #[must_use]
+    pub fn merge(self, current: u64) -> u64 {
+        current.max(self.at_least)
+    }
+}
+
 /// The error carried by a rejected out-of-range high-water advance. See
 /// [`reject_out_of_range_advance`].
 #[derive(Debug, thiserror::Error)]
@@ -97,6 +112,40 @@ mod tests {
             let back: AdvancePayload = postcard::from_bytes(&bytes).expect("deserialize");
             assert_eq!(back, payload);
         }
+    }
+
+    #[test]
+    fn merge_is_monotone_under_reordering_and_retries() {
+        // The single home for the high-water apply rule: `current = max(current,
+        // at_least)`. A higher advance ratchets the value up; a stale or
+        // duplicate advance (at or below `current`) is absorbed without moving
+        // it, which is exactly what makes the command idempotent and
+        // order-independent across every backend's apply path.
+        assert_eq!(
+            AdvancePayload { at_least: 7 }.merge(3),
+            7,
+            "higher advance ratchets up"
+        );
+        assert_eq!(
+            AdvancePayload { at_least: 3 }.merge(7),
+            7,
+            "stale advance is absorbed"
+        );
+        assert_eq!(
+            AdvancePayload { at_least: 5 }.merge(5),
+            5,
+            "equal advance is idempotent"
+        );
+        assert_eq!(
+            AdvancePayload { at_least: 0 }.merge(0),
+            0,
+            "zero from a fresh state stays zero"
+        );
+        assert_eq!(
+            AdvancePayload { at_least: u64::MAX }.merge(0),
+            u64::MAX,
+            "the extreme advance ratchets to the maximum",
+        );
     }
 
     #[test]

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -51,7 +51,6 @@ use tsoracle_openraft_toolkit::{SCHEMA_VERSION, decode, encode};
 use crate::log_entry::HighWaterCommand;
 use crate::snapshot_store::{InMemorySnapshotStore, SnapshotStore};
 use crate::type_config::{HighWaterApplied, TypeConfig};
-use tsoracle_consensus::AdvancePayload;
 
 type LogId = LogIdOf<TypeConfig>;
 type SnapMeta = SnapshotMetaOf<TypeConfig>;
@@ -295,11 +294,9 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                     }
                 }
                 EntryPayload::Normal(cmd) => {
-                    let HighWaterCommand::Advance(AdvancePayload { at_least }) = cmd;
+                    let HighWaterCommand::Advance(advance) = cmd;
                     let mut core = self.core.lock();
-                    if *at_least > core.current_value {
-                        core.current_value = *at_least;
-                    }
+                    core.current_value = advance.merge(core.current_value);
                     core.last_applied = Some(log_id);
                     HighWaterApplied {
                         value: core.current_value,

--- a/crates/tsoracle-driver-paxos/src/log_entry.rs
+++ b/crates/tsoracle-driver-paxos/src/log_entry.rs
@@ -60,10 +60,8 @@ impl omnipaxos::storage::Snapshot<HighWaterCommand> for HighWaterSnapshot {
         let mut applied_barriers: HashMap<u64, u64> = HashMap::new();
         for command in entries {
             match command {
-                HighWaterCommand::Advance(AdvancePayload { at_least }) => {
-                    if *at_least > value {
-                        value = *at_least;
-                    }
+                HighWaterCommand::Advance(advance) => {
+                    value = advance.merge(value);
                 }
                 HighWaterCommand::Barrier { node, seq } => {
                     let slot = applied_barriers.entry(*node).or_insert(0);

--- a/crates/tsoracle-driver-paxos/src/state_machine.rs
+++ b/crates/tsoracle-driver-paxos/src/state_machine.rs
@@ -40,6 +40,7 @@ use tracing::trace;
 
 use crate::log_entry::HighWaterCommand;
 use crate::snapshot_policy::SnapshotPolicy;
+#[cfg(test)]
 use tsoracle_consensus::AdvancePayload;
 
 /// Shared apply-task state.
@@ -126,11 +127,12 @@ where
     if let Some(entries) = entries {
         for entry in &entries {
             match entry {
-                LogEntry::Decided(HighWaterCommand::Advance(AdvancePayload { at_least })) => {
+                LogEntry::Decided(HighWaterCommand::Advance(advance)) => {
                     let prev = state.high_water.load(Ordering::SeqCst);
-                    if *at_least > prev {
-                        state.high_water.store(*at_least, Ordering::SeqCst);
-                        trace!(prev, new = at_least, "high-water advanced");
+                    let new = advance.merge(prev);
+                    if new > prev {
+                        state.high_water.store(new, Ordering::SeqCst);
+                        trace!(prev, new, "high-water advanced");
                     }
                 }
                 LogEntry::Decided(HighWaterCommand::Barrier { node, seq }) => {


### PR DESCRIPTION
## Summary

The monotonic high-water apply rule — `current = max(current, at_least)`, the one piece of genuine cross-backend *business* logic — was reimplemented as an inline `if at_least > current` at three apply sites across two driver crates:

- `tsoracle-driver-paxos` `state_machine.rs` (`drain_decided_into`)
- `tsoracle-driver-paxos` `log_entry.rs` (`HighWaterSnapshot::create`)
- `tsoracle-driver-openraft` `state_machine.rs` (`apply`)

This adds `AdvancePayload::merge(self, current) -> u64` in `tsoracle-consensus` as the single named home for the invariant, gives it one focused test, and rewires all three sites to call it. Reinforces the shared-payload design from #267.

Behavior is unchanged at every site: each previously ran `if at_least > current` and `merge` returns the same `max`. The paxos `drain_decided_into` site keeps its `if new > prev` guard so the `"high-water advanced"` trace still fires only on a real advance (and the traced `new` value is identical, since `merge` returns `at_least` exactly when `at_least > prev`). The two pure-assignment sites had a redundant guard that the method subsumes. The now test-only `AdvancePayload` imports in the two `state_machine.rs` files were narrowed accordingly (`#[cfg(test)]` / removed).

Labelled `feat` rather than the issue's `refactor` label: it adds a public method to a library crate consumed by the driver crates, and under release-plz's `release_commits = "^(feat|fix|perf)"` filter a `refactor`-labelled public-API add would not publish a new `tsoracle-consensus` version — a dependent referencing the new symbol would then fail `cargo publish --verify` against the stale registry.

Closes #348

## Test Plan

- [x] New unit test `merge_is_monotone_under_reordering_and_retries` pins the invariant (higher advance ratchets up, stale/duplicate absorbed, equal is idempotent, zero stays zero, `u64::MAX` extreme) — watched it fail (RED, method missing) before implementing
- [x] `cargo fmt --all --check` clean (also enforced by pre-commit hook)
- [x] `cargo clippy --workspace --all-targets --all-features` — no warnings
- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo test --workspace --all-features` — all green, 0 failures (existing per-backend apply tests guard the behavior-preserving rewire)