### PR TITLE
refactor(client): thread compact TimestampRange through decode and delivery

### DIFF
--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -27,6 +27,7 @@ use tsoracle_core::Timestamp;
 
 use crate::MAX_TIMESTAMPS_PER_RPC;
 use crate::error::ClientError;
+use crate::response::TimestampRange;
 
 /// Bound on the total number of waiters that can exist inside the driver
 /// at any moment. A slow server combined with a fast caller must not grow
@@ -58,7 +59,7 @@ pub(crate) struct Driver {
 }
 
 type RpcFn = Arc<
-    dyn Fn(u32) -> futures::future::BoxFuture<'static, Result<Vec<Timestamp>, ClientError>>
+    dyn Fn(u32) -> futures::future::BoxFuture<'static, Result<TimestampRange, ClientError>>
         + Send
         + Sync,
 >;
@@ -73,7 +74,7 @@ type BatchHandle = tokio::task::JoinHandle<()>;
 impl Driver {
     pub fn spawn<F>(rpc: F, flush_interval: Duration) -> Self
     where
-        F: Fn(u32) -> futures::future::BoxFuture<'static, Result<Vec<Timestamp>, ClientError>>
+        F: Fn(u32) -> futures::future::BoxFuture<'static, Result<TimestampRange, ClientError>>
             + Send
             + Sync
             + 'static,
@@ -303,16 +304,16 @@ fn set_in_flight_gauge(state: u8) {
 /// timestamps.
 fn deliver(
     waiters: &mut VecDeque<Waiter>,
-    result: Result<Vec<Timestamp>, ClientError>,
+    result: Result<TimestampRange, ClientError>,
     expected: u32,
 ) {
     match result {
-        Ok(all) => {
-            if all.len() != expected as usize {
+        Ok(range) => {
+            if range.count() != expected {
                 let msg = format!(
                     "tsoracle protocol violation: requested {} timestamps, server returned {}",
                     expected,
-                    all.len(),
+                    range.count(),
                 );
                 while let Some(w) = waiters.pop_front() {
                     let _ = w
@@ -321,7 +322,7 @@ fn deliver(
                 }
                 return;
             }
-            let mut iter = all.into_iter();
+            let mut iter = range.iter();
             while let Some(w) = waiters.pop_front() {
                 let slice: Vec<Timestamp> = iter.by_ref().take(w.count as usize).collect();
                 debug_assert_eq!(
@@ -382,7 +383,7 @@ mod tests {
     /// exactly that many timestamps. Used to assert chunking shape.
     fn recording_ok_rpc(
         calls: Arc<Mutex<Vec<u32>>>,
-    ) -> impl Fn(u32) -> futures::future::BoxFuture<'static, Result<Vec<Timestamp>, ClientError>>
+    ) -> impl Fn(u32) -> futures::future::BoxFuture<'static, Result<TimestampRange, ClientError>>
     + Send
     + Sync
     + 'static {
@@ -390,10 +391,7 @@ mod tests {
             let calls = calls.clone();
             Box::pin(async move {
                 calls.lock().push(count);
-                let timestamps: Vec<Timestamp> = (0..count)
-                    .map(|i| Timestamp::pack(1_000, i % (LOGICAL_MAX + 1)))
-                    .collect();
-                Ok(timestamps)
+                Ok(TimestampRange::new(1_000, 0, count))
             })
         }
     }
@@ -516,14 +514,11 @@ mod tests {
     async fn short_response_errors_waiters_in_chunk() {
         let rpc = |count: u32| -> futures::future::BoxFuture<
             'static,
-            Result<Vec<Timestamp>, ClientError>,
+            Result<TimestampRange, ClientError>,
         > {
             Box::pin(async move {
                 let short = count.saturating_sub(1);
-                let timestamps: Vec<Timestamp> = (0..short)
-                    .map(|i| Timestamp::pack(1_000, i % (LOGICAL_MAX + 1)))
-                    .collect();
-                Ok(timestamps)
+                Ok(TimestampRange::new(1_000, 0, short))
             })
         };
         let driver = Driver::spawn(rpc, Duration::ZERO);
@@ -540,14 +535,11 @@ mod tests {
     async fn long_response_errors_waiters_in_chunk() {
         let rpc = |count: u32| -> futures::future::BoxFuture<
             'static,
-            Result<Vec<Timestamp>, ClientError>,
+            Result<TimestampRange, ClientError>,
         > {
             Box::pin(async move {
                 let long = count.saturating_add(3);
-                let timestamps: Vec<Timestamp> = (0..long)
-                    .map(|i| Timestamp::pack(1_000, i % (LOGICAL_MAX + 1)))
-                    .collect();
-                Ok(timestamps)
+                Ok(TimestampRange::new(1_000, 0, long))
             })
         };
         let driver = Driver::spawn(rpc, Duration::ZERO);
@@ -691,7 +683,7 @@ mod tests {
         let calls_for_rpc = rpc_calls.clone();
         let rpc = move |_count: u32| -> futures::future::BoxFuture<
             'static,
-            Result<Vec<Timestamp>, ClientError>,
+            Result<TimestampRange, ClientError>,
         > {
             calls_for_rpc.fetch_add(1, Ordering::Relaxed);
             Box::pin(async {
@@ -752,7 +744,7 @@ mod tests {
         let released_rx_for_rpc = released_rx.clone();
         let rpc = move |count: u32| -> futures::future::BoxFuture<
             'static,
-            Result<Vec<Timestamp>, ClientError>,
+            Result<TimestampRange, ClientError>,
         > {
             let is_first = rpc_invocations_for_rpc.fetch_add(1, Ordering::SeqCst) == 0;
             let mut released = released_rx_for_rpc.clone();
@@ -767,10 +759,7 @@ mod tests {
                     }
                 }
                 calls.lock().push(count);
-                let timestamps: Vec<Timestamp> = (0..count)
-                    .map(|i| Timestamp::pack(1_000, i % (LOGICAL_MAX + 1)))
-                    .collect();
-                Ok(timestamps)
+                Ok(TimestampRange::new(1_000, 0, count))
             })
         };
 
@@ -828,7 +817,7 @@ mod tests {
         let release_second_for_rpc = release_second.clone();
         let rpc = move |count: u32| -> futures::future::BoxFuture<
             'static,
-            Result<Vec<Timestamp>, ClientError>,
+            Result<TimestampRange, ClientError>,
         > {
             let invocation = rpc_invocations_for_rpc.fetch_add(1, Ordering::SeqCst);
             let release = release_second_for_rpc.clone();
@@ -838,10 +827,7 @@ mod tests {
                 if invocation >= 1 {
                     release.notified().await;
                 }
-                let timestamps: Vec<Timestamp> = (0..count)
-                    .map(|i| Timestamp::pack(1_000, i % (LOGICAL_MAX + 1)))
-                    .collect();
-                Ok(timestamps)
+                Ok(TimestampRange::new(1_000, 0, count))
             })
         };
 
@@ -891,7 +877,7 @@ mod tests {
     async fn rpc_closure_panic_surfaces_as_driver_gone() {
         let rpc = |_count: u32| -> futures::future::BoxFuture<
             'static,
-            Result<Vec<Timestamp>, ClientError>,
+            Result<TimestampRange, ClientError>,
         > {
             Box::pin(async {
                 panic!("synthetic panic exercising driver supervision");

--- a/crates/tsoracle-client/src/response.rs
+++ b/crates/tsoracle-client/src/response.rs
@@ -10,8 +10,8 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-//! Decode a `GetTsResponse` into `Vec<Timestamp>` with the protocol-level
-//! safety checks the retry loop used to perform inline.
+//! Decode a `GetTsResponse` into a validated [`TimestampRange`] with the
+//! protocol-level safety checks the retry loop used to perform inline.
 //!
 //! All checks (count match, range, physical range, logical overflow) are moved
 //! verbatim from `lib.rs::issue_rpc` and surface the same
@@ -25,10 +25,57 @@ use tsoracle_proto::v1::GetTsResponse;
 use crate::MAX_TIMESTAMPS_PER_RPC;
 use crate::error::ClientError;
 
+/// A compact, validated view of a `GetTsResponse`'s contiguous timestamp
+/// range: the three wire fields (`physical_ms`, `logical_start`, `count`)
+/// instead of an expanded `Vec<Timestamp>`. A maxed-out chunk stays ~16 bytes
+/// from decode through coalescing and delivery rather than ballooning into
+/// ~2 MB; the `Vec<Timestamp>` is materialized only per waiter, in
+/// `driver::deliver`, at the public-API boundary.
+///
+/// Valid-by-construction: the only non-test producer is
+/// [`decode_get_ts_response`], which validates `physical_ms` and the full
+/// logical span before constructing the range. That invariant is what lets
+/// [`TimestampRange::iter`] pack with the infallible [`Timestamp::pack`].
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TimestampRange {
+    physical_ms: u64,
+    logical_start: u32,
+    count: u32,
+}
+
+impl TimestampRange {
+    /// Construct a range from its wire fields. The caller must ensure the
+    /// fields are in range — `physical_ms <= PHYSICAL_MS_MAX` and
+    /// `logical_start + count - 1 <= LOGICAL_MAX`. `decode_get_ts_response`
+    /// validates this before calling; test stubs pass known-good values.
+    pub(crate) fn new(physical_ms: u64, logical_start: u32, count: u32) -> Self {
+        TimestampRange {
+            physical_ms,
+            logical_start,
+            count,
+        }
+    }
+
+    /// Number of timestamps in the range.
+    pub(crate) fn count(&self) -> u32 {
+        self.count
+    }
+
+    /// Iterate the `count` contiguous timestamps, packing each on demand.
+    /// Uses the infallible [`Timestamp::pack`]: the range is
+    /// valid-by-construction, so every `(physical_ms, logical_start + i)` is
+    /// in range and cannot panic.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = Timestamp> {
+        let physical_ms = self.physical_ms;
+        let logical_start = self.logical_start;
+        (0..self.count).map(move |i| Timestamp::pack(physical_ms, logical_start + i))
+    }
+}
+
 pub(crate) fn decode_get_ts_response(
     resp: GetTsResponse,
     requested: u32,
-) -> Result<Vec<Timestamp>, ClientError> {
+) -> Result<TimestampRange, ClientError> {
     // Defense in depth: a buggy or malicious server could return fields that
     // do not fit the packed timestamp layout. Catch them before constructing
     // any Timestamp so invalid wire data cannot panic or truncate.
@@ -55,16 +102,22 @@ pub(crate) fn decode_get_ts_response(
             ))));
         }
     }
-    let mut out = Vec::with_capacity(resp.count as usize);
-    for i in 0..resp.count {
-        let ts = Timestamp::try_pack(resp.physical_ms, resp.logical_start + i).map_err(|e| {
-            ClientError::Rpc(tonic::Status::internal(format!(
-                "server returned invalid timestamp fields: {e}"
-            )))
-        })?;
-        out.push(ts);
-    }
-    Ok(out)
+    // Validate the packing invariants once, on the range's start endpoint.
+    // The logical-overflow check above already bounds
+    // `logical_start + count - 1 <= LOGICAL_MAX` (and `count >= 1`, so
+    // `logical_start <= LOGICAL_MAX`), so a single successful pack proves
+    // `physical_ms` fits the 46-bit field and the whole contiguous range
+    // packs — no per-element loop, no `count`-sized `Vec`.
+    Timestamp::try_pack(resp.physical_ms, resp.logical_start).map_err(|e| {
+        ClientError::Rpc(tonic::Status::internal(format!(
+            "server returned invalid timestamp fields: {e}"
+        )))
+    })?;
+    Ok(TimestampRange::new(
+        resp.physical_ms,
+        resp.logical_start,
+        resp.count,
+    ))
 }
 
 #[cfg(test)]
@@ -72,6 +125,21 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
     use tsoracle_core::PHYSICAL_MS_MAX;
+
+    #[test]
+    fn timestamp_range_iter_yields_contiguous_packed_timestamps() {
+        let range = TimestampRange::new(1_000, 5, 3);
+        assert_eq!(range.count(), 3);
+        let timestamps: Vec<Timestamp> = range.iter().collect();
+        assert_eq!(
+            timestamps,
+            vec![
+                Timestamp::pack(1_000, 5),
+                Timestamp::pack(1_000, 6),
+                Timestamp::pack(1_000, 7),
+            ],
+        );
+    }
 
     #[test]
     fn rejects_out_of_range_physical_ms() {
@@ -195,8 +263,10 @@ mod tests {
         #[test]
         fn well_formed_response_decodes_successfully(response in well_formed_response()) {
             let GetTsResponse { physical_ms, logical_start, count, .. } = response;
-            let timestamps = decode_get_ts_response(response, count).unwrap();
+            let range = decode_get_ts_response(response, count).unwrap();
 
+            prop_assert_eq!(range.count(), count);
+            let timestamps: Vec<Timestamp> = range.iter().collect();
             prop_assert_eq!(timestamps.len(), count as usize);
             for (index, timestamp) in timestamps.iter().enumerate() {
                 prop_assert_eq!(timestamp.physical_ms(), physical_ms);

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -59,17 +59,17 @@ use std::collections::{HashSet, VecDeque};
 use std::time::Duration;
 
 use tokio::time::Instant;
-use tsoracle_core::{Epoch, Timestamp};
+use tsoracle_core::Epoch;
 
 use crate::error::ClientError;
 use crate::leader_resolved::{ChannelPool, LeaderHintLookup, decode_leader_hint};
-use crate::response::decode_get_ts_response;
+use crate::response::{TimestampRange, decode_get_ts_response};
 use crate::retry_policy::{is_transport_failure, jittered_backoff, should_backoff};
 
 pub(crate) async fn issue_rpc(
     pool: &ChannelPool,
     count: u32,
-) -> Result<Vec<Timestamp>, ClientError> {
+) -> Result<TimestampRange, ClientError> {
     let policy = pool.retry_policy().clone();
     let start = Instant::now();
     let deadline = start + policy.overall_deadline;
@@ -101,9 +101,9 @@ pub(crate) async fn issue_rpc(
         );
 
         match attempt(pool, &endpoint, count, attempt_budget).await {
-            AttemptOutcome::Ok { timestamps, epoch } => {
+            AttemptOutcome::Ok { range, epoch } => {
                 pool.record_success(&endpoint, epoch);
-                return Ok(timestamps);
+                return Ok(range);
             }
             AttemptOutcome::LeaderHint {
                 endpoint: hinted_endpoint,
@@ -187,7 +187,9 @@ pub(crate) async fn issue_rpc(
 #[cfg_attr(test, derive(Debug))]
 enum AttemptOutcome {
     Ok {
-        timestamps: Vec<Timestamp>,
+        /// Compact validated range decoded from `GetTsResponse`; expanded to
+        /// per-waiter `Vec<Timestamp>`s only in `driver::deliver`.
+        range: TimestampRange,
         /// Leader epoch carried in `GetTsResponse` (reassembled from the
         /// `epoch_hi`/`epoch_lo` halves). Plumbed to
         /// `ChannelPool::record_success` so the cache can compare it
@@ -331,7 +333,7 @@ async fn attempt(
     // epoch from the same response to gate future `LeaderHint` arrivals.
     let epoch = Epoch::from_wire(inner.epoch_hi, inner.epoch_lo).0;
     match decode_get_ts_response(inner, count) {
-        Ok(timestamps) => AttemptOutcome::Ok { timestamps, epoch },
+        Ok(range) => AttemptOutcome::Ok { range, epoch },
         Err(err) => {
             #[cfg(feature = "metrics")]
             metrics::counter!(


### PR DESCRIPTION
Closes #356.

## Problem

The `GetTs` wire response is a compact range — `physical_ms`, `logical_start`, `count` (~16 bytes). The client expanded it into a full `Vec<Timestamp>` **twice** on the hot path:

1. `response.rs::decode_get_ts_response` materialized a `Vec<Timestamp>` of `count` entries (one heap allocation sized `count`).
2. `driver.rs::deliver` consumed that vector via `into_iter()` and re-sliced it into per-waiter `Vec<Timestamp>`s.

The whole-chunk vector stayed fully alive for the entire `deliver` loop, so peak retained memory was roughly `count`-sized + one waiter slice. With `MAX_TIMESTAMPS_PER_RPC = LOGICAL_MAX + 1 = 262_144`, a single maxed-out chunk ballooned ~16 wire bytes into ~2 MB materialized once on decode and churned again per waiter.

## Change

Introduce an internal, valid-by-construction `TimestampRange { physical_ms, logical_start, count }` (~16 bytes) and thread it from decode through coalescing and delivery:

- `decode_get_ts_response` now returns `TimestampRange`. The per-element `try_pack` loop (the source of the whole-chunk allocation) is replaced by a **single** `try_pack` on the range's start endpoint — the logical-overflow check already bounds `logical_start + count - 1 <= LOGICAL_MAX`, so one successful pack proves `physical_ms` fits and the whole contiguous range packs.
- `RpcFn`, `Driver::spawn`, `issue_rpc`, and `AttemptOutcome::Ok` carry the range instead of `Vec<Timestamp>`.
- `deliver` is the single materialization point: it expands a `Vec<Timestamp>` per waiter (`range.iter().take(w.count)`), which is the irreducible public-API boundary. No whole-chunk vector is ever built.

The per-waiter vectors were always required — they are exactly what `get_ts_batch -> Vec<Timestamp>` hands back. This removes the redundant whole-chunk allocation (the ~2 MB transient spike), not the caller's own data.

**No public API or wire-format change.** `Client::get_ts`/`get_ts_batch` and `Waiter::respond` still deliver `Vec<Timestamp>`. The blast radius is entirely within `tsoracle-client`; `tsoracle-tests` exercises only the unchanged public surface. Labelled `refactor:` because no library crate's public API gains a symbol a dependent uses (no publish-ordering hazard).

## Test plan

- [x] `cargo test -p tsoracle-client` — 85 pass (incl. new `timestamp_range_iter_yields_contiguous_packed_timestamps`; the `well_formed_response` proptest now asserts over `range.iter()`; the short/long-response protocol-violation tests drive `deliver`'s `range.count() != expected` guard)
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all --check` — clean