### PR TITLE
refactor(openraft-toolkit): range-delete truncate/purge instead of per-key loop

### DIFF
--- a/crates/tsoracle-openraft-toolkit/src/log_store/key_space.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/key_space.rs
@@ -52,6 +52,14 @@ impl MetaLabel {
 pub trait KeySpace: Clone + Debug + Send + Sync + 'static {
     fn log_key(&self, index: u64) -> Vec<u8>;
     fn log_range(&self) -> (Vec<u8>, Vec<u8>);
+    /// Exclusive upper bound for a `delete_range_cf` that must cover every log
+    /// key this instance can produce, including `log_key(u64::MAX)`.
+    ///
+    /// The returned key is strictly greater than `log_key(u64::MAX)` and, for
+    /// multi-group layouts, strictly less than any other group's `log_range`
+    /// lower bound — so a range tombstone bounded by it deletes the whole tail
+    /// of this instance's log without ever spanning into a neighbor's keys.
+    fn log_end_bound(&self) -> Vec<u8>;
     fn meta_key(&self, label: MetaLabel) -> Vec<u8>;
 }
 
@@ -67,6 +75,15 @@ impl KeySpace for Flat {
 
     fn log_range(&self) -> (Vec<u8>, Vec<u8>) {
         (vec![0u8; 8], vec![0xFFu8; 8])
+    }
+
+    fn log_end_bound(&self) -> Vec<u8> {
+        // A key that has `hi` as a strict prefix plus one more byte sorts
+        // immediately after `hi`; no fixed-width log key falls between them.
+        let (_lo, hi) = self.log_range();
+        let mut end = hi;
+        end.push(0);
+        end
     }
 
     fn meta_key(&self, label: MetaLabel) -> Vec<u8> {
@@ -106,6 +123,13 @@ impl KeySpace for GroupPrefixed {
         hi.extend_from_slice(&self.group_id.to_be_bytes());
         hi.extend_from_slice(&[0xFFu8; 8]);
         (lo, hi)
+    }
+
+    fn log_end_bound(&self) -> Vec<u8> {
+        let (_lo, hi) = self.log_range();
+        let mut end = hi;
+        end.push(0);
+        end
     }
 
     fn meta_key(&self, label: MetaLabel) -> Vec<u8> {
@@ -148,6 +172,12 @@ mod tests {
         let (lo, hi) = k.log_range();
         assert!(lo <= k.log_key(0));
         assert!(k.log_key(u64::MAX) <= hi);
+    }
+
+    #[test]
+    fn flat_log_end_bound_exceeds_max_index() {
+        let k = Flat;
+        assert!(k.log_key(u64::MAX) < k.log_end_bound());
     }
 
     #[test]
@@ -205,6 +235,15 @@ mod tests {
             let mut arr = [0u8; 8];
             arr.copy_from_slice(&bytes);
             prop_assert_eq!(u64::from_be_bytes(arr), i);
+        }
+
+        // log_end_bound is an exclusive upper bound strictly greater than every
+        // representable log key — the property `delete_range_cf` relies on to
+        // delete through `log_key(u64::MAX)`.
+        #[test]
+        fn flat_log_end_bound_exceeds_every_index(i in any::<u64>()) {
+            let k = Flat;
+            prop_assert!(k.log_key(i) < k.log_end_bound());
         }
     }
 }
@@ -337,6 +376,26 @@ mod group_prefixed_tests {
             let mk = GroupPrefixed::new(g_meta).meta_key(label);
             let lk = GroupPrefixed::new(g_log).log_key(i);
             prop_assert_ne!(mk, lk);
+        }
+
+        // Within a group, log_end_bound exceeds every index.
+        #[test]
+        fn group_log_end_bound_exceeds_every_index_in_group(
+            g_id in any::<u64>(),
+            i in any::<u64>(),
+        ) {
+            let g = GroupPrefixed::new(g_id);
+            prop_assert!(g.log_key(i) < g.log_end_bound());
+        }
+
+        // The load-bearing isolation property: a range delete bounded by group
+        // g's log_end_bound can never reach group (g+1)'s keys. (Guarded so g+1
+        // is a distinct, larger group.)
+        #[test]
+        fn group_log_end_bound_below_next_group(g_id in 0u64..u64::MAX) {
+            let g = GroupPrefixed::new(g_id);
+            let (next_lo, _next_hi) = GroupPrefixed::new(g_id + 1).log_range();
+            prop_assert!(g.log_end_bound() < next_lo);
         }
     }
 }

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -402,20 +402,13 @@ where
         let truncate_at = last_log_id.next_index();
         let cf_log = self.log_cf_handle();
         let start_key = self.keys.log_key(truncate_at);
-        let (_lo, hi) = self.keys.log_range();
-        let it = self.db.iterator_cf(
-            &cf_log,
-            IteratorMode::From(&start_key, rocksdb::Direction::Forward),
-        );
+        // Exclusive end past `log_key(u64::MAX)`; a single range tombstone
+        // replaces the former per-key delete loop (matches the paxos `trim`
+        // strategy). For `GroupPrefixed` the bound stays below the next group.
+        let end_key = self.keys.log_end_bound();
 
         let mut batch = WriteBatch::default();
-        for item in it {
-            let (k, _v) = item.map_err(io::Error::other)?;
-            if &*k > hi.as_slice() {
-                break;
-            }
-            batch.delete_cf(&cf_log, &k);
-        }
+        batch.delete_range_cf(&cf_log, &start_key, &end_key);
         // fsync: a lost truncate would resurrect conflicting tail entries on
         // recovery, contradicting the durable vote/append that drove it (see
         // `write_sync_opts`).

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -434,18 +434,15 @@ where
 
         let mut batch = WriteBatch::default();
         let (lo, _hi) = self.keys.log_range();
-        let stop_at = self.keys.log_key(log_id.index);
-        let it = self.db.iterator_cf(
-            &cf_log,
-            IteratorMode::From(&lo, rocksdb::Direction::Forward),
-        );
-        for item in it {
-            let (k, _v) = item.map_err(io::Error::other)?;
-            if &*k > stop_at.as_slice() {
-                break;
-            }
-            batch.delete_cf(&cf_log, &k);
-        }
+        // purge removes entries up to AND INCLUDING `log_id.index`, so the
+        // exclusive end is `log_key(index + 1)`. At u64::MAX there is no next
+        // index; `log_end_bound()` covers everything. A single range tombstone
+        // replaces the former per-key delete loop.
+        let end_key = match log_id.index.checked_add(1) {
+            Some(next) => self.keys.log_key(next),
+            None => self.keys.log_end_bound(),
+        };
+        batch.delete_range_cf(&cf_log, &lo, &end_key);
 
         meta::put::<LogIdOf<C>, K>(
             &mut batch,

--- a/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
@@ -290,3 +290,88 @@ async fn truncate_after_none_empties_log() {
     let state = store.get_log_state().await.unwrap();
     assert!(state.last_log_id.is_none());
 }
+
+// purge(log_id@index=k) removes [0..=k] inclusive and keeps [k+1..=N]. Pins
+// the inclusive-of-index semantics that the `index+1` exclusive end encodes,
+// and that LastPurged reads back as the purged log_id.
+#[tokio::test]
+async fn purge_removes_inclusive_prefix() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
+
+    store
+        .append((0..=5).map(blank_entry_at), IOFlushed::noop())
+        .await
+        .unwrap();
+
+    let purge_through = LogId::new(
+        TestLeaderId {
+            term: 1,
+            node_id: 1,
+        },
+        2,
+    );
+    store.purge(purge_through).await.unwrap();
+
+    let surviving = store.try_get_log_entries(0..=5).await.unwrap();
+    let indices: Vec<u64> = surviving.iter().map(|e| e.log_id().index).collect();
+    assert_eq!(
+        indices,
+        vec![3, 4, 5],
+        "[0..=2] inclusive must be purged, [3..=5] kept"
+    );
+
+    let state = store.get_log_state().await.unwrap();
+    assert_eq!(
+        state.last_purged_log_id.map(|id| id.index),
+        Some(2),
+        "purge must record LastPurged at the purged index",
+    );
+}
+
+// A range delete on group g must never reach group (g+1)'s entries sharing the
+// same column family — the GroupPrefixed isolation guarantee at the storage
+// layer (mirrors the key_space proptest, but end-to-end through RocksDB).
+#[tokio::test]
+async fn truncate_on_one_group_leaves_neighbor_intact() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+
+    let mut store_g4: RocksdbLogStore<TestTypeConfig, GroupPrefixed> =
+        RocksdbLogStore::open(Arc::clone(&db), LOG_CF, META_CF, GroupPrefixed::new(4)).unwrap();
+    let mut store_g5: RocksdbLogStore<TestTypeConfig, GroupPrefixed> =
+        RocksdbLogStore::open(Arc::clone(&db), LOG_CF, META_CF, GroupPrefixed::new(5)).unwrap();
+
+    store_g4
+        .append((0..=3).map(blank_entry_at), IOFlushed::noop())
+        .await
+        .unwrap();
+    store_g5
+        .append((0..=3).map(blank_entry_at), IOFlushed::noop())
+        .await
+        .unwrap();
+
+    // Wipe all of group 4's tail; group 5 must be untouched.
+    store_g4.truncate_after(None).await.unwrap();
+
+    let g4 = store_g4.try_get_log_entries(0..=3).await.unwrap();
+    assert!(
+        g4.is_empty(),
+        "group 4 should be empty after truncate_after(None)"
+    );
+
+    let g5: Vec<u64> = store_g5
+        .try_get_log_entries(0..=3)
+        .await
+        .unwrap()
+        .iter()
+        .map(|e| e.log_id().index)
+        .collect();
+    assert_eq!(
+        g5,
+        vec![0, 1, 2, 3],
+        "group 5's entries must survive group 4's range delete"
+    );
+}

--- a/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
@@ -224,3 +224,69 @@ async fn get_log_state_isolates_groups_in_shared_column_family() {
         "group 4 should still observe its own entry",
     );
 }
+
+fn blank_entry_at(index: u64) -> Entry<TestLeaderId, common::TestAppData, u64, common::TestPeer> {
+    Entry::new_blank(LogId::new(
+        TestLeaderId {
+            term: 1,
+            node_id: 1,
+        },
+        index,
+    ))
+}
+
+// truncate_after(Some(k)) must keep [0..=k] and remove the tail (k+1..=N)
+// exactly — no over-delete at the boundary, no surviving tail entry.
+#[tokio::test]
+async fn truncate_after_removes_exact_tail() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
+
+    store
+        .append((0..=5).map(blank_entry_at), IOFlushed::noop())
+        .await
+        .unwrap();
+
+    let keep_through = LogId::new(
+        TestLeaderId {
+            term: 1,
+            node_id: 1,
+        },
+        3,
+    );
+    store.truncate_after(Some(keep_through)).await.unwrap();
+
+    let surviving = store.try_get_log_entries(0..=5).await.unwrap();
+    let indices: Vec<u64> = surviving.iter().map(|e| e.log_id().index).collect();
+    assert_eq!(
+        indices,
+        vec![0, 1, 2, 3],
+        "tail [4,5] must be gone, [0..=3] kept"
+    );
+}
+
+// truncate_after(None) empties the log entirely.
+#[tokio::test]
+async fn truncate_after_none_empties_log() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
+
+    store
+        .append((0..=3).map(blank_entry_at), IOFlushed::noop())
+        .await
+        .unwrap();
+
+    store.truncate_after(None).await.unwrap();
+
+    let surviving = store.try_get_log_entries(0..=3).await.unwrap();
+    assert!(
+        surviving.is_empty(),
+        "truncate_after(None) must remove all entries"
+    );
+    let state = store.get_log_state().await.unwrap();
+    assert!(state.last_log_id.is_none());
+}


### PR DESCRIPTION
## Summary

Closes #358.

The openraft log store deleted log keys one-by-one in `truncate_after` and `purge`: it opened a RocksDB iterator over the log range and emitted one `batch.delete_cf(&cf_log, &k)` per surviving key. The paxos store removes the same logical span with a single `batch.delete_range_cf(&cf, &lower, &upper)` (`trim`). This PR switches both openraft paths to a single bounded `delete_range_cf`, eliminating the latency-grows-with-span asymmetry and the backend drift in deletion strategy.

The tricky part is that `delete_range_cf` is half-open `[start, end)` while log keys are fixed-width and `log_key(u64::MAX)` is the maximum-valued key — there is no larger same-width key to use as the exclusive end. That bound math is localized in `KeySpace` so it is computed and proptested in exactly one place.

## Changes

- **`KeySpace::log_end_bound`** (new trait method): returns an exclusive upper bound strictly greater than `log_key(u64::MAX)` and — for `GroupPrefixed` — strictly below any other group's keys, so a range tombstone never spans into a neighbor's data. Implemented as the inclusive `hi` from `log_range` with a trailing `0x00` appended (a key with `hi` as a strict prefix sorts immediately after it, with no fixed-width log key in between).
- **`truncate_after`**: range-deletes `[log_key(truncate_at), log_end_bound())`. `truncate_after(None)` still empties the log; `Some(id)` still keeps `[0..=id]`.
- **`purge`**: range-deletes `[lo, log_key(index + 1))`. purge is inclusive of `log_id.index`, so the exclusive end is `index + 1`; at `u64::MAX` it falls back to `log_end_bound()`. The `LastPurged` meta write stays in the same atomic batch.

The single synced `write_opt(batch, &write_sync_opts())` and both failpoint sites are unchanged — durability and write ordering are identical to before; only the delete mechanism changes.

## Testing

- `KeySpace` proptests (both `Flat` and `GroupPrefixed`): `log_end_bound` exceeds every representable index, and a group's `log_end_bound` stays below the next group's lower bound.
- RocksDB-backed behavioral tests: truncate removes the exact tail (boundary-correct), `truncate_after(None)` empties the log, purge removes the inclusive prefix and records `LastPurged`, and a range delete on one `GroupPrefixed` group leaves a neighbor group sharing the same column family intact.
- `cargo test -p tsoracle-openraft-toolkit --features test-fakes` (incl. the openraft conformance suite) and `--features failpoints` (the truncate/purge write-ordering regression tests) both pass.
- `cargo test --workspace`, `cargo fmt --all --check`, and `cargo clippy --workspace --all-targets --all-features` all green.

## Notes

No cross-backend conformance harness: the two stores diverge intentionally (paxos `trim` is exclusive-below-idx; openraft `purge` is inclusive-through-index), consistent with the won't-fix on shared test-fakes extraction (#264). Tests live on the openraft side.