### PR TITLE
fix(driver-paxos): rebase snapshot baseline at recovery to avoid spurious post-restart snapshot

### DIFF
--- a/crates/tsoracle-driver-paxos/src/apply.rs
+++ b/crates/tsoracle-driver-paxos/src/apply.rs
@@ -91,6 +91,14 @@ impl ApplyEngine {
     /// storage. Recovery deliberately skips compaction — a node that just
     /// recovered should not immediately re-snapshot — which is why this is
     /// distinct from [`Self::apply_step`].
+    ///
+    /// Recovery also rebases the snapshot policy's baseline to the recovered
+    /// decided index. The baseline starts at 0, so without this a node
+    /// reopening its log at a decided index past the snapshot interval would
+    /// snapshot spuriously on its first post-recovery [`Self::apply_step`]
+    /// (`decided_idx >= 0 + every_n`). Rebasing makes the next snapshot fire
+    /// `every_n` entries past the restart point — extending the "skip
+    /// compaction at recovery" intent to the first decision after recovery.
     pub(crate) fn recover<S>(
         &self,
         omnipaxos: &Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
@@ -99,6 +107,7 @@ impl ApplyEngine {
         S: Storage<HighWaterCommand> + Send + 'static,
     {
         drain_decided_into(omnipaxos, cursor, &self.apply_state);
+        self.policy.lock().rebase(*cursor);
     }
 
     /// Drain newly-decided entries from `*cursor` into the apply state, then

--- a/crates/tsoracle-driver-paxos/src/snapshot_policy.rs
+++ b/crates/tsoracle-driver-paxos/src/snapshot_policy.rs
@@ -44,6 +44,19 @@ impl SnapshotPolicy {
         Self::every(0)
     }
 
+    /// Rebase the snapshot baseline to `decided_idx`.
+    ///
+    /// `every` starts the baseline at 0, which is correct for a fresh log but
+    /// wrong after a restart: a node reopening its log at a decided index far
+    /// past `every_n_decided` would satisfy `decided_idx >= 0 + N` on its first
+    /// post-recovery check and snapshot spuriously. Seeding the baseline to the
+    /// recovered decided index makes the next snapshot fire `every_n_decided`
+    /// entries past the restart point instead. Called once at recovery; a
+    /// disabled policy is unaffected (it never fires regardless of baseline).
+    pub fn rebase(&mut self, decided_idx: u64) {
+        self.last_snapshot_at = decided_idx;
+    }
+
     /// Decide whether to trigger a snapshot for the given decided index.
     ///
     /// Updates internal state to remember the last triggered index so
@@ -101,6 +114,32 @@ mod tests {
     #[test]
     fn default_is_disabled() {
         let mut policy = SnapshotPolicy::default();
+        assert!(!policy.should_snapshot(u64::MAX));
+    }
+
+    #[test]
+    fn rebase_suppresses_spurious_first_trigger_after_restart() {
+        // Simulates a restart at a decided index far past the interval. A
+        // freshly-constructed `every(100)` has `last_snapshot_at = 0`, so its
+        // first check would fire (5000 >= 0 + 100) and snapshot spuriously.
+        // Rebasing the baseline to the recovered index suppresses that.
+        let mut policy = SnapshotPolicy::every(100);
+        policy.rebase(5_000);
+        assert!(
+            !policy.should_snapshot(5_000),
+            "must not snapshot on the first decision after recovery",
+        );
+        assert!(!policy.should_snapshot(5_099));
+        assert!(
+            policy.should_snapshot(5_100),
+            "the every-N cadence resumes relative to the rebased baseline",
+        );
+    }
+
+    #[test]
+    fn rebase_on_disabled_policy_stays_disabled() {
+        let mut policy = SnapshotPolicy::disabled();
+        policy.rebase(5_000);
         assert!(!policy.should_snapshot(u64::MAX));
     }
 }

--- a/crates/tsoracle-driver-paxos/src/state_machine.rs
+++ b/crates/tsoracle-driver-paxos/src/state_machine.rs
@@ -713,6 +713,62 @@ mod drain_tests {
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn recovery_does_not_snapshot_on_first_post_restart_apply() {
+            use crate::apply::ApplyEngine;
+
+            // Decide several entries so the recovered decided index sits past
+            // the snapshot interval. This is the post-restart state described
+            // in the issue: a node reopens its log at decided_idx >> N.
+            let mut cluster = build_cluster(3);
+            drive_to_leader_election(&mut cluster).await;
+            {
+                let leader = leader_handle(&cluster);
+                let mut handle = leader.lock();
+                for value in 1..=3 {
+                    handle
+                        .append(HighWaterCommand::Advance(AdvancePayload {
+                            at_least: value,
+                        }))
+                        .expect("append");
+                }
+            }
+            drive_until(
+                &mut cluster,
+                |state| {
+                    state
+                        .nodes
+                        .iter()
+                        .all(|node| node.omnipaxos.lock().get_decided_idx() >= 3)
+                },
+                500,
+            )
+            .await;
+
+            let handle = leader_handle(&cluster);
+            // `every(1)` fires for any decided_idx >= 1, so a baseline of 0
+            // would snapshot on the very first post-recovery apply.
+            let engine = ApplyEngine::new(SnapshotPolicy::every(1));
+            let mut cursor = 0u64;
+            engine.recover(&handle, &mut cursor);
+            assert!(cursor >= 3, "recovery folds the decided suffix");
+
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                let mut apply_cursor = cursor;
+                engine.apply_step(&handle, &mut apply_cursor);
+            });
+
+            let snapshot = snapshotter.snapshot().into_vec();
+            assert_eq!(
+                counter(&snapshot, "tsoracle.paxos.snapshot.total"),
+                0,
+                "recovery must rebase the snapshot baseline so the first \
+                 post-restart apply does not snapshot spuriously",
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn failed_snapshot_increments_failure_counter() {
             let mut cluster = build_cluster(3);
             drive_to_leader_election(&mut cluster).await;


### PR DESCRIPTION
Closes #258.

## Problem

`SnapshotPolicy::every(N)` initializes `last_snapshot_at = 0` and is reconstructed fresh on every restart. A node reopening its log at a decided index far past `N` satisfies `decided_idx >= 0 + N` on its first post-recovery check, firing an unintended snapshot on the first decision after restart.

## Fix

The recovered decided index is already known at construction: `StandaloneHost::new` → `ApplyEngine::recover` folds the decided suffix and leaves the cursor at `decided_idx`. `recover` now rebases the snapshot policy baseline to that index (`self.policy.lock().rebase(*cursor)`), so the next snapshot fires `N` entries past the restart point rather than immediately.

This is the issue's **derive** option rather than **persist**: it needs no new persisted state and no storage-codec change. It also completes an intent the code already documented — `recover`'s comment states "a node that just recovered should not immediately re-snapshot", but previously that only skipped compaction *during* the recovery fold, not on the first `apply_step` *after* it.

`recover` is the single chokepoint both drive paths (synchronous stepping and the async apply task) flow through, so seeding there covers both without touching either drive loop.

## Changes

- `snapshot_policy.rs`: new `SnapshotPolicy::rebase(decided_idx)` seeding `last_snapshot_at`.
- `apply.rs`: `recover` rebases the policy after folding the decided suffix.
- Tests: unit coverage for the rebased cadence (including the disabled-policy no-op), plus an integration test that reproduces the spurious snapshot via the `tsoracle.paxos.snapshot.total` metric (fails with count `1` before the fix, passes with `0` after).

## Verification

- `cargo test -p tsoracle-driver-paxos --features metrics`: pass
- `cargo fmt --check`, `cargo clippy --features metrics --all-targets`: clean
- `cargo build --workspace --all-targets`: pass