### PR TITLE
test(paxos): isolate async_write failpoint tests into the integration binary

### DIFF
--- a/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
@@ -923,8 +923,10 @@ mod crash_recovery_conformance {
     //! resurrect an earlier write while losing a later one. Because OmniPaxos
     //! (and this crate's own pairing tests) issue `trim(idx)` before
     //! `set_compacted_idx(idx)`, the realistic partial-crash state is "trim
-    //! persisted, compacted-index update lost", which the failpoint test below
-    //! reproduces faithfully.
+    //! persisted, compacted-index update lost", which
+    //! `lost_compacted_index_after_trim_recovers_forward_only` in
+    //! `tests/failpoints.rs` reproduces faithfully via the `async_write`
+    //! failpoint.
     //!
     //! fsync itself is not in-process observable (a clean drop + reopen flushes
     //! everything), so a lost write is modeled by making that specific write
@@ -979,147 +981,6 @@ mod crash_recovery_conformance {
         assert_eq!(
             single[0].value, 99,
             "next append continues at absolute idx 4"
-        );
-    }
-
-    #[cfg(feature = "failpoints")]
-    #[test]
-    fn lost_compacted_index_after_trim_recovers_forward_only() {
-        // Realistic crash: trim persists, then the set_compacted_idx write is
-        // lost (the WAL tail is truncated past trim). On reopen the compacted
-        // offset is stale-low, but recovery must stay forward-only — surviving
-        // entries remain readable at their absolute indices, no phantom entry
-        // appears at a low index, and the next append lands past the survivors
-        // rather than overwriting one.
-        let dir = TempDir::new().unwrap();
-        {
-            let db = open_db(&dir, "tso_paxos");
-            let mut storage: RocksdbStorage<TestEntry> =
-                RocksdbStorage::open_in(db, "tso_paxos").unwrap();
-            storage
-                .append_entries(vec![
-                    TestEntry { value: 1 },
-                    TestEntry { value: 2 },
-                    TestEntry { value: 3 },
-                    TestEntry { value: 4 },
-                ])
-                .unwrap();
-            // trim persists (deletes physical keys 0,1).
-            storage.trim(2).unwrap();
-            // The paired compacted-index update is lost in the crash.
-            tsoracle_failpoint::fail::cfg("paxos_toolkit::storage::async_write", "return").unwrap();
-            let lost = storage.set_compacted_idx(2);
-            tsoracle_failpoint::fail::remove("paxos_toolkit::storage::async_write");
-            assert!(
-                lost.is_err(),
-                "the failpoint must drop the compacted-index write"
-            );
-        }
-
-        let db = open_db(&dir, "tso_paxos");
-        let mut storage: RocksdbStorage<TestEntry> =
-            RocksdbStorage::open_in(db, "tso_paxos").unwrap();
-        assert_eq!(
-            storage.get_compacted_idx().unwrap(),
-            0,
-            "the lost compacted-index update leaves the offset stale-low",
-        );
-        // The trimmed-but-uncompacted entries are still readable at their
-        // absolute indices; the trimmed-away keys 0,1 do NOT reappear.
-        let suffix = storage.get_suffix(0).unwrap();
-        assert_eq!(suffix.len(), 2, "only the untrimmed entries survive");
-        assert_eq!(suffix[0].value, 3);
-        assert_eq!(suffix[1].value, 4);
-
-        // Forward-only: the next append lands at idx 4 (past the survivors at
-        // 2,3), never overwriting a survivor or planting a phantom at idx 0.
-        storage.append_entry(TestEntry { value: 99 }).unwrap();
-        let single = storage.get_entries(4, 5).unwrap();
-        assert_eq!(single.len(), 1);
-        assert_eq!(single[0].value, 99);
-        let suffix = storage.get_suffix(2).unwrap();
-        assert_eq!(suffix.len(), 3);
-        assert_eq!(suffix[2].value, 99);
-    }
-}
-
-#[cfg(all(
-    test,
-    feature = "metrics",
-    feature = "failpoints",
-    feature = "rocksdb-storage"
-))]
-mod async_write_metrics_tests {
-    //! A failing async (non-synced) write must increment
-    //! `tsoracle.paxos.storage.async_write_failures.total`, labelled with the
-    //! storage operation that failed. The `async_write` failpoint forces the
-    //! `batch_async` body to return an error; a thread-local recorder captures
-    //! the emitted counter so the assertion observes real emission, not a mock.
-
-    use super::log_tests::fresh_storage;
-    use metrics_util::{
-        MetricKind,
-        debugging::{DebugValue, DebuggingRecorder},
-    };
-    use omnipaxos::storage::Storage;
-    use tempfile::TempDir;
-
-    const ASYNC_WRITE_FP: &str = "paxos_toolkit::storage::async_write";
-
-    /// Counter value for `name` whose label set contains `op = <expected_op>`.
-    fn counter_with_op(
-        snapshot: &[(
-            metrics_util::CompositeKey,
-            Option<metrics::Unit>,
-            Option<metrics::SharedString>,
-            DebugValue,
-        )],
-        name: &str,
-        expected_op: &str,
-    ) -> u64 {
-        for (composite, _unit, _desc, value) in snapshot {
-            if composite.kind() != MetricKind::Counter || composite.key().name() != name {
-                continue;
-            }
-            let has_op = composite
-                .key()
-                .labels()
-                .any(|label| label.key() == "op" && label.value() == expected_op);
-            if has_op {
-                if let DebugValue::Counter(n) = value {
-                    return *n;
-                }
-            }
-        }
-        0
-    }
-
-    #[test]
-    fn failed_async_write_increments_labelled_failure_counter() {
-        let dir = TempDir::new().unwrap();
-        let mut storage = fresh_storage(&dir);
-
-        let recorder = DebuggingRecorder::new();
-        let snapshotter = recorder.snapshotter();
-
-        tsoracle_failpoint::fail::cfg(ASYNC_WRITE_FP, "return").unwrap();
-        let result = metrics::with_local_recorder(&recorder, || storage.set_compacted_idx(5));
-        tsoracle_failpoint::fail::remove(ASYNC_WRITE_FP);
-
-        assert!(
-            result.is_err(),
-            "armed failpoint must surface a write error"
-        );
-
-        let snapshot = snapshotter.snapshot().into_vec();
-        assert_eq!(
-            counter_with_op(
-                &snapshot,
-                "tsoracle.paxos.storage.async_write_failures.total",
-                "set_compacted_idx",
-            ),
-            1,
-            "a failed set_compacted_idx must increment the op-labelled failure counter once",
         );
     }
 }

--- a/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
@@ -17,12 +17,21 @@
 #[path = "common/mod.rs"]
 mod common;
 
-use common::{TEST_CF, TestCommand, open_rocksdb_in_tempdir};
+use common::{TEST_CF, TestCommand, open_rocksdb_in_tempdir, open_rocksdb_storage};
 use omnipaxos::storage::Storage;
+use tempfile::TempDir;
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+
+/// Failpoints live in the process-global `fail` registry, but cargo runs a
+/// binary's tests concurrently. Serialize every failpoint test in this binary
+/// so one test's armed failpoint can never leak into another's storage write.
+/// `parking_lot::Mutex` is non-poisoning, so a failing test cannot cascade
+/// spurious failures into its siblings.
+static FAILPOINT_TEST_SERIAL: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
 #[test]
 fn append_entry_panics_when_failpoint_armed() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock();
     let (_dir, database) = open_rocksdb_in_tempdir(TEST_CF);
     let mut storage: RocksdbStorage<TestCommand> =
         RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
@@ -35,4 +44,129 @@ fn append_entry_panics_when_failpoint_armed() {
 
     tsoracle_failpoint::fail::remove("paxos_toolkit::storage::append_entry");
     assert!(result.is_err(), "expected panic from failpoint");
+}
+
+#[test]
+fn lost_compacted_index_after_trim_recovers_forward_only() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock();
+    // Realistic crash: trim persists, then the set_compacted_idx write is
+    // lost (the WAL tail is truncated past trim). On reopen the compacted
+    // offset is stale-low, but recovery must stay forward-only — surviving
+    // entries remain readable at their absolute indices, no phantom entry
+    // appears at a low index, and the next append lands past the survivors
+    // rather than overwriting one.
+    let dir = TempDir::new().unwrap();
+    {
+        let mut storage = open_rocksdb_storage(&dir, TEST_CF);
+        storage
+            .append_entries(vec![
+                TestCommand(1),
+                TestCommand(2),
+                TestCommand(3),
+                TestCommand(4),
+            ])
+            .unwrap();
+        // trim persists (deletes physical keys 0,1).
+        storage.trim(2).unwrap();
+        // The paired compacted-index update is lost in the crash.
+        tsoracle_failpoint::fail::cfg("paxos_toolkit::storage::async_write", "return").unwrap();
+        let lost = storage.set_compacted_idx(2);
+        tsoracle_failpoint::fail::remove("paxos_toolkit::storage::async_write");
+        assert!(
+            lost.is_err(),
+            "the failpoint must drop the compacted-index write"
+        );
+    }
+
+    let mut storage = open_rocksdb_storage(&dir, TEST_CF);
+    assert_eq!(
+        storage.get_compacted_idx().unwrap(),
+        0,
+        "the lost compacted-index update leaves the offset stale-low",
+    );
+    // The trimmed-but-uncompacted entries are still readable at their
+    // absolute indices; the trimmed-away keys 0,1 do NOT reappear.
+    let suffix = storage.get_suffix(0).unwrap();
+    assert_eq!(suffix.len(), 2, "only the untrimmed entries survive");
+    assert_eq!(suffix[0].0, 3);
+    assert_eq!(suffix[1].0, 4);
+
+    // Forward-only: the next append lands at idx 4 (past the survivors at
+    // 2,3), never overwriting a survivor or planting a phantom at idx 0.
+    storage.append_entry(TestCommand(99)).unwrap();
+    let single = storage.get_entries(4, 5).unwrap();
+    assert_eq!(single.len(), 1);
+    assert_eq!(single[0].0, 99);
+    let suffix = storage.get_suffix(2).unwrap();
+    assert_eq!(suffix.len(), 3);
+    assert_eq!(suffix[2].0, 99);
+}
+
+/// Counter value for `name` whose label set contains `op = <expected_op>`.
+#[cfg(feature = "metrics")]
+fn counter_with_op(
+    snapshot: &[(
+        metrics_util::CompositeKey,
+        Option<metrics::Unit>,
+        Option<metrics::SharedString>,
+        metrics_util::debugging::DebugValue,
+    )],
+    name: &str,
+    expected_op: &str,
+) -> u64 {
+    use metrics_util::MetricKind;
+    use metrics_util::debugging::DebugValue;
+    for (composite, _unit, _desc, value) in snapshot {
+        if composite.kind() != MetricKind::Counter || composite.key().name() != name {
+            continue;
+        }
+        let has_op = composite
+            .key()
+            .labels()
+            .any(|label| label.key() == "op" && label.value() == expected_op);
+        if has_op {
+            if let DebugValue::Counter(n) = value {
+                return *n;
+            }
+        }
+    }
+    0
+}
+
+/// A failing async (non-synced) write must increment
+/// `tsoracle.paxos.storage.async_write_failures.total`, labelled with the
+/// storage operation that failed. The `async_write` failpoint forces the
+/// `batch_async` body to return an error; a thread-local recorder captures
+/// the emitted counter so the assertion observes real emission, not a mock.
+#[cfg(feature = "metrics")]
+#[test]
+fn failed_async_write_increments_labelled_failure_counter() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock();
+    use metrics_util::debugging::DebuggingRecorder;
+
+    let dir = TempDir::new().unwrap();
+    let mut storage = open_rocksdb_storage(&dir, TEST_CF);
+
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    tsoracle_failpoint::fail::cfg("paxos_toolkit::storage::async_write", "return").unwrap();
+    let result = metrics::with_local_recorder(&recorder, || storage.set_compacted_idx(5));
+    tsoracle_failpoint::fail::remove("paxos_toolkit::storage::async_write");
+
+    assert!(
+        result.is_err(),
+        "armed failpoint must surface a write error"
+    );
+
+    let snapshot = snapshotter.snapshot().into_vec();
+    assert_eq!(
+        counter_with_op(
+            &snapshot,
+            "tsoracle.paxos.storage.async_write_failures.total",
+            "set_compacted_idx",
+        ),
+        1,
+        "a failed set_compacted_idx must increment the op-labelled failure counter once",
+    );
 }


### PR DESCRIPTION
## Problem

`cargo test --workspace --all-features` intermittently fails `tsoracle-paxos-toolkit`'s `storage::decided_compacted_tests::append_after_full_trim_survives_reopen` with:

```
called `Result::unwrap()` on an `Err` value: LogIntegrity("async_write failpoint armed for trim")
```

(Observed on the CI run for #370, a `tsoracle-client`-only change.)

The `fail` crate's failpoint registry is **process-global**, but `cargo test` runs a binary's tests concurrently. Two tests arm `paxos_toolkit::storage::async_write` via `fail::cfg(.., "return")` / `fail::remove`:

- `crash_recovery_conformance::lost_compacted_index_after_trim_recovers_forward_only`
- `async_write_metrics_tests::failed_async_write_increments_labelled_failure_counter`

Both lived as `#[cfg(test)]` **unit** tests in `src/storage/mod.rs`, so they ran in the lib test binary alongside every other storage unit test. `batch_async` (used by `trim`, `set_snapshot`, `set_compacted_idx`, …) hits the `async_write` failpoint, so any non-failpoint test doing such a write — e.g. `append_after_full_trim_survives_reopen`'s `trim(3)` — fails if it happens to run during the brief window another test has the failpoint armed. The flake was introduced by #367 (which added the `async_write` failpoint + the metrics test) and surfaces on any PR rebased onto it.

## Fix

Follow the workspace convention already used by `tsoracle-openraft-toolkit`, `tsoracle-driver-file`, and `tsoracle-tests`: failpoint-arming tests live in a dedicated `tests/failpoints.rs` integration binary, serialized by a `static FAILPOINT_TEST_SERIAL` mutex.

- **Move** both `async_write` tests out of `src/storage/mod.rs` into the existing `tests/failpoints.rs`, rewritten against the public API + the `common` test helpers (`open_rocksdb_storage`, `TestCommand`). The metrics test stays `#[cfg(feature = "metrics")]`; the binary's `required-features` is unchanged.
- **Add** `static FAILPOINT_TEST_SERIAL: parking_lot::Mutex<()>` and have all three tests in the binary acquire it first (`parking_lot` is non-poisoning, so a failing test can't cascade — and these tests are sync `#[test]`, unlike the other crates' async guards).
- The lib test binary **no longer arms any failpoint**, so concurrent unit tests can't be poisoned; the three failpoint tests are mutually serialized in their own binary.

Test-only change in one crate; no production code, no public API, no behavior change. The relocated tests keep their original assertions and feature gating.

## Test plan

- [x] `cargo test -p tsoracle-paxos-toolkit --all-features` run 6× — no flake, no `async_write failpoint armed` panic
- [x] `cargo test -p tsoracle-paxos-toolkit --all-features --test failpoints` — 3 tests pass
- [x] `cargo test -p tsoracle-paxos-toolkit --no-default-features --features failpoints,rocksdb-storage --test failpoints` — 2 tests pass (metrics test correctly cfg'd out)
- [x] `cargo test --workspace --all-features` — green (119 test binaries, 0 failures)
- [x] `cargo clippy --workspace --all-targets --all-features` clean, `cargo fmt --all --check` clean