### PR TITLE
fix(codec): reject trailing bytes after a valid postcard body

### DIFF
--- a/crates/tsoracle-codec/README.md
+++ b/crates/tsoracle-codec/README.md
@@ -9,8 +9,8 @@ Both consensus toolkits (`tsoracle-paxos-toolkit`, `tsoracle-openraft-toolkit`) 
 ## What's in the box
 
 - `encode(version, value)` — serializes `value` with `postcard` and prepends `version`, yielding `[version | postcard(value)]`.
-- `decode(expected_version, bytes)` — checks the leading byte against `expected_version` (returning `CodecError::Version` on mismatch) before deserializing the body.
-- `CodecError` — `Empty`, `Version { expected, actual }`, `Encode(postcard::Error)`, `Decode(postcard::Error)`. Encode and decode failures are kept distinct, and the underlying `postcard::Error` is carried as the error source (no `From` conversion) so a stray `?` never silently becomes a `CodecError`.
+- `decode(expected_version, bytes)` — checks the leading byte against `expected_version` (returning `CodecError::Version` on mismatch) before deserializing the body, and rejects any bytes left unconsumed past a valid body with `CodecError::TrailingBytes` rather than silently discarding them.
+- `CodecError` — `Empty`, `Version { expected, actual }`, `Encode(postcard::Error)`, `Decode(postcard::Error)`, `TrailingBytes { extra }`. Encode and decode failures are kept distinct, and the underlying `postcard::Error` is carried as the error source (no `From` conversion) so a stray `?` never silently becomes a `CodecError`. `TrailingBytes` flags surplus bytes after an otherwise-valid body — for a format that exists to catch drift, garbage appended by a partial overwrite is a corruption signal, not noise to drop.
 
 The schema-version *number* is deliberately **not** owned here. `version` is a parameter, so each consumer keeps its own `SCHEMA_VERSION` constant and evolves its on-disk format independently of the others.
 

--- a/crates/tsoracle-codec/src/lib.rs
+++ b/crates/tsoracle-codec/src/lib.rs
@@ -36,6 +36,11 @@ pub enum CodecError {
     /// `postcard` failed to deserialize the framed body.
     #[error("decode failed: {0}")]
     Decode(#[source] postcard::Error),
+    /// The body decoded successfully but `extra` bytes remained unconsumed.
+    /// For a versioned on-disk format this signals corruption — e.g. a partial
+    /// overwrite that left stale tail bytes — rather than a clean record.
+    #[error("trailing bytes: {extra} unconsumed after a valid body")]
+    TrailingBytes { extra: usize },
 }
 
 /// Encode `value` as `[version | postcard(value)]`.
@@ -56,7 +61,10 @@ pub fn encode<T: Serialize>(version: u8, value: &T) -> Result<Vec<u8>, CodecErro
 ///
 /// Returns [`CodecError::Version`] when the leading byte differs from
 /// `expected_version` — a stale reader fails loudly instead of parsing old
-/// bytes against a new struct layout.
+/// bytes against a new struct layout. Returns [`CodecError::TrailingBytes`]
+/// when the body decodes but leaves surplus bytes unconsumed: for a versioned
+/// format that exists to catch drift, garbage appended to a valid record is a
+/// corruption signal, not something to silently discard.
 pub fn decode<T: DeserializeOwned>(expected_version: u8, bytes: &[u8]) -> Result<T, CodecError> {
     let (first, rest) = bytes.split_first().ok_or(CodecError::Empty)?;
     if *first != expected_version {
@@ -65,7 +73,13 @@ pub fn decode<T: DeserializeOwned>(expected_version: u8, bytes: &[u8]) -> Result
             actual: *first,
         });
     }
-    postcard::from_bytes(rest).map_err(CodecError::Decode)
+    let (value, remainder) = postcard::take_from_bytes(rest).map_err(CodecError::Decode)?;
+    if !remainder.is_empty() {
+        return Err(CodecError::TrailingBytes {
+            extra: remainder.len(),
+        });
+    }
+    Ok(value)
 }
 
 #[cfg(test)]
@@ -129,6 +143,22 @@ mod tests {
         assert!(matches!(
             decode::<Sample>(1, truncated),
             Err(CodecError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_trailing_bytes() {
+        let original = Sample {
+            idx: 7,
+            name: "trailing".into(),
+        };
+        let mut bytes = encode(1, &original).expect("encode");
+        // Simulate a partial overwrite that left stale tail bytes behind: a
+        // valid body followed by garbage postcard never consumes.
+        bytes.extend_from_slice(&[0xAB, 0xCD, 0xEF]);
+        assert!(matches!(
+            decode::<Sample>(1, &bytes),
+            Err(CodecError::TrailingBytes { extra: 3 })
         ));
     }
 


### PR DESCRIPTION
## Summary

`decode` used `postcard::from_bytes`, which stops once the target type is fully read and silently ignores any bytes beyond it. For a version-prefixed on-disk codec whose entire purpose is catching format drift, that swallows a corruption signal: a partial overwrite that leaves stale tail bytes behind decodes as a clean record.

- Switch `decode` to `postcard::take_from_bytes` and reject a non-empty remainder with a new `CodecError::TrailingBytes { extra: usize }` variant.
- Add `decode_rejects_trailing_bytes` covering the too-many-bytes case (the existing `decode_rejects_truncated_input` only covered too-few).
- Update the crate README so its `CodecError` variant list and `decode` description stay accurate.

All three downstream `codec_io_error` matchers (`log_store`, `state_machine`) use a catch-all arm, so the new variant maps to a generic IO error without code changes. Labeled `fix` (not `refactor`) because it adds a public variant to a library crate and must land under the `feat|fix|perf` release filter to publish.

Closes #349.

## Test Plan

- [x] `cargo test -p tsoracle-codec` — new `decode_rejects_trailing_bytes` passes; verified RED (failed to compile without the variant) before GREEN
- [x] `cargo test --workspace` — no failures
- [x] `cargo build --workspace --examples` — clean
- [x] `cargo clippy -p tsoracle-codec --all-targets` — no warnings