### PR TITLE
fix(driver-paxos): reject double-start with AlreadyRunning instead of a debug-only assert

### DIFF
--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -282,7 +282,8 @@ impl PaxosTopology {
             let sink = Arc::new(MeshSink {
                 network: network.clone(),
             });
-            host.start(sink);
+            host.start(sink)
+                .context("paxos topology: host not already running")?;
 
             // ---- Driver + tsoracle server ----
             let driver = Arc::new(PaxosDriver::new(host, leader_stream));

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -26,7 +26,7 @@ pub mod type_config;
 pub use driver::PaxosDriver;
 pub use log_entry::{HighWaterCommand, HighWaterSnapshot};
 pub use snapshot_policy::SnapshotPolicy;
-pub use standalone::{BuilderError, StandaloneHost, StandaloneHostBuilder};
+pub use standalone::{AlreadyRunning, BuilderError, StandaloneHost, StandaloneHostBuilder};
 pub use state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
 /// Re-export of the cross-backend advance payload that [`HighWaterCommand::Advance`]
 /// wraps, so consumers can build commands without depending on `tsoracle-consensus`.

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -160,16 +160,20 @@ where
     /// awaits the runner's `apply_notify` and drains decided entries
     /// into the in-memory high-water on each wake.
     ///
-    /// # Preconditions
+    /// # Errors
     ///
-    /// Must not be called while the host is already running. Debug
-    /// builds assert this; release builds would leave the previous
-    /// apply task orphaned.
-    pub fn start<Sink: MessageSink<HighWaterCommand>>(&mut self, sink: Arc<Sink>) {
-        debug_assert!(
-            self.task.is_none(),
-            "StandaloneHost::start called while already running",
-        );
+    /// Returns [`AlreadyRunning`] if the host is already running (a
+    /// `start` with no intervening [`Self::stop`]). The guard runs before
+    /// either task is spawned, so a rejected call spawns nothing and leaves
+    /// the live apply/tick tasks untouched — it never orphans them. `stop`
+    /// `take()`s the task handle, so the host is startable again afterwards.
+    pub fn start<Sink: MessageSink<HighWaterCommand>>(
+        &mut self,
+        sink: Arc<Sink>,
+    ) -> Result<(), AlreadyRunning> {
+        if self.task.is_some() {
+            return Err(AlreadyRunning);
+        }
 
         // Hand the apply task the shared cursor (seeded in `new` past the
         // recovered suffix) so it resumes there instead of re-draining the
@@ -180,6 +184,7 @@ where
             self.apply_cursor.clone(),
         ));
         self.runner.start(sink);
+        Ok(())
     }
 
     /// Signal shutdown and await both the runner tick task and the
@@ -384,6 +389,14 @@ pub enum BuilderError {
     #[error("my_node_id is required")]
     MissingNodeId,
 }
+
+/// [`StandaloneHost::start`] was called while the host was already running.
+/// The call is rejected before either the apply task or the runner tick task
+/// is spawned, so nothing is orphaned; call [`StandaloneHost::stop`] before
+/// starting again.
+#[derive(Debug, thiserror::Error)]
+#[error("StandaloneHost::start called while already running")]
+pub struct AlreadyRunning;
 
 #[async_trait]
 impl<S> PaxosHighWaterHost for StandaloneHost<S>

--- a/crates/tsoracle-driver-paxos/tests/common/mod.rs
+++ b/crates/tsoracle-driver-paxos/tests/common/mod.rs
@@ -191,7 +191,7 @@ where
             "node {node_id} is already running",
         );
         let host = slot.host.as_mut().expect("host present");
-        host.start(sink);
+        host.start(sink).expect("host not already running");
         let inbox = slot.inbox.take().expect("inbox present");
         let (stop_tx, stop_rx) = oneshot::channel();
         slot.pump_stop = Some(stop_tx);

--- a/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_shutdown.rs
@@ -90,7 +90,8 @@ async fn stop_delivers_shutdown_when_apply_task_is_mid_iteration() {
     let gate = yieldpoint::cfg(APPLY_TASK_YIELD);
 
     let mut host = build_host();
-    host.start(Arc::new(NoopSink));
+    host.start(Arc::new(NoopSink))
+        .expect("fresh host is not already running");
 
     // The runner's first tick (~2 ms in) fires apply_notify; the apply
     // task wakes, runs drain+maybe_snapshot, then parks at the yield

--- a/crates/tsoracle-driver-paxos/tests/standalone_start_guard.rs
+++ b/crates/tsoracle-driver-paxos/tests/standalone_start_guard.rs
@@ -1,0 +1,89 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Regression (#355): `StandaloneHost::start` must enforce its
+//! "not already running" lifecycle invariant in *every* build profile.
+//!
+//! The original guard was a `debug_assert!` that compiled away in
+//! release, so a double-`start` there silently overwrote `self.task` —
+//! orphaning the prior apply task (duplicate apply loops folding into
+//! one high-water) and leaking the runner's tick task. The guard now
+//! returns `Err(AlreadyRunning)` before spawning anything, so the
+//! invariant holds regardless of profile and nothing is orphaned.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use omnipaxos::messages::Message;
+use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+use parking_lot::Mutex;
+use tsoracle_driver_paxos::{AlreadyRunning, HighWaterCommand, StandaloneHost};
+use tsoracle_paxos_toolkit::lifecycle::MessageSink;
+use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+
+struct NoopSink;
+
+#[async_trait]
+impl MessageSink<HighWaterCommand> for NoopSink {
+    async fn send(&self, _: Message<HighWaterCommand>) {}
+}
+
+fn build_host() -> StandaloneHost<MemStorage<HighWaterCommand>> {
+    let cluster_config = ClusterConfig {
+        configuration_id: 1,
+        nodes: vec![1, 2, 3],
+        flexible_quorum: None,
+    };
+    let server_config = ServerConfig {
+        pid: 1,
+        ..Default::default()
+    };
+    let config = OmniPaxosConfig {
+        cluster_config,
+        server_config,
+    };
+    let omnipaxos = config
+        .build(MemStorage::<HighWaterCommand>::new())
+        .expect("build omnipaxos handle");
+    StandaloneHost::builder()
+        .omnipaxos(Arc::new(Mutex::new(omnipaxos)))
+        .my_node_id(1)
+        .tick_interval(Duration::from_millis(2))
+        .build()
+        .expect("build standalone host")
+}
+
+// A second `start` on a live host must be rejected — not orphan the prior
+// apply/tick tasks — and `stop` must clear the guard so the host restarts.
+#[tokio::test(start_paused = true)]
+async fn double_start_is_rejected_and_stop_restores_startability() {
+    let mut host = build_host();
+
+    host.start(Arc::new(NoopSink))
+        .expect("first start on a fresh host succeeds");
+
+    // Already running: the second start spawns nothing and reports the misuse.
+    assert!(
+        matches!(host.start(Arc::new(NoopSink)), Err(AlreadyRunning)),
+        "start while already running must return Err(AlreadyRunning)",
+    );
+
+    host.stop().await;
+
+    // stop() took the apply-task handle, so the guard clears and a fresh start
+    // is accepted again.
+    host.start(Arc::new(NoopSink))
+        .expect("start after stop succeeds (guard cleared)");
+
+    host.stop().await;
+}

--- a/examples/paxos-embedded/src/main.rs
+++ b/examples/paxos-embedded/src/main.rs
@@ -135,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
         let sink = Arc::new(MeshSink {
             network: network.clone(),
         });
-        host.start(sink);
+        host.start(sink).context("host not already running")?;
 
         // ---- Driver + tsoracle server ----
         let driver = Arc::new(PaxosDriver::new(host, leader_stream));

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -192,7 +192,7 @@ async fn main() -> anyhow::Result<()> {
 
     // ---- Start runner + apply task ----
     let sink = Arc::new(PeerSink::new(paxos_addrs));
-    host.start(sink);
+    host.start(sink).context("host not already running")?;
 
     // ---- ConsensusDriver ----
     let driver = Arc::new(PaxosDriver::new(host, leader_stream));


### PR DESCRIPTION
## Problem

`StandaloneHost::start` (`crates/tsoracle-driver-paxos/src/standalone.rs`) enforced its "must not be called while already running" invariant with `debug_assert!(self.task.is_none(), ...)`. The doc comment admitted the gap: *"Debug builds assert this; release builds would leave the previous apply task orphaned."*

`debug_assert!` compiles away in release. There, a double-`start` (no intervening `stop`, which `take()`s the handle) silently overwrites `self.task`, orphaning the prior apply task — duplicate apply loops folding into the same high-water — and calls `self.runner.start(sink)` a second time, leaking the runner's tick task too. A lifecycle invariant whose violation causes task leaks and possible high-water races must not be a debug-only assertion.

Fixes #355.

## Change

`start` now returns `Result<(), AlreadyRunning>`, guarded by an early return placed **before either spawn**:

```rust
if self.task.is_some() {
    return Err(AlreadyRunning);
}
```

A rejected call therefore spawns nothing and never orphans the live apply/tick tasks, in any build profile. `self.task` stays the single structural "running" signal (no new field); `stop()` `take()`s it, so the host is startable again afterwards.

Chosen over an idempotent no-op (which would silently swallow the misuse and drop the second `sink`) and over promoting to `assert!` (a hard panic in a service path).

- New public `AlreadyRunning` error type, re-exported from the crate root.
- Doc comment rewritten: `# Preconditions` → `# Errors`.
- All 5 call sites updated to handle the `Result` (`.expect(...)` in tests, `.context(...)?` in the two examples and the stress benchmark).

## Test

New regression test `tests/standalone_start_guard.rs`: first `start` → `Ok`, second `start` → `Err(AlreadyRunning)`, `stop`, then `start` again → `Ok` (proves `stop` clears the guard so the host is restartable). The "nothing orphaned" property follows structurally from the guard preceding both spawns. Written test-first and watched fail before implementing.

## Verification

- `cargo build --workspace --all-targets` ✓
- `cargo test -p tsoracle-driver-paxos --features yieldpoints` — all pass ✓
- `cargo clippy -p tsoracle-driver-paxos -p stress --all-targets` clean ✓
- `cargo fmt --check` clean ✓