### PR TITLE
fix(client): reject off-list epoch-less leader hint over a fresh known-epoch leader

### DIFF
--- a/crates/tsoracle-client/src/leader_resolved.rs
+++ b/crates/tsoracle-client/src/leader_resolved.rs
@@ -172,18 +172,41 @@ impl ChannelPool {
     /// The check and the write share one lock acquisition, so a concurrent
     /// `record_success(higher_epoch)` cannot land between "the hint passed
     /// the gate" and "the hint was written" and then be clobbered by the
-    /// lower-epoch hint. The rule itself is unchanged from the former
-    /// `accept_hint` gate: reject only when the cache is fresh (within
-    /// `leader_ttl`), both epochs are known, and the hint's epoch is
-    /// strictly below the cached one. An absent or expired entry, or
-    /// either epoch being unknown, accepts the hint — covering the
-    /// bootstrap and old-server cases.
+    /// lower-epoch hint. The rule, evaluated only while the cache is fresh
+    /// (within `leader_ttl`):
+    ///
+    /// - **Both epochs known:** accept iff the hint's epoch is `>=` the
+    ///   cached one (the monotone-forward gate; rejects a strictly-stale
+    ///   hint).
+    /// - **Known cache, epoch-less hint:** there is no epoch to rank, so
+    ///   accept only when the hint names a *configured* endpoint — one we
+    ///   would dial in round-robin regardless, and that a later successful
+    ///   RPC could confirm. An off-list epoch-less hint cannot downgrade the
+    ///   confirmed leader (issue #357).
+    /// - **Unknown cached epoch:** no monotone floor to defend, so the hint
+    ///   is accepted — the bootstrap / old-server path.
+    ///
+    /// An absent or expired entry also accepts the hint (no floor).
     pub(crate) fn compare_and_set_leader(&self, endpoint: String, epoch: Option<u128>) -> bool {
         let mut guard = self.leader.lock();
         let accept = match &*guard {
             Some(cached) if cached.last_used.elapsed() < self.retry_policy.leader_ttl => {
                 match (cached.epoch, epoch) {
                     (Some(cached_epoch), Some(hint_epoch)) => hint_epoch >= cached_epoch,
+                    // No epoch to rank against a fresh, known-epoch leader
+                    // (issue #357): accept only when the hint names a
+                    // configured node — one we would dial in round-robin
+                    // anyway, and that a later successful RPC could confirm.
+                    // An off-list endpoint (a mixed-version peer's bad guess
+                    // or a misbehaving redirect source) cannot downgrade the
+                    // confirmed leader on an epoch-less claim.
+                    (Some(_), None) => self
+                        .configured
+                        .iter()
+                        .any(|configured| configured == &endpoint),
+                    // The cache itself holds no epoch (or is absent/expired):
+                    // no monotone floor to defend, so the bootstrap and
+                    // old-server paths still accept the hint.
                     _ => true,
                 }
             }
@@ -444,6 +467,94 @@ mod tests {
         // even once a known epoch has been observed.
         assert!(pool.compare_and_set_leader("a:1".into(), None));
         assert_eq!(pool.cached_leader().as_deref(), Some("a:1"));
+    }
+
+    /// An epoch-less hint must not downgrade a *fresh, known-epoch* cached
+    /// leader when the hinted endpoint is **off the configured list** (issue
+    /// #357). A mixed-version peer or a misbehaving redirect source can emit a
+    /// NOT_LEADER hint carrying no epoch; without a rankable epoch, the only
+    /// trust signal left is "is this an endpoint we'd dial anyway?". An
+    /// off-list endpoint fails that test, so the confirmed leader stands.
+    #[test]
+    fn unknown_epoch_offlist_hint_rejected_when_cache_fresh_known() {
+        let pool = ChannelPool::new(
+            vec!["a:1".into(), "b:1".into()],
+            None,
+            false,
+            RetryPolicy::default(),
+        );
+        // Confirm `a:1` at a known epoch via a successful RPC.
+        pool.record_success("a:1", 9);
+        // An epoch-less hint to an endpoint that is NOT configured must be
+        // rejected — it cannot prove it outranks the confirmed leader.
+        assert!(!pool.compare_and_set_leader("attacker:1".into(), None));
+        assert_eq!(
+            pool.cached_leader().as_deref(),
+            Some("a:1"),
+            "an off-list epoch-less hint must not unseat a fresh known-epoch leader"
+        );
+    }
+
+    /// The flip side of the #357 carve-out: an epoch-less hint to a
+    /// *configured* endpoint is still accepted over a fresh, known-epoch
+    /// leader. A node we would dial in round-robin anyway is trustworthy
+    /// enough to redirect to immediately — preserving fast failover in a
+    /// mixed-version cluster where the new leader runs an old server that
+    /// emits no epoch.
+    #[test]
+    fn unknown_epoch_configured_hint_accepted_when_cache_fresh_known() {
+        let pool = ChannelPool::new(
+            vec!["a:1".into(), "b:1".into()],
+            None,
+            false,
+            RetryPolicy::default(),
+        );
+        pool.record_success("a:1", 9);
+        // `b:1` is configured, so an epoch-less hint to it is honored.
+        assert!(pool.compare_and_set_leader("b:1".into(), None));
+        assert_eq!(pool.cached_leader().as_deref(), Some("b:1"));
+    }
+
+    /// When the cache itself holds an *unknown* epoch there is no monotone
+    /// floor to defend, so the #357 carve-out does not apply: an epoch-less
+    /// hint — even to an off-list endpoint — still seats. This is the
+    /// bootstrap / old-server path the gate must keep open.
+    #[test]
+    fn unknown_epoch_hint_still_accepted_when_cache_unknown_epoch() {
+        let pool = ChannelPool::new(
+            vec!["a:1".into(), "b:1".into()],
+            None,
+            false,
+            RetryPolicy::default(),
+        );
+        // Seat an unknown-epoch entry (the cache holds `None`).
+        assert!(pool.compare_and_set_leader("a:1".into(), None));
+        assert_eq!(pool.cached_leader().as_deref(), Some("a:1"));
+        // With no known epoch cached, an off-list epoch-less hint still wins.
+        assert!(pool.compare_and_set_leader("attacker:1".into(), None));
+        assert_eq!(pool.cached_leader().as_deref(), Some("attacker:1"));
+    }
+
+    /// Once the known-epoch entry has aged past `leader_ttl`, it imposes no
+    /// floor, so even an off-list epoch-less hint seats — the #357 carve-out
+    /// only guards a *fresh* known-epoch leader. Re-checking freshness under
+    /// the write lock is what keeps this consistent.
+    #[tokio::test(start_paused = true)]
+    async fn unknown_epoch_offlist_hint_accepted_once_cache_expires() {
+        let policy = RetryPolicy {
+            leader_ttl: std::time::Duration::from_millis(50),
+            ..RetryPolicy::default()
+        };
+        let pool = ChannelPool::new(vec!["a:1".into(), "b:1".into()], None, false, policy);
+        pool.record_success("a:1", 9);
+        // Fresh: the off-list epoch-less hint is rejected.
+        assert!(!pool.compare_and_set_leader("attacker:1".into(), None));
+        assert_eq!(pool.cached_leader().as_deref(), Some("a:1"));
+        // Advance past the TTL; the epoch-9 entry is now stale.
+        tokio::time::advance(std::time::Duration::from_millis(75)).await;
+        // No floor remains, so the same off-list epoch-less hint now seats.
+        assert!(pool.compare_and_set_leader("attacker:1".into(), None));
+        assert_eq!(pool.cached_leader().as_deref(), Some("attacker:1"));
     }
 
     /// A cache entry that has aged past `leader_ttl` is treated as absent,

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -411,8 +411,9 @@ fn classify_not_leader_hint(
                     from = %endpoint,
                     to = %hinted,
                     hint_epoch = ?hint_epoch,
-                    "tsoracle-client: dropping stale leader hint with epoch \
-                     behind the cached leader's epoch",
+                    "tsoracle-client: dropping leader hint that cannot outrank \
+                     the cached leader — either a stale epoch behind the cached \
+                     one, or an epoch-less hint to an off-list endpoint",
                 );
                 AttemptOutcome::StaleLeaderHint(status)
             }


### PR DESCRIPTION
Closes #357.

## Problem

`ChannelPool::compare_and_set_leader` gates a wire-supplied leader hint with a monotone-forward rule. When the cache is fresh, the gate was:

```rust
match (cached.epoch, epoch) {
    (Some(cached_epoch), Some(hint_epoch)) => hint_epoch >= cached_epoch,
    _ => true,
}
```

The `_ => true` arm collapsed three distinct cases. Two are intentional — `(None cached, _)`, where the cache itself holds no epoch (the bootstrap / old-server path). The third, `(Some cached, None hint)`, was the bug: a hint carrying **no** epoch was accepted even when the cache held a **fresh, known** epoch the client had just confirmed. In a mixed-version cluster (some nodes emit an epoch, some don't) or with a misbehaving/malicious redirect source, an epoch-less hint could regress routing away from a confirmed current leader.

## Fix

Split `(Some cached, None hint)` out of the catch-all. With no epoch to rank, accept the epoch-less hint over a fresh known-epoch entry **only when the hinted endpoint exactly matches a configured node** — one the client would dial in round-robin regardless, and that a later successful RPC could confirm:

```rust
match (cached.epoch, epoch) {
    (Some(cached_epoch), Some(hint_epoch)) => hint_epoch >= cached_epoch,
    (Some(_), None) => self.configured.iter().any(|configured| configured == &endpoint),
    _ => true,
}
```

- An off-list endpoint (a mixed-version peer's bad guess, a misbehaving redirect source, an attacker-controlled hint string) can no longer downgrade the confirmed leader on an epoch-less claim.
- A hint pointing at a **real configured cluster member** is still honored immediately, preserving fast failover when a legitimately-elected node runs an old server that emits no epoch.
- The trust signal — "is this in the operator-supplied endpoint list?" — is independent of the wire, mirroring the existing `tls_required` plaintext-hint refusal.
- `record_success` is unchanged: any endpoint a successful RPC confirms is still seated. A rejected off-list hint self-heals once round-robin reaches a node that actually answers.

### Endpoint matching

Exact-string equality against `self.configured`, the same identity `iter_round_robin` uses for dedup. No scheme-normalization: if config and hint strings disagree, the carve-out simply does not fire and the code degrades to the safe reject — never back to the buggy accept.

### Observability

The caller (`retry.rs`) already logs and returns `AttemptOutcome::StaleLeaderHint` on a `false` result, so off-list epoch-less rejections flow through that existing path. Its `tracing::warn!` message is reworded — it previously claimed the hint's "epoch [is] behind the cached leader's epoch", which is inaccurate for the epoch-less case. No new metric.

## Tests

- `unknown_epoch_offlist_hint_rejected_when_cache_fresh_known` — regression test; fails on `main` (off-list `None` hint was accepted), passes after the fix.
- `unknown_epoch_configured_hint_accepted_when_cache_fresh_known` — carve-out positive case: a configured-node `None` hint still seats.
- `unknown_epoch_hint_still_accepted_when_cache_unknown_epoch` — bootstrap path preserved (no known floor).
- `unknown_epoch_offlist_hint_accepted_once_cache_expires` — the carve-out only guards a *fresh* entry; an expired one imposes no floor.

The pre-existing `compare_and_set_leader_checks_and_writes_atomically` still passes — its `None`-over-epoch-9 assertion uses a configured endpoint.

## Verification

- `cargo test --workspace` — all green, 0 failures.
- `cargo build --examples` — clean.
- `cargo clippy -p tsoracle-client --all-features --tests` — clean.

No public API or wire-format change.