### PR TITLE
fix(server): count offered load in get_ts.requests.total, rename success counter

### DIFF
--- a/crates/tsoracle-server/src/docs/operations.md
+++ b/crates/tsoracle-server/src/docs/operations.md
@@ -25,8 +25,9 @@ tsoracle serve --state-dir ./tsoracle-data
 
 The server emits the following signals through the [`metrics`](https://docs.rs/metrics) crate facade. Emission is gated behind the `metrics` Cargo feature on `tsoracle-server` (off by default so the dependency stays opt-in for embedders who do not want it):
 
-- `tsoracle.get_ts.total` — total GetTs RPCs handled (counter)
-- `tsoracle.get_ts.timestamps_issued` — sum of `count` across all GetTs responses (counter)
+- `tsoracle.get_ts.requests.total` — total well-formed GetTs RPCs offered, counted at entry before the NOT_LEADER gate; the honest offered load (counter)
+- `tsoracle.get_ts.success.total` — GetTs RPCs that returned a grant; `requests.total - success.total` is the failure count (counter)
+- `tsoracle.get_ts.timestamps_issued` — sum of `count` across all successful GetTs responses (counter)
 - `tsoracle.window.extensions.total` — number of persist_high_water calls (counter)
 - `tsoracle.window.extension_latency` — duration of persist_high_water (histogram, seconds)
 - `tsoracle.leader_transition.total` — leader-watch saw a state change (counter)

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -106,6 +106,16 @@ impl TsoService for TsoServiceImpl {
             return Err(Status::invalid_argument("count must be >= 1"));
         }
 
+        // Offered load: count every well-formed request exactly once, here at
+        // entry before the NOT_LEADER gate and the allocator. `success.total`
+        // below bumps only on the Ok arm, so `requests.total - success.total`
+        // is the failure count — a node rejecting every request shows this
+        // total climbing while successes stay flat (vs. flat-at-zero, which is
+        // indistinguishable from no traffic). Outside the retry loop, so a
+        // single-extend-retry call still counts exactly once.
+        #[cfg(feature = "metrics")]
+        metrics::counter!("tsoracle.get_ts.requests.total").increment(1);
+
         // Fast NOT_LEADER gate.
         if let ServingState::NotServing {
             leader_endpoint,
@@ -150,7 +160,7 @@ impl TsoService for TsoServiceImpl {
                 Ok(grant) => {
                     #[cfg(feature = "metrics")]
                     {
-                        metrics::counter!("tsoracle.get_ts.total").increment(1);
+                        metrics::counter!("tsoracle.get_ts.success.total").increment(1);
                         metrics::counter!("tsoracle.get_ts.timestamps_issued")
                             .increment(u64::from(grant.count()));
                     }

--- a/crates/tsoracle-server/tests/metrics.rs
+++ b/crates/tsoracle-server/tests/metrics.rs
@@ -102,7 +102,8 @@ async fn emits_documented_signals_end_to_end() {
         .unwrap();
 
     // First call lands inside the post-fence window: drives
-    // get_ts.total (+1) and get_ts.timestamps_issued (+5).
+    // get_ts.requests.total (+1), get_ts.success.total (+1), and
+    // get_ts.timestamps_issued (+5).
     let resp = client
         .get_ts(GetTsRequest { count: 5 })
         .await
@@ -146,9 +147,24 @@ async fn emits_documented_signals_end_to_end() {
     // Every documented signal must have fired at least once. Inequalities
     // (not strict equalities) keep the test robust against the initial
     // LeaderState::Unknown the watch channel may surface ahead of Leader.
+    // success.total counts only the two successful grants; the trailing
+    // NOT_LEADER call returns before the Ok arm and must not bump it.
     assert!(
-        counter_value(&snapshot, "tsoracle.get_ts.total") >= 2,
-        "tsoracle.get_ts.total did not increment for both GetTs calls"
+        counter_value(&snapshot, "tsoracle.get_ts.success.total") >= 2,
+        "tsoracle.get_ts.success.total did not increment for both successful GetTs calls"
+    );
+    // requests.total is the honest offered load: both successes plus the
+    // NOT_LEADER rejection, counted at entry before the leader gate.
+    let requests_total = counter_value(&snapshot, "tsoracle.get_ts.requests.total");
+    assert!(
+        requests_total >= 3,
+        "tsoracle.get_ts.requests.total did not count all three GetTs RPCs (2 ok + 1 NOT_LEADER), got {requests_total}"
+    );
+    // The regression this guards: a node failing requests must show offered
+    // load climbing above successes, not flat at the success count.
+    assert!(
+        requests_total > counter_value(&snapshot, "tsoracle.get_ts.success.total"),
+        "tsoracle.get_ts.requests.total must exceed success.total when a request is rejected (NOT_LEADER)"
     );
     assert!(
         counter_value(&snapshot, "tsoracle.get_ts.timestamps_issued") >= 8,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,8 +18,9 @@ Default is 1 second. On leadership gain, the new leader first computes `serving_
 
 **Server signals**
 
-- `tsoracle.get_ts.total` — total GetTs RPCs handled (counter)
-- `tsoracle.get_ts.timestamps_issued` — sum of `count` across all GetTs responses (counter)
+- `tsoracle.get_ts.requests.total` — total well-formed GetTs RPCs offered, counted at entry before the NOT_LEADER gate; the honest offered load (counter)
+- `tsoracle.get_ts.success.total` — GetTs RPCs that returned a grant; `requests.total - success.total` is the failure count (counter)
+- `tsoracle.get_ts.timestamps_issued` — sum of `count` across all successful GetTs responses (counter)
 - `tsoracle.window.extensions.total` — number of persist_high_water calls (counter)
 - `tsoracle.window.extension_latency` — duration of persist_high_water (histogram, seconds)
 - `tsoracle.window.extensions.ignored.not_leader.total` — a persisted window extension was dropped because this node was no longer leader; sustained non-zero rates indicate epoch churn (counter)

--- a/examples/metrics-prometheus/README.md
+++ b/examples/metrics-prometheus/README.md
@@ -21,8 +21,10 @@ curl -s http://127.0.0.1:9552/metrics | grep ^tsoracle_
 After a few seconds the scrape body looks roughly like this (exact values move with load):
 
 ```
-# TYPE tsoracle_get_ts_total counter
-tsoracle_get_ts_total 47
+# TYPE tsoracle_get_ts_requests_total counter
+tsoracle_get_ts_requests_total 49
+# TYPE tsoracle_get_ts_success_total counter
+tsoracle_get_ts_success_total 47
 # TYPE tsoracle_get_ts_timestamps_issued counter
 tsoracle_get_ts_timestamps_issued 235
 # TYPE tsoracle_leader_transition_total counter
@@ -35,7 +37,7 @@ tsoracle_window_extension_latency_sum 0.00031
 tsoracle_window_extension_latency_count 1
 ```
 
-The `metrics` crate translates `.` to `_` in the exposition output, so the documented `tsoracle.get_ts.total` is scraped as `tsoracle_get_ts_total`. Counters whose names end in `.total` keep that suffix (Prometheus tooling expects it). The full signal catalog lives in [`docs/operations.md`](../../docs/operations.md#monitoring-hooks).
+The `metrics` crate translates `.` to `_` in the exposition output, so the documented `tsoracle.get_ts.requests.total` is scraped as `tsoracle_get_ts_requests_total`. Counters whose names end in `.total` keep that suffix (Prometheus tooling expects it). The gap between `requests_total` (offered load) and `success_total` (grants returned) is the failed-request count. The full signal catalog lives in [`docs/operations.md`](../../docs/operations.md#monitoring-hooks).
 
 ## What to look at in `src/main.rs`
 


### PR DESCRIPTION
Closes #345.

## Problem

`tsoracle.get_ts.total` incremented only on the `Ok(grant)` arm, so NOT_LEADER, double `WindowExhausted`, invalid-count, and out-of-range requests went uncounted. A node failing every request showed the counter flat at zero — indistinguishable from no traffic — despite the name implying a total.

## Change

- Add `tsoracle.get_ts.requests.total`, incremented once at entry after the `count == 0` check and before the NOT_LEADER gate, so every well-formed request counts exactly once regardless of outcome. It sits outside the retry loop, so a single-extend-retry call still counts once.
- Rename the existing success-only counter `tsoracle.get_ts.total` → `tsoracle.get_ts.success.total`.
- `tsoracle.get_ts.timestamps_issued` unchanged.

Operators now get an honest offered-load signal: `requests.total - success.total` is the failure count, and offered load climbs while successes stay flat when a node is failing requests.

This renames an operator-visible metric (`get_ts.total` → `get_ts.success.total`), a breaking change to dashboards scraping the old name. The crate is pre-1.0.

## Test plan

- [x] `cargo test -p tsoracle-server --features "test-support metrics"` — all pass
- [x] Metrics integration test updated: renamed the success assertion and added `requests.total >= 3` (2 grants + 1 NOT_LEADER) plus `requests.total > success.total` (the regression guard)
- [x] Red→green verified for the new assertions (disabled the entry counter, watched `requests.total` fail at 0, restored)
- [x] `cargo clippy --features "test-support metrics" --all-targets` clean; default no-metrics build compiles
- [x] Updated both `operations.md` catalogs and the Prometheus example README