### PR TITLE
fix(core): name all operands on window-extension overflow

### DIFF
--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -124,6 +124,14 @@ pub enum CoreError {
         fence_floor: u64,
         committed_ceiling: u64,
     },
+    #[error(
+        "window extension overflow: max(floor {floor}, now_ms {now_ms}) + ahead_ms {ahead_ms} exceeds u64::MAX"
+    )]
+    WindowExtensionOverflow {
+        floor: u64,
+        now_ms: u64,
+        ahead_ms: u64,
+    },
 }
 
 /// The result of a `try_commit_window_extension` that passed range validation.
@@ -388,9 +396,13 @@ impl Allocator {
                 let floor = committed_high_water
                     .checked_add(1)
                     .ok_or(CoreError::PhysicalMsOutOfRange(*committed_high_water))?;
-                let requested = core::cmp::max(floor, now_ms)
-                    .checked_add(ahead_ms)
-                    .ok_or(CoreError::PhysicalMsOutOfRange(u64::MAX))?;
+                let requested = core::cmp::max(floor, now_ms).checked_add(ahead_ms).ok_or(
+                    CoreError::WindowExtensionOverflow {
+                        floor,
+                        now_ms,
+                        ahead_ms,
+                    },
+                )?;
                 if requested > PHYSICAL_MS_MAX {
                     return Err(CoreError::PhysicalMsOutOfRange(requested));
                 }
@@ -644,6 +656,26 @@ mod tests {
         assert_eq!(
             allocator.try_prepare_window_extension(PHYSICAL_MS_MAX, 1),
             Err(CoreError::PhysicalMsOutOfRange(PHYSICAL_MS_MAX + 2))
+        );
+    }
+
+    #[test]
+    fn prepare_window_extension_overflow_names_all_operands() {
+        // A saturated clock (SystemClock::now_ms saturates to u64::MAX) plus any
+        // non-zero ahead_ms overflows max(floor, now_ms) + ahead_ms. The error
+        // must name the three real operands so the log points at the clock, not
+        // a phantom "someone passed an absurd physical_ms".
+        let mut allocator = Allocator::new();
+        allocator
+            .try_on_leadership_gained(1_000, 1_000, Epoch(1))
+            .unwrap();
+        assert_eq!(
+            allocator.try_prepare_window_extension(u64::MAX, 1),
+            Err(CoreError::WindowExtensionOverflow {
+                floor: 1_001,
+                now_ms: u64::MAX,
+                ahead_ms: 1,
+            })
         );
     }
 

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -75,6 +75,13 @@ fn core_status(error: CoreError) -> Status {
         } => Status::internal(format!(
             "invalid leadership window: fence_floor {fence_floor} exceeds committed_ceiling {committed_ceiling}"
         )),
+        CoreError::WindowExtensionOverflow {
+            floor,
+            now_ms,
+            ahead_ms,
+        } => Status::internal(format!(
+            "window extension overflow: max(floor {floor}, now_ms {now_ms}) + ahead_ms {ahead_ms} exceeds u64::MAX"
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #339.

`Allocator::try_prepare_window_extension` returned `PhysicalMsOutOfRange(u64::MAX)` as a hardcoded placeholder when `max(floor, now_ms).checked_add(ahead_ms)` overflowed — discarding the actual operands. The sibling overflow one line up honestly reports `*committed_high_water`, so the placeholder was the odd one out.

This path is reachable in production: a saturated `SystemClock` (`now_ms` saturates to `u64::MAX`) plus any non-zero `ahead_ms` overflows the add. The resulting log read as *"someone passed an absurd physical_ms"* when the real cause was a misconfigured clock.

## Change

- Add `CoreError::WindowExtensionOverflow { floor, now_ms, ahead_ms }`, naming all three inputs. This is the only option that fully resolves the issue's goal: with the minimal `max(floor, now_ms)` alternative, the reported value would *still* be `u64::MAX` in the exact saturated-clock scenario, leaving the cause ambiguous. Naming `now_ms` separately makes a saturated clock immediately distinguishable from a large `ahead_ms`.
- Return the new variant at the overflow site.
- Add the `core_status` arm mapping it to `Status::internal` — the operands are server-side (clock + window config), never client-supplied, so this is a server fault like `InvalidLeadershipWindow`, not an `out_of_range` request.

The sibling floor overflow (`committed_high_water`) and the `requested > PHYSICAL_MS_MAX` out-of-range check are deliberately left unchanged; the issue scopes to the one placeholder.

## Notes

`tsoracle-core` is a published library and `CoreError` is not `#[non_exhaustive]`, so this adds a public variant (a breaking change for external exhaustive matchers — acceptable pre-1.0). Labeled `fix:` so it lands inside the release filter and the new symbol publishes.

## Testing

- New unit test `prepare_window_extension_overflow_names_all_operands` (written test-first, watched it fail before implementing).
- `cargo test --workspace` — all suites pass, 0 failures (includes the `tsoracle-tests` integration crate where runtime `CoreError` match arms live).
- `cargo fmt --check` and `cargo clippy` clean.