### PR TITLE
refactor(server): drop parked state_rx; read/publish via state_tx

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -95,7 +95,7 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
 
                 // Clear serving so new GetTs requests return NOT_LEADER until the
                 // fence republishes Serving below.
-                let _ = server.state_tx.send(ServingState::NotServing {
+                server.state_tx.send_replace(ServingState::NotServing {
                     leader_endpoint: None,
                     leader_epoch: None,
                 });
@@ -201,7 +201,7 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                         )?;
 
                         // Publish serving, then release the drain guard.
-                        let _ = server.state_tx.send(ServingState::Serving);
+                        server.state_tx.send_replace(ServingState::Serving);
                         drop(drain_guard);
 
                         tsoracle_failpoint::failpoint!("server::fence::after_serving_published");
@@ -222,7 +222,7 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                         Err(ServerError::Consensus(
                             ConsensusError::NotLeader { .. } | ConsensusError::Fenced { .. },
                         )) => {
-                            let _ = server.state_tx.send(ServingState::NotServing {
+                            server.state_tx.send_replace(ServingState::NotServing {
                                 leader_endpoint: None,
                                 leader_epoch: None,
                             });
@@ -275,7 +275,7 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
                 leader_epoch,
             } => {
                 server.allocator.lock().on_leadership_lost();
-                let _ = server.state_tx.send(ServingState::NotServing {
+                server.state_tx.send_replace(ServingState::NotServing {
                     leader_endpoint,
                     leader_epoch,
                 });
@@ -286,7 +286,7 @@ pub(crate) async fn run_leader_watch(server: Arc<Server>) -> Result<(), ServerEr
             }
             LeaderState::Unknown => {
                 server.allocator.lock().on_leadership_lost();
-                let _ = server.state_tx.send(ServingState::NotServing {
+                server.state_tx.send_replace(ServingState::NotServing {
                     leader_endpoint: None,
                     leader_epoch: None,
                 });

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -127,7 +127,13 @@ impl ServerBuilder {
     pub fn build(self) -> Result<Server, BuildError> {
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
-        let (state_tx, state_rx) = watch::channel(ServingState::NotServing {
+        // Discard the receiver minted by `watch::channel`: `state_tx` is the
+        // single source of truth. It mints fresh receivers on demand via
+        // `subscribe()` and reads its current value via `borrow()`, so no parked
+        // receiver needs to live on the server. Publish sites use `send_replace`
+        // (not `send`) so a transition still mutates and notifies even when no
+        // embedder has subscribed and `receiver_count` is zero.
+        let (state_tx, _) = watch::channel(ServingState::NotServing {
             leader_endpoint: None,
             leader_epoch: None,
         });
@@ -138,7 +144,6 @@ impl ServerBuilder {
             failover_advance: self.failover_advance,
             allocator: Arc::new(Mutex::new(Allocator::new())),
             state_tx,
-            state_rx,
             extension_lock: Arc::new(tokio::sync::Mutex::new(())),
             extension_gate: Arc::new(tokio::sync::RwLock::new(())),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
@@ -153,8 +158,10 @@ pub struct Server {
     pub(crate) window_ahead: Duration,
     pub(crate) failover_advance: Duration,
     pub(crate) allocator: Arc<Mutex<Allocator>>,
+    /// Source of truth for serving state. Mints receivers for [`Server::subscribe`]
+    /// and is read synchronously via `borrow()` by the service layer; publish
+    /// sites use `send_replace` so transitions land even with zero receivers.
     pub(crate) state_tx: watch::Sender<ServingState>,
-    pub(crate) state_rx: watch::Receiver<ServingState>,
     /// Serializes window extensions so a stampeding burst of `WindowExhausted`
     /// requests resolves to a single `persist_high_water` round-trip. Acquired
     /// before `extension_gate`; combined with a recheck-after-acquire inside
@@ -184,11 +191,12 @@ impl Server {
     /// `embedded_router` and piggyback examples). Because `into_router`
     /// consumes the `Server`, capture the receiver before mounting.
     ///
-    /// This method is the stable observation API: the underlying field is
-    /// `pub(crate)`, so the receiver's type can evolve (e.g. a future newtype
-    /// around `ServingState`) without breaking embedders that go through it.
+    /// This method is the stable observation API: the receiver is minted from
+    /// the server's `watch::Sender`, so the receiver's type can evolve (e.g. a
+    /// future newtype around `ServingState`) without breaking embedders that
+    /// go through it.
     pub fn subscribe(&self) -> watch::Receiver<ServingState> {
-        self.state_rx.clone()
+        self.state_tx.subscribe()
     }
 
     /// Single transition API used in response to evidence that the current
@@ -221,7 +229,7 @@ impl Server {
         leader_epoch: Option<Epoch>,
     ) {
         self.allocator.lock().on_leadership_lost();
-        let _ = self.state_tx.send(ServingState::NotServing {
+        self.state_tx.send_replace(ServingState::NotServing {
             leader_endpoint,
             leader_epoch,
         });
@@ -608,6 +616,42 @@ mod tests {
             panic_payload_to_string(payload),
             "watch task panicked with non-string payload",
         );
+    }
+
+    #[test]
+    fn serving_transitions_publish_without_an_external_subscriber() {
+        // Regression guard for #346. With the parked `state_rx` field gone, the
+        // plain `serve(addr)` path holds zero receivers unless an embedder calls
+        // `subscribe()`. `watch::Sender::send` is a no-op that leaves the value
+        // untouched when `receiver_count == 0`, so the publish sites use
+        // `send_replace` (which mutates and notifies unconditionally) and reads
+        // go through `state_tx.borrow()`. Were a publish site to use `send`,
+        // this transition would be silently dropped and a leaderless-then-leader
+        // server could stay NotServing forever.
+        //
+        // Built without `subscribe()`, so `receiver_count` is zero when the
+        // production publish site below fires.
+        let server = Server::builder()
+            .consensus_driver(Arc::new(crate::test_fakes::InMemoryDriver::new()))
+            .build()
+            .expect("build must succeed");
+        assert_eq!(server.state_tx.receiver_count(), 0);
+
+        server.step_down_due_to_consensus_rejection(
+            Some("http://new-leader:9000".into()),
+            Some(Epoch(7)),
+        );
+
+        match &*server.state_tx.borrow() {
+            ServingState::NotServing {
+                leader_endpoint,
+                leader_epoch,
+            } => {
+                assert_eq!(leader_endpoint.as_deref(), Some("http://new-leader:9000"));
+                assert_eq!(*leader_epoch, Some(Epoch(7)));
+            }
+            ServingState::Serving => panic!("expected NotServing after step_down"),
+        }
     }
 
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -36,11 +36,11 @@ fn wire_epoch(epoch: Option<Epoch>) -> Option<EpochWire> {
     })
 }
 
-/// Snapshot the best-available leader hint from `state_rx`. Used wherever we
-/// need to surface a `FAILED_PRECONDITION` "not leader" response from a
-/// service-layer code path; matches what the fast NOT_LEADER gate emits.
+/// Snapshot the best-available leader hint from the serving-state channel. Used
+/// wherever we need to surface a `FAILED_PRECONDITION` "not leader" response
+/// from a service-layer code path; matches what the fast NOT_LEADER gate emits.
 fn leader_hint_from(server: &Server) -> LeaderHint {
-    let (leader_endpoint, leader_epoch) = match server.state_rx.borrow().clone() {
+    let (leader_endpoint, leader_epoch) = match server.state_tx.borrow().clone() {
         ServingState::NotServing {
             leader_endpoint,
             leader_epoch,
@@ -110,7 +110,7 @@ impl TsoService for TsoServiceImpl {
         if let ServingState::NotServing {
             leader_endpoint,
             leader_epoch,
-        } = self.server.state_rx.borrow().clone()
+        } = self.server.state_tx.borrow().clone()
         {
             return Err(not_leader_status(LeaderHint {
                 leader_endpoint,
@@ -216,8 +216,9 @@ impl TsoServiceImpl {
             let allocator = self.server.allocator.lock();
             let Some(epoch) = allocator.epoch() else {
                 // Lost leadership between the outer fast-gate check and here.
-                // Surface as a leader redirect (with the hint state_rx knows
-                // about), not a bare FAILED_PRECONDITION without metadata.
+                // Surface as a leader redirect (with the hint the serving-state
+                // channel knows about), not a bare FAILED_PRECONDITION without
+                // metadata.
                 return Err(not_leader_status(leader_hint_from(&self.server)));
             };
             let target = allocator
@@ -339,7 +340,7 @@ mod tests {
             .clock(std::sync::Arc::new(tsoracle_core::SystemClock))
             .build()
             .unwrap();
-        let _ = server.state_tx.send(ServingState::NotServing {
+        server.state_tx.send_replace(ServingState::NotServing {
             leader_endpoint: Some("http://other-node:9000".into()),
             leader_epoch: Some(Epoch(7)),
         });
@@ -352,7 +353,7 @@ mod tests {
         assert_eq!(hint.leader_epoch, Some(EpochWire { hi, lo }));
 
         // The Serving branch flips endpoint and epoch to None.
-        let _ = server.state_tx.send(ServingState::Serving);
+        server.state_tx.send_replace(ServingState::Serving);
         let hint = leader_hint_from(&server);
         assert!(hint.leader_endpoint.is_none());
         assert!(hint.leader_epoch.is_none());


### PR DESCRIPTION
Closes #346.

## Problem

`Server` stored both `state_tx` and a permanently-parked `state_rx`, the latter purely so the service layer could `borrow()` the current `ServingState` synchronously. Holding a parked receiver muddied ownership (which half is the source of truth?) and invited someone to `.changed().await` on the wrong handle.

## Change

`state_tx` is now the single source of truth:

- Dropped the `state_rx` field from the `Server` struct and `build()`.
- `subscribe()` mints fresh receivers via `state_tx.subscribe()`.
- The two synchronous service-layer reads (`leader_hint_from` and the fast NOT_LEADER gate) read via `state_tx.borrow()`.

## Why the publish sites switch `send` → `send_replace`

This is the non-obvious part the issue's suggested fix didn't call out. With the parked `state_rx` gone, the plain `serve(addr)` path holds **zero** receivers unless an embedder calls `subscribe()`. `watch::Sender::send` is documented (and verified in the tokio source) to return `Err` **and leave the value unmodified** when `receiver_count == 0` — so a transition published via `send` against zero receivers would be silently dropped, stranding the server in `NotServing`. `send_replace` mutates and notifies unconditionally, so all 8 publish sites (5 in `fence.rs`, 1 in `step_down_due_to_consensus_rejection`, 2 in-crate tests) now use it. The result was already discarded (`let _ = …send(…)`), so this is behavior-preserving for the ≥1-receiver case and fixes the zero-receiver case.

## Test

Added `serving_transitions_publish_without_an_external_subscriber`: builds a server, asserts `receiver_count() == 0`, drives a real publish site (`step_down_due_to_consensus_rejection`), and asserts the value propagated. Existing integration tests all call `subscribe()` first, so none of them would have caught a regression here. Demonstrated the test has teeth — with naive `send` it fails (`left: None, right: Some(...)`); with `send_replace` it passes.

## Scope

Intentionally does **not** include the parenthetical `ServingCore` extraction the issue mentions — that's a larger, separable refactor; dropping the field stands on its own.

## Verification

- `cargo test --workspace` — all green
- `cargo clippy -p tsoracle-server --all-targets --all-features` — clean
- `cargo fmt --all -- --check` — clean
- All example crates build (including the piggyback demos that consume `subscribe()`)