### PR TITLE
refactor(paxos-toolkit): require Send + Sync on box_err input

### DIFF
--- a/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
@@ -167,8 +167,18 @@ impl<T: Entry> RocksdbStorage<T> {
     }
 }
 
+/// Box a storage-side error for OmniPaxos's [`omnipaxos::storage::StorageResult`].
+///
+/// OmniPaxos fixes the error type at `Box<dyn Error>` (no `Send + Sync`), and
+/// every call site funnels straight into a `StorageResult` via `?`, so that is
+/// the return type here — `?` narrows through the `From<E>` conversion, never
+/// the unsize coercion a wider box would require. The `E: Send + Sync` bound on
+/// the *input* keeps this consistent with the project-wide
+/// `Box<dyn Error + Send + Sync>` convention and statically guarantees every
+/// error we box is thread-movable at the source, even though OmniPaxos's
+/// signature erases that capability at the trait boundary.
 #[cfg(feature = "rocksdb-storage")]
-fn box_err<E: std::error::Error + 'static>(err: E) -> Box<dyn std::error::Error> {
+fn box_err<E: std::error::Error + Send + Sync + 'static>(err: E) -> Box<dyn std::error::Error> {
     Box::new(err)
 }
 


### PR DESCRIPTION
Closes #350.

## Background

`box_err` (`crates/tsoracle-paxos-toolkit/src/storage/mod.rs`) is the single helper that boxes storage-side errors into OmniPaxos's `StorageResult` (`Box<dyn Error>`). It previously bounded its input only on `Error + 'static`, so the project-wide convention that errors are `Box<dyn Error + Send + Sync>` (e.g. `ConsensusError::TransientDriver`) was not enforced at the source.

## On the issue's suggested fix

The issue suggested widening the **return** type to `Box<dyn Error + Send + Sync>`, on the premise that "the omnipaxos bound is satisfied by the wider type." That premise does not hold for how the helper is actually used:

- OmniPaxos hard-codes `StorageResult<T> = Result<T, Box<dyn Error>>` (no `Send + Sync`), and every call site funnels into it via `.map_err(box_err)?`.
- `?` desugars to `From::from`, and std provides **no** `From<Box<dyn Error + Send + Sync>> for Box<dyn Error>` (and `Box<dyn Error + Send + Sync>` does not itself implement `Error`). The wide→narrow conversion is an unsize *coercion* that only fires at coercion sites such as a direct `return`, never through `?`.
- Widening the return type therefore fails to compile across the ~40 `?` call sites, and even if forced through would be erased back to the bare box at the trait boundary — no caller could observe `Send + Sync`.

## This change

Bound the **input** `E: Error + Send + Sync + 'static` and keep the OmniPaxos-mandated `Box<dyn Error>` return type. This is the meaningful, compilable improvement: it statically guarantees every error we box is thread-movable at the source — a future non-`Send` `StorageError` variant would fail to compile right here — while matching the project convention where it is actually checkable. A doc comment records the OmniPaxos constraint.

## Verification

- `cargo test -p tsoracle-paxos-toolkit --features rocksdb-storage storage::` → 38 passed, 0 failed
- `cargo clippy -p tsoracle-paxos-toolkit --features rocksdb-storage --all-targets` → clean
- workspace `cargo fmt --check` + `cargo clippy` (pre-commit hook) → clean