### PR TITLE
docs: reflect paxos stress topology in README and stress-testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A distributed timestamp oracle for Rust — highly available and fault-tolerant,
 - 🔌 **Pluggable consensus, openraft + OmniPaxos included** — `tsoracle-driver-openraft` and `tsoracle-driver-paxos` ship production-ready replicated drivers; implement one trait (`ConsensusDriver`) to back tsoracle with raft-rs, etcd, or your own replicated log instead. See [`docs/consensus-integration.md`](docs/consensus-integration.md#choosing-a-driver) for picking between drivers.
 - 📦 **gRPC client included** — `tsoracle-client` handles leader discovery, request coalescing, and reconnection for you.
 - 📈 **Operational metrics** — enable the `metrics` feature on `tsoracle-server` to emit allocator, leader, and request metrics through the `metrics` facade.
-- 🧪 **Hardened** — coverage-guided fuzzing on the postcard decoders, failpoint-driven crash tests, and a stress harness covering single-process and multi-process raft topologies.
+- 🧪 **Hardened** — coverage-guided fuzzing on the postcard decoders, failpoint-driven crash tests, and a stress harness covering in-process and multi-process topologies across the openraft and OmniPaxos backends.
 - 🧩 **Embeddable** — host the server inside your own binary with a few lines of Rust, or run the standalone CLI.
 
 ## Quickstart

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -10,10 +10,11 @@ The single most important invariant the stress harness checks is *global monoton
 
 ## Topologies
 
-Three modes, behind `--topology={mem,raft,process}`:
+Four modes, behind `--topology={mem,raft,paxos,process}`:
 
 - **mem** — single in-process tsoracle server backed by `InMemoryDriver`. Chaos via the driver's `become_leader`/`become_follower` affordances plus in-process failpoints. Fastest, cheapest, catches allocator + fence + leader-watch bugs. Use this for the bulk of development.
 - **raft** — three-node openraft cluster on `MemNetwork`, all in-process. Chaos via raft network partition (drop the leader's messages, let the cluster elect a new one) plus in-process failpoints. Catches openraft-driver-side bugs that mem cannot see.
+- **paxos** — three-node OmniPaxos cluster on `MemNetwork`, all in-process (OmniPaxos requires a 3-node quorum, so `--nodes` must be at least 3). Chaos by partitioning the leader's outbound messages to force the remaining quorum to re-elect, plus in-process failpoints. Catches paxos-driver-side bugs that mem cannot see.
 - **process** — spawned `tsoracle` binaries. Chaos via POSIX signals (SIGKILL/SIGSTOP/SIGCONT) plus `FAILPOINTS` env propagation. Unix-only. Catches process-level fault recovery, exit handling, and reconnection paths.
 
 Each topology speaks the same `ChaosController` vocabulary (`kill_leader`, `pause_leader`, `arm_failpoint`, `disarm_failpoint`), so the same scenario runs against any of them.
@@ -44,6 +45,9 @@ cargo run --release -p stress -- run --topology mem --scenario killer-loop --dur
 # Raft topology, 5m soak with the failpoint-cycle scenario (requires stress-failpoints feature).
 cargo run --release -p stress --features stress-failpoints -- \
   run --topology raft --scenario failpoint-cycle --duration 5m --nodes 3 --clients 16
+
+# Paxos topology, killer-loop, 30s (OmniPaxos requires a 3-node quorum).
+cargo run --release -p stress -- run --topology paxos --scenario killer-loop --duration 30s --nodes 3 --clients 16
 
 # Process topology, with schedule dump for replay.
 cargo run --release -p stress -- run --topology process --scenario killer-loop --duration 30s --nodes 3 --schedule-out /tmp/sched.json
@@ -96,8 +100,8 @@ The schedule pins both the named-or-random source and the materialized op sequen
 
 ## CI surface
 
-- **Per-PR**: `.github/workflows/ci.yml` contains a `stress-smoke` job that runs all three topologies with `--ci-smoke` plus the `inject-violation` positive control. Builds the tsoracle and stress binaries once, then exercises all four steps.
-- **Nightly**: `.github/workflows/stress-nightly.yml` runs the full scenario menu against each topology at `--duration 5m` (matrix of 3 topologies × 7 scenarios = 21 jobs). Results are uploaded as artifacts; failures auto-file a deduplicated GitHub issue via `.github/actions/stress-auto-issue`.
+- **Per-PR**: `.github/workflows/ci.yml` contains a `stress-smoke` job that runs all four topologies with `--ci-smoke` plus the `inject-violation` positive control. Builds the tsoracle and stress binaries once, then exercises all five steps.
+- **Nightly**: `.github/workflows/stress-nightly.yml` runs the full scenario menu against each topology at `--duration 5m` (matrix of 4 topologies × 7 scenarios = 28 jobs). Results are uploaded as artifacts; failures auto-file a deduplicated GitHub issue via `.github/actions/stress-auto-issue`.
 - **Multi-hour soak**: not CI-gated. Run locally against a candidate release build:
 
   ```bash


### PR DESCRIPTION
## Summary

The stress harness gained a fourth `--topology` (`paxos`, an in-process 3-node OmniPaxos cluster) in #176, so prose describing it as covering only raft topologies went stale. This is the post-merge follow-up filed as #214.

- **`README.md`** — the "Hardened" feature bullet now names both consensus backends instead of "single-process and multi-process raft topologies".
- **`docs/stress-testing.md`** — brought in line with the four-topology reality:
  - "Three modes, `={mem,raft,process}`" → "Four modes, `={mem,raft,paxos,process}`"
  - added a **paxos** topology bullet (3-node quorum, `MemNetwork`, leader-partition chaos)
  - added a paxos example to the Running section
  - corrected CI-surface counts: per-PR runs four topology smokes + the `inject-violation` control (five steps); nightly is a 4 topologies × 7 scenarios = 28-job matrix

## Verification

Docs-only; numbers verified against source rather than guessed:
- `benchmarks/stress/src/config.rs` — `TopologyKind::Paxos` and the `--nodes >= 3` quorum guard
- `.github/workflows/ci.yml` — four `--ci-smoke` topology steps + `inject-violation`
- `.github/workflows/stress-nightly.yml` — 4-topology × 7-scenario matrix

Closes #214