### PR TITLE
docs(consensus): specify persist_high_water epoch-fencing contract

### DIFF
--- a/crates/tsoracle-consensus/src/docs/consensus_integration.md
+++ b/crates/tsoracle-consensus/src/docs/consensus_integration.md
@@ -19,7 +19,7 @@ Return the durably-persisted high-water. The read MUST be linearized — the ret
 
 ## persist_high_water
 
-"Advance the durable high-water to at least `at_least`, return the actual value." Critical properties: monotonic-advance, durable before returning Ok, fenced by `epoch`.
+"Advance the durable high-water to at least `at_least`, return the actual value." Critical properties: monotonic-advance, durable before returning Ok, and stale-leader rejection. The `epoch` enables that last property, but the *mechanism* is the driver's choice: a driver MAY reject a stale-leader write with an up-front `epoch` pre-check (returning `ConsensusError::Fenced`), or rely on the `max(prev, at_least)` apply plus consensus leader-forwarding (returning `ConsensusError::NotLeader`) and ignore `epoch` entirely. Both are trait-compliant; the server treats `Fenced` and `NotLeader` identically — "this leader is stale, retry against the new leader." See the rustdoc on `ConsensusDriver::persist_high_water` for the normative statement.
 
 - **openraft:** submit `TsoExtend { at_least, epoch }` through `Raft::client_write()`. State machine apply does `stored = max(stored, at_least)`; returns the post-apply value. Stale leaders' writes fail because openraft refuses non-leader client_writes.
 - **raft-rs:** propose a `TsoExtend` log entry. On commit, apply does `max(stored, at_least)`. Stale leaders fail at the propose layer.

--- a/crates/tsoracle-consensus/src/driver.rs
+++ b/crates/tsoracle-consensus/src/driver.rs
@@ -61,8 +61,30 @@ pub trait ConsensusDriver: Send + Sync + 'static {
     /// least," never "absolute set." For consensus-backed implementations,
     /// the state-machine apply path computes `max(prev, at_least)`.
     ///
-    /// The `epoch` lets the driver reject stale-leader writes; single-node
-    /// drivers may ignore it.
+    /// **Contract — epoch-fencing (driver's choice of mechanism):** the
+    /// `epoch` names the leadership term the caller believed it held when it
+    /// issued the write. A consensus-backed driver MAY reject a stale-leader
+    /// write through *either* of two trait-compliant mechanisms, and which one
+    /// it uses is a driver-internal detail callers must not depend on:
+    ///   * **Pre-check** — compare `epoch` against the driver's current term
+    ///     before proposing and return [`ConsensusError::Fenced`] on mismatch.
+    ///     The paxos driver does this against its current ballot-derived epoch
+    ///     to avoid wasting a log slot on a write that would be superseded
+    ///     downstream anyway.
+    ///   * **Apply-time monotonicity + leader-forwarding** — admit the
+    ///     proposal and rely on the `max(prev, at_least)` apply (above) plus
+    ///     consensus leader-forwarding, which surfaces a superseded leader as
+    ///     [`ConsensusError::NotLeader`]. The openraft driver does this and
+    ///     ignores `epoch` entirely: a stale write either no-ops under `max`
+    ///     or is rejected because the node is no longer leader.
+    ///
+    /// Both outcomes carry the same meaning to the caller — *this leader is
+    /// stale; retry against the new leader* — so callers MUST treat
+    /// [`ConsensusError::Fenced`] and [`ConsensusError::NotLeader`]
+    /// identically (the server fence collapses them into one step-down arm,
+    /// and both map to `FAILED_PRECONDITION` + `LeaderHint`; see
+    /// [`ConsensusError`]). Single-node drivers have no term to fence against
+    /// and may ignore `epoch`.
     async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError>;
 }
 


### PR DESCRIPTION
Closes #337.

## Problem

The `persist_high_water` trait doc left the `epoch` parameter's role underspecified. The two consensus drivers reject stale-leader writes through different — but both correct — mechanisms:

- **paxos** (`tsoracle-driver-paxos/src/driver.rs`): an up-front pre-check that compares `epoch` against the current ballot-derived epoch and returns `ConsensusError::Fenced` on mismatch.
- **openraft** (`tsoracle-driver-openraft/src/driver.rs`): ignores `epoch` entirely, relying on the `max(prev, at_least)` apply plus raft leader-forwarding, which surfaces a superseded leader as `ConsensusError::NotLeader`.

Both are trait-compliant, but the trait never stated that this divergence is permitted, so the server fence's obligation to tolerate both `Fenced` and `NotLeader` was implicit. This is the documentation/contract gap called out in the issue — no behavior is wrong.

## Change (docs-only)

- **`crates/tsoracle-consensus/src/driver.rs`** — expanded the one-line epoch note into a normative "epoch-fencing (driver's choice of mechanism)" contract on `persist_high_water`: a consensus-backed driver MAY fence via up-front pre-check (`Fenced`) *or* apply-time monotonicity + leader-forwarding (`NotLeader`); callers MUST treat both identically as "stale leader, retry against the new leader." Names the paxos and openraft drivers as the two concrete instances and points back to the `ConsensusError` mapping table.
- **`crates/tsoracle-consensus/src/docs/consensus_integration.md`** — corrected the companion prose, which previously claimed the call is flatly "fenced by `epoch`" — contradicting the openraft path that ignores `epoch`.

No code paths change.

## Verification

- `cargo doc -p tsoracle-consensus --no-deps` with `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links` — clean; all intra-doc links resolve.
- `cargo test -p tsoracle-consensus` — 7 unit + doc tests pass.
- Pre-commit `cargo fmt --check` + `cargo clippy` — pass.