### PR TITLE
fix(openraft-toolkit): version-frame the log-store meta column (#331)

### DIFF
--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -859,13 +859,14 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_payload_pins_v1_layout() {
-        // Hand-built v1 frame: [SCHEMA_VERSION | postcard(payload)]. The
-        // postcard body of {current_value: 7, last_applied: None,
-        // last_membership: default} is [7, 0, 0, 0, 0] — value 7, Option::None,
+    fn snapshot_payload_pins_v2_layout() {
+        // Hand-built v2 frame: [SCHEMA_VERSION | postcard(payload)]. The leading
+        // byte advanced 1 -> 2 when the log-store meta column gained the same
+        // version frame (a breaking on-disk change); the postcard body is
+        // unchanged. Body [7, 0, 0, 0, 0] = current_value 7, last_applied None,
         // then default StoredMembership (None log id + empty configs + empty
-        // nodes). Reordering or inserting a field changes these bytes and
-        // trips this test, forcing a SCHEMA_VERSION bump.
+        // nodes). Reordering or inserting a field changes these bytes and trips
+        // this test, forcing a SCHEMA_VERSION bump.
         let payload = HighWaterStateMachineSnapshot {
             current_value: 7,
             last_applied: None,
@@ -874,16 +875,17 @@ mod tests {
         let framed =
             tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
                 .expect("encode");
-        assert_eq!(framed, vec![1, 7, 0, 0, 0, 0]);
+        assert_eq!(framed, vec![2, 7, 0, 0, 0, 0]);
     }
 
     #[test]
-    fn log_entry_pins_v1_layout() {
-        // The bytes RocksdbLogStore<TypeConfig> persists per entry: the v1
+    fn log_entry_pins_v2_layout() {
+        // The bytes RocksdbLogStore<TypeConfig> persists per entry: the v2
         // frame around a Normal entry carrying Advance(AdvancePayload { at_least: 5 })
-        // at log id (term 1, node 1, index 1). Body [1,1,1,1,0,5] = leader
-        // (term 1, node 1), index 1, EntryPayload::Normal tag (1), Advance
-        // variant (0), at_least 5 — byte-identical to the pre-newtype layout.
+        // at log id (term 1, node 1, index 1). Leading byte 2 is SCHEMA_VERSION;
+        // body [1,1,1,1,0,5] = leader (term 1, node 1), index 1,
+        // EntryPayload::Normal tag (1), Advance variant (0), at_least 5 —
+        // byte-identical to the pre-newtype layout.
         let lid = openraft::testing::log_id::<TypeConfig>(1, 1, 1);
         let entry: EntryOf<TypeConfig> = EntryOf::<TypeConfig>::new_normal(
             lid,
@@ -892,7 +894,24 @@ mod tests {
         let framed =
             tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &entry)
                 .expect("encode");
-        assert_eq!(framed, vec![1, 1, 1, 1, 1, 0, 5]);
+        assert_eq!(framed, vec![2, 1, 1, 1, 1, 0, 5]);
+    }
+
+    #[test]
+    fn meta_vote_pins_v2_layout() {
+        // The bytes RocksdbLogStore<TypeConfig> now persists in the meta column
+        // for a Vote — historically a bare, unversioned postcard blob, now the
+        // same [SCHEMA_VERSION | postcard] frame as the log column. This is the
+        // recovery-critical field (term/leader-election safety) the framing
+        // protects: a foreign version loud-rejects instead of misdecoding. Body
+        // [7, 3, 1] = leader (term 7, node 3), committed flag true; leading byte
+        // 2 is SCHEMA_VERSION. A layout change to Vote trips this test.
+        let vote: openraft::type_config::alias::VoteOf<TypeConfig> =
+            openraft::Vote::new_committed(7, 3);
+        let framed =
+            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &vote)
+                .expect("encode");
+        assert_eq!(framed, vec![2, 7, 3, 1]);
     }
 
     #[tokio::test]

--- a/crates/tsoracle-openraft-toolkit/Cargo.toml
+++ b/crates/tsoracle-openraft-toolkit/Cargo.toml
@@ -25,7 +25,6 @@ failpoints         = ["tsoracle-failpoint/failpoints"]
 
 [dependencies]
 async-trait      = { workspace = true }
-postcard         = { workspace = true }
 futures          = { workspace = true }
 openraft         = { workspace = true }
 parking_lot      = { workspace = true, optional = true }

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -25,6 +25,12 @@ pub use tsoracle_codec::{CodecError, decode, encode};
 /// On-disk/wire schema version stamped as the leading byte of every framed
 /// snapshot, log entry, and storage record produced by this toolkit. Bump
 /// when a persisted struct's postcard layout changes in a
-/// backward-incompatible way (field reorder/insert/remove); a stale reader
-/// then fails loudly with [`CodecError::Version`] instead of misdecoding.
-pub const SCHEMA_VERSION: u8 = 1;
+/// backward-incompatible way (field reorder/insert/remove), or when the set of
+/// framed records changes; a stale reader then fails loudly with
+/// [`CodecError::Version`] instead of misdecoding.
+///
+/// v2 brought the log-store meta column (Vote/Committed/LastPurged) under this
+/// same frame — it was previously persisted as bare, unversioned postcard, so a
+/// v1 store's meta records read against this version loud-reject rather than
+/// risk a silent misdecode of the recovery-critical vote.
+pub const SCHEMA_VERSION: u8 = 2;

--- a/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
@@ -15,25 +15,29 @@
 //! The meta CF holds four small openraft values: current vote, last-committed
 //! log id, last-purged log id, last-applied membership. Each is keyed by a
 //! [`MetaLabel`](super::MetaLabel) via the active [`KeySpace`](super::KeySpace).
-//! These helpers serialize values with `postcard` and translate rocksdb errors
-//! into [`RocksdbLogStoreError`](super::RocksdbLogStoreError).
+//! These helpers frame values with the same `[SCHEMA_VERSION | postcard]` codec
+//! the log column uses ([`super::encode_record`] / [`super::decode_record`]), so
+//! a recovery-critical meta record (Vote/Committed/LastPurged) loud-rejects on a
+//! version mismatch instead of misdecoding silently. rocksdb errors are mapped
+//! to [`io::Error`] to match the storage trait surface.
 
 use rocksdb::{BoundColumnFamily, DB, WriteBatch};
 use serde::{Serialize, de::DeserializeOwned};
+use std::io;
 use std::sync::Arc;
 
-use super::RocksdbLogStoreError;
 use super::key_space::{KeySpace, MetaLabel};
+use super::{decode_record, encode_record};
 
 pub(super) fn read<T: DeserializeOwned, K: KeySpace>(
     db: &DB,
     cf: &Arc<BoundColumnFamily<'_>>,
     keys: &K,
     label: MetaLabel,
-) -> Result<Option<T>, RocksdbLogStoreError> {
+) -> io::Result<Option<T>> {
     let key = keys.meta_key(label);
-    match db.get_pinned_cf(cf, &key)? {
-        Some(bytes) => Ok(Some(postcard::from_bytes(&bytes)?)),
+    match db.get_pinned_cf(cf, &key).map_err(io::Error::other)? {
+        Some(bytes) => Ok(Some(decode_record(&bytes)?)),
         None => Ok(None),
     }
 }
@@ -44,9 +48,9 @@ pub(super) fn put<T: Serialize, K: KeySpace>(
     keys: &K,
     label: MetaLabel,
     value: &T,
-) -> Result<(), RocksdbLogStoreError> {
+) -> io::Result<()> {
     let key = keys.meta_key(label);
-    let bytes = postcard::to_stdvec(value)?;
+    let bytes = encode_record(value)?;
     batch.put_cf(cf, &key, &bytes);
     Ok(())
 }

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -19,13 +19,15 @@ pub use key_space::{Flat, GroupPrefixed, KeySpace, MetaLabel};
 
 use thiserror::Error;
 
-/// Errors produced by the rocksdb-backed log store.
+/// Errors produced opening the rocksdb-backed log store.
+///
+/// Construction (`open`) only fails when a named column family is absent;
+/// every later storage operation reports through `io::Error` to match the
+/// `RaftLogStorage` trait surface (decode/version failures route through the
+/// `[SCHEMA_VERSION | postcard]` codec, surfacing a foreign version as
+/// `InvalidData`).
 #[derive(Debug, Error)]
 pub enum RocksdbLogStoreError {
-    #[error("rocksdb error: {0}")]
-    RocksDb(#[from] rocksdb::Error),
-    #[error("decode error: {0}")]
-    Decode(#[from] postcard::Error),
     #[error("column family `{0}` not found")]
     MissingColumnFamily(String),
 }
@@ -290,7 +292,6 @@ where
     async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, io::Error> {
         let cf = self.meta_cf_handle();
         meta::read::<VoteOf<C>, K>(&self.db, &cf, &self.keys, MetaLabel::Vote)
-            .map_err(io::Error::other)
     }
 }
 
@@ -309,8 +310,7 @@ where
     async fn get_log_state(&mut self) -> Result<LogState<C>, io::Error> {
         let cf_meta = self.meta_cf_handle();
         let last_purged_log_id: Option<LogIdOf<C>> =
-            meta::read::<LogIdOf<C>, K>(&self.db, &cf_meta, &self.keys, MetaLabel::LastPurged)
-                .map_err(io::Error::other)?;
+            meta::read::<LogIdOf<C>, K>(&self.db, &cf_meta, &self.keys, MetaLabel::LastPurged)?;
 
         let last_in_log = self.last_log_id_in_cf()?;
         let last_log_id = last_in_log.or_else(|| last_purged_log_id.clone());
@@ -324,8 +324,7 @@ where
     async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), io::Error> {
         let cf_meta = self.meta_cf_handle();
         let mut batch = WriteBatch::default();
-        meta::put::<VoteOf<C>, K>(&mut batch, &cf_meta, &self.keys, MetaLabel::Vote, vote)
-            .map_err(io::Error::other)?;
+        meta::put::<VoteOf<C>, K>(&mut batch, &cf_meta, &self.keys, MetaLabel::Vote, vote)?;
         // fsync: the vote must be durable before it is acknowledged, or a crash
         // could let this node vote twice in one term and split the cluster.
         let wo = Self::write_sync_opts();
@@ -343,8 +342,7 @@ where
                 &self.keys,
                 MetaLabel::Committed,
                 &committed,
-            )
-            .map_err(io::Error::other)?,
+            )?,
             None => meta::delete::<K>(&mut batch, &cf_meta, &self.keys, MetaLabel::Committed),
         }
         // No fsync (the deliberate exception to `write_sync_opts`): persisting
@@ -357,7 +355,6 @@ where
     async fn read_committed(&mut self) -> Result<Option<LogIdOf<C>>, io::Error> {
         let cf_meta = self.meta_cf_handle();
         meta::read::<LogIdOf<C>, K>(&self.db, &cf_meta, &self.keys, MetaLabel::Committed)
-            .map_err(io::Error::other)
     }
 
     async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), io::Error>
@@ -450,8 +447,7 @@ where
             &self.keys,
             MetaLabel::LastPurged,
             &log_id,
-        )
-        .map_err(io::Error::other)?;
+        )?;
 
         // fsync: the prefix deletes and the `LastPurged` marker share one
         // atomic batch; losing them would let recovery rebuild log state from a

--- a/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
@@ -83,6 +83,39 @@ async fn save_and_read_vote_roundtrips() {
     assert_eq!(got, Some(vote));
 }
 
+// The meta column holds recovery-critical fields (Vote/Committed/LastPurged),
+// yet historically persisted them as bare `postcard` with no version frame —
+// unlike every other persisted blob in the store. After a layout-changing
+// upgrade an unframed `Vote` would misdecode silently instead of loud-rejecting.
+// This pins the on-disk meta record to the same `[SCHEMA_VERSION | postcard]`
+// frame the log column uses: a save_vote must persist a version-prefixed record
+// that decodes back through the toolkit's public codec.
+#[tokio::test]
+async fn save_vote_persists_version_framed_meta() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(Arc::clone(&db), LOG_CF, META_CF, Flat).unwrap();
+
+    let vote: Vote<TestLeaderId> = Vote::new_committed(7, 3);
+    store.save_vote(&vote).await.unwrap();
+
+    // Read the raw persisted bytes back out from under the Vote key.
+    let key = Flat.meta_key(MetaLabel::Vote);
+    let cf = db.cf_handle(META_CF).unwrap();
+    let raw = db.get_cf(&cf, &key).unwrap().expect("vote bytes present");
+
+    assert_eq!(
+        raw[0],
+        tsoracle_openraft_toolkit::SCHEMA_VERSION,
+        "meta record must be framed with the leading schema-version byte",
+    );
+    let decoded: Vote<TestLeaderId> =
+        tsoracle_openraft_toolkit::decode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &raw)
+            .expect("framed vote must decode through the toolkit codec");
+    assert_eq!(decoded, vote);
+}
+
 #[tokio::test]
 async fn empty_store_log_state_is_empty() {
     let dir = TempDir::new().unwrap();
@@ -140,21 +173,23 @@ async fn save_committed_with_none_clears_existing_record() {
     assert!(store.read_committed().await.unwrap().is_none());
 }
 
-// Corrupt the bytes stored at the Vote key, then verify `read_vote` surfaces
-// the decode error rather than silently returning `None` or panicking. Drives
-// the `postcard::from_bytes` error arm in `meta::read` which is unreachable
-// from any legitimate API call sequence.
+// A meta record written under a foreign schema version must loud-reject on
+// read rather than misdecode silently against the current struct layout. This
+// is the core safety property the version frame buys: an upgrade that changed
+// the `Vote` layout would otherwise risk corrupting term/leader-election
+// safety. The injected record carries a `0xFF` version byte (never our
+// `SCHEMA_VERSION`), so `read_vote` must surface `InvalidData`.
 #[tokio::test]
-async fn read_vote_surfaces_decode_error_on_corrupted_meta() {
+async fn read_vote_rejects_foreign_version_meta() {
     let dir = TempDir::new().unwrap();
     let db = open_db(&dir);
 
-    // Inject garbage bytes under the `Flat` keyspace's Vote key directly via the
-    // shared `Arc<DB>` — the public store API has no "write raw bytes" door.
+    // Inject a foreign-version record under the `Flat` keyspace's Vote key
+    // directly via the shared `Arc<DB>` — the public store API has no "write
+    // raw bytes" door. Byte 0xFF stands in for any non-current schema version.
     let key = Flat.meta_key(MetaLabel::Vote);
     let cf = db.cf_handle(META_CF).unwrap();
-    db.put_cf(&cf, &key, b"not a valid postcard-encoded vote")
-        .unwrap();
+    db.put_cf(&cf, &key, [0xFF, 7, 3, 1]).unwrap();
 
     let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
         RocksdbLogStore::open(Arc::clone(&db), LOG_CF, META_CF, Flat).unwrap();
@@ -162,10 +197,12 @@ async fn read_vote_surfaces_decode_error_on_corrupted_meta() {
     let err = store
         .read_vote()
         .await
-        .expect_err("read_vote should propagate the decode failure");
-    // The exact message comes from postcard; we just want to confirm an error
-    // path actually fires rather than asserting a brittle substring.
-    let _ = err.to_string();
+        .expect_err("read_vote must reject a foreign-version meta record");
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::InvalidData,
+        "a foreign schema version must surface as InvalidData, not a generic decode error",
+    );
 }
 
 // Regression test for a cross-group keyspace leak in `last_log_id_in_cf`.


### PR DESCRIPTION
## Summary

The openraft log-store **meta column** holds the recovery-critical `Vote`, `Committed`, and `LastPurged`, yet `log_store/meta.rs` persisted them as bare, unversioned `postcard` — unlike every other persisted blob in the store, which is framed `[SCHEMA_VERSION | postcard]` and loud-rejects a foreign version. After a layout-changing upgrade a `Vote` could misdecode against the new shape **silently**, corrupting term/leader-election safety, rather than failing with a version error.

This is the deferred half of the codec-schema work (#93, which explicitly left "log_store meta column (Vote/LastPurged) raw" as a follow-up) — the single largest persisted-format consistency gap between the two stores.

A regression test makes the hazard concrete: an injected foreign-version record (`[0xFF, 7, 3, 1]`) decoded into a valid-looking but wrong `Vote { term: 1023, node_id: 3, committed: true }`.

## What changed

- **`log_store/meta.rs`** — `read`/`put` now route through the same `encode_record`/`decode_record` helpers the log column uses, so the meta record gets the `[SCHEMA_VERSION | postcard]` frame and surfaces a foreign version as `io::ErrorKind::InvalidData` (matching log entries and snapshots). Signatures move to `io::Result` to match the `RaftLogStorage` trait surface.
- **`log_store/mod.rs`** — with meta on `io::Result`, `open()` is the only producer of `RocksdbLogStoreError` and only emits `MissingColumnFamily`, so the now-dead `Decode(postcard::Error)` and `RocksDb(rocksdb::Error)` variants are removed.
- **`Cargo.toml`** — drop the now-unused `postcard` from `[dependencies]` (kept in dev-deps for the fuzz-seed generator).
- **`codec.rs`** — `SCHEMA_VERSION` bumped `1 → 2`, the breaking-on-disk-change pairing for framing the meta column. (The paxos toolkit owns its own version and is untouched.)
- **Tests** — added `save_vote_persists_version_framed_meta` and `read_vote_rejects_foreign_version_meta` (replacing the old "surfaces decode error" test); advanced the `snapshot_payload`/`log_entry` golden pins to v2 and added `meta_vote_pins_v2_layout` for the meta-column on-disk format.

## Compatibility

Breaking on-disk format change: a v1 store's records (log entries, snapshots, and the newly framed meta) loud-reject against v2 rather than risk a silent misdecode of the recovery-critical vote. Pre-1.0; requires re-bootstrapping an existing store.

## Verification

- `cargo test --workspace --all-features` — 0 failures.
- `cargo clippy --workspace --all-targets --all-features` — clean.
- New/changed tests verified red → green; golden pins verified red → green across the version bump.

Closes #331.