### PR TITLE
perf(paxos-toolkit): cache next/compacted log indices instead of scanning per append

### DIFF
--- a/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/storage/mod.rs
@@ -62,6 +62,19 @@ pub enum StorageError {
 pub struct RocksdbStorage<T: Entry> {
     db: Arc<DB>,
     cf_name: String,
+    /// Cached next absolute write index. Holds `(highest_log_key + 1).max(compacted_idx)`
+    /// when the log is non-empty, else `compacted_idx` — the same value the old
+    /// per-append reverse scan computed. Seeded once at [`RocksdbStorage::open_in`]
+    /// and maintained in lockstep with every mutating write (always *after* the
+    /// write succeeds), so the append hot path discovers the next index from
+    /// memory rather than from a RocksDB iterator. The `&mut self` on every
+    /// mutating `Storage` method makes this sound without interior mutability;
+    /// correctness assumes a single `RocksdbStorage` owns its column family,
+    /// which is the documented usage.
+    next_idx: u64,
+    /// Cached compaction offset, a mirror of the persisted `M/compacted_idx`.
+    /// Only [`omnipaxos::storage::Storage::set_compacted_idx`] writes it.
+    compacted_idx: u64,
     _marker: PhantomData<T>,
 }
 
@@ -81,11 +94,60 @@ impl<T: Entry> RocksdbStorage<T> {
         if db.cf_handle(cf_name).is_none() {
             return Err(StorageError::ColumnFamilyNotFound(cf_name.to_string()));
         }
-        Ok(Self {
+        let mut storage = Self {
             db,
             cf_name: cf_name.to_string(),
+            next_idx: 0,
+            compacted_idx: 0,
             _marker: PhantomData,
-        })
+        };
+        // Seed the in-memory cursors from disk exactly once. This is the only
+        // place the log is scanned for its tail; every later mutation keeps the
+        // cursors current, so appends never re-scan. A reopen after a crash
+        // re-derives both from the persisted state here.
+        storage.compacted_idx = storage.read_compacted_idx()?;
+        storage.next_idx = storage.scan_next_log_idx(storage.compacted_idx)?;
+        Ok(storage)
+    }
+
+    /// Reverse-scan the log column family for the highest absolute index,
+    /// returning `(highest + 1).max(compacted)`, or `compacted` when the log
+    /// is empty. Used only by [`RocksdbStorage::open_in`] to seed `next_idx`;
+    /// the floor matches the on-disk invariant a fresh append must satisfy
+    /// (`next >= compacted_idx`) so a snapshot that trims every surviving log
+    /// key cannot let an append land below the compaction floor.
+    fn scan_next_log_idx(&self, compacted: u64) -> Result<u64, StorageError> {
+        use crate::storage::key_space::{LOG_PREFIX, log_key_range, parse_log_key};
+        use rocksdb::IteratorMode;
+
+        let cf = self.cf()?;
+        let (_, upper) = log_key_range();
+        let iter = self
+            .db
+            .iterator_cf(&cf, IteratorMode::From(&upper, rocksdb::Direction::Reverse));
+        for result in iter {
+            let (key, _value) = result?;
+            if key.starts_with(LOG_PREFIX) {
+                let idx = parse_log_key(&key).ok_or_else(|| {
+                    StorageError::LogIntegrity(format!("malformed log key: {key:?}"))
+                })?;
+                return Ok((idx + 1).max(compacted));
+            }
+        }
+        Ok(compacted)
+    }
+
+    /// Read the persisted compaction offset (`M/compacted_idx`), defaulting to
+    /// `0` when absent. Used only to seed `compacted_idx` at
+    /// [`RocksdbStorage::open_in`]; thereafter the cached field is authoritative.
+    fn read_compacted_idx(&self) -> Result<u64, StorageError> {
+        use crate::storage::key_space::meta_compacted_idx_key;
+        use crate::storage::meta::decode_u64;
+        let cf = self.cf()?;
+        match self.db.get_cf(&cf, meta_compacted_idx_key())? {
+            Some(bytes) => Ok(decode_u64(&bytes)?),
+            None => Ok(0),
+        }
     }
 
     pub(crate) fn cf(&self) -> Result<Arc<BoundColumnFamily<'_>>, StorageError> {
@@ -177,42 +239,6 @@ impl<T> RocksdbStorage<T>
 where
     T: Entry + serde::Serialize + serde::de::DeserializeOwned + Clone + 'static,
 {
-    fn next_log_idx(&self) -> Result<u64, StorageError> {
-        use crate::storage::key_space::{LOG_PREFIX, log_key_range, parse_log_key};
-        use rocksdb::IteratorMode;
-
-        // The next absolute write index must satisfy
-        // `next >= compacted_idx`; otherwise a snapshot that trims every
-        // surviving log key would let a fresh append land at L/0 and
-        // become unreachable via get_suffix(compacted_idx).
-        let compacted = self.compacted_idx_inner()?;
-        let cf = self.cf()?;
-        let (_, upper) = log_key_range();
-        let iter = self
-            .db
-            .iterator_cf(&cf, IteratorMode::From(&upper, rocksdb::Direction::Reverse));
-        for result in iter {
-            let (key, _value) = result?;
-            if key.starts_with(LOG_PREFIX) {
-                let idx = parse_log_key(&key).ok_or_else(|| {
-                    StorageError::LogIntegrity(format!("malformed log key: {key:?}"))
-                })?;
-                return Ok((idx + 1).max(compacted));
-            }
-        }
-        Ok(compacted)
-    }
-
-    fn compacted_idx_inner(&self) -> Result<u64, StorageError> {
-        use crate::storage::key_space::meta_compacted_idx_key;
-        use crate::storage::meta::decode_u64;
-        let cf = self.cf()?;
-        match self.db.get_cf(&cf, meta_compacted_idx_key())? {
-            Some(bytes) => Ok(decode_u64(&bytes)?),
-            None => Ok(0),
-        }
-    }
-
     fn store_log_entry(
         &self,
         batch: &mut WriteBatch,
@@ -237,15 +263,17 @@ where
 {
     fn append_entry(&mut self, entry: T) -> omnipaxos::storage::StorageResult<u64> {
         tsoracle_failpoint::failpoint!("paxos_toolkit::storage::append_entry");
-        let next = self.next_log_idx().map_err(box_err)?;
+        let next = self.next_idx;
         self.batch_sync(|cf, batch| self.store_log_entry(batch, &cf, next, &entry))
             .map_err(box_err)?;
-        let compacted = self.get_compacted_idx()?;
-        Ok((next + 1).saturating_sub(compacted))
+        // Advance the cursor only after the write commits, so a failed write
+        // leaves the cache matching disk.
+        self.next_idx = next + 1;
+        Ok(self.next_idx.saturating_sub(self.compacted_idx))
     }
 
     fn append_entries(&mut self, entries: Vec<T>) -> omnipaxos::storage::StorageResult<u64> {
-        let start = self.next_log_idx().map_err(box_err)?;
+        let start = self.next_idx;
         let count = entries.len() as u64;
         self.batch_sync(|cf, batch| {
             for (offset, entry) in entries.iter().enumerate() {
@@ -254,8 +282,8 @@ where
             Ok(())
         })
         .map_err(box_err)?;
-        let compacted = self.get_compacted_idx()?;
-        Ok((start + count).saturating_sub(compacted))
+        self.next_idx = start + count;
+        Ok(self.next_idx.saturating_sub(self.compacted_idx))
     }
 
     fn append_on_prefix(
@@ -275,8 +303,11 @@ where
             Ok(())
         })
         .map_err(box_err)?;
-        let compacted = self.get_compacted_idx()?;
-        Ok((from_idx + count).saturating_sub(compacted))
+        // The write truncated every key `>= from_idx` and re-appended `count`
+        // of them, so the new tail is `from_idx + count`, floored at the
+        // compaction offset just as a fresh append would be.
+        self.next_idx = (from_idx + count).max(self.compacted_idx);
+        Ok(self.next_idx.saturating_sub(self.compacted_idx))
     }
 
     fn set_promise(
@@ -389,9 +420,7 @@ where
     }
 
     fn get_log_len(&self) -> omnipaxos::storage::StorageResult<u64> {
-        let next = self.next_log_idx().map_err(box_err)?;
-        let compacted = self.get_compacted_idx()?;
-        Ok(next.saturating_sub(compacted))
+        Ok(self.next_idx.saturating_sub(self.compacted_idx))
     }
 
     fn get_suffix(&self, from: u64) -> omnipaxos::storage::StorageResult<Vec<T>> {
@@ -479,6 +508,12 @@ where
             Ok(())
         })
         .map_err(box_err)?;
+        // Trimming a prefix leaves the tail untouched unless it removes every
+        // live key (`idx` past the highest one). A now-empty log falls back to
+        // the compaction floor, matching what a reverse scan would find.
+        if idx >= self.next_idx {
+            self.next_idx = self.compacted_idx;
+        }
         Ok(())
     }
 
@@ -491,11 +526,15 @@ where
             Ok(())
         })
         .map_err(box_err)?;
+        self.compacted_idx = idx;
+        // Raising the floor past every live key floats the next write up to it,
+        // preserving the `next >= compacted_idx` invariant.
+        self.next_idx = self.next_idx.max(idx);
         Ok(())
     }
 
     fn get_compacted_idx(&self) -> omnipaxos::storage::StorageResult<u64> {
-        self.compacted_idx_inner().map_err(box_err)
+        Ok(self.compacted_idx)
     }
 
     fn set_snapshot(
@@ -796,6 +835,29 @@ mod decided_compacted_tests {
         let mut storage = fresh_storage(&dir);
         storage.set_compacted_idx(17).unwrap();
         assert_eq!(storage.get_compacted_idx().unwrap(), 17);
+    }
+
+    #[test]
+    fn append_floors_at_compacted_idx_raised_past_live_keys() {
+        // Advancing compacted_idx past every live key WITHOUT trimming must
+        // float the next write index up to the compaction floor: the next
+        // append lands at `compacted_idx`, not just past the highest key.
+        // Otherwise the entry would persist below the floor and be
+        // unreachable via get_suffix(compacted_idx). (This is RocksdbStorage's
+        // own contract — the `.max(compacted)` floor — and is intentionally a
+        // Rocksdb-only test: MemStorage floors only on an empty log, so the
+        // two impls diverge in this OmniPaxos-unreachable corner.)
+        let dir = TempDir::new().unwrap();
+        let mut storage = fresh_storage(&dir);
+        storage
+            .append_entries(vec![TestEntry { value: 1 }, TestEntry { value: 2 }])
+            .unwrap();
+        storage.set_compacted_idx(10).unwrap();
+        let new_len = storage.append_entry(TestEntry { value: 7 }).unwrap();
+        assert_eq!(new_len, 1, "physical remaining = (10 + 1) - 10");
+        let at_floor = storage.get_entries(10, 11).unwrap();
+        assert_eq!(at_floor.len(), 1);
+        assert_eq!(at_floor[0].value, 7, "append floors at compacted_idx = 10");
     }
 
     #[test]

--- a/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
+++ b/crates/tsoracle-paxos-toolkit/src/test_fakes/mem_storage.rs
@@ -79,9 +79,10 @@ where
     fn append_entry(&mut self, entry: T) -> StorageResult<u64> {
         let mut inner = self.inner.lock();
         // After a full trim the log is empty; the next absolute write index
-        // must floor at `compacted_idx` (matching production `next_log_idx`),
-        // not reset to 0, or the entry lands below the compaction floor and
-        // becomes unreachable via get_suffix(compacted_idx).
+        // must floor at `compacted_idx` (matching production `RocksdbStorage`,
+        // whose cached `next_idx` falls back to the compaction floor), not
+        // reset to 0, or the entry lands below the floor and becomes
+        // unreachable via get_suffix(compacted_idx).
         let next = inner
             .log
             .keys()

--- a/crates/tsoracle-paxos-toolkit/tests/storage_conformance.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/storage_conformance.rs
@@ -124,6 +124,61 @@ fn run_scenario<S: Storage<TestCommand>>(mut storage: S) {
     assert!(storage.get_stopsign().unwrap().is_none());
 }
 
+/// Exercises how the next absolute write index moves under operations that
+/// do not simply grow the log: `append_on_prefix` that shrinks the tail, and
+/// an unpaired full `trim`. Both impls must agree on where the following
+/// append lands. These are the corners a cached `next_idx` is most likely to
+/// get wrong (a naive cache only ever increments), so the cross-impl check
+/// pins the cache to the source-of-truth model `MemStorage` embodies.
+fn run_index_tracking_scenario<S: Storage<TestCommand>>(mut storage: S) {
+    // append_on_prefix that shrinks the log must move `next` *backward*: the
+    // next append continues from the new, lower tail rather than the old one.
+    storage
+        .append_entries(vec![
+            TestCommand(1),
+            TestCommand(2),
+            TestCommand(3),
+            TestCommand(4),
+            TestCommand(5),
+        ])
+        .unwrap();
+    storage
+        .append_on_prefix(2, vec![TestCommand(20), TestCommand(30)])
+        .unwrap();
+    // Log now holds absolute indices 0,1,2,3 -> next == 4.
+    let len = storage.append_entry(TestCommand(40)).unwrap();
+    assert_eq!(len, 5, "append continues at idx 4; physical len = 5");
+    let at_four = storage.get_entries(4, 5).unwrap();
+    assert_eq!(at_four.len(), 1);
+    assert_eq!(
+        at_four[0].0, 40,
+        "new entry lands at absolute idx 4, no gap"
+    );
+    let all = storage.get_suffix(0).unwrap();
+    assert_eq!(all.len(), 5);
+    assert_eq!(all[2].0, 20);
+    assert_eq!(all[4].0, 40);
+}
+
+/// An unpaired full `trim` (every key removed, `compacted_idx` left at 0)
+/// must reset the next write index to `compacted_idx`, so the following
+/// append re-fills from idx 0 rather than leaving a phantom gap.
+fn run_unpaired_full_trim_scenario<S: Storage<TestCommand>>(mut storage: S) {
+    storage
+        .append_entries(vec![TestCommand(1), TestCommand(2), TestCommand(3)])
+        .unwrap();
+    storage.trim(3).unwrap();
+    assert_eq!(storage.get_log_len().unwrap(), 0, "every key trimmed");
+    let len = storage.append_entry(TestCommand(9)).unwrap();
+    assert_eq!(len, 1);
+    let at_zero = storage.get_entries(0, 1).unwrap();
+    assert_eq!(at_zero.len(), 1);
+    assert_eq!(
+        at_zero[0].0, 9,
+        "after a full unpaired trim, append resumes at idx 0"
+    );
+}
+
 #[test]
 fn mem_storage_conforms() {
     run_scenario(MemStorage::<TestCommand>::new());
@@ -135,4 +190,30 @@ fn rocksdb_storage_conforms() {
     let storage: RocksdbStorage<TestCommand> =
         RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
     run_scenario(storage);
+}
+
+#[test]
+fn mem_storage_tracks_index_under_shrink() {
+    run_index_tracking_scenario(MemStorage::<TestCommand>::new());
+}
+
+#[test]
+fn rocksdb_storage_tracks_index_under_shrink() {
+    let (_dir, database) = open_rocksdb_in_tempdir(TEST_CF);
+    let storage: RocksdbStorage<TestCommand> =
+        RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
+    run_index_tracking_scenario(storage);
+}
+
+#[test]
+fn mem_storage_resets_index_after_unpaired_full_trim() {
+    run_unpaired_full_trim_scenario(MemStorage::<TestCommand>::new());
+}
+
+#[test]
+fn rocksdb_storage_resets_index_after_unpaired_full_trim() {
+    let (_dir, database) = open_rocksdb_in_tempdir(TEST_CF);
+    let storage: RocksdbStorage<TestCommand> =
+        RocksdbStorage::open_in(database, TEST_CF).expect("open_in");
+    run_unpaired_full_trim_scenario(storage);
 }


### PR DESCRIPTION
Closes #336.

## Problem

`RocksdbStorage::next_log_idx` ran a reverse column-family iterator plus a `compacted_idx` point-get on every append, and `append_entry`/`append_entries` then re-read `compacted_idx` a second time after the batch. That was a scan + two point-reads per decided entry, on every node, on the critical replication path. OmniPaxos's append API carries no index, so the store had to rediscover the log tail each time — unlike openraft, whose entries carry their own index and so never scan.

## Change

Cache `next_idx` and `compacted_idx` as fields on `RocksdbStorage`, seed them once at `open_in` (the only remaining scan), and maintain them in lockstep with every mutating write:

- `append_entry` / `append_entries`: increment `next_idx`
- `append_on_prefix`: `next_idx = (from + count).max(compacted_idx)`
- `trim`: reset `next_idx` to `compacted_idx` only when the trim empties the log (`idx >= next_idx`)
- `set_compacted_idx`: `compacted_idx = idx; next_idx = next_idx.max(idx)`

The cache is updated only *after* the write commits, so a failed write leaves it matching disk, and `open_in` re-derives both cursors from persisted state on reopen — crash-recovery semantics are unchanged. `append_entry` / `append_entries` / `get_log_len` / `get_compacted_idx` now touch **zero** RocksDB reads.

The maintenance rules reproduce the source-of-truth formula `MemStorage` embodies (`(highest_key + 1).max(compacted)`, else `compacted`), so the cross-impl conformance harness remains the contract.

## Behavior preserved, not changed

This is a behavior-preserving refactor. The cache is `&mut self`-guarded (no interior mutability), and correctness assumes a single `RocksdbStorage` owns its column family — the already-documented usage.

One pre-existing, out-of-scope quirk surfaced while writing tests: `MemStorage` and `RocksdbStorage` already disagree in the OmniPaxos-unreachable corner of raising `compacted_idx` past every live key *without* trimming (Mem writes at the old tail; Rocks floors at `compacted`). Rocks's existing `.max(compacted)` floor is preserved and the divergence is documented in the guard test, not silently altered.

## Tests

Added first, confirmed green on the pre-refactor code, then kept green:

- two cross-impl conformance scenarios — `append_on_prefix` that shrinks the tail, and an unpaired full `trim`
- a `RocksdbStorage`-only guard for the compacted-floor case

Verification: paxos-toolkit lib (75, all features), conformance (6), failpoints (2, incl. the lost-compacted-index crash-recovery test), full driver-paxos suite incl. every restart/reopen path, `cargo build --workspace --all-targets`, and clippy — all clean.