### PR TITLE
docs(site): document zola bump procedure and verify checksum in PR build

### DIFF
--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Install Zola
         run: |
           ZOLA_VERSION="0.22.1"
+          ZOLA_SHA256="0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef"
           curl -fsSL -o zola.tar.gz \
             "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${ZOLA_SHA256}  zola.tar.gz" | sha256sum --check -
           tar -xzf zola.tar.gz
           sudo mv zola /usr/local/bin/zola
           zola --version

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,60 @@
+# tsoracle.rs
+
+The marketing and landing site for tsoracle, served at [tsoracle.rs](https://tsoracle.rs). It is a static site built with [Zola](https://www.getzola.org/) and deployed to GitHub Pages.
+
+This is **not** the documentation. The long-form prose guide lives in [`docs/`](../docs/) and the API reference is on [docs.rs](https://docs.rs/tsoracle-server).
+
+## Layout
+
+- `config.toml` — Zola configuration (base URL, taxonomies, Markdown options).
+- `content/` — page and post sources. Social cards are generated per post under `content/posts/`.
+- `templates/` — Tera templates.
+- `sass/` — stylesheets compiled by Zola.
+- `static/` — assets copied verbatim into the build. The `static/og/` directory and `static/og-default.png` are generated social cards and are gitignored.
+
+## Building locally
+
+Social cards are rendered by the `scripts/og-image` Rust tool before Zola runs, exactly as CI does. Run it from the repository root, then build or serve from this directory:
+
+```sh
+# From the repository root: regenerate the og:image PNGs into site/static/og/
+cargo run --release --manifest-path scripts/og-image/Cargo.toml
+
+# From site/: live-reloading preview at http://127.0.0.1:1111
+zola serve
+
+# Or produce the static build into site/public/
+zola build
+
+# Validate internal links the way the PR check does
+zola check --skip-external-links
+```
+
+## Deployment
+
+`.github/workflows/pages.yml` builds and deploys to GitHub Pages on every push to `main` that touches `site/**`, `scripts/og-image/**`, or the workflow itself. `.github/workflows/pages-build-check.yml` runs the same build (plus link checking) on pull requests so breakage is caught before merge.
+
+## Upgrading Zola
+
+The Zola binary is downloaded from GitHub Releases and verified against a pinned SHA-256 in **both** workflows. The version and checksum must be updated together, and in both files, or the build will fail the integrity check:
+
+- `.github/workflows/pages.yml` — the deploy workflow.
+- `.github/workflows/pages-build-check.yml` — the pull-request build check.
+
+Each pins the same two values in its `Install Zola` step:
+
+```sh
+ZOLA_VERSION="0.22.1"
+ZOLA_SHA256="0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef"
+```
+
+To bump to a new release (for example `0.23.0`), compute the checksum of the Linux artifact the workflows download and update both files in lockstep:
+
+```sh
+ZOLA_VERSION="0.23.0"
+curl -fsSL -o zola.tar.gz \
+  "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+sha256sum zola.tar.gz
+```
+
+Paste the resulting digest into `ZOLA_SHA256` and the new version into `ZOLA_VERSION` in both workflows. Verify the upgrade still builds the site locally (`zola build`) before opening the pull request — the `pages-build-check` workflow will also exercise the new pin on CI.


### PR DESCRIPTION
Closes #212 (post-merge follow-up from #207).

## Why

When zola is upgraded, contributors must update `ZOLA_SHA256` alongside `ZOLA_VERSION`. The pin is duplicated across two workflows, and they were inconsistent: the deploy workflow verified the download against the pinned digest, but the PR build check downloaded and extracted an unverified binary. There was also no `site/README.md` documenting any of this.

## Changes

- **`chore(ci)`** — Pin `ZOLA_SHA256` and run `sha256sum --check` in `pages-build-check.yml`, making its `Install Zola` step byte-for-byte identical to the deploy workflow. Both workflows now enforce the same supply-chain guarantee, and the bump procedure is symmetric across the two files.
- **`docs(site)`** — Add `site/README.md` covering the site layout, local build/serve/check commands (including the og:image generation step), deployment, and a step-by-step **Upgrading Zola** procedure that computes the new checksum and updates both workflows in lockstep.

## Notes

The zola version still lives in two separate workflow files. GitHub Actions can't cleanly share a constant across separate workflow files, so the documented procedure is the pragmatic mitigation rather than a code-level dedup.