### PR TITLE
refactor(server): extract ServingCore for lock/step-down invariants

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 
 use tsoracle_consensus::{ConsensusError, LeaderState};
 
-use crate::server::{Server, ServerError, ServingState};
+use crate::server::{Server, ServerError};
 
 // Fence retry tuning for the volatile post-election window. When a fence hits
 // `TransientDriver`, the retry loop does NOT give up: a still-elected leader
@@ -89,7 +89,7 @@ pub(crate) async fn run_leader_watch(
                     // instead of dispatching one more leadership event first.
                     biased;
                     _ = &mut cancel => {
-                        server.step_down_due_to_consensus_rejection(None, None);
+                        server.core.step_down(None, None);
                         return Ok(());
                     }
                     next = stream.next() => match next {
@@ -117,11 +117,8 @@ pub(crate) async fn run_leader_watch(
 
                 // Clear serving so new GetTs requests return NOT_LEADER until the
                 // fence republishes Serving below.
-                server.state_tx.send_replace(ServingState::NotServing {
-                    leader_endpoint: None,
-                    leader_epoch: None,
-                });
-                server.allocator.lock().on_leadership_lost();
+                server.core.publish_not_serving(None, None);
+                server.core.clear_allocator();
 
                 // Count the transition after the clear above, not on the fence's
                 // success path below: a Leader event is "observed" the moment we
@@ -168,7 +165,7 @@ pub(crate) async fn run_leader_watch(
                         // would deadlock against an extender holding
                         // `extension_lock` and waiting on `read()`. Keep the
                         // fence `extension_lock`-free.
-                        let drain_guard = server.extension_gate.write().await;
+                        let drain_guard = server.core.drain_barrier_write().await;
 
                         // Linearized load of the durably-persisted high-water.
                         // prior_max is an INCLUSIVE high-water: the prior leader
@@ -216,14 +213,12 @@ pub(crate) async fn run_leader_watch(
                         // the lower bound; committed_ceiling = actual is the
                         // post-persist upper bound the allocator can serve
                         // through without an extra extension round-trip.
-                        server.allocator.lock().try_on_leadership_gained(
-                            serving_floor,
-                            actual,
-                            epoch,
-                        )?;
+                        server
+                            .core
+                            .seed_on_leadership_gained(serving_floor, actual, epoch)?;
 
                         // Publish serving, then release the drain guard.
-                        server.state_tx.send_replace(ServingState::Serving);
+                        server.core.publish_serving();
                         drop(drain_guard);
 
                         tsoracle_failpoint::failpoint!("server::fence::after_serving_published");
@@ -244,10 +239,7 @@ pub(crate) async fn run_leader_watch(
                         Err(ServerError::Consensus(
                             ConsensusError::NotLeader { .. } | ConsensusError::Fenced { .. },
                         )) => {
-                            server.state_tx.send_replace(ServingState::NotServing {
-                                leader_endpoint: None,
-                                leader_epoch: None,
-                            });
+                            server.core.publish_not_serving(None, None);
                             break;
                         }
                         // Recoverable driver hiccup. Retry, but race the backoff
@@ -279,7 +271,7 @@ pub(crate) async fn run_leader_watch(
                                 // is honored rather than spun past.
                                 biased;
                                 _ = &mut cancel => {
-                                    server.step_down_due_to_consensus_rejection(None, None);
+                                    server.core.step_down(None, None);
                                     return Ok(());
                                 }
                                 _ = tokio::time::sleep(backoff) => {}
@@ -304,22 +296,18 @@ pub(crate) async fn run_leader_watch(
                 leader_endpoint,
                 leader_epoch,
             } => {
-                server.allocator.lock().on_leadership_lost();
-                server.state_tx.send_replace(ServingState::NotServing {
-                    leader_endpoint,
-                    leader_epoch,
-                });
+                server.core.clear_allocator();
+                server
+                    .core
+                    .publish_not_serving(leader_endpoint, leader_epoch);
                 // Emit after the NotServing publish so a blocking recorder
                 // cannot delay the safety state change.
                 #[cfg(feature = "metrics")]
                 metrics::counter!("tsoracle.leader_transition.total").increment(1);
             }
             LeaderState::Unknown => {
-                server.allocator.lock().on_leadership_lost();
-                server.state_tx.send_replace(ServingState::NotServing {
-                    leader_endpoint: None,
-                    leader_epoch: None,
-                });
+                server.core.clear_allocator();
+                server.core.publish_not_serving(None, None);
                 // Emit after the NotServing publish so a blocking recorder
                 // cannot delay the safety state change.
                 #[cfg(feature = "metrics")]

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -19,6 +19,7 @@ mod fence;
 mod leader_hint;
 mod server;
 mod service;
+mod serving_core;
 
 pub mod docs;
 

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -11,7 +11,6 @@
 //
 
 use core::time::Duration;
-use parking_lot::Mutex;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -19,12 +18,13 @@ use tokio::sync::watch;
 use tonic::service::Routes;
 use tonic::transport::Server as TonicServer;
 use tsoracle_consensus::ConsensusDriver;
-use tsoracle_core::{Allocator, Bt, Clock, Epoch, SystemClock};
+use tsoracle_core::{Bt, Clock, Epoch, SystemClock};
 #[cfg(any(test, feature = "test-fakes"))]
 use tsoracle_core::{CoreError, WindowGrant};
 use tsoracle_proto::v1::tso_service_server::TsoServiceServer;
 
 use crate::service::TsoServiceImpl;
+use crate::serving_core::ServingCore;
 
 #[derive(Debug, thiserror::Error)]
 pub enum BuildError {
@@ -127,25 +127,12 @@ impl ServerBuilder {
     pub fn build(self) -> Result<Server, BuildError> {
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
-        // Discard the receiver minted by `watch::channel`: `state_tx` is the
-        // single source of truth. It mints fresh receivers on demand via
-        // `subscribe()` and reads its current value via `borrow()`, so no parked
-        // receiver needs to live on the server. Publish sites use `send_replace`
-        // (not `send`) so a transition still mutates and notifies even when no
-        // embedder has subscribed and `receiver_count` is zero.
-        let (state_tx, _) = watch::channel(ServingState::NotServing {
-            leader_endpoint: None,
-            leader_epoch: None,
-        });
         Ok(Server {
             consensus,
             clock,
             window_ahead: self.window_ahead,
             failover_advance: self.failover_advance,
-            allocator: Arc::new(Mutex::new(Allocator::new())),
-            state_tx,
-            extension_lock: Arc::new(tokio::sync::Mutex::new(())),
-            extension_gate: Arc::new(tokio::sync::RwLock::new(())),
+            core: ServingCore::new(),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: self.tls_config,
         })
@@ -157,23 +144,9 @@ pub struct Server {
     pub(crate) clock: Arc<dyn Clock>,
     pub(crate) window_ahead: Duration,
     pub(crate) failover_advance: Duration,
-    pub(crate) allocator: Arc<Mutex<Allocator>>,
-    /// Source of truth for serving state. Mints receivers for [`Server::subscribe`]
-    /// and is read synchronously via `borrow()` by the service layer; publish
-    /// sites use `send_replace` so transitions land even with zero receivers.
-    pub(crate) state_tx: watch::Sender<ServingState>,
-    /// Serializes window extensions so a stampeding burst of `WindowExhausted`
-    /// requests resolves to a single `persist_high_water` round-trip. Acquired
-    /// before `extension_gate`; combined with a recheck-after-acquire inside
-    /// `extend_window`, latecomers find the window already extended and
-    /// return without contacting consensus.
-    pub(crate) extension_lock: Arc<tokio::sync::Mutex<()>>,
-    /// Read-locked by window-extension calls for the duration of their
-    /// prepare → persist → commit dance. The leader-watch task takes a
-    /// write lock between clearing serving and calling load_high_water,
-    /// which drains all in-flight extensions started under the prior epoch
-    /// before the fence proceeds.
-    pub(crate) extension_gate: Arc<tokio::sync::RwLock<()>>,
+    /// Owns the allocator, serving-state channel, and both extension locks, with
+    /// the lock-ordering and step-down invariants private behind its methods.
+    pub(crate) core: ServingCore,
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     pub(crate) tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
@@ -207,43 +180,7 @@ impl Server {
     /// future newtype around `ServingState`) without breaking embedders that
     /// go through it.
     pub fn subscribe(&self) -> watch::Receiver<ServingState> {
-        self.state_tx.subscribe()
-    }
-
-    /// Single transition API used in response to evidence that the current
-    /// epoch is no longer valid: consensus rejection (NotLeader/Fenced
-    /// during persist), leader-watch task termination, or other authoritative
-    /// signals of leadership loss.
-    ///
-    /// Clears the allocator BEFORE publishing `NotServing` so a racing
-    /// `try_grant` either (a) observes `CoreError::NotLeader` rather than
-    /// handing out a stale-epoch grant, or (b) succeeds against a still-valid
-    /// epoch and the *next* call observes `NotServing`. Either ordering is
-    /// safe; what is not safe is the inverse (publish first, clear later)
-    /// because a request between those two steps would see `Serving` AND a
-    /// still-leader allocator.
-    ///
-    /// Does NOT take `extension_gate.write()`. That would deadlock against
-    /// in-flight extensions currently holding the read lock and awaiting
-    /// `persist_high_water`. Those in-flights will either complete cleanly
-    /// (the next `try_grant` then sees `NotServing`) or fail with
-    /// NotLeader/Fenced (and reach this helper themselves — it is idempotent).
-    ///
-    /// `leader_epoch` carries the authoritative new-leader epoch when the
-    /// rejection reveals it — e.g. `ConsensusError::Fenced { current, .. }`
-    /// names the epoch that fenced us. Publishing it lets the resulting
-    /// `NotServing` hint redirect clients with an epoch to validate against;
-    /// callers with no epoch to offer (stream closure, panic) pass `None`.
-    pub(crate) fn step_down_due_to_consensus_rejection(
-        &self,
-        leader_endpoint: Option<String>,
-        leader_epoch: Option<Epoch>,
-    ) {
-        self.allocator.lock().on_leadership_lost();
-        self.state_tx.send_replace(ServingState::NotServing {
-            leader_endpoint,
-            leader_epoch,
-        });
+        self.core.subscribe()
     }
 }
 
@@ -332,7 +269,7 @@ impl Server {
                     if let Err(ref _e) = result {
                         // Poison BEFORE returning so embedders who do not observe
                         // the guard still get fail-safe behavior.
-                        watch_server.step_down_due_to_consensus_rejection(None, None);
+                        watch_server.core.step_down(None, None);
                         #[cfg(feature = "tracing")]
                         tracing::error!(error = %_e, "leader-watch terminated; serving disabled");
                     }
@@ -341,7 +278,7 @@ impl Server {
                 Err(panic_payload) => {
                     // Mirror the Err branch: poison BEFORE re-raising so
                     // guard-dropping embedders still observe NotServing.
-                    watch_server.step_down_due_to_consensus_rejection(None, None);
+                    watch_server.core.step_down(None, None);
                     #[cfg(feature = "tracing")]
                     tracing::error!("leader-watch panicked; serving disabled");
                     std::panic::resume_unwind(panic_payload);
@@ -713,7 +650,7 @@ impl Server {
     /// timestamp at or below the prior leader's high-water) directly.
     #[doc(hidden)]
     pub fn try_grant_for_tests(&self, count: u32) -> Result<WindowGrant, CoreError> {
-        self.allocator.lock().try_grant(self.clock.now_ms(), count)
+        self.core.try_grant(self.clock.now_ms(), count)
     }
 }
 
@@ -749,36 +686,27 @@ mod tests {
     }
 
     #[test]
-    fn serving_transitions_publish_without_an_external_subscriber() {
-        // Regression guard for #346. With the parked `state_rx` field gone, the
-        // plain `serve(addr)` path holds zero receivers unless an embedder calls
-        // `subscribe()`. `watch::Sender::send` is a no-op that leaves the value
-        // untouched when `receiver_count == 0`, so the publish sites use
-        // `send_replace` (which mutates and notifies unconditionally) and reads
-        // go through `state_tx.borrow()`. Were a publish site to use `send`,
-        // this transition would be silently dropped and a leaderless-then-leader
-        // server could stay NotServing forever.
-        //
-        // Built without `subscribe()`, so `receiver_count` is zero when the
-        // production publish site below fires.
+    fn serving_transitions_publish_through_core() {
+        // The Server delegates serving-state transitions to its ServingCore; a
+        // step_down on a freshly built Server lands as NotServing with the hint.
+        // (The #346 send_replace-with-zero-receivers regression is pinned by the
+        // ServingCore unit tests, which can observe `receiver_count` directly.)
         let server = Server::builder()
             .consensus_driver(Arc::new(crate::test_fakes::InMemoryDriver::new()))
             .build()
             .expect("build must succeed");
-        assert_eq!(server.state_tx.receiver_count(), 0);
 
-        server.step_down_due_to_consensus_rejection(
-            Some("http://new-leader:9000".into()),
-            Some(Epoch(7)),
-        );
+        server
+            .core
+            .step_down(Some("http://new-leader:9000".into()), Some(Epoch(7)));
 
-        match &*server.state_tx.borrow() {
+        match server.core.serving_state() {
             ServingState::NotServing {
                 leader_endpoint,
                 leader_epoch,
             } => {
                 assert_eq!(leader_endpoint.as_deref(), Some("http://new-leader:9000"));
-                assert_eq!(*leader_epoch, Some(Epoch(7)));
+                assert_eq!(leader_epoch, Some(Epoch(7)));
             }
             ServingState::Serving => panic!("expected NotServing after step_down"),
         }

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -40,7 +40,7 @@ fn wire_epoch(epoch: Option<Epoch>) -> Option<EpochWire> {
 /// wherever we need to surface a `FAILED_PRECONDITION` "not leader" response
 /// from a service-layer code path; matches what the fast NOT_LEADER gate emits.
 fn leader_hint_from(server: &Server) -> LeaderHint {
-    let (leader_endpoint, leader_epoch) = match server.state_tx.borrow().clone() {
+    let (leader_endpoint, leader_epoch) = match server.core.serving_state() {
         ServingState::NotServing {
             leader_endpoint,
             leader_epoch,
@@ -127,7 +127,7 @@ impl TsoService for TsoServiceImpl {
         if let ServingState::NotServing {
             leader_endpoint,
             leader_epoch,
-        } = self.server.state_tx.borrow().clone()
+        } = self.server.core.serving_state()
         {
             return Err(not_leader_status(LeaderHint {
                 leader_endpoint,
@@ -159,10 +159,7 @@ impl TsoService for TsoServiceImpl {
         let now_ms = self.server.clock.now_ms();
         let mut attempt = 0;
         loop {
-            let outcome = {
-                let mut allocator = self.server.allocator.lock();
-                allocator.try_grant(now_ms, count)
-            };
+            let outcome = self.server.core.try_grant(now_ms, count);
             match outcome {
                 Ok(grant) => {
                     #[cfg(feature = "metrics")]
@@ -211,38 +208,36 @@ impl TsoServiceImpl {
     /// the clock) so the would_grant predicate matches the retry try_grant at the
     /// same logical instant — see the sampling comment in `get_ts`.
     async fn extend_window(&self, now_ms: u64, count: u32) -> Result<(), Status> {
-        // Single-flight gate: serialize peer extenders so consensus is hit
-        // once per stampede, not once per stampeder.
-        let _extension_lock = self.server.extension_lock.lock().await;
+        // Single-flight gate: serialize peer extenders so consensus is hit once
+        // per stampede, not once per stampeder. The slot holds `extension_lock`.
+        let slot = self.server.core.extension_slot().await;
 
-        // Recheck-after-acquire: a peer extender may have run prepare →
-        // persist → commit while we waited for the lock. If the outer
-        // try_grant retry would now succeed, skip the consensus round-trip.
-        // Using get_ts's single `now_ms` sample keeps the predicate aligned
-        // with what the outer loop's retry try_grant will observe.
-        if self.server.allocator.lock().would_grant(now_ms, count) {
+        // Recheck-after-acquire: a peer extender may have run prepare → persist →
+        // commit while we waited for the slot. If the outer try_grant retry would
+        // now succeed, skip the consensus round-trip. Uses get_ts's single
+        // `now_ms` sample so the predicate matches the retry try_grant.
+        if slot.would_grant(now_ms, count) {
             return Ok(());
         }
 
-        // Drain barrier: leader-watch's write() waits behind this read until
-        // our commit applies (or is silently dropped by the epoch check).
-        let _gate = self.server.extension_gate.read().await;
+        // Drain barrier: the fence's write() waits behind this read until our
+        // commit applies (or is dropped by the epoch check). Reachable only
+        // through the slot, so `extension_lock` → `extension_gate` cannot invert.
+        let _gate = slot.drain_barrier().await;
         tsoracle_failpoint::failpoint!("server::service::extension_gate_held");
 
-        let (requested, epoch) = {
-            let allocator = self.server.allocator.lock();
-            let Some(epoch) = allocator.epoch() else {
+        let (requested, epoch) =
+            match slot.prepare_extension(now_ms, self.server.window_ahead.as_millis() as u64) {
+                Ok(prepared) => prepared,
                 // Lost leadership between the outer fast-gate check and here.
                 // Surface as a leader redirect (with the hint the serving-state
                 // channel knows about), not a bare FAILED_PRECONDITION without
                 // metadata.
-                return Err(not_leader_status(leader_hint_from(&self.server)));
+                Err(CoreError::NotLeader) => {
+                    return Err(not_leader_status(leader_hint_from(&self.server)));
+                }
+                Err(other) => return Err(core_status(other)),
             };
-            let target = allocator
-                .try_prepare_window_extension(now_ms, self.server.window_ahead.as_millis() as u64)
-                .map_err(core_status)?;
-            (target, epoch)
-        };
         // Count and time only the consensus round-trip itself: the
         // recheck-after-acquire short-circuit above skips it, and operators
         // tuning `window_ahead` care about how often a stampede actually
@@ -275,12 +270,11 @@ impl TsoServiceImpl {
             // its next leader against. NotLeader during persist exposes no
             // such epoch here, so its hint omits one.
             Err(ConsensusError::Fenced { current, .. }) => {
-                self.server
-                    .step_down_due_to_consensus_rejection(None, Some(current));
+                self.server.core.step_down(None, Some(current));
                 return Err(not_leader_status(leader_hint_from(&self.server)));
             }
             Err(ConsensusError::NotLeader { .. }) => {
-                self.server.step_down_due_to_consensus_rejection(None, None);
+                self.server.core.step_down(None, None);
                 return Err(not_leader_status(leader_hint_from(&self.server)));
             }
             // Transient driver failure: storage hiccup, peer transport flap,
@@ -297,9 +291,8 @@ impl TsoServiceImpl {
         };
         let commit_outcome = self
             .server
-            .allocator
-            .lock()
-            .try_commit_window_extension(actual, epoch)
+            .core
+            .commit_extension(actual, epoch)
             .map_err(core_status)?;
         // A dropped commit after a paid-for persist round-trip is benign but
         // worth surfacing: the epoch-fencing / monotonic-bound logic discarded
@@ -357,10 +350,9 @@ mod tests {
             .clock(std::sync::Arc::new(tsoracle_core::SystemClock))
             .build()
             .unwrap();
-        server.state_tx.send_replace(ServingState::NotServing {
-            leader_endpoint: Some("http://other-node:9000".into()),
-            leader_epoch: Some(Epoch(7)),
-        });
+        server
+            .core
+            .publish_not_serving(Some("http://other-node:9000".into()), Some(Epoch(7)));
         let hint = leader_hint_from(&server);
         assert_eq!(
             hint.leader_endpoint.as_deref(),
@@ -370,7 +362,7 @@ mod tests {
         assert_eq!(hint.leader_epoch, Some(EpochWire { hi, lo }));
 
         // The Serving branch flips endpoint and epoch to None.
-        server.state_tx.send_replace(ServingState::Serving);
+        server.core.publish_serving();
         let hint = leader_hint_from(&server);
         assert!(hint.leader_endpoint.is_none());
         assert!(hint.leader_epoch.is_none());

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -1,0 +1,306 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! The serving-state + allocator + extension-lock domain, extracted from
+//! `Server` so the load-bearing ordering invariants are private and testable.
+//!
+//! Four invariants used to live as prose spread across `server.rs`,
+//! `service.rs`, and `fence.rs`. They now live here:
+//!
+//! 1. `extension_lock` is acquired before `extension_gate.read()`. Enforced by
+//!    construction: the read barrier is [`ExtensionSlot::drain_barrier`], a
+//!    method on the guard returned by [`ServingCore::extension_slot`], which
+//!    already holds `extension_lock`. There is no other way to reach the read
+//!    lock, so the order cannot be inverted.
+//! 2. [`ServingCore::step_down`] clears the allocator *before* publishing
+//!    `NotServing`, so a racing `try_grant` never sees `Serving` together with a
+//!    still-leader allocator at a stale epoch.
+//! 3. [`ServingCore::step_down`] does **not** take `extension_gate.write()`.
+//!    Doing so would deadlock against in-flight extensions holding the read
+//!    lock and awaiting `persist_high_water`.
+//! 4. The fence takes `extension_gate.write()` via
+//!    [`ServingCore::drain_barrier_write`] and never takes `extension_lock`, so
+//!    it cannot close a lock cycle with an extender.
+
+use parking_lot::Mutex;
+use tokio::sync::{
+    Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
+    watch,
+};
+use tsoracle_core::{Allocator, CommitOutcome, CoreError, Epoch, WindowGrant};
+
+use crate::server::ServingState;
+
+pub(crate) struct ServingCore {
+    allocator: Mutex<Allocator>,
+    /// Source of truth for serving state. Mints receivers for `subscribe` and is
+    /// read synchronously via `serving_state`; publish sites use `send_replace`
+    /// so transitions land even with zero receivers (see #346).
+    state_tx: watch::Sender<ServingState>,
+    /// Serializes window extensions so a stampeding burst of `WindowExhausted`
+    /// requests resolves to a single `persist_high_water` round-trip. Acquired
+    /// before `extension_gate` — enforced by the [`ExtensionSlot`] API.
+    extension_lock: AsyncMutex<()>,
+    /// Read-locked by window-extension calls for their prepare → persist →
+    /// commit dance. The fence takes the write lock between clearing serving and
+    /// reloading the high-water, draining all in-flight extensions started under
+    /// the prior epoch before it proceeds.
+    extension_gate: RwLock<()>,
+}
+
+impl ServingCore {
+    pub(crate) fn new() -> Self {
+        let (state_tx, _) = watch::channel(ServingState::NotServing {
+            leader_endpoint: None,
+            leader_epoch: None,
+        });
+        ServingCore {
+            allocator: Mutex::new(Allocator::new()),
+            state_tx,
+            extension_lock: AsyncMutex::new(()),
+            extension_gate: RwLock::new(()),
+        }
+    }
+
+    pub(crate) fn subscribe(&self) -> watch::Receiver<ServingState> {
+        self.state_tx.subscribe()
+    }
+
+    pub(crate) fn serving_state(&self) -> ServingState {
+        self.state_tx.borrow().clone()
+    }
+
+    pub(crate) fn publish_serving(&self) {
+        self.state_tx.send_replace(ServingState::Serving);
+    }
+
+    pub(crate) fn publish_not_serving(
+        &self,
+        leader_endpoint: Option<String>,
+        leader_epoch: Option<Epoch>,
+    ) {
+        self.state_tx.send_replace(ServingState::NotServing {
+            leader_endpoint,
+            leader_epoch,
+        });
+    }
+
+    /// Step down in response to authoritative evidence the current epoch is no
+    /// longer valid (consensus rejection, leader-watch termination).
+    ///
+    /// Clears the allocator BEFORE publishing `NotServing` (invariant 2) and
+    /// deliberately does NOT take `extension_gate.write()` (invariant 3): an
+    /// in-flight extension holding the read lock and awaiting `persist_high_water`
+    /// would deadlock against a write here. Those in-flights complete cleanly or
+    /// fail and reach this method themselves — it is idempotent.
+    pub(crate) fn step_down(&self, leader_endpoint: Option<String>, leader_epoch: Option<Epoch>) {
+        self.allocator.lock().on_leadership_lost();
+        self.state_tx.send_replace(ServingState::NotServing {
+            leader_endpoint,
+            leader_epoch,
+        });
+    }
+
+    pub(crate) fn try_grant(&self, now_ms: u64, count: u32) -> Result<WindowGrant, CoreError> {
+        self.allocator.lock().try_grant(now_ms, count)
+    }
+
+    pub(crate) fn clear_allocator(&self) {
+        self.allocator.lock().on_leadership_lost();
+    }
+
+    pub(crate) fn seed_on_leadership_gained(
+        &self,
+        serving_floor: u64,
+        committed_ceiling: u64,
+        epoch: Epoch,
+    ) -> Result<(), CoreError> {
+        self.allocator
+            .lock()
+            .try_on_leadership_gained(serving_floor, committed_ceiling, epoch)
+    }
+
+    pub(crate) fn commit_extension(
+        &self,
+        actual: u64,
+        epoch: Epoch,
+    ) -> Result<CommitOutcome, CoreError> {
+        self.allocator
+            .lock()
+            .try_commit_window_extension(actual, epoch)
+    }
+
+    /// Enter the window-extension single-flight slot, holding `extension_lock`
+    /// for the returned guard's lifetime. The read barrier is reachable only
+    /// from this guard (see [`ExtensionSlot::drain_barrier`]).
+    pub(crate) async fn extension_slot(&self) -> ExtensionSlot<'_> {
+        let lock = self.extension_lock.lock().await;
+        ExtensionSlot {
+            _lock: lock,
+            core: self,
+        }
+    }
+
+    /// The fence's drain barrier (write side). Fence-only: it takes
+    /// `extension_gate.write()` and never `extension_lock`, so it cannot close a
+    /// lock cycle with an extender (invariant 4). Held by the fence across its
+    /// load → persist → seed → publish sequence; in-flight extension readers
+    /// drain before it is granted.
+    pub(crate) async fn drain_barrier_write(&self) -> RwLockWriteGuard<'_, ()> {
+        self.extension_gate.write().await
+    }
+}
+
+/// RAII guard holding `extension_lock`. The only way to obtain the extension
+/// read barrier, so `extension_lock → extension_gate.read()` ordering is a
+/// compile-time guarantee (invariant 1).
+pub(crate) struct ExtensionSlot<'a> {
+    _lock: AsyncMutexGuard<'a, ()>,
+    core: &'a ServingCore,
+}
+
+impl<'a> ExtensionSlot<'a> {
+    /// Recheck-after-acquire: would the outer retry's `try_grant(now_ms, count)`
+    /// now succeed (a peer extender already made room)?
+    pub(crate) fn would_grant(&self, now_ms: u64, count: u32) -> bool {
+        self.core.allocator.lock().would_grant(now_ms, count)
+    }
+
+    /// Compute the pre-extended ceiling to request from consensus, under a single
+    /// allocator lock. Returns `Err(CoreError::NotLeader)` if leadership was lost
+    /// (no epoch) between the outer fast gate and here — the caller surfaces that
+    /// as a leader redirect. `try_prepare_window_extension` never itself returns
+    /// `NotLeader`, so the two error classes stay disjoint.
+    pub(crate) fn prepare_extension(
+        &self,
+        now_ms: u64,
+        window_ahead_ms: u64,
+    ) -> Result<(u64, Epoch), CoreError> {
+        let allocator = self.core.allocator.lock();
+        let Some(epoch) = allocator.epoch() else {
+            return Err(CoreError::NotLeader);
+        };
+        let requested = allocator.try_prepare_window_extension(now_ms, window_ahead_ms)?;
+        Ok((requested, epoch))
+    }
+
+    /// The extension drain barrier (read side). Reachable only through the slot,
+    /// so the `extension_lock → extension_gate` order cannot be inverted. The
+    /// returned guard's lifetime is the slot's `'a` (not the `&self` borrow), so
+    /// the caller can keep using the slot — e.g. call `prepare_extension` —
+    /// while holding the barrier.
+    pub(crate) async fn drain_barrier(&self) -> RwLockReadGuard<'a, ()> {
+        let core = self.core;
+        core.extension_gate.read().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn step_down_clears_and_publishes_not_serving_with_hint() {
+        // Regression for #346: publish sites use `send_replace`, so a transition
+        // lands even when no receiver is subscribed (`receiver_count == 0`). Were
+        // a publish site to use `send`, this would be silently dropped and a
+        // leaderless-then-leader core could stay NotServing forever.
+        let core = ServingCore::new();
+        assert_eq!(core.state_tx.receiver_count(), 0);
+
+        core.step_down(Some("http://new-leader:9000".into()), Some(Epoch(7)));
+
+        match core.serving_state() {
+            ServingState::NotServing {
+                leader_endpoint,
+                leader_epoch,
+            } => {
+                assert_eq!(leader_endpoint.as_deref(), Some("http://new-leader:9000"));
+                assert_eq!(leader_epoch, Some(Epoch(7)));
+            }
+            ServingState::Serving => panic!("expected NotServing after step_down"),
+        }
+    }
+
+    #[tokio::test]
+    async fn step_down_does_not_take_the_gate() {
+        // Invariant 3: step_down must NOT acquire `extension_gate.write()`. Hold
+        // the read barrier on the current task; if step_down tried to take the
+        // write lock it would deadlock here (single-threaded runtime, lock held
+        // by us). Reaching the assertion proves it never touches the gate.
+        let core = ServingCore::new();
+        let slot = core.extension_slot().await;
+        let _barrier = slot.drain_barrier().await;
+
+        core.step_down(None, None);
+
+        assert!(matches!(
+            core.serving_state(),
+            ServingState::NotServing { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn write_barrier_excludes_held_read_barrier() {
+        // Invariants 1 & 4: the fence's write barrier must wait for in-flight
+        // extension readers to drain. `try_write` is a deterministic probe of
+        // that exclusion (no timing): it fails while a read barrier is held and
+        // succeeds once it is released.
+        let core = ServingCore::new();
+        let slot = core.extension_slot().await;
+        let barrier = slot.drain_barrier().await;
+
+        assert!(
+            core.extension_gate.try_write().is_err(),
+            "write barrier must be blocked while a read barrier is held"
+        );
+
+        drop(barrier);
+        drop(slot);
+        assert!(
+            core.extension_gate.try_write().is_ok(),
+            "write barrier must be free once the read barrier drains"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_extension_without_leadership_is_not_leader() {
+        // A fresh core is NotLeader (no epoch). prepare_extension must surface
+        // that as `NotLeader` so the caller emits a redirect, and would_grant is
+        // false.
+        let core = ServingCore::new();
+        let slot = core.extension_slot().await;
+        assert!(matches!(
+            slot.prepare_extension(1, 1_000),
+            Err(CoreError::NotLeader)
+        ));
+        assert!(!slot.would_grant(1, 1));
+    }
+
+    #[test]
+    fn try_grant_without_leadership_is_not_leader() {
+        let core = ServingCore::new();
+        assert!(matches!(core.try_grant(1, 1), Err(CoreError::NotLeader)));
+    }
+
+    #[test]
+    fn seed_then_try_grant_succeeds_at_seeded_epoch() {
+        // try_on_leadership_gained(floor, ceiling, epoch) seeds a serveable
+        // window; a grant at the floor returns timestamps stamped with the
+        // seeded epoch.
+        let core = ServingCore::new();
+        core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
+            .expect("seed must succeed (ceiling >= floor)");
+        let grant = core.try_grant(1_000, 1).expect("grant must succeed");
+        assert_eq!(grant.epoch(), Epoch(3));
+    }
+}

--- a/crates/tsoracle-tests/tests/server_failpoints.rs
+++ b/crates/tsoracle-tests/tests/server_failpoints.rs
@@ -142,7 +142,7 @@ async fn fence_panic_after_persist_advances_durable_but_not_serving() {
 /// drain guard. A `panic` action verifies the fail-safe documented on
 /// `Server::into_router`: when the leader-watch task panics from a `Serving`
 /// state, the `catch_unwind` wrapper in `into_router` calls
-/// `step_down_due_to_consensus_rejection` before resuming the unwind, so
+/// `ServingCore::step_down` before resuming the unwind, so
 /// embedders who mount `into_router` directly and never observe the
 /// `WatchGuard`'s outcome still see serving state transition to `NotServing`
 /// and subsequent RPCs fail fast with `FAILED_PRECONDITION`. Without the


### PR DESCRIPTION
## Summary

Closes #335. `Server` bundled config, runtime collaborators, serving-state pub/sub, and two lock domains (`allocator` + `extension_lock`/`extension_gate`), so four load-bearing invariants — the `extension_lock → extension_gate` acquisition order, `step_down`'s clear-allocator-before-publish, `step_down`'s deliberate avoidance of `extension_gate.write()` (deadlock), and the fence's write-only barrier — were enforced only by prose spread across `server.rs`, `service.rs`, and `fence.rs`.

This extracts a private `ServingCore` (`crates/tsoracle-server/src/serving_core.rs`) that owns the allocator, the serving-state channel, and both locks, exposing the invariant-bearing operations as methods:

- The extension **read** barrier is `ExtensionSlot::drain_barrier`, a method on the guard returned by `extension_slot()` — which already holds `extension_lock`. There is no other path to the read lock, so the `extension_lock → extension_gate` order is now a **compile-time guarantee** rather than a convention.
- `step_down` privately encapsulates clear-before-publish and stays gate-free; the fence's write barrier (`drain_barrier_write`) is a separate, slot-free method.
- Consensus calls, `tonic::Status` mapping, and metrics stay in `service.rs`/`fence.rs`, so `ServingCore` has no dependency on `ConsensusDriver`, `Status`, or the metrics catalog.

`Server` keeps `consensus`/`clock`/config and holds the core by value (it is already shared via `Arc<Server>`, so an inner `Arc` would be redundant; this also drops the now-redundant per-field `Arc`s). No public-API or wire-format change.

The two "folded-in" items in the issue (redundant `state_rx`, success-only metric) already landed on `main` via the merged #385 and #382, so this PR is purely the extraction.

## Test Plan

- [x] New `serving_core` unit tests: step-down clears-before-publishes (with `receiver_count == 0`, the #346 regression), step-down completes while a read barrier is held (proves it never takes the gate), `try_write` is excluded while a read barrier is held (the drain-barrier exclusion), prepare/try_grant without leadership return `NotLeader`, seed→grant stamps the seeded epoch.
- [x] `cargo test --workspace` — all suites pass (incl. `leader_watch`, `leadership_churn`, `serve_shutdown`, `metrics`, `e2e`, `embedded_router`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Examples build.