### PR TITLE
fix(driver-paxos): re-subscribe leadership_events instead of take-once (#262)

### DIFF
--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -275,8 +275,8 @@ impl PaxosTopology {
                 .snapshot_policy(SnapshotPolicy::disabled())
                 .build()
                 .with_context(|| format!("paxos topology: build StandaloneHost for node {id}"))?;
-            let leader_stream = host.take_leader_stream().ok_or_else(|| {
-                anyhow::anyhow!("paxos topology: leader stream for node {id} already taken")
+            let leader_subscriber = host.take_leader_subscriber().ok_or_else(|| {
+                anyhow::anyhow!("paxos topology: leader subscriber for node {id} already taken")
             })?;
 
             let sink = Arc::new(MeshSink {
@@ -286,7 +286,7 @@ impl PaxosTopology {
                 .context("paxos topology: host not already running")?;
 
             // ---- Driver + tsoracle server ----
-            let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+            let driver = Arc::new(PaxosDriver::new(host, leader_subscriber));
             let server = Server::builder()
                 .consensus_driver(driver)
                 .build()

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -727,15 +727,21 @@ mod tests {
         let server_handles = topology.server_handles;
         // Fire the per-node shutdown signals.
         Box::new(topology.controller).shutdown().await;
-        // Each server task must complete within a generous window after
-        // its shutdown oneshot fires. A hung handle means `shutdown` is
-        // not actually triggering the server's drain path.
+        // Each server task must complete within a generous window after its
+        // shutdown oneshot fires. The window only guards against a genuine
+        // hang — `shutdown` failing to trigger the server's drain path — which
+        // never completes regardless of how long we wait; a healthy drain
+        // finishes in milliseconds. It is sized at 30s (not 5s) because the
+        // libtest harness runs this file's many `multi_thread` topology tests
+        // concurrently, each demanding 4 workers, so on an oversubscribed CI
+        // runner the spawned drain task can be scheduling-starved well past a
+        // few seconds of wall-clock without anything being wrong.
         for (idx, handle) in server_handles.into_iter().enumerate() {
-            match tokio::time::timeout(Duration::from_secs(5), handle).await {
+            match tokio::time::timeout(Duration::from_secs(30), handle).await {
                 Ok(Ok(())) => {}
                 Ok(Err(join_err)) => panic!("server task {idx} did not exit cleanly: {join_err:?}"),
                 Err(_elapsed) => {
-                    panic!("server task {idx} did not complete within 5s after shutdown")
+                    panic!("server task {idx} did not complete within 30s after shutdown")
                 }
             }
         }

--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -21,10 +21,9 @@ use core::pin::Pin;
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
-use parking_lot::Mutex;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::Epoch;
-use tsoracle_paxos_toolkit::lifecycle::LeaderEventStream;
+use tsoracle_paxos_toolkit::lifecycle::LeaderEventSubscriber;
 
 use crate::host::PaxosHighWaterHost;
 use crate::type_config::encode_epoch;
@@ -41,7 +40,12 @@ where
     H: PaxosHighWaterHost,
 {
     host: H,
-    leader_stream: Mutex<Option<LeaderEventStream>>,
+    /// Re-subscribable handle over the runner's leader-event channel. Each
+    /// [`ConsensusDriver::leadership_events`] call mints a fresh stream from it,
+    /// so a second subscriber (e.g. an in-process restart) is never blacked out
+    /// — mirroring the openraft driver, which re-derives its stream from the
+    /// raft metrics watch on every call.
+    leader_subscriber: LeaderEventSubscriber,
 }
 
 impl<H> PaxosDriver<H>
@@ -50,16 +54,15 @@ where
 {
     /// Build a driver around a host.
     ///
-    /// `leader_stream` is taken from the host (typically via
-    /// `StandaloneHost::take_leader_stream`). The driver consumes it
-    /// once on the first call to [`ConsensusDriver::leadership_events`];
-    /// subsequent calls return an empty stream that closes immediately
-    /// (the trait permits this since it is documented as a once-per-
-    /// lifetime subscription).
-    pub fn new(host: H, leader_stream: LeaderEventStream) -> Self {
+    /// `leader_subscriber` is taken from the host (typically via
+    /// `StandaloneHost::take_leader_subscriber`). It is re-subscribable: every
+    /// call to [`ConsensusDriver::leadership_events`] mints a fresh, live stream
+    /// that synchronously yields the current leadership state, so repeated
+    /// subscriptions are well-defined rather than a one-shot take.
+    pub fn new(host: H, leader_subscriber: LeaderEventSubscriber) -> Self {
         Self {
             host,
-            leader_stream: Mutex::new(Some(leader_stream)),
+            leader_subscriber,
         }
     }
 
@@ -76,25 +79,24 @@ where
     H: PaxosHighWaterHost,
 {
     fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
-        let raw = self.leader_stream.lock().take();
+        // Mint a fresh stream on every call. The subscriber's first poll yields
+        // the channel's current state synchronously (the trait's first-item
+        // contract), so a second subscriber sees the live leadership state
+        // rather than an empty stream.
+        let stream = self.leader_subscriber.subscribe();
         let omnipaxos = self.host.omnipaxos();
-        match raw {
-            Some(stream) => {
-                let mapped = stream.map(move |state| match state {
-                    LeaderState::Leader { .. } => {
-                        // Re-derive epoch from the host's view of the
-                        // current ballot. This is what fence checks see.
-                        let ballot = omnipaxos.lock().get_promise();
-                        LeaderState::Leader {
-                            epoch: encode_epoch(ballot),
-                        }
-                    }
-                    other => other,
-                });
-                Box::pin(mapped)
+        let mapped = stream.map(move |state| match state {
+            LeaderState::Leader { .. } => {
+                // Re-derive epoch from the host's view of the current ballot.
+                // This is what fence checks see.
+                let ballot = omnipaxos.lock().get_promise();
+                LeaderState::Leader {
+                    epoch: encode_epoch(ballot),
+                }
             }
-            None => Box::pin(futures::stream::empty()),
-        }
+            other => other,
+        });
+        Box::pin(mapped)
     }
 
     async fn load_high_water(&self) -> Result<u64, ConsensusError> {
@@ -135,6 +137,7 @@ mod tests {
     use super::*;
     use crate::log_entry::HighWaterCommand;
     use omnipaxos::OmniPaxos;
+    use parking_lot::Mutex;
     use std::sync::Arc;
     use tsoracle_paxos_toolkit::lifecycle::leader_event_channel;
     use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
@@ -194,8 +197,8 @@ mod tests {
     #[tokio::test]
     async fn persist_with_stale_epoch_returns_fenced() {
         let host = StubHost::new();
-        let (_sender, stream) = leader_event_channel();
-        let driver = PaxosDriver::new(host, stream);
+        let (_sender, subscriber) = leader_event_channel();
+        let driver = PaxosDriver::new(host, subscriber);
 
         let stale_epoch = Epoch(0xDEAD_BEEF);
         let result = driver.persist_high_water(42, stale_epoch).await;
@@ -216,8 +219,8 @@ mod tests {
         let current_ballot = host.omnipaxos().lock().get_promise();
         let current_epoch = encode_epoch(current_ballot);
 
-        let (_sender, stream) = leader_event_channel();
-        let driver = PaxosDriver::new(host, stream);
+        let (_sender, subscriber) = leader_event_channel();
+        let driver = PaxosDriver::new(host, subscriber);
 
         // The range guard must run before the Advance is appended to the log,
         // so an out-of-range fence value is never durably committed. StubHost's
@@ -248,8 +251,8 @@ mod tests {
         let current_ballot = host.omnipaxos().lock().get_promise();
         let current_epoch = encode_epoch(current_ballot);
 
-        let (_sender, stream) = leader_event_channel();
-        let driver = PaxosDriver::new(host, stream);
+        let (_sender, subscriber) = leader_event_channel();
+        let driver = PaxosDriver::new(host, subscriber);
 
         let result = driver.persist_high_water(99, current_epoch).await;
         // StubHost::submit_advance returns Ok(at_least).
@@ -257,23 +260,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn leadership_events_is_take_once() {
+    async fn leadership_events_resubscribes_on_each_call() {
         let host = StubHost::new();
-        let (_sender, stream) = leader_event_channel();
-        let driver = PaxosDriver::new(host, stream);
+        let (sender, subscriber) = leader_event_channel();
+        let driver = PaxosDriver::new(host, subscriber);
 
-        // First call returns a real stream.
-        let _first = driver.leadership_events();
-        // Second call returns an empty stream that closes immediately.
+        // Drive the channel to a leader state so a fresh subscription has a
+        // non-`Unknown` current value to surface synchronously.
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(7) })
+            .unwrap();
+
+        // The first subscription yields the current leader state...
+        let mut first = driver.leadership_events();
+        assert!(
+            matches!(first.next().await, Some(LeaderState::Leader { .. })),
+            "first subscription must yield the current leader state",
+        );
+
+        // ...and a SECOND subscription is NOT a silent blackout: it re-derives
+        // a fresh stream that synchronously yields the current state too. The
+        // pre-fix driver `take()`s the stream once and returns `stream::empty()`
+        // here, so this would observe `None`.
         let mut second = driver.leadership_events();
-        assert!(second.next().await.is_none());
+        assert!(
+            matches!(second.next().await, Some(LeaderState::Leader { .. })),
+            "a second subscription must re-derive a live stream, not blackout",
+        );
     }
 
     #[tokio::test]
     async fn load_high_water_delegates_to_host() {
         let host = StubHost::new();
-        let (_sender, stream) = leader_event_channel();
-        let driver = PaxosDriver::new(host, stream);
+        let (_sender, subscriber) = leader_event_channel();
+        let driver = PaxosDriver::new(host, subscriber);
         assert_eq!(driver.load_high_water().await.unwrap(), 0);
     }
 }

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -29,7 +29,7 @@ use omnipaxos::messages::Message;
 use omnipaxos::storage::Storage;
 use parking_lot::Mutex;
 use tsoracle_consensus::{AdvancePayload, ConsensusError};
-use tsoracle_paxos_toolkit::lifecycle::{LeaderEventStream, MessageSink, PaxosRunner, TsoPeer};
+use tsoracle_paxos_toolkit::lifecycle::{LeaderEventSubscriber, MessageSink, PaxosRunner, TsoPeer};
 
 use crate::apply::{ApplyEngine, ApplyTask};
 use crate::host::PaxosHighWaterHost;
@@ -45,7 +45,7 @@ where
     my_node_id: u64,
     barrier_seq: AtomicU64,
     runner: PaxosRunner<HighWaterCommand, S>,
-    leader_stream: Mutex<Option<LeaderEventStream>>,
+    leader_subscriber: Mutex<Option<LeaderEventSubscriber>>,
     /// Apply state + snapshot policy + the drain/snapshot step. Drives the
     /// synchronous stepping path and the barrier-linearized reads directly,
     /// and the async apply path via a clone moved into the spawned task.
@@ -103,7 +103,7 @@ where
         barrier_timeout: Duration,
     ) -> Self {
         let mut runner = PaxosRunner::new(omnipaxos.clone(), my_node_id, peers, tick_interval);
-        let leader_stream = runner.take_leader_stream();
+        let leader_subscriber = runner.take_leader_subscriber();
 
         // Resume the barrier-nonce counter above any seq this node already
         // used in a prior process lifetime. `barrier_seq` is process-local
@@ -135,7 +135,7 @@ where
             my_node_id,
             barrier_seq: AtomicU64::new(recovered_seq),
             runner,
-            leader_stream: Mutex::new(leader_stream),
+            leader_subscriber: Mutex::new(leader_subscriber),
             engine,
             task: None,
             apply_cursor: Arc::new(Mutex::new(recovery_cursor)),
@@ -143,10 +143,13 @@ where
         }
     }
 
-    /// Take ownership of the leader-event stream. Returns `None` if
-    /// already taken. The driver consumes this at construction.
-    pub fn take_leader_stream(&self) -> Option<LeaderEventStream> {
-        self.leader_stream.lock().take()
+    /// Take ownership of the leader-event subscriber. Returns `None` if
+    /// already taken. The driver consumes this at construction and re-derives a
+    /// fresh stream from it on every `leadership_events` call. The host retains
+    /// no receiver after this hand-off, so the runner's drop-based shutdown
+    /// still fires once the driver (and any stream it minted) is dropped.
+    pub fn take_leader_subscriber(&self) -> Option<LeaderEventSubscriber> {
+        self.leader_subscriber.lock().take()
     }
 
     /// Borrow the OmniPaxos handle for direct interaction.

--- a/crates/tsoracle-driver-paxos/tests/common/mod.rs
+++ b/crates/tsoracle-driver-paxos/tests/common/mod.rs
@@ -44,7 +44,7 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tsoracle_driver_paxos::{HighWaterCommand, SnapshotPolicy, StandaloneHost};
-use tsoracle_paxos_toolkit::lifecycle::{LeaderEventStream, MessageSink};
+use tsoracle_paxos_toolkit::lifecycle::{LeaderEventSubscriber, MessageSink};
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
 
@@ -102,10 +102,11 @@ where
     /// Inbox receiver registered with the shared [`MemNetwork`]. `Option`
     /// because the spawned pump task takes ownership of it.
     inbox: Option<mpsc::Receiver<Message<HighWaterCommand>>>,
-    /// The leader-event stream taken off the host before start. Used by
-    /// tests that build a `PaxosDriver` directly. Optional because a test
-    /// can leave it on the host instead.
-    pub leader_stream: Option<LeaderEventStream>,
+    /// The leader-event subscriber taken off the host before start. Used by
+    /// tests that build a `PaxosDriver` directly, and otherwise retained so the
+    /// channel stays open. Optional because a test can leave it on the host
+    /// instead.
+    pub leader_subscriber: Option<LeaderEventSubscriber>,
     /// Shared OmniPaxos handle for direct inspection (`get_decided_idx`,
     /// `get_current_leader`, `append`, etc.).
     ///
@@ -501,12 +502,12 @@ fn build_mem_cluster_inner(
             builder = builder.barrier_timeout(barrier_timeout);
         }
         let host = builder.build().expect("build standalone host");
-        let leader_stream = host.take_leader_stream();
+        let leader_subscriber = host.take_leader_subscriber();
         nodes.push(NodeHandle {
             node_id,
             host: Some(host),
             inbox: Some(inbox),
-            leader_stream,
+            leader_subscriber,
             omnipaxos: Some(shared_omnipaxos),
             pump_stop: None,
             pump_handle: None,
@@ -580,13 +581,13 @@ pub fn build_rocksdb_cluster_with_policy(
             .snapshot_policy(policy)
             .build()
             .expect("build standalone host");
-        let leader_stream = host.take_leader_stream();
+        let leader_subscriber = host.take_leader_subscriber();
         tempdirs.insert(node_id, dir);
         nodes.push(NodeHandle {
             node_id,
             host: Some(host),
             inbox: Some(inbox),
-            leader_stream,
+            leader_subscriber,
             omnipaxos: Some(shared_omnipaxos),
             pump_stop: None,
             pump_handle: None,
@@ -640,7 +641,7 @@ impl Cluster<RocksdbStorage<HighWaterCommand>> {
             .snapshot_policy(SnapshotPolicy::disabled())
             .build()
             .expect("build standalone host after restart");
-        let leader_stream = host.take_leader_stream();
+        let leader_subscriber = host.take_leader_subscriber();
 
         let slot = self
             .nodes
@@ -649,7 +650,7 @@ impl Cluster<RocksdbStorage<HighWaterCommand>> {
             .expect("node id present");
         slot.host = Some(host);
         slot.inbox = Some(inbox);
-        slot.leader_stream = leader_stream;
+        slot.leader_subscriber = leader_subscriber;
         slot.omnipaxos = Some(shared_omnipaxos);
     }
 }

--- a/crates/tsoracle-driver-paxos/tests/three_node.rs
+++ b/crates/tsoracle-driver-paxos/tests/three_node.rs
@@ -129,11 +129,11 @@ async fn fence_check_rejects_stale_epoch_and_accepts_current() {
     let follower_handle = cluster.node(follower_id).omnipaxos();
     let follower_apply = FollowerProxyHost::new(follower_handle.clone());
 
-    // The PaxosDriver doesn't actually use leader_stream for
-    // persist_high_water; it only consumes it via leadership_events. Use
-    // an empty channel.
-    let (_sender, stream) = tsoracle_paxos_toolkit::lifecycle::leader_event_channel();
-    let driver = PaxosDriver::new(follower_apply, stream);
+    // The PaxosDriver doesn't actually use the leader-event channel for
+    // persist_high_water; it only consumes it via leadership_events. Use a
+    // bare channel and hand the driver its subscriber.
+    let (_sender, subscriber) = tsoracle_paxos_toolkit::lifecycle::leader_event_channel();
+    let driver = PaxosDriver::new(follower_apply, subscriber);
 
     // Path A: stale epoch is rejected.
     let stale_epoch = Epoch(0xDEAD_BEEF);

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/events.rs
@@ -37,19 +37,17 @@ pub enum SendError {
 
 /// Create a new leader-event channel.
 ///
-/// The returned [`LeaderEventStream`] yields `LeaderState::Unknown` on its
-/// first poll (the channel's initial value) and every distinct subsequent
-/// value sent via the [`LeaderEventSender`]. Identical successive sends
-/// are debounced — receivers see one transition per unique value, not
-/// one per `send()` call.
-pub fn leader_event_channel() -> (LeaderEventSender, LeaderEventStream) {
+/// Returns a [`LeaderEventSender`] (the runner's emit half) and a
+/// [`LeaderEventSubscriber`] (the consumer's subscribe half). The
+/// subscriber mints a fresh [`LeaderEventStream`] on every
+/// [`LeaderEventSubscriber::subscribe`] call; each stream yields the
+/// channel's *current* value (`LeaderState::Unknown` until the first
+/// transition is sent) on its first poll and every distinct subsequent
+/// value. Identical successive sends are debounced — a stream sees one
+/// transition per unique value, not one per `send()` call.
+pub fn leader_event_channel() -> (LeaderEventSender, LeaderEventSubscriber) {
     let (tx, rx) = watch::channel(LeaderState::Unknown);
-    (
-        LeaderEventSender { tx },
-        LeaderEventStream {
-            inner: WatchStream::new(rx),
-        },
-    )
+    (LeaderEventSender { tx }, LeaderEventSubscriber { rx })
 }
 
 /// Sending half of the leader-event channel.
@@ -79,6 +77,45 @@ impl LeaderEventSender {
             return Ok(());
         }
         self.tx.send(state).map_err(|_| SendError::Closed)
+    }
+}
+
+/// Subscribe half of the leader-event channel.
+///
+/// Holds a `watch::Receiver` and mints a fresh [`LeaderEventStream`] on every
+/// [`Self::subscribe`] call — the analogue of cloning an openraft metrics watch
+/// receiver. Two properties make this the right handle to hand a consumer that
+/// may subscribe more than once (e.g. a driver re-derived across an in-process
+/// restart):
+///
+/// - **Re-subscribable:** every `subscribe()` returns an independent live
+///   stream whose first poll yields the channel's *current* value, so a second
+///   (or third) subscription is never a silent blackout.
+/// - **Keeps the channel open:** the retained receiver counts toward the
+///   channel's receiver count, so while a subscriber is held the sender's
+///   `send` cannot observe a closed channel. The runner's drop-based shutdown
+///   (all receivers gone ⇒ [`SendError::Closed`]) therefore fires only once
+///   this subscriber *and* every stream it minted have been dropped.
+///
+/// Cloneable: each clone is an independent receiver over the same channel.
+#[derive(Clone)]
+pub struct LeaderEventSubscriber {
+    rx: watch::Receiver<LeaderState>,
+}
+
+impl LeaderEventSubscriber {
+    /// Mint a fresh [`LeaderEventStream`] over this channel.
+    ///
+    /// The returned stream yields the channel's current [`LeaderState`] on its
+    /// first poll (`WatchStream::new` reads the held value rather than waiting
+    /// for the next change) and every distinct subsequent value. Calling this
+    /// repeatedly is well-defined: each call hands back a new, independent
+    /// stream, so a late or second subscriber is never blacked out.
+    #[must_use]
+    pub fn subscribe(&self) -> LeaderEventStream {
+        LeaderEventStream {
+            inner: WatchStream::new(self.rx.clone()),
+        }
     }
 }
 
@@ -131,7 +168,8 @@ mod tests {
         // Watch channels coalesce intermediate values: multiple sends without
         // an intervening poll collapse to the latest. Poll between sends so
         // each transition is yielded distinctly.
-        let (sender, mut stream) = leader_event_channel();
+        let (sender, subscriber) = leader_event_channel();
+        let mut stream = subscriber.subscribe();
         assert_eq!(stream.next().await, Some(LeaderState::Unknown));
 
         sender
@@ -162,7 +200,7 @@ mod tests {
         // on identical payloads while a receiver is alive. Stream output
         // cannot be used to observe debounce because watch already
         // coalesces.
-        let (sender, _stream) = leader_event_channel();
+        let (sender, _subscriber) = leader_event_channel();
         let same = LeaderState::Leader { epoch: Epoch(1) };
         assert!(sender.send(same.clone()).is_ok());
         assert!(sender.send(same).is_ok());
@@ -170,12 +208,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_returns_closed_after_stream_dropped() {
-        // Atomicity contract: dropping the stream makes the next send
-        // return SendError::Closed immediately. Exercises the change-path
-        // in `send` (the watch::Sender::send arm).
-        let (sender, stream) = leader_event_channel();
-        drop(stream);
+    async fn send_returns_closed_after_subscriber_dropped() {
+        // Atomicity contract: dropping the last receiver (here the subscriber,
+        // which has minted no stream) makes the next send return
+        // SendError::Closed immediately. Exercises the change-path in `send`
+        // (the watch::Sender::send arm).
+        let (sender, subscriber) = leader_event_channel();
+        drop(subscriber);
         let result = sender.send(LeaderState::Leader { epoch: Epoch(1) });
         assert!(matches!(result, Err(SendError::Closed)));
     }
@@ -183,15 +222,87 @@ mod tests {
     #[tokio::test]
     async fn send_returns_closed_for_debounced_payload_after_drop() {
         // Exercises the debounce-with-closed-channel arm: an unchanged
-        // payload still surfaces SendError::Closed when the receiver is
+        // payload still surfaces SendError::Closed when every receiver is
         // gone, so the runner can shut down even when nothing changed.
-        let (sender, stream) = leader_event_channel();
+        let (sender, subscriber) = leader_event_channel();
         sender
             .send(LeaderState::Leader { epoch: Epoch(1) })
-            .expect("first send succeeds while stream alive");
-        drop(stream);
+            .expect("first send succeeds while subscriber alive");
+        drop(subscriber);
         let result = sender.send(LeaderState::Leader { epoch: Epoch(1) });
         assert!(matches!(result, Err(SendError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn send_stays_open_while_a_minted_stream_outlives_the_subscriber() {
+        // A stream minted from a subscriber is itself a receiver, so dropping
+        // the subscriber while a stream is still alive must NOT close the
+        // channel — the runner keeps emitting to the surviving stream.
+        let (sender, subscriber) = leader_event_channel();
+        let _stream = subscriber.subscribe();
+        drop(subscriber);
+        assert!(
+            sender.send(LeaderState::Leader { epoch: Epoch(1) }).is_ok(),
+            "channel must stay open while a minted stream survives the subscriber",
+        );
+    }
+
+    #[tokio::test]
+    async fn into_pin_stream_dropped_closes_channel() {
+        // The into_pin'd trait-object stream is still a watch receiver: once it
+        // and the subscriber are dropped, the channel closes. Guards the boxed
+        // path the driver actually hands the server.
+        let (sender, subscriber) = leader_event_channel();
+        let pinned = subscriber.subscribe().into_pin();
+        drop(subscriber);
+        drop(pinned);
+        assert!(matches!(
+            sender.send(LeaderState::Leader { epoch: Epoch(1) }),
+            Err(SendError::Closed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn subscriber_mints_independent_streams_each_yielding_current_state() {
+        // A subscriber re-derives a fresh stream on every call, and each fresh
+        // stream yields the channel's *current* value on its first poll — the
+        // synchronous-first-item contract `ConsensusDriver::leadership_events`
+        // requires. Crucially a *second* subscription is not a blackout: both
+        // streams below see the post-send leader state, not an empty stream.
+        let (sender, subscriber) = leader_event_channel();
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(1) })
+            .unwrap();
+
+        let mut first = subscriber.subscribe();
+        let mut second = subscriber.subscribe();
+        assert_eq!(
+            first.next().await,
+            Some(LeaderState::Leader { epoch: Epoch(1) })
+        );
+        assert_eq!(
+            second.next().await,
+            Some(LeaderState::Leader { epoch: Epoch(1) })
+        );
+    }
+
+    #[tokio::test]
+    async fn subscriber_streams_observe_transitions_after_subscribe() {
+        // A stream minted before a transition still observes the transition:
+        // proves subscribe() returns a live WatchStream, not a one-shot
+        // snapshot of the value at subscription time.
+        let (sender, subscriber) = leader_event_channel();
+        let mut stream = subscriber.subscribe();
+        assert_eq!(stream.next().await, Some(LeaderState::Unknown));
+
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(2) })
+            .unwrap();
+        yield_now().await;
+        assert_eq!(
+            stream.next().await,
+            Some(LeaderState::Leader { epoch: Epoch(2) })
+        );
     }
 
     #[tokio::test]
@@ -200,8 +311,8 @@ mod tests {
         // equivalent to the underlying LeaderEventStream — yields the
         // initial value and subsequent changes via the boxed-pinned
         // trait object path consumers use.
-        let (sender, stream) = leader_event_channel();
-        let mut pinned = stream.into_pin();
+        let (sender, subscriber) = leader_event_channel();
+        let mut pinned = subscriber.subscribe().into_pin();
         assert_eq!(pinned.next().await, Some(LeaderState::Unknown));
 
         sender

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -15,7 +15,9 @@
 pub mod events;
 pub mod state;
 
-pub use events::{LeaderEventSender, LeaderEventStream, SendError, leader_event_channel};
+pub use events::{
+    LeaderEventSender, LeaderEventStream, LeaderEventSubscriber, SendError, leader_event_channel,
+};
 pub use state::LeadershipState;
 pub use tsoracle_core::TsoPeer;
 
@@ -70,7 +72,7 @@ where
     peers: Vec<TsoPeer>,
     tick_interval: Duration,
     leader_sender: LeaderEventSender,
-    leader_stream: Option<LeaderEventStream>,
+    leader_subscriber: Option<LeaderEventSubscriber>,
     apply_notify: Arc<Notify>,
     handle: Option<JoinHandle<()>>,
     sender_handle: Option<JoinHandle<()>>,
@@ -98,14 +100,14 @@ where
         peers: Vec<TsoPeer>,
         tick_interval: Duration,
     ) -> Self {
-        let (leader_sender, leader_stream) = leader_event_channel();
+        let (leader_sender, leader_subscriber) = leader_event_channel();
         Self {
             omnipaxos,
             my_node_id,
             peers,
             tick_interval,
             leader_sender,
-            leader_stream: Some(leader_stream),
+            leader_subscriber: Some(leader_subscriber),
             apply_notify: Arc::new(Notify::new()),
             handle: None,
             sender_handle: None,
@@ -114,10 +116,18 @@ where
         }
     }
 
-    /// Take ownership of the leader-event stream. Returns `None` if already taken.
+    /// Take ownership of the leader-event subscriber. Returns `None` if already
+    /// taken.
+    ///
+    /// The runner keeps only the [`LeaderEventSender`] after this hand-off, not
+    /// a receiver, so the consumer that holds the returned subscriber is the
+    /// sole owner of the channel's receiver side. Dropping it (and every stream
+    /// it minted) closes the channel, which is the runner's drop-based shutdown
+    /// signal. The subscriber itself is re-subscribable, so a consumer can mint
+    /// fresh streams without coming back to the runner.
     #[must_use]
-    pub fn take_leader_stream(&mut self) -> Option<LeaderEventStream> {
-        self.leader_stream.take()
+    pub fn take_leader_subscriber(&mut self) -> Option<LeaderEventSubscriber> {
+        self.leader_subscriber.take()
     }
 
     /// Notification fired once per tick, after outbound messages have been
@@ -536,10 +546,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn take_leader_stream_is_once_only() {
+    async fn take_leader_subscriber_is_once_only() {
         let mut runner = build_runner(1);
-        assert!(runner.take_leader_stream().is_some());
-        assert!(runner.take_leader_stream().is_none());
+        assert!(runner.take_leader_subscriber().is_some());
+        assert!(runner.take_leader_subscriber().is_none());
     }
 
     #[tokio::test]
@@ -572,7 +582,11 @@ mod tests {
         // observes leader = None, emits LeaderState::Unknown via the
         // leader-event channel, and calls notify_waiters().
         let mut runner = build_runner(1);
-        let mut stream = runner.take_leader_stream().expect("stream").into_pin();
+        let mut stream = runner
+            .take_leader_subscriber()
+            .expect("subscriber")
+            .subscribe()
+            .into_pin();
         runner.start(Arc::new(NoopSink));
 
         // First yielded value is the initial Unknown.
@@ -666,19 +680,20 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn tick_loop_exits_when_leader_stream_dropped() {
+    async fn tick_loop_exits_when_leader_subscriber_dropped() {
         // The tick loop emits every leadership transition through the
-        // leader-event channel. Once every subscriber has dropped the stream,
+        // leader-event channel. Once every receiver is gone,
         // `LeaderEventSender::send` returns `SendError::Closed`, and the loop
         // must exit on its own rather than spin forever emitting into a closed
-        // channel. Take the stream and drop it before starting, so the first
-        // tick's leader-event send observes the closed channel and breaks —
-        // without anyone firing the shutdown signal. This is the only path
-        // that ends the loop here, so the task finishing before we call
-        // `stop()` is proof the closed-channel arm ran.
+        // channel. Take the subscriber and drop it before starting (it has
+        // minted no stream, so it is the sole receiver), so the first tick's
+        // leader-event send observes the closed channel and breaks — without
+        // anyone firing the shutdown signal. This is the only path that ends
+        // the loop here, so the task finishing before we call `stop()` is proof
+        // the closed-channel arm ran.
         let mut runner = build_runner(1);
-        let stream = runner.take_leader_stream().expect("stream");
-        drop(stream);
+        let subscriber = runner.take_leader_subscriber().expect("subscriber");
+        drop(subscriber);
         runner.start(Arc::new(NoopSink));
 
         let exited = wait_until(Duration::from_secs(1), || {
@@ -691,7 +706,7 @@ mod tests {
         .await;
         assert!(
             exited,
-            "tick loop must exit once the leader-event stream is dropped",
+            "tick loop must exit once the leader-event subscriber is dropped",
         );
 
         // `stop()` remains safe to call after the task has already exited.

--- a/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
@@ -67,7 +67,11 @@ async fn runners_emit_leader_or_follower_event_after_election() {
             peers,
             Duration::from_millis(10),
         );
-        let stream = runner.take_leader_stream().expect("stream").into_pin();
+        let stream = runner
+            .take_leader_subscriber()
+            .expect("subscriber")
+            .subscribe()
+            .into_pin();
         runner.start(sink.clone());
         runners.push(runner);
         streams.push(stream);

--- a/examples/paxos-embedded/src/main.rs
+++ b/examples/paxos-embedded/src/main.rs
@@ -128,9 +128,9 @@ async fn main() -> anyhow::Result<()> {
             .snapshot_policy(SnapshotPolicy::disabled())
             .build()
             .context("build StandaloneHost")?;
-        let leader_stream = host
-            .take_leader_stream()
-            .context("leader stream is fresh")?;
+        let leader_subscriber = host
+            .take_leader_subscriber()
+            .context("leader subscriber is fresh")?;
 
         let sink = Arc::new(MeshSink {
             network: network.clone(),
@@ -138,7 +138,7 @@ async fn main() -> anyhow::Result<()> {
         host.start(sink).context("host not already running")?;
 
         // ---- Driver + tsoracle server ----
-        let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+        let driver = Arc::new(PaxosDriver::new(host, leader_subscriber));
         let server = TsoServer::builder().consensus_driver(driver).build()?;
 
         let (tso_shutdown_tx, tso_shutdown_rx) = oneshot::channel::<()>();

--- a/examples/paxos-piggyback/src/demo.rs
+++ b/examples/paxos-piggyback/src/demo.rs
@@ -157,11 +157,11 @@ async fn build_node(
     ));
     let state = HostState::new();
 
-    // ---- Runner + leader stream ----
+    // ---- Runner + leader subscriber ----
     let mut runner = PaxosRunner::new(omnipaxos.clone(), id, vec![], TICK_INTERVAL);
-    let leader_stream = runner
-        .take_leader_stream()
-        .context("leader stream is fresh")?;
+    let leader_subscriber = runner
+        .take_leader_subscriber()
+        .context("leader subscriber is fresh")?;
     let runner_apply_notify = runner.apply_notify();
 
     // ---- Pumps: inbox + apply ----
@@ -204,7 +204,7 @@ async fn build_node(
 
     // ---- Driver + tsoracle server ----
     let host = PiggybackHost::new(omnipaxos.clone(), state.clone(), id);
-    let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+    let driver = Arc::new(PaxosDriver::new(host, leader_subscriber));
     let server = TsoServer::builder().consensus_driver(driver).build()?;
     let serving_state_rx = server.subscribe();
 

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -186,16 +186,16 @@ async fn main() -> anyhow::Result<()> {
         .build()
         .context("build StandaloneHost")?;
 
-    let leader_stream = host
-        .take_leader_stream()
-        .context("leader stream available on a fresh host")?;
+    let leader_subscriber = host
+        .take_leader_subscriber()
+        .context("leader subscriber available on a fresh host")?;
 
     // ---- Start runner + apply task ----
     let sink = Arc::new(PeerSink::new(paxos_addrs));
     host.start(sink).context("host not already running")?;
 
     // ---- ConsensusDriver ----
-    let driver = Arc::new(PaxosDriver::new(host, leader_stream));
+    let driver = Arc::new(PaxosDriver::new(host, leader_subscriber));
 
     // ---- Tsoracle gRPC server ----
     let tso = TsoServer::builder().consensus_driver(driver).build()?;


### PR DESCRIPTION
Closes #262.

## Problem

`PaxosDriver::leadership_events` (`crates/tsoracle-driver-paxos/src/driver.rs`) held the leader-event stream in a `Mutex<Option<..>>` and `take()`'d it on the first call; every later call returned `stream::empty()`. A second subscriber — e.g. a driver re-derived across an in-process restart — got a permanent, silent leader-event blackout with no error. The openraft driver never had this: it re-derives its stream from the raft metrics watch on every call.

## Fix

Mint fresh streams per call, mirroring the openraft side.

- Add a cloneable `LeaderEventSubscriber` wrapping the leader-event `watch::Receiver`, with `subscribe()` minting a fresh `LeaderEventStream`. `WatchStream::new` yields the channel's *current* value on its first poll, so every subscription honours the `ConsensusDriver::leadership_events` synchronous-first-item contract — a late or second subscriber sees the live leadership state, never an empty stream.
- `leader_event_channel()` now returns `(LeaderEventSender, LeaderEventSubscriber)`; `PaxosRunner` and `StandaloneHost` expose `take_leader_subscriber()` in place of `take_leader_stream()`.
- `PaxosDriver` holds the subscriber and re-subscribes on every `leadership_events()` call — no one-shot take, no empty fallback.

The runner's drop-based shutdown is preserved by construction: the runner retains only the sender (never a receiver), so once the driver and every stream it minted are dropped, the channel closes and the tick loop exits on `SendError::Closed`. The driver's retained subscriber is what keeps the channel open while the driver lives.

## Scope

Pre-1.0 API change across the paxos toolkit, the driver crate, the three paxos examples, and the stress topology.

## Verification

- TDD: the driver test reproduces the exact blackout (a second subscription returning `None`) before the fix, and passes after.
- `cargo test --workspace` — 755 passed, 0 failed.
- `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean; all examples build.