### PR TITLE
test(stress): run paxos shutdown test under virtual time

### DIFF
--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -719,7 +719,15 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    // Runs under tokio virtual time (`start_paused`). The whole topology — the
+    // in-process `MemNetwork`, the per-node runner `interval` ticks, election,
+    // and `wait_for_leader`'s poll `sleep` — advances in simulated time, and so
+    // does the completion guard below. The tonic servers serve over real
+    // loopback but have no peer connections (peers talk via `MemNetwork`), so a
+    // healthy graceful drain finishes the instant its shutdown oneshot fires.
+    // `start_paused` implies the current-thread runtime; the storage and paxos
+    // work is short and cooperative, so a single worker is sufficient.
+    #[tokio::test(start_paused = true)]
     async fn shutdown_completes_server_tasks() {
         let topology = PaxosTopology::spawn(3, Duration::from_millis(1000))
             .await
@@ -727,21 +735,20 @@ mod tests {
         let server_handles = topology.server_handles;
         // Fire the per-node shutdown signals.
         Box::new(topology.controller).shutdown().await;
-        // Each server task must complete within a generous window after its
-        // shutdown oneshot fires. The window only guards against a genuine
-        // hang — `shutdown` failing to trigger the server's drain path — which
-        // never completes regardless of how long we wait; a healthy drain
-        // finishes in milliseconds. It is sized at 30s (not 5s) because the
-        // libtest harness runs this file's many `multi_thread` topology tests
-        // concurrently, each demanding 4 workers, so on an oversubscribed CI
-        // runner the spawned drain task can be scheduling-starved well past a
-        // few seconds of wall-clock without anything being wrong.
+        // Liveness guard, not a latency assertion. Each server task must drain
+        // and complete once its shutdown oneshot fires; a `shutdown` that failed
+        // to trigger the drain path would leave the task running forever. Under
+        // virtual time the timeout only elapses when the runtime goes idle with
+        // the handle unfinished — i.e. a genuine hang — so it can never trip on
+        // CI scheduling starvation (the old wall-clock bound's flake), and the
+        // bound is simulated time that costs no wall clock. Any finite value
+        // distinguishes "drained" from "hung".
         for (idx, handle) in server_handles.into_iter().enumerate() {
             match tokio::time::timeout(Duration::from_secs(30), handle).await {
                 Ok(Ok(())) => {}
                 Ok(Err(join_err)) => panic!("server task {idx} did not exit cleanly: {join_err:?}"),
                 Err(_elapsed) => {
-                    panic!("server task {idx} did not complete within 30s after shutdown")
+                    panic!("server task {idx} did not complete after shutdown (drain hung?)")
                 }
             }
         }


### PR DESCRIPTION
## Problem

`topology::paxos::tests::shutdown_completes_server_tasks` flaked on CI (the `test` job, e.g. PR #396) with:

```
server task 0 did not complete within 5s after shutdown
```

The test guarded server-task completion with a wall-clock `tokio::time::timeout`. On a 2-vCPU CI runner, the libtest harness runs this file's many `#[tokio::test(multi_thread, worker_threads = 4)]` topology tests concurrently — each spinning up a 4-worker runtime plus per-node rocksdb threads — so the spawned drain task can be scheduling-starved past the bound with nothing actually wrong.

This is a self-inflicted wall-clock race, not a logic bug: server-task completion goes through tonic's graceful drain on the shutdown oneshot (the watch task is `abort()`ed, never awaited), and the topology's peers talk over an in-process `MemNetwork`, so the tonic servers have no peer connections and a healthy drain finishes the instant the signal fires. Tuning the bound (5s → 30s, as the merged #396 did) only moves the cliff; the timeout is wall-clock and the contention is unbounded.

## Fix

Run the test under tokio virtual time (`start_paused`), matching the existing `standalone_shutdown` regression test. The topology's `MemNetwork`, runner `interval` ticks, election, `wait_for_leader`'s poll `sleep`, and the completion guard all advance in simulated time. The timeout now only elapses when the runtime goes idle with a handle unfinished — i.e. a genuine drain hang — so it **cannot** trip on CPU starvation, and the bound costs no wall clock. `start_paused` implies a current-thread runtime; the storage/paxos work is short and cooperative, so a single worker suffices.

## Verification

- Healthy run completes in **~0.03s** and stays green **20/20** under a 12-core CPU load that previously drove the topology group to the old 5s ceiling (the group dropped from ~5.1s → 1.6s once this test stopped being the wall-clock bottleneck).
- Full `cargo test -p stress --lib` green 3/3.
- Negative check (shutdown never fired): the test still **fails fast (~0.1s)** via the sim-time guard advancing through tick timers — proving the guard catches a genuine shutdown regression and isn't vacuous.

## Note

This supersedes the 5s → 30s timeout bump that rode in with #396; that only widened the flake window. The follow-up should drop that wall-clock bound from `main` in favor of this approach (this branch already replaces it).