### PR TITLE
ci(coverage): exclude the benchmarks/ folder from coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,13 @@ deny:
 # consumer; the compile-time signature shims catch API drift.
 COV_IGNORE_OPENRAFT_LIFECYCLE := crates/tsoracle-openraft-toolkit/src/lifecycle/(bootstrap|membership)
 
-# `clap` argument-parsing wrapper around `stress::run` /
-# `stress::run_inject_violation`. The library entry points are exercised
-# end-to-end by `benchmarks/stress/tests/smoke.rs`.
-COV_IGNORE_STRESS_BIN := benchmarks/stress/src/bin/stress
+# Benchmark harnesses (`benchmarks/minimal` / `benchmarks/stress`): load-gen,
+# chaos, and topology tooling, not shipped product. `benchmarks/minimal` is
+# also `--exclude`d below as a whole crate so it never builds under coverage;
+# `benchmarks/stress` keeps building so its `tests/smoke.rs` still runs in the
+# coverage job, but its sources are dropped from the report. The trailing `.*`
+# is required because the variables share the `\.rs$` suffix appended below.
+COV_IGNORE_BENCHMARKS := benchmarks/.*
 
 # Shared integration-test bootstrap helper. Gated by `test-support` (and
 # `cfg(test)`); never ships in the published library. Lives in `src/` only
@@ -141,7 +144,7 @@ COV_IGNORE_STRESS_BIN := benchmarks/stress/src/bin/stress
 # legitimate "rare race" retry paths that local CI never trips.
 COV_IGNORE_TEST_SUPPORT := crates/tsoracle-server/src/test_support
 
-COV_IGNORE := ($(COV_IGNORE_OPENRAFT_LIFECYCLE)|$(COV_IGNORE_STRESS_BIN)|$(COV_IGNORE_TEST_SUPPORT))\.rs
+COV_IGNORE := ($(COV_IGNORE_OPENRAFT_LIFECYCLE)|$(COV_IGNORE_BENCHMARKS)|$(COV_IGNORE_TEST_SUPPORT))\.rs
 
 # Shared exclude flags so `coverage` (lcov for CI) and `coverage-html` (local
 # browsable report) cannot drift apart on which crates participate.


### PR DESCRIPTION
## What

Excludes everything under `benchmarks/` from the Coveralls coverage report.

## Why

The `benchmarks/` harnesses (load-gen, chaos, topology tooling) are not shipped product, but coverage only excluded them partially:

- `benchmarks/minimal` (crate `bench-minimal`) was already `--exclude`d as a whole crate, so it never built under coverage.
- `benchmarks/stress` (crate `stress`) was **not** excluded — only its binary (`benchmarks/stress/src/bin/stress.rs`) was dropped via the `COV_IGNORE` regex. The stress *library* sources (supervisor, chaos, topology, etc.) were still measured, diluting the signal with code that exists only to exercise the system under stress.

## How

Replace the stress-binary-only `COV_IGNORE` entry with one matching the whole folder:

- `COV_IGNORE_STRESS_BIN := benchmarks/stress/src/bin/stress` → `COV_IGNORE_BENCHMARKS := benchmarks/.*`

The `COV_IGNORE` variables are joined as `(A|B|C)\.rs$`, so the new alternative expands to `benchmarks/.*\.rs$` and drops every `.rs` under the folder. This single regex feeds both the CI `coverage` (lcov) target and the local `coverage-html` target, so they cannot drift.

This is a report-only exclusion, not a package exclude: the `stress` crate keeps building, so its `tests/smoke.rs` still runs in the coverage job — its sources just no longer count toward the reported total. The previously separate stress-binary entry is now subsumed and removed.

## Verification

Extracted the assembled `--ignore-filename-regex` from `make -n coverage` and tested it against real paths:

- ✅ All benchmark files ignored (`stress/src/lib.rs`, `supervisor.rs`, `topology/paxos.rs`, `bin/stress.rs`, `minimal/src/lib.rs`, `bin/bench.rs`)
- ✅ Pre-existing exclusions intact (openraft lifecycle)
- ✅ Product code still measured (`consensus/src/driver.rs`, `server/src/lib.rs`, `core/src/clock.rs`)
- ✅ `make -n coverage` assembles with no Makefile errors