### PR TITLE
ci: reclaim runner disk in the disk-hungry build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,23 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+      # Coverage links every test binary with `-C instrument-coverage` and full
+      # debuginfo, so the artifacts are even larger than the plain `test` job —
+      # `make coverage` was hitting ENOSPC inside `ld` at the final link step.
+      # Same reclaim as the `test` job: strip the pre-installed Android SDK /
+      # .NET / Haskell toolchains (~30 GB) before any cargo work begins. The
+      # Rust toolchain installed below lives in ~/.cargo and the rust-cache
+      # restore is untouched by `tool-cache: false`.
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -47,6 +47,21 @@ jobs:
           - paxos_meta_ballot_decode
           - paxos_codec_roundtrip
     steps:
+      # cargo-fuzz compiles the whole dependency tree (rocksdb included) with
+      # ASAN instrumentation, so the artifacts are large. Reclaim ~30 GB before
+      # cargo starts; tool-cache: false keeps the runner tool cache (where
+      # cargo-fuzz is installed) intact.
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@v6
 
       - name: Skip non-matching target (manual dispatch)

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -33,6 +33,21 @@ jobs:
           - paxos_meta_ballot_decode
           - paxos_codec_roundtrip
     steps:
+      # cargo-fuzz compiles the whole dependency tree (rocksdb included) with
+      # ASAN instrumentation, so the artifacts are large. Reclaim ~30 GB before
+      # cargo starts; tool-cache: false keeps the runner tool cache (where
+      # cargo-fuzz is installed) intact.
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@v6
 
       - name: Install pinned nightly toolchain

--- a/.github/workflows/leak-nightly.yml
+++ b/.github/workflows/leak-nightly.yml
@@ -18,6 +18,22 @@ jobs:
     permissions:
       contents: read
     steps:
+      # -Zbuild-std rebuilds libstd with the leak-sanitizer runtime on top of a
+      # full `--workspace --all-features` test build, making this the heaviest
+      # build in the repo. Reclaim ~30 GB before cargo starts so the final link
+      # does not ENOSPC; tool-cache: false leaves ~/.cargo and the rust-cache
+      # restore untouched.
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@v6
 
       - name: Install pinned nightly toolchain

--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -65,6 +65,22 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # The release build pulls in rocksdb/openraft; reclaim ~30 GB up front to
+      # keep headroom for the link step. Gated on the same filter as the build
+      # below so skipped matrix cells stay no-ops; tool-cache: false leaves
+      # ~/.cargo and the rust-cache restore untouched.
+      - name: free disk space
+        if: steps.filter.outputs.skip != 'true'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@v6
         if: steps.filter.outputs.skip != 'true'
 


### PR DESCRIPTION
## What

Add the `jlumbroso/free-disk-space` reclaim step to every disk-hungry ubuntu build job that lacked it:

- **`ci.yml` → `coverage`** (the job that actually failed)
- **`leak-nightly.yml`** — LeakSanitizer + `-Zbuild-std`
- **`fuzz-nightly.yml`** / **`fuzz-pr.yml`** — ASAN fuzz builds
- **`stress-nightly.yml`** — release build of server + stress harness

The `test` job in `ci.yml` already carried this step; this brings the rest of the heavy builds in line.

## Why

The `coverage` job failed in [run 26383570888](https://github.com/prisma-risk/tsoracle/actions/runs/26383570888/job/77657419822) with:

```
error: linking with `cc` failed: exit status: 1
  = note: /usr/bin/ld: final link failed: No space left on device
          collect2: error: ld returned 1 exit status
```

repeated for `mem_network_negative`, `failpoints`, and `log_store_basic`, cascading to `make: *** [Makefile:167: coverage] Error 101`. This is disk exhaustion, not a code or test failure — nothing ran; it never linked.

`coverage` links every test binary with `-C instrument-coverage` plus full debuginfo, so its artifacts overflow the standard `ubuntu-latest` disk budget at the final `ld` step. The nightly sanitizer/fuzz/stress jobs build at least as much (LeakSanitizer rebuilds libstd via `-Zbuild-std`; fuzz compiles the whole tree incl rocksdb under ASAN), so they get the same treatment proactively before they hit the same wall.

## How

Each step:

- Frees ~30 GB by stripping the pre-installed Android SDK / .NET / Haskell toolchains before any cargo work begins.
- Uses `tool-cache: false` so the runner tool cache (where `cargo-llvm-cov` / `cargo-fuzz` land) stays intact.
- Runs **before checkout** (and before the `Swatinem/rust-cache` restore), so it never touches `~/.cargo` or `target/` — caching behavior is unchanged.
- `large-packages: false` matches the existing `test`-job step (the apt sweep is slow and unneeded once ~30 GB is reclaimed).

`stress-nightly`'s step carries the workflow's existing per-cell `steps.filter.outputs.skip` guard so skipped matrix cells stay no-ops. `free-disk-space` is Linux-only; every job touched here runs on `ubuntu-latest`.

`actionlint` passes (the two pre-existing SC2086 notes in the fuzz workflows are unrelated to this change).