### PR TITLE
fix(driver-paxos): enforce single active leadership stream via Drop-released lease

### DIFF
--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -18,6 +18,9 @@
 //! `persist_high_water` compares against.
 
 use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
@@ -40,12 +43,20 @@ where
     H: PaxosHighWaterHost,
 {
     host: H,
-    /// Re-subscribable handle over the runner's leader-event channel. Each
+    /// Handle over the runner's leader-event channel. Each
     /// [`ConsensusDriver::leadership_events`] call mints a fresh stream from it,
-    /// so a second subscriber (e.g. an in-process restart) is never blacked out
-    /// — mirroring the openraft driver, which re-derives its stream from the
-    /// raft metrics watch on every call.
+    /// gated by `stream_active` so at most one is live at a time: a *sequential*
+    /// re-subscription (e.g. an in-process restart that fully stops the prior
+    /// server before starting the replacement) is well-defined, while a
+    /// *concurrent* second subscription fails closed.
     leader_subscriber: LeaderEventSubscriber,
+    /// Single-active-stream lease. `leadership_events` flips this `false -> true`
+    /// when it hands out a live stream and the stream flips it back on `Drop`.
+    /// A second call observing `true` returns a fail-closed empty stream instead
+    /// of a second live one, so two `Server`s built from one `Arc<PaxosDriver>`
+    /// cannot both seed allocators and issue overlapping timestamps. Shared via
+    /// `Arc` so the released-on-`Drop` guard outlives the borrow that minted it.
+    stream_active: Arc<AtomicBool>,
 }
 
 impl<H> PaxosDriver<H>
@@ -55,14 +66,16 @@ where
     /// Build a driver around a host.
     ///
     /// `leader_subscriber` is taken from the host (typically via
-    /// `StandaloneHost::take_leader_subscriber`). It is re-subscribable: every
-    /// call to [`ConsensusDriver::leadership_events`] mints a fresh, live stream
-    /// that synchronously yields the current leadership state, so repeated
-    /// subscriptions are well-defined rather than a one-shot take.
+    /// `StandaloneHost::take_leader_subscriber`). [`ConsensusDriver::leadership_events`]
+    /// mints a fresh, live stream that synchronously yields the current leadership
+    /// state, but only one such stream may be live at a time (see `stream_active`):
+    /// a *sequential* re-subscription after the prior stream is dropped is
+    /// well-defined, while a *concurrent* second subscription fails closed.
     pub fn new(host: H, leader_subscriber: LeaderEventSubscriber) -> Self {
         Self {
             host,
             leader_subscriber,
+            stream_active: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -79,10 +92,39 @@ where
     H: PaxosHighWaterHost,
 {
     fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
-        // Mint a fresh stream on every call. The subscriber's first poll yields
-        // the channel's current state synchronously (the trait's first-item
-        // contract), so a second subscriber sees the live leadership state
-        // rather than an empty stream.
+        // Single-active-stream lease. Acquire it before minting a stream so the
+        // driver hands out at most one live leadership stream at a time.
+        //
+        // A *sequential* re-subscription (the prior stream already dropped, e.g.
+        // an in-process restart) re-acquires the freed lease and is live. A
+        // *concurrent* second subscription (two `Server`s built from one
+        // `Arc<PaxosDriver>`, or a replacement `Server` started before the old
+        // one's stream is dropped) observes the lease held and FAILS CLOSED: it
+        // returns an empty stream. The server's leader-watch loop reads that EOF
+        // as `WatchStreamClosed`, poisons serving state, and stays `NotServing`,
+        // so the second server never seeds an independent allocator and the two
+        // endpoints cannot issue overlapping (duplicate) timestamps.
+        if self
+            .stream_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            tracing::error!(
+                "PaxosDriver::leadership_events called while a leadership stream is already \
+                 active; refusing the concurrent second subscription and returning a \
+                 fail-closed empty stream. Build exactly one Server per consensus driver, and \
+                 fully stop a server (drop its WatchGuard) before starting a replacement."
+            );
+            return Box::pin(futures::stream::empty());
+        }
+        // Released on `Drop` of the returned stream, which re-opens the lease for
+        // the next (sequential) subscription.
+        let lease = StreamLease {
+            active: Arc::clone(&self.stream_active),
+        };
+
+        // Mint the live stream. The subscriber's first poll yields the channel's
+        // current state synchronously (the trait's first-item contract).
         let stream = self.leader_subscriber.subscribe();
         let omnipaxos = self.host.omnipaxos();
         let mapped = stream.map(move |state| match state {
@@ -96,7 +138,10 @@ where
             }
             other => other,
         });
-        Box::pin(mapped)
+        Box::pin(LeasedStream {
+            _lease: lease,
+            inner: Box::pin(mapped),
+        })
     }
 
     async fn load_high_water(&self) -> Result<u64, ConsensusError> {
@@ -129,6 +174,44 @@ where
             });
         }
         self.host.submit_advance(at_least).await
+    }
+}
+
+/// RAII guard for the driver's single-active-stream lease.
+///
+/// Held by the live [`LeasedStream`] `leadership_events` returns. Storing
+/// `false` back on `Drop` is what permits *sequential* re-subscription: once the
+/// live stream is dropped the next `leadership_events` call re-acquires the lease
+/// and mints a fresh live stream.
+struct StreamLease {
+    active: Arc<AtomicBool>,
+}
+
+impl Drop for StreamLease {
+    fn drop(&mut self) {
+        // Release pairs with the `Acquire` failure-ordering on the next
+        // `compare_exchange`, so a re-subscription observes the freed lease.
+        self.active.store(false, Ordering::Release);
+    }
+}
+
+/// The live leadership stream `leadership_events` hands out, pairing the mapped
+/// event stream with the [`StreamLease`] that keeps the driver's single-active
+/// slot occupied for exactly as long as this stream lives.
+///
+/// Both fields are `Unpin` (the lease is a plain `Arc` handle; `inner` is an
+/// already-pinned box), so the `Stream` impl projects to `inner` without
+/// `unsafe` or a pin-projection dependency.
+struct LeasedStream {
+    _lease: StreamLease,
+    inner: Pin<Box<dyn Stream<Item = LeaderState> + Send>>,
+}
+
+impl Stream for LeasedStream {
+    type Item = LeaderState;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
     }
 }
 
@@ -260,7 +343,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn leadership_events_resubscribes_on_each_call() {
+    async fn leadership_events_resubscribes_after_drop() {
         let host = StubHost::new();
         let (sender, subscriber) = leader_event_channel();
         let driver = PaxosDriver::new(host, subscriber);
@@ -278,15 +361,73 @@ mod tests {
             "first subscription must yield the current leader state",
         );
 
-        // ...and a SECOND subscription is NOT a silent blackout: it re-derives
-        // a fresh stream that synchronously yields the current state too. The
-        // pre-fix driver `take()`s the stream once and returns `stream::empty()`
-        // here, so this would observe `None`.
+        // ...and once it is dropped, the single-active lease is released, so a
+        // SEQUENTIAL re-subscription (e.g. an in-process restart that fully
+        // stops the prior server before starting the replacement) re-derives a
+        // fresh, live stream rather than a one-shot blackout. This is the #396
+        // behavior we must preserve.
+        drop(first);
         let mut second = driver.leadership_events();
         assert!(
             matches!(second.next().await, Some(LeaderState::Leader { .. })),
-            "a second subscription must re-derive a live stream, not blackout",
+            "a sequential re-subscription after drop must re-derive a live stream",
         );
+    }
+
+    #[tokio::test]
+    async fn leadership_events_second_concurrent_subscription_fails_closed() {
+        let host = StubHost::new();
+        let (sender, subscriber) = leader_event_channel();
+        let driver = PaxosDriver::new(host, subscriber);
+
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(7) })
+            .unwrap();
+
+        // The first subscription holds the single-active lease for as long as
+        // its stream is alive.
+        let mut first = driver.leadership_events();
+
+        // A SECOND subscription taken while the first is still live must fail
+        // closed: it returns an empty stream (yields `None` immediately) rather
+        // than a second live stream. The server's leader-watch loop treats that
+        // EOF as `WatchStreamClosed` and stays `NotServing`, so two `Server`s
+        // built from one `Arc<PaxosDriver>` cannot both seed allocators and
+        // issue overlapping timestamps.
+        let mut second = driver.leadership_events();
+        assert!(
+            second.next().await.is_none(),
+            "a concurrent second subscription must fail closed with an empty stream",
+        );
+
+        // The first stream is unaffected by the rejected second subscription.
+        assert!(
+            matches!(first.next().await, Some(LeaderState::Leader { .. })),
+            "the live first stream must keep yielding after a rejected second subscription",
+        );
+    }
+
+    #[tokio::test]
+    async fn leadership_events_lease_round_trips_across_generations() {
+        let host = StubHost::new();
+        let (sender, subscriber) = leader_event_channel();
+        let driver = PaxosDriver::new(host, subscriber);
+
+        sender
+            .send(LeaderState::Leader { epoch: Epoch(7) })
+            .unwrap();
+
+        // Acquire and drop the lease repeatedly: each generation is live so long
+        // as the prior one was fully dropped first. This guards the lease's
+        // Drop-release against a single-shot regression.
+        for _ in 0..3 {
+            let mut stream = driver.leadership_events();
+            assert!(
+                matches!(stream.next().await, Some(LeaderState::Leader { .. })),
+                "each sequential generation must re-derive a live stream",
+            );
+            drop(stream);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `PaxosDriver::leadership_events()` minted a fresh live stream on every call with no guard. Two `Server` instances built from one `Arc<PaxosDriver>` (an in-process restart that overlaps the old and new server, or a misembedding) each ran the failover fence, seeded **independent** `ServingCore` allocators from the same floor, and could issue duplicate `(physical_ms, logical_start, epoch)` tuples to their respective endpoints — an integrity failure.
- This was a regression from the earlier re-subscribe change (#396): that fix correctly unblocked *sequential* re-subscription after a one-shot blackout, but also permitted *concurrent* active subscriptions.
- Add a `stream_active: Arc<AtomicBool>` lease to `PaxosDriver`. `leadership_events()` `compare_exchange`-acquires it and returns the live stream wrapped in a `LeasedStream` that releases the lease on `Drop`. A **concurrent** second call observes the lease held and **fails closed** with an empty stream — which the server's leader-watch loop reads as `WatchStreamClosed`, poisoning serving state to `NotServing`, so the second server never seeds an allocator and cannot issue overlapping timestamps. A `tracing::error!` flags the misembedding.
- **Sequential** re-subscription (the prior stream dropped first) still re-acquires the freed lease and mints a live stream, preserving the #396 behavior.
- The toolkit's `LeaderEventSubscriber` is unchanged — it stays a pure re-subscribable primitive; the single-active invariant is enforced in the driver that owns the trait method. `LeasedStream` needs no `unsafe`/pin-project because both fields are `Unpin`.

## Test plan

- [x] New `leadership_events_second_concurrent_subscription_fails_closed`: a second subscription while the first is live yields `None` (empty), and the first stream keeps working. (Written test-first; failed against the unguarded driver, passes with the lease.)
- [x] Rewrote `leadership_events_resubscribes_on_each_call` → `leadership_events_resubscribes_after_drop`: dropping the first stream then re-subscribing yields a live stream (sequential restart preserved).
- [x] New `leadership_events_lease_round_trips_across_generations`: acquire/drop the lease repeatedly, each generation live.
- [x] `cargo test -p tsoracle-driver-paxos` — 49 lib tests + integration tests pass.
- [x] `cargo clippy -p tsoracle-driver-paxos --all-targets -- -D warnings` clean.
- [x] `tsoracle-server` and all paxos examples build.

## Out of scope

- `OpenraftDriver` re-derives its stream from the raft metrics watch on every call and has the analogous (unvalidated) exposure — noted as a possible follow-up.