### PR TITLE
test(e2e): sketch a kind-based multi-node cluster harness

### DIFF
--- a/docs/kubernetes-e2e.md
+++ b/docs/kubernetes-e2e.md
@@ -1,0 +1,112 @@
+# Kubernetes end-to-end testing (kind)
+
+> Status: design sketch / proposal. The manifests referenced here live under `e2e/kube/`. Nothing in this lane runs in CI yet; it is opt-in and nightly/manual by intent.
+
+## Why a kind lane at all
+
+The existing test suite already covers consensus correctness far better than a real cluster ever could. Turmoil [deterministic simulation](testing-and-examples.md) drives the real gRPC server and client over a simulated network and clock, so leader churn, fence retries, and window-extension races replay byte-for-byte from a seed. The [stress harness](stress-testing.md) runs four topologies — `mem`, `raft`, `paxos`, `process` — under sustained load while a programmable nemesis injects faults and four invariants (global monotonicity, batch ordering, failover-fence freshness, liveness) are checked in real time.
+
+What none of those reach is the **deployment envelope**: the layer between "the process is correct" and "N real processes come up, find each other over a real network, and survive Kubernetes lifecycle events." Concretely, the gaps are:
+
+- The `process` topology is **single-node**. Its doc comment is explicit: `tsoracle serve` is single-node, and `StressConfig::validate` rejects `nodes != 1`. It SIGKILLs and respawns one child to exercise the file driver's persisted high-water across crashes. It never runs a multi-process cluster.
+- The `raft` and `paxos` topologies are multi-node but share an in-process `MemNetwork`. There are no sockets, no TCP, no DNS, no real peer transport between separate OS processes.
+- The multi-node **example** binaries lag the stock binary on **SIGTERM**. `tsoracle serve` already drives graceful drain on SIGTERM via its `shutdown_signal()` helper (`crates/tsoracle-bin/src/main.rs`, added in #245), but `examples/openraft-standalone` and `examples/paxos-standalone` wire only `tokio::signal::ctrl_c()` (SIGINT) into `serve_with_shutdown`. Those examples are exactly what a cluster runs (the stock binary is single-node), so under Kubernetes — which terminates pods with SIGTERM — the cooperative-cancel and `WatchGuard` shutdown machinery never runs.
+
+A kind ("Kubernetes IN Docker") lane fills exactly this envelope and nothing below it.
+
+## What this lane is allowed to test (and what it is not)
+
+This lane validates deployment-level properties only. It must not re-derive protocol correctness — that belongs in the deterministic harnesses, where failures are reproducible.
+
+In scope:
+
+- **Image + manifest correctness.** The Dockerfile builds, the container starts with the real entrypoint, the headless Service DNS names resolve, config and volumes mount.
+- **Cluster formation over a real network.** Three separate pods, each a real `openraft-standalone` process, discover peers via StatefulSet DNS and elect a leader over real gRPC.
+- **StatefulSet semantics.** Stable ordinal identity → stable node ID, PVC reattach on reschedule, ordered rollout.
+- **Real network faults.** True partitions and asymmetric splits via `NetworkPolicy` (and latency/jitter via a `tc netem` sidecar), rather than the `process` topology's `SIGSTOP`.
+- **Kubernetes lifecycle.** SIGTERM + `terminationGracePeriodSeconds` graceful shutdown, readiness-gated rolling restarts, `PodDisruptionBudget` enforcement, leader-pod deletion and re-election.
+
+Out of scope (already covered, cheaper and deterministic elsewhere):
+
+- Allocator monotonicity, fence freshness, consensus safety/liveness at the protocol level.
+- Single-node crash/respawn against the file driver (that is the `process` topology's job).
+- Leader-churn and partition-heal cycles at the protocol level (turmoil + `raft`/`paxos` topologies).
+
+## Concrete defects only this lane can catch
+
+These are the findings that justify the lane. Each is invisible to every current harness.
+
+1. **SIGTERM is ignored by the example binaries.** Pods would ride out the full grace period and get SIGKILLed on every ordinary rollout or scale-down, never running cooperative cancel. The stock `tsoracle serve` already handles this (#245); the standalone examples a cluster actually runs do not — see "Prerequisites" below.
+2. **PVC reattach correctness.** When a pod reschedules onto a new node, does the RocksDB raft log/snapshot survive and recover to the right cursor? The [snapshot-policy restart](consensus-integration.md) logic is exercised only against tempdirs today.
+3. **DNS-based peer discovery.** The standalone example takes static `id=host:port` peer maps. Mapping StatefulSet ordinals to node IDs and headless-Service FQDNs to peer addresses is new wiring with its own failure modes (resolution timing on cold start, pod IP churn).
+4. **Readiness semantics.** A follower returning `FAILED_PRECONDITION` with a leader hint is healthy and must stay in Service rotation. A naive `GetTs`-based readiness probe would wrongly evict every follower; this lane pins the correct TCP-based contract.
+5. **Bootstrap-once under reschedule.** `--bootstrap` is idempotent, but the lane confirms that a rescheduled ordinal-0 pod re-running with the flag does not disturb an already-formed cluster.
+
+## Architecture
+
+```
+                    ┌────────────────────────── kind cluster ───────────────────────────┐
+                    │                                                                   │
+   client ─────────►│  Service: tsoracle (ClusterIP, round-robin)                       │
+   (round-robin,    │     │   followers redirect via LeaderHint trailer                 │
+    redirected to   │     ▼                                                             │
+    leader)         │  StatefulSet: tsoracle  (replicas: 3, anti-affinity per node)     │
+                    │     ├── tsoracle-0  ── PVC data-tsoracle-0  (raft log + snapshot) │
+                    │     ├── tsoracle-1  ── PVC data-tsoracle-1                        │
+                    │     └── tsoracle-2  ── PVC data-tsoracle-2                        │
+                    │            ▲                                                      │
+                    │            │ raft peer RPCs (5100) over headless DNS              │
+                    │  Service: tsoracle-peer (headless, clusterIP: None)               │
+                    │     tsoracle-{0,1,2}.tsoracle-peer.<ns>.svc.cluster.local         │
+                    │                                                                   │
+                    │  PodDisruptionBudget: minAvailable: 2  (quorum-safe drains)       │
+                    └───────────────────────────────────────────────────────────────────┘
+```
+
+### Binary
+
+The cluster runs the `openraft-standalone` example binary (package `example-openraft-standalone`, bin `openraft-standalone`), not `tsoracle serve` — the stock binary is single-node by design. The paxos variant (`paxos-standalone`) is a drop-in alternative with the same shape; the lane should parametrize on backend so both get coverage.
+
+Relevant flags (`examples/openraft-standalone/src/main.rs`):
+
+| Flag | Source in k8s |
+| --- | --- |
+| `--id <u64>` | StatefulSet ordinal + 1 |
+| `--raft-addr 0.0.0.0:5100` | fixed per pod (own netns) |
+| `--tso-addr 0.0.0.0:5051` | fixed per pod |
+| `--peers id=fqdn:5100,…` | built from replica count + headless DNS |
+| `--tso-peers id=fqdn:5051,…` | same, tso port |
+| `--raft-dir /data/raft` | PVC mount |
+| `--bootstrap` | ordinal 0 only (idempotent) |
+
+An entrypoint script derives the node ID and peer maps from `$HOSTNAME` (`tsoracle-${ORDINAL}`) and a `REPLICAS` env var, so the StatefulSet ships one spec for all pods. See `e2e/kube/entrypoint.sh`.
+
+### Services
+
+- **`tsoracle-peer`** — headless (`clusterIP: None`), the `serviceName` of the StatefulSet. Publishes the stable per-pod DNS the raft transport dials.
+- **`tsoracle`** — ordinary ClusterIP, round-robins clients across all pods. Followers redirect to the leader via the `LeaderHint` trailer, so a dumb round-robin Service is correct and needs no leader-aware routing.
+
+### Probes
+
+- **Readiness:** `tcpSocket` on the tso port (5051). A follower is ready — it serves redirects. Do **not** use a `GetTs` exec probe; it would evict every non-leader.
+- **Liveness:** `tcpSocket` on the raft port (5100), proving the peer transport is up.
+
+True "is this node serving as leader" is observable in-process via `Server::subscribe()` → `ServingState`, but it is intentionally not a readiness signal here.
+
+## How it relates to the stress harness
+
+The `ChaosController` trait (`benchmarks/stress/src/topology/mod.rs`) — `kill_leader`, `pause_leader`, `arm_failpoint`, `disarm_failpoint`, `endpoints`, `current_leader` — is a tempting seam: a `KubeController` could be a fifth topology, inheriting the shared supervisor and all four invariant checks for free.
+
+Recommendation: **do not** make it a stress topology. The stress harness's whole value is fast, seed-reproducible replay; bolting multi-minute, wall-clock-nondeterministic cluster spin-up onto it couples slow flaky infra to a binary designed for the opposite. Instead, build a **separate `e2e/kube/` lane** with its own workflow (manual + nightly trigger) that reuses only the client library and the invariant-checking code, not the chaos scheduler. `arm_failpoint`/`disarm_failpoint` also do not map cleanly: `FAILPOINTS` is read from the environment at process start, so in-place arming would require a pod restart or an admin endpoint that does not exist — the kube lane should rely on pod/network chaos instead.
+
+## Tradeoffs
+
+- **Nondeterminism.** This lane trades reproducibility for realism. It belongs in nightly/manual, never the per-PR smoke path, and every assertion needs generous retry/backoff against wall-clock timing.
+- **Cost.** Docker-in-Docker or a privileged runner, image builds, and multi-minute cluster startup. Budget 5–15 minutes per scenario versus seconds-to-minutes for stress cells.
+- **Layer.** Everything below the gRPC socket is already better-covered. Keep the scenario set small: cold-start formation, rolling restart, leader-pod delete, network partition, PVC reattach.
+
+## Prerequisites this lane surfaces
+
+1. **A Dockerfile.** None exists in the repo today. `e2e/kube/Dockerfile` is part of this sketch.
+2. **SIGTERM handling in the example binaries.** The standalone examples should feed `serve_with_shutdown` a future that resolves on SIGTERM (and SIGINT), not `ctrl_c()` alone. The stock binary's `shutdown_signal()` helper (`crates/tsoracle-bin/src/main.rs`) is the pattern to copy. Until that lands, set a long `terminationGracePeriodSeconds` and treat SIGKILL-on-drain as a known gap the lane documents rather than asserts against.
+3. **Optional: `grpc.health.v1.Health`.** Adding the standard gRPC health service would let probes use `grpc_health_probe` and report leader/serving state precisely. Not required for the TCP-based contract above, but a clean follow-up.

--- a/e2e/kube/Dockerfile
+++ b/e2e/kube/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-stage build for the openraft-standalone cluster node.
+#
+# The stock `tsoracle serve` binary is single-node (file driver); a real
+# cluster runs the `openraft-standalone` example, which takes peer topology
+# on the command line. The entrypoint derives that topology from the
+# StatefulSet ordinal at runtime.
+
+FROM rust:1-bookworm AS build
+WORKDIR /src
+
+# RocksDB (pulled in by the openraft toolkit) needs a C/C++ toolchain + clang
+# for its bindgen step.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends clang libclang-dev cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+RUN cargo build --release -p example-openraft-standalone --bin openraft-standalone
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --create-home tsoracle
+
+COPY --from=build /src/target/release/openraft-standalone /usr/local/bin/openraft-standalone
+COPY e2e/kube/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER tsoracle
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/e2e/kube/Dockerfile.dockerignore
+++ b/e2e/kube/Dockerfile.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+**/*.md
+docs/
+benchmarks/stress/target/

--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -1,0 +1,36 @@
+# Kubernetes (kind) e2e cluster
+
+A 3-node `openraft-standalone` tsoracle cluster on a local [kind](https://kind.sigs.k8s.io/) cluster. This validates the deployment envelope — cluster formation over a real network, StatefulSet identity, PVC reattach, lifecycle events — that the in-process harnesses cannot reach. See [`docs/kubernetes-e2e.md`](../../docs/kubernetes-e2e.md) for the design and scope.
+
+This is opt-in tooling, not a CI gate. It runs the example binary, not `tsoracle serve` (which is single-node by design).
+
+## Layout
+
+- `Dockerfile` — multi-stage build of the `openraft-standalone` binary.
+- `entrypoint.sh` — derives `--id` and peer maps from the StatefulSet ordinal.
+- `kind-config.yaml` — 1 control-plane + 3 workers (one per replica, for anti-affinity).
+- `manifests/` — headless + client Services, StatefulSet, PodDisruptionBudget.
+
+## Run
+
+```sh
+# From the repo root.
+kind create cluster --config e2e/kube/kind-config.yaml
+
+# Build the node image and load it into the kind nodes (no registry needed).
+docker build -f e2e/kube/Dockerfile -t tsoracle-e2e:latest .
+kind load docker-image tsoracle-e2e:latest --name tsoracle-e2e
+
+kubectl apply -f e2e/kube/manifests/
+kubectl rollout status statefulset/tsoracle --timeout=120s
+
+# Smoke a GetTs through the client Service.
+kubectl port-forward svc/tsoracle 5051:5051 &
+# ... drive a tsoracle-client against 127.0.0.1:5051 ...
+
+kind delete cluster --name tsoracle-e2e
+```
+
+## Known gap
+
+The `openraft-standalone` example handles only SIGINT, not SIGTERM, so pod drains currently ride out `terminationGracePeriodSeconds` and end in SIGKILL — the cooperative-shutdown path does not run. (The stock `tsoracle serve` binary already handles SIGTERM via its `shutdown_signal()` helper, added in #245; the example simply never got the same treatment.) `terminationGracePeriodSeconds` is set generously so this does not flap the lane. Wiring SIGTERM into the example's shutdown future is the first follow-up.

--- a/e2e/kube/entrypoint.sh
+++ b/e2e/kube/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+# Derive this node's raft identity and peer maps from the StatefulSet ordinal.
+#
+# A StatefulSet ships one pod spec for every replica, so each pod must work
+# out its own --id and the full --peers / --tso-peers maps at start time.
+# Pod hostnames are "<statefulset>-<ordinal>" (e.g. tsoracle-0); node IDs are
+# 1-based, so id = ordinal + 1. Peer FQDNs come from the headless service.
+set -eu
+
+: "${REPLICAS:?REPLICAS must be set}"
+: "${STATEFULSET_NAME:?STATEFULSET_NAME must be set}"
+: "${PEER_SERVICE:?PEER_SERVICE must be set}"
+: "${POD_NAMESPACE:?POD_NAMESPACE must be set}"
+: "${RAFT_PORT:=5100}"
+: "${TSO_PORT:=5051}"
+: "${DATA_DIR:=/data}"
+
+ordinal="${HOSTNAME##*-}"
+node_id=$((ordinal + 1))
+
+peers=""
+tso_peers=""
+i=0
+while [ "$i" -lt "$REPLICAS" ]; do
+    id=$((i + 1))
+    fqdn="${STATEFULSET_NAME}-${i}.${PEER_SERVICE}.${POD_NAMESPACE}.svc.cluster.local"
+    peers="${peers}${peers:+,}${id}=${fqdn}:${RAFT_PORT}"
+    tso_peers="${tso_peers}${tso_peers:+,}${id}=${fqdn}:${TSO_PORT}"
+    i=$((i + 1))
+done
+
+# Initialize the cluster from exactly one node. --bootstrap is idempotent
+# (a re-run on an already-formed cluster logs and continues), so pinning it
+# to ordinal 0 is safe across reschedules.
+bootstrap=""
+if [ "$node_id" -eq 1 ]; then
+    bootstrap="--bootstrap"
+fi
+
+exec openraft-standalone \
+    --id "$node_id" \
+    --raft-addr "0.0.0.0:${RAFT_PORT}" \
+    --tso-addr "0.0.0.0:${TSO_PORT}" \
+    --peers "$peers" \
+    --tso-peers "$tso_peers" \
+    --raft-dir "${DATA_DIR}/raft" \
+    $bootstrap

--- a/e2e/kube/kind-config.yaml
+++ b/e2e/kube/kind-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: tsoracle-e2e
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker

--- a/e2e/kube/manifests/pdb.yaml
+++ b/e2e/kube/manifests/pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: tsoracle
+  labels:
+    app.kubernetes.io/name: tsoracle
+spec:
+  # A 3-node raft cluster tolerates one member down. minAvailable: 2 keeps
+  # voluntary disruptions (node drains, rollouts) from breaking quorum.
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tsoracle

--- a/e2e/kube/manifests/service.yaml
+++ b/e2e/kube/manifests/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tsoracle-peer
+  labels:
+    app.kubernetes.io/name: tsoracle
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: tsoracle
+  publishNotReadyAddresses: true
+  ports:
+    - name: raft
+      port: 5100
+      targetPort: raft
+    - name: tso
+      port: 5051
+      targetPort: tso
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tsoracle
+  labels:
+    app.kubernetes.io/name: tsoracle
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tsoracle
+  ports:
+    - name: tso
+      port: 5051
+      targetPort: tso

--- a/e2e/kube/manifests/statefulset.yaml
+++ b/e2e/kube/manifests/statefulset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tsoracle
+  labels:
+    app.kubernetes.io/name: tsoracle
+spec:
+  serviceName: tsoracle-peer
+  replicas: 3
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tsoracle
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle
+    spec:
+      # Spread the three replicas across the three kind workers so a node
+      # drain takes out at most one quorum member.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: tsoracle
+              topologyKey: kubernetes.io/hostname
+      # The standalone example only handles SIGINT today; until SIGTERM is
+      # wired into serve_with_shutdown, drains hit this grace window and then
+      # SIGKILL. Keep it generous so the known gap does not flap the lane.
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: tsoracle
+          image: tsoracle-e2e:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: REPLICAS
+              value: "3"
+            - name: STATEFULSET_NAME
+              value: tsoracle
+            - name: PEER_SERVICE
+              value: tsoracle-peer
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RAFT_PORT
+              value: "5100"
+            - name: TSO_PORT
+              value: "5051"
+            - name: DATA_DIR
+              value: /data
+            - name: RUST_LOG
+              value: info
+          ports:
+            - name: raft
+              containerPort: 5100
+            - name: tso
+              containerPort: 5051
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          # Readiness on the tso port: a follower is ready — it serves
+          # LeaderHint redirects and must stay in Service rotation. A GetTs
+          # probe would wrongly evict every non-leader.
+          readinessProbe:
+            tcpSocket:
+              port: tso
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          # Liveness on the raft port proves the peer transport is up.
+          livenessProbe:
+            tcpSocket:
+              port: raft
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
## What

Adds an **opt-in** Kubernetes (kind) end-to-end lane that runs a 3-node `openraft-standalone` tsoracle cluster, plus a design doc that scopes it. This is scaffolding for review only — **nothing is wired into CI**.

## Why

The existing harnesses cover protocol correctness deterministically but never exercise the **deployment envelope**:

- The `process` topology is single-node (`StressConfig::validate` rejects `nodes != 1`).
- The `raft`/`paxos` topologies are multi-node but share an in-process `MemNetwork` — no sockets, no TCP, no DNS, no real peer transport between separate OS processes.

This lane fills exactly that envelope (cluster formation over real gRPC, StatefulSet identity, PVC reattach, lifecycle events) and nothing below it. Protocol correctness stays in the deterministic harnesses where failures are reproducible.

## Contents

- `docs/kubernetes-e2e.md` — gap analysis, in/out-of-scope, architecture, the "don't fold it into the stress harness" recommendation, tradeoffs, and a staged rollout plan.
- `e2e/kube/` — multi-stage `Dockerfile` for the `openraft-standalone` binary, an ordinal-derived `entrypoint.sh`, a `kind` cluster config, and StatefulSet + headless/client Services + PodDisruptionBudget manifests.

## Design notes

- Runs the `openraft-standalone` **example** binary, not `tsoracle serve` (which is single-node by design).
- **Readiness is a TCP check on the tso port, not a `GetTs` probe**: a follower returning a `LeaderHint` redirect is healthy and must stay in Service rotation.
- The headless peer Service sets `publishNotReadyAddresses: true` so peers resolve each other during cold-start bootstrap, before any pod is Ready.
- `minAvailable: 2` PDB keeps voluntary disruptions quorum-safe.

## Known gap (follow-up PR)

The standalone example binaries handle only SIGINT, not SIGTERM, so pod drains ride out `terminationGracePeriodSeconds` and end in SIGKILL — the cooperative-shutdown path never runs. The stock `tsoracle serve` binary **already** handles SIGTERM via its `shutdown_signal()` helper (#245); the examples a cluster actually runs simply never got the same treatment. `terminationGracePeriodSeconds` is set generously here so the gap doesn't flap the lane; the fix lands separately.

## Validation

- `sh -n entrypoint.sh` clean; committed `100755`.
- pre-commit `cargo fmt --check` + `cargo clippy` pass.
- Manifests reviewed by hand (no live cluster in the dev env to `kubectl apply --dry-run` against) — worth a server-side dry-run before relying on them.