### PR TITLE
feat(server): add public shutdown_signal() and wire the cluster examples to it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "postcard",
  "prost",
  "rocksdb",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -140,45 +140,8 @@ async fn run_serve(args: ServeArgs) -> Result<()> {
     );
 
     server
-        .serve_with_listener(listener, shutdown_signal())
+        .serve_with_listener(listener, tsoracle_server::shutdown_signal())
         .await
         .context("serve")?;
     Ok(())
-}
-
-/// Resolves when the process receives an OS request to terminate.
-///
-/// Container orchestrators (Kubernetes, `docker stop`) and systemd stop
-/// processes with SIGTERM, while an interactive Ctrl-C sends SIGINT. Both must
-/// drive tonic's graceful drain; otherwise the default SIGTERM disposition
-/// kills the process mid-flight and the supervisor SIGKILLs it after the grace
-/// period (#245). On non-unix targets only Ctrl-C is available.
-#[cfg(unix)]
-async fn shutdown_signal() {
-    use tokio::signal::unix::{SignalKind, signal};
-
-    let mut sigterm = match signal(SignalKind::terminate()) {
-        Ok(stream) => stream,
-        Err(error) => {
-            // Installing the SIGTERM handler only fails on resource exhaustion
-            // or an invalid signal — neither expected here. Degrade to Ctrl-C
-            // rather than refuse to serve an otherwise-healthy node.
-            tracing::warn!(%error, "could not install SIGTERM handler; only Ctrl-C will trigger shutdown");
-            let _ = tokio::signal::ctrl_c().await;
-            tracing::info!(signal = "SIGINT", "shutdown signal received");
-            return;
-        }
-    };
-
-    let signal_name = tokio::select! {
-        _ = tokio::signal::ctrl_c() => "SIGINT",
-        _ = sigterm.recv() => "SIGTERM",
-    };
-    tracing::info!(signal = signal_name, "shutdown signal received");
-}
-
-#[cfg(not(unix))]
-async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
-    tracing::info!(signal = "SIGINT", "shutdown signal received");
 }

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -36,7 +36,7 @@ metrics            = { workspace = true, optional = true }
 parking_lot        = { workspace = true }
 prost              = { workspace = true }
 thiserror          = { workspace = true }
-tokio              = { workspace = true }
+tokio              = { workspace = true, features = ["signal"] }
 tokio-stream       = { workspace = true }
 tonic              = { workspace = true }
 tonic-prost        = { workspace = true }

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -20,10 +20,12 @@ mod leader_hint;
 mod server;
 mod service;
 mod serving_core;
+mod signal;
 
 pub mod docs;
 
 pub use server::{BuildError, Server, ServerBuilder, ServerError, ServingState, WatchGuard};
+pub use signal::shutdown_signal;
 
 #[cfg(any(test, feature = "test-fakes"))]
 pub mod test_fakes;

--- a/crates/tsoracle-server/src/signal.rs
+++ b/crates/tsoracle-server/src/signal.rs
@@ -1,0 +1,67 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! A graceful-shutdown signal future for embedders that run their own `main`.
+
+/// Resolves when the process receives an OS request to terminate.
+///
+/// Container orchestrators (Kubernetes, `docker stop`) and systemd stop
+/// processes with SIGTERM, while an interactive Ctrl-C sends SIGINT. Feed this
+/// to [`Server::serve_with_shutdown`](crate::Server::serve_with_shutdown) (or
+/// [`Server::serve_with_listener`](crate::Server::serve_with_listener)) so both
+/// drive tonic's graceful drain; otherwise the default SIGTERM disposition
+/// kills the process mid-flight and a supervisor SIGKILLs it after the grace
+/// period. On non-unix targets only Ctrl-C is available.
+///
+/// ```no_run
+/// # async fn run(server: tsoracle_server::Server) -> Result<(), tsoracle_server::ServerError> {
+/// let addr = "0.0.0.0:50551".parse().unwrap();
+/// server
+///     .serve_with_shutdown(addr, tsoracle_server::shutdown_signal())
+///     .await
+/// # }
+/// ```
+#[cfg(unix)]
+pub async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(stream) => stream,
+        Err(_error) => {
+            // Installing the SIGTERM handler only fails on resource exhaustion
+            // or an invalid signal — neither expected here. Degrade to Ctrl-C
+            // rather than refuse to shut down an otherwise-healthy node.
+            #[cfg(feature = "tracing")]
+            tracing::warn!(error = %_error, "could not install SIGTERM handler; only Ctrl-C will trigger shutdown");
+            let _ = tokio::signal::ctrl_c().await;
+            #[cfg(feature = "tracing")]
+            tracing::info!(signal = "SIGINT", "shutdown signal received");
+            return;
+        }
+    };
+
+    let _signal_name = tokio::select! {
+        _ = tokio::signal::ctrl_c() => "SIGINT",
+        _ = sigterm.recv() => "SIGTERM",
+    };
+    #[cfg(feature = "tracing")]
+    tracing::info!(signal = _signal_name, "shutdown signal received");
+}
+
+/// Resolves when the process receives Ctrl-C. See the unix variant for the full
+/// contract; non-unix targets expose only SIGINT.
+#[cfg(not(unix))]
+pub async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+    #[cfg(feature = "tracing")]
+    tracing::info!(signal = "SIGINT", "shutdown signal received");
+}

--- a/examples/openraft-standalone/Cargo.toml
+++ b/examples/openraft-standalone/Cargo.toml
@@ -40,3 +40,7 @@ anyhow             = { workspace = true }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }
+
+[dev-dependencies]
+tokio    = { workspace = true, features = ["process", "net", "time", "macros", "rt-multi-thread"] }
+tempfile = { workspace = true }

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -218,14 +218,11 @@ async fn main() -> anyhow::Result<()> {
 
     // ---- Tsoracle gRPC server ----
     let tso = TsoServer::builder().consensus_driver(driver).build()?;
-    let shutdown = async {
-        let _ = tokio::signal::ctrl_c().await;
-        tracing::info!("ctrl-c received, shutting down");
-    };
     println!(
         "tsoracle openraft node {} on http://{}",
         cli.id, cli.tso_addr
     );
-    tso.serve_with_shutdown(cli.tso_addr, shutdown).await?;
+    tso.serve_with_shutdown(cli.tso_addr, tsoracle_server::shutdown_signal())
+        .await?;
     Ok(())
 }

--- a/examples/openraft-standalone/tests/sigterm.rs
+++ b/examples/openraft-standalone/tests/sigterm.rs
@@ -1,0 +1,113 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Regression test for the multi-node example honouring SIGTERM. Under
+//! Kubernetes / `docker stop` / systemd the supervisor sends SIGTERM, not
+//! SIGINT, so the cluster binary must treat SIGTERM as a graceful-shutdown
+//! trigger — otherwise the default disposition kills it mid-flight and it is
+//! SIGKILLed after the grace period. The stock `tsoracle serve` binary has
+//! covered this since #245; this pins the same contract on the standalone
+//! example a cluster actually runs.
+
+#![cfg(unix)]
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tempfile::tempdir;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::process::Command;
+use tokio::time::{sleep, timeout};
+
+/// Bind an ephemeral port, learn the address, then release it so the child can
+/// claim it. Same TOCTOU-tolerant trick the stock binary's smoke test uses.
+async fn lease_port() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+/// Poll TCP connectability until the child's tso listener accepts — proof that
+/// the gRPC accept loop (and therefore the shutdown handler it installs) is
+/// live.
+async fn wait_until_accepting(addr: SocketAddr, budget: Duration) {
+    timeout(budget, async move {
+        loop {
+            if TcpStream::connect(addr).await.is_ok() {
+                return;
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("tso server at {addr} did not accept within {budget:?}"));
+}
+
+#[tokio::test]
+async fn sigterm_triggers_graceful_shutdown() {
+    let binary = env!("CARGO_BIN_EXE_openraft-standalone");
+    let raft_dir = tempdir().unwrap();
+    let raft_addr = lease_port().await;
+    let tso_addr = lease_port().await;
+
+    // Single-node cluster: enough for the tso gRPC server to bind and accept,
+    // which is all the SIGTERM path needs.
+    let mut child = Command::new(binary)
+        .arg("--id")
+        .arg("1")
+        .arg("--raft-addr")
+        .arg(raft_addr.to_string())
+        .arg("--tso-addr")
+        .arg(tso_addr.to_string())
+        .arg("--peers")
+        .arg(format!("1={raft_addr}"))
+        .arg("--tso-peers")
+        .arg(format!("1={tso_addr}"))
+        .arg("--raft-dir")
+        .arg(raft_dir.path())
+        .arg("--bootstrap")
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+
+    // Race readiness against an early exit so a startup crash fails loudly
+    // rather than as a readiness timeout.
+    let readiness = wait_until_accepting(tso_addr, Duration::from_secs(15));
+    tokio::pin!(readiness);
+    tokio::select! {
+        () = &mut readiness => {}
+        child_result = child.wait() => {
+            let status = child_result.expect("wait on child failed");
+            panic!("example exited before accepting connections: status={status}");
+        }
+    }
+
+    let pid = child.id().expect("child has a pid before exit");
+    let kill = Command::new("kill")
+        .arg("-TERM")
+        .arg(pid.to_string())
+        .status()
+        .await
+        .expect("spawn kill");
+    assert!(kill.success(), "failed to deliver SIGTERM to pid {pid}");
+
+    let status = timeout(Duration::from_secs(10), child.wait())
+        .await
+        .expect("example did not exit within the grace period after SIGTERM")
+        .expect("wait on child failed");
+
+    assert!(
+        status.success(),
+        "expected graceful exit (status 0) after SIGTERM, got {status}"
+    );
+}

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -199,14 +199,11 @@ async fn main() -> anyhow::Result<()> {
 
     // ---- Tsoracle gRPC server ----
     let tso = TsoServer::builder().consensus_driver(driver).build()?;
-    let shutdown = async {
-        let _ = tokio::signal::ctrl_c().await;
-        tracing::info!("ctrl-c received, draining");
-    };
     println!(
         "tsoracle paxos node {} on http://{}",
         cli.node_id, cli.tso_listen
     );
-    tso.serve_with_shutdown(cli.tso_listen, shutdown).await?;
+    tso.serve_with_shutdown(cli.tso_listen, tsoracle_server::shutdown_signal())
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
## What

Adds `tsoracle_server::shutdown_signal()` — a graceful-shutdown future that resolves on **SIGTERM or SIGINT** (Ctrl-C only on non-unix) — and routes every caller through it: both standalone examples, plus the stock binary, which drops its private copy.

## Why

The stock `tsoracle serve` binary has handled SIGTERM since #245. But it is single-node — a real cluster runs the **example** binaries (`openraft-standalone`, `paxos-standalone`), and those fed `serve_with_shutdown` a bare `ctrl_c()` future. Under Kubernetes / `docker stop` / systemd — which terminate with SIGTERM — those nodes:

1. ignored the signal,
2. rode out `terminationGracePeriodSeconds`,
3. got SIGKILLed mid-flight,

so tonic never drained in-flight requests and the cooperative-cancel / `WatchGuard` shutdown machinery never ran. This is the gap called out in the kind-harness sketch (#405).

## Design

- New `tsoracle-server::shutdown_signal()` (module `signal`, re-exported from the crate root). Lifting it into the embedder-facing crate gives one source of truth: examples + stock binary consume it, and embedders writing their own `main()` get correct graceful shutdown for free.
- `tracing::` calls are gated behind the crate's existing `tracing` feature (verified to compile cleanly with the feature off under `-D warnings`).
- `tsoracle-server`'s `tokio` gains the `signal` feature.
- Public-API addition → `feat:`, so it publishes ahead of the example crates that now depend on it.

## Test

New subprocess regression test (`examples/openraft-standalone/tests/sigterm.rs`): spawns the example, waits for the tso listener to accept, sends `SIGTERM`, and asserts a clean exit 0 within the grace period — mirrors the stock binary's existing `sigterm_triggers_graceful_shutdown` smoke test. Confirmed RED before the fix (`got signal: 15 (SIGTERM)`) → GREEN after.

`paxos-standalone` takes the identical one-line wiring change and shares the same helper, so it is not separately spawned (same helper is already exercised by this test and the stock smoke test).

## Verification

- `cargo fmt --all --check` clean.
- `cargo clippy --all-targets -- -D warnings` clean on all touched crates; also clean with `tsoracle-server`'s `tracing` feature disabled.
- `cargo build --workspace --all-targets` green.
- New example test + stock binary smoke tests (2) + the `shutdown_signal` doctest all pass.

Relates to #405 (the kind e2e harness sketch flagged this as the prerequisite fix).