### PR TITLE
ci: force JavaScript actions onto Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -17,6 +17,9 @@ on:
         default: "1800"
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   fuzz:
     name: ${{ matrix.target }}

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -3,6 +3,9 @@ name: fuzz (per-PR)
 on:
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   fuzz:
     name: ${{ matrix.target }}

--- a/.github/workflows/leak-nightly.yml
+++ b/.github/workflows/leak-nightly.yml
@@ -7,6 +7,9 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lsan:
     name: workspace tests under LeakSanitizer

--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/pages-build-check.yml'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/post-merge-followups.yml
+++ b/.github/workflows/post-merge-followups.yml
@@ -26,6 +26,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   file-issues:
     if: |

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Publishes (tags + cargo publish + GitHub Release) whenever the release PR
   # has been merged into main. No-op on every other push.

--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -22,6 +22,9 @@ on:
         default: 5m
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stress:
     name: ${{ matrix.topology }}/${{ matrix.scenario }}


### PR DESCRIPTION
## Problem

CI runs surface a flood of Node.js 20 deprecation warnings (e.g. [run 26383284245](https://github.com/prisma-risk/tsoracle/actions/runs/26383284245)). The warnings are **not** from our own `uses:` pins — every direct action is already on a Node 24 runtime. They come from two upstream actions whose *latest* releases still declare a `node20` runtime, so a version bump can't fix them:

- `actions/cache/restore@v4.3.0` (and `save`) — pulled in **transitively** by `awalsh128/cache-apt-pkgs-action@v1.6.0`, whose newest release still pins `actions/cache` v4. Used in `ci`, `fuzz-nightly`, `fuzz-pr`, `leak-nightly`, `release-plz`, `stress-nightly`.
- `bufbuild/buf-setup-action@v1.50.0` — latest release (Jan 2025), still declares `using: "node20"`. Direct dependency in `ci.yml`.

## Fix

Add a top-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to every workflow. The runner reads this at action-execution time and forces all JS actions onto Node 24 — including the **nested** `actions/cache` invoked by `awalsh128` that we cannot reach by pinning. This is the exact remedy named in GitHub's deprecation notice.

This silences the warnings now and de-risks GitHub's forced Node 24 default on **2026-06-02**, after which Node 24 is the default regardless. `actions/cache@v4.3.0` and `buf-setup` both run fine on Node 24 (cache v5 is the same code retargeted), so there is no compatibility risk.

Applied to all 9 workflows (not just the 6 currently warning) so a clean workflow can't regress before the cutover.

## Follow-up

Once `awalsh128/cache-apt-pkgs-action` and `bufbuild/buf-setup-action` ship Node 24 releases, this env var can be dropped — though it is harmless to leave after the June cutover.

## Verification

- All 9 workflow files parse as valid YAML with `env.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 == true`.
- Diff is scoped entirely to `.github/workflows/`.