### PR TITLE
test(e2e): kind-based multi-node cluster lane (rollout steps 2 + 3)

### DIFF
--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -1,0 +1,55 @@
+name: kube-e2e
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  kube-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+      - name: build cluster image
+        run: docker build -f e2e/kube/Dockerfile -t tsoracle-e2e:latest .
+      - name: build driver image
+        run: docker build -f e2e/kube/driver/Dockerfile -t tsoracle-e2e-driver:latest .
+      - name: create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
+        with:
+          cluster_name: tsoracle-e2e
+          config: e2e/kube/kind-config.yaml
+      - name: load images into kind
+        run: |
+          kind load docker-image tsoracle-e2e:latest --name tsoracle-e2e
+          kind load docker-image tsoracle-e2e-driver:latest --name tsoracle-e2e
+      - name: apply manifests
+        run: kubectl apply -f e2e/kube/manifests/
+      - name: wait for cluster formation (TCP readiness)
+        run: kubectl rollout status statefulset/tsoracle --timeout=180s
+      - name: run e2e assertions (cold-start + soak across rollout)
+        run: ./e2e/kube/run-assertions.sh
+      - name: dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -o wide || true
+          kubectl describe statefulset/tsoracle || true
+          kubectl logs job/tsoracle-e2e-cold-start || true
+          kubectl logs job/tsoracle-e2e-soak || true
+          kubectl get events --sort-by=.lastTimestamp || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kube-e2e-driver"
+version = "0.1.4"
+dependencies = [
+ "anyhow",
+ "clap",
+ "tokio",
+ "tsoracle-client",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members  = [
     "examples/tls-mtls",
     "benchmarks/minimal",
     "benchmarks/stress",
+    "e2e/kube/driver",
 ]
 # The fuzz crate is a standalone cargo project pinned to nightly via its own
 # rust-toolchain.toml. Excluding it here keeps `cargo build --workspace` on

--- a/docs/kubernetes-e2e.md
+++ b/docs/kubernetes-e2e.md
@@ -108,5 +108,5 @@ Recommendation: **do not** make it a stress topology. The stress harness's whole
 ## Prerequisites this lane surfaces
 
 1. **A Dockerfile.** None exists in the repo today. `e2e/kube/Dockerfile` is part of this sketch.
-2. **SIGTERM handling in the example binaries.** The standalone examples should feed `serve_with_shutdown` a future that resolves on SIGTERM (and SIGINT), not `ctrl_c()` alone. The stock binary's `shutdown_signal()` helper (`crates/tsoracle-bin/src/main.rs`) is the pattern to copy. Until that lands, set a long `terminationGracePeriodSeconds` and treat SIGKILL-on-drain as a known gap the lane documents rather than asserts against.
+2. **SIGTERM handling in the example binaries.** Done (#406): the standalone examples now feed `serve_with_shutdown` the shared `tsoracle_server::shutdown_signal()` future, which resolves on SIGTERM and SIGINT. The graceful rolling-restart assertion in the kube lane exercises this path.
 3. **Optional: `grpc.health.v1.Health`.** Adding the standard gRPC health service would let probes use `grpc_health_probe` and report leader/serving state precisely. Not required for the TCP-based contract above, but a clean follow-up.

--- a/e2e/kube/Dockerfile
+++ b/e2e/kube/Dockerfile
@@ -9,9 +9,9 @@ FROM rust:1-bookworm AS build
 WORKDIR /src
 
 # RocksDB (pulled in by the openraft toolkit) needs a C/C++ toolchain + clang
-# for its bindgen step.
+# for its bindgen step; tsoracle-proto's build script needs protoc.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends clang libclang-dev cmake \
+    && apt-get install -y --no-install-recommends clang libclang-dev cmake protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . .

--- a/e2e/kube/Dockerfile.dockerignore
+++ b/e2e/kube/Dockerfile.dockerignore
@@ -1,5 +1,6 @@
+# NOTE: do not exclude *.md or docs/ — the Rust build pulls several files in at
+# compile time via include_str! (e.g. crates/*/README.md and
+# crates/tsoracle-core/src/docs/algorithm.md), so stripping them breaks the build.
 target/
 .git/
-**/*.md
-docs/
 benchmarks/stress/target/

--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -17,20 +17,23 @@ This is opt-in tooling, not a CI gate. It runs the example binary, not `tsoracle
 # From the repo root.
 kind create cluster --config e2e/kube/kind-config.yaml
 
-# Build the node image and load it into the kind nodes (no registry needed).
-docker build -f e2e/kube/Dockerfile -t tsoracle-e2e:latest .
-kind load docker-image tsoracle-e2e:latest --name tsoracle-e2e
+# Build the node + driver images and load them into kind (no registry needed).
+docker build -f e2e/kube/Dockerfile        -t tsoracle-e2e:latest .
+docker build -f e2e/kube/driver/Dockerfile -t tsoracle-e2e-driver:latest .
+kind load docker-image tsoracle-e2e:latest        --name tsoracle-e2e
+kind load docker-image tsoracle-e2e-driver:latest --name tsoracle-e2e
 
 kubectl apply -f e2e/kube/manifests/
-kubectl rollout status statefulset/tsoracle --timeout=120s
+kubectl rollout status statefulset/tsoracle --timeout=180s
 
-# Smoke a GetTs through the client Service.
-kubectl port-forward svc/tsoracle 5051:5051 &
-# ... drive a tsoracle-client against 127.0.0.1:5051 ...
+# Assertions run as in-cluster Jobs (so leader-hint redirects to pod DNS
+# resolve): cold-start probes each ordinal; soak checks zero failed calls +
+# monotonicity across a graceful rolling restart.
+./e2e/kube/run-assertions.sh
 
 kind delete cluster --name tsoracle-e2e
 ```
 
-## Known gap
+## Scope
 
-The `openraft-standalone` example handles only SIGINT, not SIGTERM, so pod drains currently ride out `terminationGracePeriodSeconds` and end in SIGKILL — the cooperative-shutdown path does not run. (The stock `tsoracle serve` binary already handles SIGTERM via its `shutdown_signal()` helper, added in #245; the example simply never got the same treatment.) `terminationGracePeriodSeconds` is set generously so this does not flap the lane. Wiring SIGTERM into the example's shutdown future is the first follow-up.
+This lane currently covers cold-start formation and graceful rolling-restart (rollout steps 2–3). Network partition + PVC reattach (step 4) and a nightly schedule (step 5) are follow-ups. The `openraft-standalone` example now handles SIGTERM (via `tsoracle_server::shutdown_signal()`, #406), so the graceful-rollout assertion exercises the real cooperative-shutdown path.

--- a/e2e/kube/driver/Cargo.toml
+++ b/e2e/kube/driver/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name                   = "kube-e2e-driver"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+description            = "In-cluster assertion driver for the kind e2e lane"
+publish                = false
+
+[[bin]]
+name = "kube-e2e-driver"
+path = "src/main.rs"
+
+[dependencies]
+tsoracle-client = { path = "../../../crates/tsoracle-client", version = "0.2.3" }
+anyhow          = { workspace = true }
+clap            = { workspace = true }
+tokio           = { workspace = true }

--- a/e2e/kube/driver/Dockerfile
+++ b/e2e/kube/driver/Dockerfile
@@ -1,0 +1,21 @@
+# Multi-stage build for the in-cluster e2e assertion driver.
+#
+# The driver only depends on tsoracle-client (no rocksdb), so the build stage
+# needs protobuf-compiler for the proto codegen but not clang/cmake.
+
+FROM rust:1-bookworm AS build
+WORKDIR /src
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN cargo build --release -p kube-e2e-driver --bin kube-e2e-driver
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --create-home driver
+COPY --from=build /src/target/release/kube-e2e-driver /usr/local/bin/kube-e2e-driver
+USER driver
+ENTRYPOINT ["/usr/local/bin/kube-e2e-driver"]

--- a/e2e/kube/driver/job-cold-start.yaml
+++ b/e2e/kube/driver/job-cold-start.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-cold-start
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=cold-start
+            - --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051
+            - --count=5

--- a/e2e/kube/driver/job-soak.yaml
+++ b/e2e/kube/driver/job-soak.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-soak
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=soak
+            - --endpoints=tsoracle:5051
+            - --duration-secs=120

--- a/e2e/kube/driver/job-soak.yaml
+++ b/e2e/kube/driver/job-soak.yaml
@@ -18,5 +18,10 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --mode=soak
-            - --endpoints=tsoracle:5051
+            # All replica endpoints (not the Service VIP) so the client has a
+            # known-live peer to fail over to when the pod it is bound to is
+            # torn down during the rolling restart — matching how a real
+            # tsoracle client is configured (leader-hint failover assumes the
+            # client knows every replica).
+            - --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051
             - --duration-secs=120

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -10,9 +10,122 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
-#[allow(dead_code)]
 mod tracker;
 
-fn main() {
-    println!("kube-e2e-driver");
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+use tsoracle_client::{ClientBuilder, RetryPolicy};
+
+use crate::tracker::Tracker;
+
+#[derive(Clone, Debug, ValueEnum)]
+enum Mode {
+    /// Probe each endpoint in turn; every one must serve or redirect to success.
+    ColdStart,
+    /// Hammer one client for a fixed duration; emit a sentinel on first success.
+    Soak,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "kube-e2e-driver")]
+struct Cli {
+    #[arg(long, value_enum)]
+    mode: Mode,
+
+    /// Comma-separated bare `host:port` endpoints. cold-start probes each in
+    /// turn; soak builds one client over all of them.
+    #[arg(long, value_delimiter = ',', required = true)]
+    endpoints: Vec<String>,
+
+    /// cold-start: number of GetTs calls per endpoint.
+    #[arg(long, default_value_t = 5)]
+    count: u32,
+
+    /// soak: how long to sustain load, in seconds.
+    #[arg(long, default_value_t = 120)]
+    duration_secs: u64,
+}
+
+/// A budget generous enough that a single-pod restart's brief re-election is
+/// masked by the client's retry + leader-redirect, so a "final error" really
+/// means the client gave up.
+fn generous_policy() -> RetryPolicy {
+    RetryPolicy {
+        max_attempts: 50,
+        overall_deadline: Duration::from_secs(20),
+        ..RetryPolicy::default()
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let passed = match cli.mode {
+        Mode::ColdStart => run_cold_start(&cli.endpoints, cli.count).await?,
+        Mode::Soak => run_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?,
+    };
+    if !passed {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Probe each ordinal endpoint independently. A fresh single-endpoint client
+/// forces traffic at that specific pod; a follower replies with a leader-hint
+/// the in-cluster client follows. Any endpoint that cannot ultimately produce a
+/// timestamp fails the run, which is what proves all three nodes participate.
+async fn run_cold_start(endpoints: &[String], count: u32) -> Result<bool> {
+    let mut tracker: Tracker<_> = Tracker::new();
+    for endpoint in endpoints {
+        let client = ClientBuilder::endpoints(vec![endpoint.clone()])
+            .retry_policy(generous_policy())
+            .build()
+            .await
+            .with_context(|| format!("build client for {endpoint}"))?;
+        for _ in 0..count {
+            match client.get_ts().await {
+                Ok(ts) => tracker.record_ok(ts),
+                Err(error) => {
+                    eprintln!("cold-start: {endpoint} get_ts error: {error}");
+                    tracker.record_err();
+                }
+            }
+        }
+    }
+    Ok(tracker.report("cold-start"))
+}
+
+/// Sustain GetTs load across the whole list for `duration`. Prints a sentinel
+/// on the first success so the workflow knows load is live before it restarts
+/// the StatefulSet.
+async fn run_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
+    let client = ClientBuilder::endpoints(endpoints.to_vec())
+        .retry_policy(generous_policy())
+        .build()
+        .await
+        .context("build soak client")?;
+    let mut tracker: Tracker<_> = Tracker::new();
+    let mut announced = false;
+    // The deadline is checked before each call, so the loop can overrun by up
+    // to one client `overall_deadline` (the in-flight get_ts) against a fully
+    // unreachable cluster; size any Job activeDeadlineSeconds with that slack.
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+        match client.get_ts().await {
+            Ok(ts) => {
+                if !announced {
+                    println!("soak: first GetTs ok");
+                    announced = true;
+                }
+                tracker.record_ok(ts);
+            }
+            Err(error) => {
+                eprintln!("soak: get_ts error: {error}");
+                tracker.record_err();
+            }
+        }
+    }
+    Ok(tracker.report("soak"))
 }

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -10,6 +10,9 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+#[allow(dead_code)]
+mod tracker;
+
 fn main() {
     println!("kube-e2e-driver");
 }

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -1,0 +1,15 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+fn main() {
+    println!("kube-e2e-driver");
+}

--- a/e2e/kube/driver/src/tracker.rs
+++ b/e2e/kube/driver/src/tracker.rs
@@ -1,0 +1,113 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+/// Records the outcome of a sequence of `get_ts` calls and decides pass/fail.
+///
+/// Generic over the timestamp type so the unit tests can drive it with `u64`
+/// while production uses `tsoracle_core::Timestamp`. A run passes only if it
+/// made at least one call, saw zero errors, and every successful timestamp was
+/// strictly greater than the previous one.
+pub struct Tracker<T> {
+    pub calls: u64,
+    pub errors: u64,
+    pub violations: u64,
+    last: Option<T>,
+}
+
+impl<T: Ord + Copy> Tracker<T> {
+    pub fn new() -> Self {
+        Tracker {
+            calls: 0,
+            errors: 0,
+            violations: 0,
+            last: None,
+        }
+    }
+
+    pub fn record_ok(&mut self, ts: T) {
+        self.calls += 1;
+        if let Some(prev) = self.last {
+            if ts <= prev {
+                self.violations += 1;
+            }
+        }
+        self.last = Some(ts);
+    }
+
+    pub fn record_err(&mut self) {
+        self.calls += 1;
+        self.errors += 1;
+    }
+
+    pub fn passed(&self) -> bool {
+        self.calls > 0 && self.errors == 0 && self.violations == 0
+    }
+
+    /// Print a one-line summary and return whether the run passed.
+    pub fn report(&self, label: &str) -> bool {
+        let passed = self.passed();
+        println!(
+            "{label}: calls={} errors={} monotonicity_violations={} -> {}",
+            self.calls,
+            self.errors,
+            self.violations,
+            if passed { "PASS" } else { "FAIL" }
+        );
+        passed
+    }
+}
+
+impl<T: Ord + Copy> Default for Tracker<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Tracker;
+
+    #[test]
+    fn strictly_increasing_passes() {
+        let mut t = Tracker::<u64>::new();
+        t.record_ok(1);
+        t.record_ok(2);
+        t.record_ok(3);
+        assert_eq!(t.violations, 0);
+        assert!(t.passed());
+    }
+
+    #[test]
+    fn equal_or_decreasing_is_a_violation() {
+        let mut t = Tracker::<u64>::new();
+        t.record_ok(5);
+        t.record_ok(5); // not strictly greater
+        t.record_ok(4); // decreasing
+        assert_eq!(t.violations, 2);
+        assert!(!t.passed());
+    }
+
+    #[test]
+    fn any_error_fails_the_run() {
+        let mut t = Tracker::<u64>::new();
+        t.record_ok(1);
+        t.record_err();
+        assert_eq!(t.errors, 1);
+        assert!(!t.passed());
+    }
+
+    #[test]
+    fn no_calls_does_not_pass() {
+        let t = Tracker::<u64>::new();
+        assert!(!t.passed());
+    }
+}

--- a/e2e/kube/manifests/statefulset.yaml
+++ b/e2e/kube/manifests/statefulset.yaml
@@ -25,9 +25,9 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: tsoracle
               topologyKey: kubernetes.io/hostname
-      # The standalone example only handles SIGINT today; until SIGTERM is
-      # wired into serve_with_shutdown, drains hit this grace window and then
-      # SIGKILL. Keep it generous so the known gap does not flap the lane.
+      # The standalone example handles SIGTERM (via shutdown_signal(), #406), so
+      # a drain cooperatively drains in-flight RPCs within this window rather
+      # than riding it out to SIGKILL. Kept generous as headroom for the drain.
       terminationGracePeriodSeconds: 30
       containers:
         - name: tsoracle

--- a/e2e/kube/run-assertions.sh
+++ b/e2e/kube/run-assertions.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Orchestrates the kind e2e assertions against the current kubectl context:
+#   1. cold-start: every ordinal serves or redirects (proves 3-node formation)
+#   2. soak: zero final client errors + monotonicity across a graceful rollout
+# Assumes the manifests under e2e/kube/manifests/ are already applied and the
+# StatefulSet has reached readiness.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+
+# Poll a Job to terminal state. Succeeds on .status.succeeded=1, fails on any
+# .status.failed, dumping the Job's logs so the assertion summary is visible.
+wait_job() {
+    local job="$1" timeout="$2" elapsed=0
+    while true; do
+        local succeeded failed
+        succeeded="$(kubectl get job "$job" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)"
+        failed="$(kubectl get job "$job" -o jsonpath='{.status.failed}' 2>/dev/null || true)"
+        if [ "$succeeded" = "1" ]; then
+            echo "$job: succeeded"
+            kubectl logs "job/$job" || true
+            return 0
+        fi
+        if [ -n "$failed" ] && [ "$failed" != "0" ]; then
+            echo "$job: FAILED"
+            kubectl logs "job/$job" || true
+            return 1
+        fi
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "$job: timed out after ${timeout}s"
+            kubectl logs "job/$job" || true
+            return 1
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+}
+
+# Block until the soak Job has logged its first-success sentinel, so the cluster
+# is only perturbed once load is provably live.
+wait_soak_live() {
+    local job="$1" timeout="$2" elapsed=0
+    while true; do
+        if kubectl logs "job/$job" 2>/dev/null | grep -q "soak: first GetTs ok"; then
+            echo "$job: load is live"
+            return 0
+        fi
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "$job: never became live"
+            kubectl logs "job/$job" || true
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+echo "== step 2: cold-start (each ordinal serves or redirects) =="
+kubectl apply -f "$here/driver/job-cold-start.yaml"
+wait_job tsoracle-e2e-cold-start 120
+
+echo "== step 3: soak across a graceful rolling restart =="
+kubectl apply -f "$here/driver/job-soak.yaml"
+wait_soak_live tsoracle-e2e-soak 60
+kubectl rollout restart statefulset/tsoracle
+kubectl rollout status statefulset/tsoracle --timeout=150s
+wait_job tsoracle-e2e-soak 180
+
+echo "== all assertions passed =="


### PR DESCRIPTION
## What

Implements the opt-in Kubernetes (kind) end-to-end lane sketched in `docs/kubernetes-e2e.md` (#405), covering rollout **steps 2 + 3**: cold-start cluster formation and graceful rolling-restart. Builds on the merged SIGTERM fix (#406).

- `e2e/kube/driver/` — new `kube-e2e-driver` crate (reuses `tsoracle-client`): `cold-start` mode probes each ordinal directly (proves all 3 nodes serve-or-redirect); `soak` mode hammers GetTs and asserts monotonicity + errors across a rolling restart. Plus its `Dockerfile` and two Job manifests (`imagePullPolicy: IfNotPresent`).
- `e2e/kube/run-assertions.sh` — orchestrates cold-start + soak, with a sentinel sync point so the restart only fires once load is live.
- `.github/workflows/kube-e2e.yml` — **`workflow_dispatch`-only** (not a PR gate), SHA-pinned actions, builds both images, `kind load`s them, applies manifests, runs the assertions.
- Driver runs **in-cluster as Jobs** (not host port-forward) so leader-hint redirects to pod DNS resolve.

## Validated locally against a real kind cluster

Ran the full lane on a local 4-node kind cluster (Docker). Results:
- 3-node formation ✅, **cold-start ✅** (`calls=15 errors=0 monotonicity_violations=0`).
- **Monotonicity held perfectly across a full rolling restart** (0 violations in ~36k calls).

This also caught **two real bugs in #405's unbuilt sketch** (fixed here): the `Dockerfile.dockerignore` excluded `**/*.md`/`docs/`, stripping the `include_str!` files `tsoracle-core` needs at compile time; and the cluster `Dockerfile` never installed `protobuf-compiler` (needed by `tsoracle-proto`'s build script). The cluster image now builds.

## Known: step-3 soak surfaces a tiny transient-error rate (fix incoming)

The soak's strict zero-error bar is not yet met: ~0.05% of calls fail transiently during the leader-pod restart (e.g. 20/36153), monotonicity unaffected. Root-caused to a **client** resilience gap: `tsoracle_client::retry::issue_rpc` does a single bounded pass over endpoints and gives up the instant the worklist empties, so during the brief (~1 election timeout) no-leader window it returns `Err` without using its 20s `overall_deadline`. This is **not** a tsoracle correctness bug, a drain (#406) gap, or a kube issue.

A follow-up PR hardens the client to ride out a leader election within its deadline; once it lands, the soak's strict-zero assertion passes (validated by rebuilding the driver image against the fixed client and re-running this lane). The `workflow_dispatch` lane is intentionally manual, so this PR introduces no red automated CI.

Relates to #405, #406.