### PR TITLE
fix(server): make the clear-before-publish invariant unbypassable in the fence

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -115,10 +115,11 @@ pub(crate) async fn run_leader_watch(
                 #[cfg(feature = "metrics")]
                 let fence_started_at = std::time::Instant::now();
 
-                // Clear serving so new GetTs requests return NOT_LEADER until the
-                // fence republishes Serving below.
-                server.core.publish_not_serving(None, None);
-                server.core.clear_allocator();
+                // Enter the fence: clear the allocator and publish NotServing so
+                // new GetTs requests return NOT_LEADER until the fence
+                // republishes Serving below. `enter_fencing` clears *before* it
+                // publishes (invariant 2), so the order cannot be inverted here.
+                server.core.enter_fencing();
 
                 // Count the transition after the clear above, not on the fence's
                 // success path below: a Leader event is "observed" the moment we
@@ -296,18 +297,14 @@ pub(crate) async fn run_leader_watch(
                 leader_endpoint,
                 leader_epoch,
             } => {
-                server.core.clear_allocator();
-                server
-                    .core
-                    .publish_not_serving(leader_endpoint, leader_epoch);
+                server.core.step_down(leader_endpoint, leader_epoch);
                 // Emit after the NotServing publish so a blocking recorder
                 // cannot delay the safety state change.
                 #[cfg(feature = "metrics")]
                 metrics::counter!("tsoracle.leader_transition.total").increment(1);
             }
             LeaderState::Unknown => {
-                server.core.clear_allocator();
-                server.core.publish_not_serving(None, None);
+                server.core.step_down(None, None);
                 // Emit after the NotServing publish so a blocking recorder
                 // cannot delay the safety state change.
                 #[cfg(feature = "metrics")]

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -21,9 +21,12 @@
 //!    method on the guard returned by [`ServingCore::extension_slot`], which
 //!    already holds `extension_lock`. There is no other way to reach the read
 //!    lock, so the order cannot be inverted.
-//! 2. [`ServingCore::step_down`] clears the allocator *before* publishing
-//!    `NotServing`, so a racing `try_grant` never sees `Serving` together with a
-//!    still-leader allocator at a stale epoch.
+//! 2. Clearing the allocator and publishing `NotServing` happen together, clear
+//!    *before* publish, so a racing `try_grant` never sees `Serving` together
+//!    with a still-leader allocator at a stale epoch. Enforced by construction:
+//!    [`ServingCore::step_down`] and [`ServingCore::enter_fencing`] are the only
+//!    ways to clear the allocator (there is no standalone clear primitive), and
+//!    both bake in the order, so no call site can invert it.
 //! 3. [`ServingCore::step_down`] does **not** take `extension_gate.write()`.
 //!    Doing so would deadlock against in-flight extensions holding the read
 //!    lock and awaiting `persist_high_water`.
@@ -110,12 +113,22 @@ impl ServingCore {
         });
     }
 
-    pub(crate) fn try_grant(&self, now_ms: u64, count: u32) -> Result<WindowGrant, CoreError> {
-        self.allocator.lock().try_grant(now_ms, count)
+    /// Enter the fencing window at the start of a leadership transition: clear
+    /// the allocator and publish `NotServing` (with no leader hint) so a racing
+    /// `try_grant` returns NOT_LEADER until the fence republishes `Serving`.
+    ///
+    /// Shares [`step_down`](Self::step_down)'s clear-before-publish body
+    /// (invariant 2); it is named for the leadership-*gain* path, where
+    /// `step_down` would read backwards at the call site. Together with
+    /// `step_down` these are the *only* ways to clear the allocator: there is no
+    /// standalone clear primitive, so a clear can never be published out of
+    /// order with `NotServing`.
+    pub(crate) fn enter_fencing(&self) {
+        self.step_down(None, None);
     }
 
-    pub(crate) fn clear_allocator(&self) {
-        self.allocator.lock().on_leadership_lost();
+    pub(crate) fn try_grant(&self, now_ms: u64, count: u32) -> Result<WindowGrant, CoreError> {
+        self.allocator.lock().try_grant(now_ms, count)
     }
 
     pub(crate) fn seed_on_leadership_gained(
@@ -302,5 +315,35 @@ mod tests {
             .expect("seed must succeed (ceiling >= floor)");
         let grant = core.try_grant(1_000, 1).expect("grant must succeed");
         assert_eq!(grant.epoch(), Epoch(3));
+    }
+
+    #[test]
+    fn enter_fencing_clears_allocator_then_publishes_not_serving() {
+        // The leadership-gain path enters the fence through this single method,
+        // so the clear-before-publish order (invariant 2) cannot be inverted at
+        // the call site. Seed a serveable window first so the clear is
+        // observable, then assert both effects: NotServing with no leader hint,
+        // and a now-cleared allocator (try_grant -> NotLeader).
+        let core = ServingCore::new();
+        core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
+            .expect("seed must succeed (ceiling >= floor)");
+        assert!(core.try_grant(1_000, 1).is_ok(), "seeded core must grant");
+
+        core.enter_fencing();
+
+        assert!(
+            matches!(
+                core.serving_state(),
+                ServingState::NotServing {
+                    leader_endpoint: None,
+                    leader_epoch: None,
+                }
+            ),
+            "enter_fencing must publish NotServing with no leader hint"
+        );
+        assert!(
+            matches!(core.try_grant(1_000, 1), Err(CoreError::NotLeader)),
+            "enter_fencing must clear the allocator"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The Leader arm of the leader-watch published `NotServing` **before** clearing the allocator (`fence.rs:120-121`) — the inverse of invariant 2 in `serving_core.rs`, which every other transition upholds. It was benign only because the published `NotServing` closes the gate, so `try_grant` is unreachable in the window between the two calls. But it silently violated an invariant the codebase claims to enforce uniformly: a future edit that read the allocator without the gate would turn this into a stale-epoch grant.

Rather than just swap the two lines, this removes the ability to get the order wrong at all:

- **Add `ServingCore::enter_fencing()`** — delegates to `step_down(None, None)`, so it shares the one clear-before-publish body. Named for the leadership-*gain* path, where `step_down` reads backwards at the call site.
- **Delete `clear_allocator()`.** After collapsing the call sites it has no callers. With no standalone clear primitive, `step_down` and `enter_fencing` become the *only* ways to clear the allocator, and both bake in clear-before-publish — so no call site can invert it. This makes invariant 2 **enforced by construction**, mirroring how invariant 1's `ExtensionSlot` makes the lock order unbypassable.
- **Collapse all three fence arms** onto the encapsulated methods: Leader → `enter_fencing()`; Unknown → `step_down(None, None)` (a loss of leadership *certainty*, not a gain); Follower → `step_down(endpoint, epoch)`. The Follower/Unknown rewrites are byte-for-byte equivalent to their prior two-call bodies — zero behavior change.
- **Upgrade invariant 2's module doc** from "step_down does X" to "enforced by construction".

`fence.rs:242` (`publish_not_serving(None, None)` on the NotLeader/Fenced retry) is intentionally left untouched: it's a standalone republish on an already-clear allocator, not a clear+publish composition, so it is outside this footgun.

## Test plan

- [x] New unit test `enter_fencing_clears_allocator_then_publishes_not_serving` (red before the method existed, green after)
- [x] `cargo test -p tsoracle-server` — lib + doc tests pass
- [x] `cargo test -p tsoracle-server --test leadership_churn --features test-support` — pass
- [x] `cargo test -p tsoracle-tests --test server_failpoints --features failpoints` — pass (drives the real fence flow)
- [x] `RUSTFLAGS="-D warnings" cargo build --workspace --all-targets` — clean (confirms no dangling `clear_allocator` references)
- [x] `cargo clippy -p tsoracle-server --all-targets --features test-support,failpoints -- -D warnings` — clean