### PR TITLE
test: cover remaining reachable branches (95.5% -> 95.8%)

### DIFF
--- a/crates/tsoracle-client/src/driver_supervisor.rs
+++ b/crates/tsoracle-client/src/driver_supervisor.rs
@@ -63,6 +63,19 @@ pub(crate) async fn observe_driver_handle(handle: JoinHandle<()>) {
 mod tests {
     use super::*;
 
+    /// Install a process-global `TRACE` subscriber so the supervisor's
+    /// `tracing::error!` death-rattle actually formats its fields under test —
+    /// without a subscriber the macro short-circuits before evaluating its
+    /// arguments, leaving those lines unexecuted. Idempotent across tests;
+    /// mirrors the helper in `retry`.
+    fn enable_tracing() {
+        use tracing_subscriber::filter::LevelFilter;
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(LevelFilter::TRACE)
+            .with_test_writer()
+            .try_init();
+    }
+
     /// Normal-exit arm: a `JoinHandle` that completes cleanly drops
     /// through the supervisor without logging. The supervisor must
     /// return, not park.
@@ -79,6 +92,7 @@ mod tests {
     /// worse. The supervisor must absorb the panic and return.
     #[tokio::test]
     async fn observe_absorbs_panic_without_repanicking() {
+        enable_tracing();
         let handle = tokio::spawn(async {
             panic!("synthetic driver-task panic");
         });
@@ -94,6 +108,7 @@ mod tests {
     /// behaviour, different code path.
     #[tokio::test]
     async fn observe_handles_aborted_handle() {
+        enable_tracing();
         let handle = tokio::spawn(async {
             // Long enough that `abort()` reliably wins over the body.
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;

--- a/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
@@ -205,6 +205,76 @@ async fn read_vote_rejects_foreign_version_meta() {
     );
 }
 
+// A meta record carrying the CURRENT schema version but an undecodable body
+// must surface as a generic `io::Error` — the non-`Version` arm of
+// `codec_io_error` — distinct from the `InvalidData` a version *mismatch*
+// yields. The foreign-version test above pins the `Version` arm; this pins its
+// sibling, so a future edit that collapses the two error kinds is caught.
+#[tokio::test]
+async fn read_vote_surfaces_corrupt_body_as_generic_io_error() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+
+    // Correct leading version byte, but no decodable `Vote` body behind it, so
+    // the codec fails at `take_from_bytes` rather than the version check.
+    let key = Flat.meta_key(MetaLabel::Vote);
+    let cf = db.cf_handle(META_CF).unwrap();
+    db.put_cf(&cf, &key, [tsoracle_openraft_toolkit::SCHEMA_VERSION])
+        .unwrap();
+
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(Arc::clone(&db), LOG_CF, META_CF, Flat).unwrap();
+
+    let err = store
+        .read_vote()
+        .await
+        .expect_err("a same-version corrupt body must fail to decode");
+    assert_ne!(
+        err.kind(),
+        std::io::ErrorKind::InvalidData,
+        "a corrupt body at the current version is a generic decode failure, \
+         not the InvalidData reserved for a version mismatch",
+    );
+}
+
+// purge at index `u64::MAX` exercises the `checked_add(1)` overflow arm, where
+// the exclusive range end falls back to `log_end_bound()` because there is no
+// next index. A normal purge takes the `Some(next)` arm (see
+// `purge_removes_inclusive_prefix`); this pins the boundary.
+#[tokio::test]
+async fn purge_at_max_index_uses_log_end_bound() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir);
+    let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
+        RocksdbLogStore::open(db, LOG_CF, META_CF, Flat).unwrap();
+
+    store
+        .append((0..=3).map(blank_entry_at), IOFlushed::noop())
+        .await
+        .unwrap();
+
+    let purge_all = LogId::new(
+        TestLeaderId {
+            term: 1,
+            node_id: 1,
+        },
+        u64::MAX,
+    );
+    store.purge(purge_all).await.unwrap();
+
+    let surviving = store.try_get_log_entries(0..=3).await.unwrap();
+    assert!(
+        surviving.is_empty(),
+        "purge at u64::MAX must remove every entry via the log_end_bound fallback",
+    );
+    let state = store.get_log_state().await.unwrap();
+    assert_eq!(
+        state.last_purged_log_id.map(|id| id.index),
+        Some(u64::MAX),
+        "purge must record LastPurged at the purged index",
+    );
+}
+
 // Regression test for a cross-group keyspace leak in `last_log_id_in_cf`.
 //
 // When two `GroupPrefixed` keyspaces share a single log column family — the

--- a/crates/tsoracle-openraft-toolkit/tests/mem_network_negative.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/mem_network_negative.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use openraft::Vote;
 use openraft::error::{RPCError, StreamingError};
 use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
-use openraft::raft::{AppendEntriesRequest, VoteRequest};
+use openraft::raft::{AppendEntriesRequest, TransferLeaderRequest, VoteRequest};
 use openraft::storage::{Snapshot, SnapshotMeta};
 use openraft::type_config::alias::{SnapshotOf, VoteOf};
 use tsoracle_openraft_toolkit::test_fakes::MemNetwork;
@@ -161,6 +161,37 @@ async fn full_snapshot_blocked_by_partition_returns_streaming_network_error() {
         .expect_err("isolated target must surface as a Network error");
     let StreamingError::Network(net_err) = err else {
         panic!("expected StreamingError::Network, got {err:?}");
+    };
+    assert!(net_err.to_string().contains("partitioned"));
+}
+
+#[tokio::test]
+async fn transfer_leader_to_unknown_peer_returns_network_error() {
+    let net = MemNetwork::<TestTypeConfig>::new();
+    let mut peer = new_peer_targeting(&net, 1, 99);
+    let req = TransferLeaderRequest::<TestTypeConfig>::new(sample_vote(), 99, None);
+    let err = peer
+        .transfer_leader(req, rpc_opt())
+        .await
+        .expect_err("unknown peer must surface as a Network error");
+    let RPCError::Network(net_err) = err else {
+        panic!("expected RPCError::Network, got {err:?}");
+    };
+    assert!(net_err.to_string().contains("unknown peer"));
+}
+
+#[tokio::test]
+async fn transfer_leader_blocked_by_partition_returns_network_error() {
+    let net = MemNetwork::<TestTypeConfig>::new();
+    net.partitions().cut_edge(1, 2);
+    let mut peer = new_peer_targeting(&net, 1, 2);
+    let req = TransferLeaderRequest::<TestTypeConfig>::new(sample_vote(), 2, None);
+    let err = peer
+        .transfer_leader(req, rpc_opt())
+        .await
+        .expect_err("cut edge must surface as a Network error");
+    let RPCError::Network(net_err) = err else {
+        panic!("expected RPCError::Network, got {err:?}");
     };
     assert!(net_err.to_string().contains("partitioned"));
 }

--- a/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
@@ -389,3 +389,108 @@ async fn transfer_leader_moves_leadership_to_target() {
     .await
     .unwrap_or_else(|_| panic!("leadership did not transfer to target {target} within 10s"));
 }
+
+/// Build a single-node `Raft` backed by a fresh RocksDB store and register it on
+/// `net` under `id`. Returns the handle plus the `TempDir`, which the caller
+/// must keep alive so the on-disk store outlives the raft.
+async fn build_and_register_node(
+    net: &Arc<MemNetwork<SmokeConfig>>,
+    id: u64,
+) -> (Raft<SmokeConfig, SmokeStateMachine>, tempfile::TempDir) {
+    use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+    use tempfile::TempDir;
+    use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
+
+    let dir = TempDir::new().unwrap();
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cfs = vec![
+        ColumnFamilyDescriptor::new("raft_log", Options::default()),
+        ColumnFamilyDescriptor::new("raft_meta", Options::default()),
+    ];
+    let db = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap());
+    let log: RocksdbLogStore<SmokeConfig, Flat> =
+        RocksdbLogStore::open(db, "raft_log", "raft_meta", Flat).unwrap();
+    let sm = SmokeStateMachine::new();
+    let cfg = Arc::new(Config::default().validate().unwrap());
+    let raft = Raft::new(id, cfg, net.factory_for(id), log, sm)
+        .await
+        .expect("Raft::new");
+    net.register(id, raft.clone());
+    (raft, dir)
+}
+
+/// A registered target whose `Raft` core has been shut down returns
+/// `Fatal::Stopped` from every RPC. `MemNetworkPeer` must wrap each such
+/// receiver-side failure in its `*::Network` error and never panic. This drives
+/// the remote-error `map_err` arm of all four RPCs — and, for the snapshot path,
+/// the dispatch plus the receiver-side `RaftAdapter::install_full_snapshot`
+/// shim — which the happy-path election / replication / leader-transfer tests
+/// reach only on success.
+#[tokio::test]
+async fn rpcs_to_a_stopped_target_surface_remote_network_errors() {
+    use openraft::Vote;
+    use openraft::error::{RPCError, ReplicationClosed, StreamingError};
+    use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
+    use openraft::raft::{AppendEntriesRequest, TransferLeaderRequest, VoteRequest};
+    use openraft::storage::{Snapshot, SnapshotMeta};
+
+    let net = MemNetwork::<SmokeConfig>::new();
+    let (target, _dir) = build_and_register_node(&net, 2).await;
+    // Stop the target's core. The registry entry stays in place, so each RPC
+    // still reaches the adapter; the underlying `Raft` then returns
+    // `Fatal::Stopped`, exercising the peer's remote-error wrapping.
+    target.shutdown().await.expect("shutdown the target raft");
+
+    let mut factory = net.factory_for(1);
+    let mut peer = factory.new_client(2, &SmokeNode).await;
+    let opt = RPCOption::new(Duration::from_secs(1));
+    let vote = Vote::new(1, 1);
+
+    let append = AppendEntriesRequest::<SmokeConfig> {
+        vote,
+        prev_log_id: None,
+        entries: Vec::new(),
+        leader_commit: None,
+    };
+    assert!(
+        matches!(
+            peer.append_entries(append, opt.clone()).await,
+            Err(RPCError::Network(_))
+        ),
+        "append_entries to a stopped target must surface RPCError::Network",
+    );
+
+    let vote_req = VoteRequest::<SmokeConfig>::new(vote, None);
+    assert!(
+        matches!(
+            peer.vote(vote_req, opt.clone()).await,
+            Err(RPCError::Network(_))
+        ),
+        "vote to a stopped target must surface RPCError::Network",
+    );
+
+    let snapshot = Snapshot {
+        meta: SnapshotMeta::default(),
+        snapshot: std::io::Cursor::new(Vec::new()),
+    };
+    let cancel = futures::future::pending::<ReplicationClosed>();
+    assert!(
+        matches!(
+            peer.full_snapshot(vote, snapshot, cancel, opt.clone())
+                .await,
+            Err(StreamingError::Network(_))
+        ),
+        "full_snapshot to a stopped target must surface StreamingError::Network",
+    );
+
+    let transfer = TransferLeaderRequest::<SmokeConfig>::new(vote, 2, None);
+    assert!(
+        matches!(
+            peer.transfer_leader(transfer, opt).await,
+            Err(RPCError::Network(_))
+        ),
+        "transfer_leader to a stopped target must surface RPCError::Network",
+    );
+}

--- a/crates/tsoracle-server/tests/leadership_churn.rs
+++ b/crates/tsoracle-server/tests/leadership_churn.rs
@@ -121,6 +121,48 @@ impl ConsensusDriver for FaultyLoadDriver {
     }
 }
 
+/// Wraps `InMemoryDriver`: the leader-transition fence persist succeeds (so the
+/// server reaches `Serving` and the allocator seats a ceiling), but every
+/// *later* persist durably returns a stale value (`0`) that sits below that
+/// ceiling. The server's `commit_extension` then drops the extension as
+/// `NotAdvanced` — the benign "persisted but cannot advance" outcome (a leading
+/// indicator of persist reordering) that `extend_window` logs and counts
+/// without stepping the leader down.
+struct StalePersistDriver {
+    inner: Arc<InMemoryDriver>,
+    persists_observed: AtomicUsize,
+}
+
+impl StalePersistDriver {
+    fn new(inner: Arc<InMemoryDriver>) -> Self {
+        Self {
+            inner,
+            persists_observed: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsensusDriver for StalePersistDriver {
+    fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
+        self.inner.leadership_events()
+    }
+
+    async fn load_high_water(&self) -> Result<u64, ConsensusError> {
+        self.inner.load_high_water().await
+    }
+
+    async fn persist_high_water(&self, at_least: u64, epoch: Epoch) -> Result<u64, ConsensusError> {
+        if self.persists_observed.fetch_add(1, Ordering::SeqCst) == 0 {
+            // Fence persist: let it through so the allocator seats a ceiling.
+            return self.inner.persist_high_water(at_least, epoch).await;
+        }
+        // A durable success that returns a value below the seated ceiling: the
+        // commit that follows cannot advance and is dropped as NotAdvanced.
+        Ok(0)
+    }
+}
+
 /// Boot a server with the given driver, drive it to `Serving`, and force the
 /// clock past the seeded high-water so the next `GetTs` triggers an extension.
 async fn boot_serving<D: ConsensusDriver + 'static>(
@@ -299,6 +341,58 @@ async fn extend_window_maps_permanent_driver_to_internal() {
     // Permanent driver errors do not step the server down either: the
     // server has no proof the epoch is stale, only that the driver is sick.
     assert!(matches!(*booted.state_rx.borrow(), ServingState::Serving));
+
+    booted.shutdown().await.unwrap();
+}
+
+/// A persist that durably succeeds but returns a value below the committed
+/// ceiling makes `commit_extension` drop the extension as `NotAdvanced` — a
+/// benign outcome (persist reordering) that `extend_window` logs and counts but
+/// must NOT step the leader down. Drives the `CommitOutcome::Ignored` arm of
+/// `extend_window`, which the error-injection tests above never reach: persist
+/// returns `Ok`, so the loud `NotLeader` / `Fenced` / driver-error arms are all
+/// skipped and only the post-persist ignored-commit branch runs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extend_window_ignored_commit_is_benign_and_keeps_serving() {
+    // A TRACE subscriber so the "window extension commit ignored after persist"
+    // debug line formats its fields under test rather than short-circuiting.
+    use tracing_subscriber::filter::LevelFilter;
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::TRACE)
+        .with_test_writer()
+        .try_init();
+
+    let in_memory = Arc::new(InMemoryDriver::new());
+    let stale = Arc::new(StalePersistDriver::new(in_memory.clone()));
+
+    let (booted, _clock) = boot_serving(stale, &in_memory).await;
+
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
+        .await
+        .unwrap();
+    // The extension persists, but its returned value cannot advance the ceiling,
+    // so the window stays exhausted and the retried grant surfaces Internal.
+    let status = client
+        .get_ts(GetTsRequest { count: 1 })
+        .await
+        .expect_err("a dropped (NotAdvanced) extension leaves the window exhausted");
+    assert_eq!(
+        status.code(),
+        tonic::Code::Internal,
+        "got status: {status:?}"
+    );
+    assert!(
+        status.message().contains("window exhausted"),
+        "got message: {}",
+        status.message(),
+    );
+
+    // NotAdvanced is benign: unlike NotLeader / Fenced it must leave the leader
+    // serving, since there is no evidence the epoch is stale.
+    assert!(
+        matches!(*booted.state_rx.borrow(), ServingState::Serving),
+        "an ignored (NotAdvanced) commit must not step the leader down",
+    );
 
     booted.shutdown().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Follow-up to #414. Pushes library line coverage from **95.49% → 95.83%** (488 → 451 missed lines; region 94.95% → 95.16%, function 96.12% → 96.53%) by covering the reachable branches left after the first round, in three tiers of decreasing ROI. Test-only — no production code or public API changes.

### Tier 1 — `tracing` death-rattle (client `driver_supervisor`)
The panic/abort arms were already tested, but with no subscriber the `tracing::error!` field expressions never ran. Installing a TRACE subscriber in those two tests covers them — the same lever as #414.

### Tier 2 — openraft `MemNetwork` fake
- `transfer_leader` unknown-peer / partition negative tests (the only RPC the negative suite hadn't covered).
- A stopped-target test: register a `Raft`, shut it down, then drive all four RPCs into it so each receiver returns `Fatal::Stopped`, exercising the remote-error `map_err` arms plus the full-snapshot dispatch and its receiver-side adapter shim.
- The fake's RPC surface now has no uncovered lines.

### Tier 3 — fault-injection error paths
- `RocksdbLogStore`: a same-version-but-corrupt-body read (the non-`Version` arm of `codec_io_error`, distinct from the `InvalidData` a version mismatch yields), and a purge at `u64::MAX` (the `checked_add` overflow arm that falls back to `log_end_bound`).
- `extend_window`: a `StalePersistDriver` whose post-fence persist returns a value below the committed ceiling drives the benign `CommitOutcome::Ignored` (NotAdvanced) arm — which must be logged and counted but must NOT step the leader down.

### Left uncovered by design
- paxos `standalone.rs` append-failure arms — would need an omnipaxos pending-reconfiguration stopsign, too fragile to stage for error-formatting closures.
- log-store `?`-operator error edges and the IO-write-failure callback — unreachable without a rocksdb write failure.
- The known timing-flaky paxos `lifecycle/mod.rs` paths.

## Test Plan
- [x] `make coverage` — full workspace suite green (exit 0)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean on touched crates
- [x] `cargo fmt --check` clean