### PR TITLE
fix(server): bound graceful shutdown so a hung driver call can't stall exit

### DIFF
--- a/crates/tsoracle-consensus/src/driver.rs
+++ b/crates/tsoracle-consensus/src/driver.rs
@@ -26,6 +26,27 @@ use crate::leadership::LeaderState;
 /// Implementations own leadership election, peer transport, durable storage,
 /// and the topology knowledge needed to populate `LeaderHint` on follower
 /// redirects. The library never names peers or opens peer sockets.
+///
+/// **Contract — cancellation & latency (`load_high_water` / `persist_high_water`):**
+/// the server drives these inside its leader-watch fence, which it may stop at
+/// any time — most importantly on graceful shutdown. That stop is cooperative
+/// and observed only *between* fence steps, never inside an in-flight call, so a
+/// method that blocks indefinitely (e.g. waiting out a lost quorum) stalls the
+/// fence and, on shutdown, forces the server to abort the watch task once its
+/// shutdown grace elapses, dropping the in-flight future. Implementations
+/// therefore MUST honour two rules:
+///   * **Cancel-safety.** Dropping an in-flight `load_high_water` /
+///     `persist_high_water` future MUST NOT corrupt durable state. A
+///     `persist_high_water` whose proposal was already submitted MAY still
+///     commit after its future is dropped; the monotonic-advance contract on
+///     that method makes the late apply safe — it can only raise the
+///     high-water, never regress it.
+///   * **Latency bound.** Prefer returning [`ConsensusError::TransientDriver`]
+///     once a round-trip exceeds a sane internal deadline over blocking
+///     forever. The fence's retry loop is cancel-observant: a `TransientDriver`
+///     lets it back off, race the leadership stream, and honour a pending stop,
+///     whereas an unbounded await can only be broken by a forced abort during
+///     shutdown.
 #[async_trait::async_trait]
 pub trait ConsensusDriver: Send + Sync + 'static {
     /// Stream of leadership transitions. The server holds this for its lifetime.

--- a/crates/tsoracle-server/src/docs/operations.md
+++ b/crates/tsoracle-server/src/docs/operations.md
@@ -34,6 +34,7 @@ The server emits the following signals through the [`metrics`](https://docs.rs/m
 - `tsoracle.leader_transition.fence_latency` — duration of the failover fence (histogram, seconds)
 - `tsoracle.leader_transition.fence_transient_retries.total` — fence retried a transient consensus error during failover (counter)
 - `tsoracle.not_leader.total` — RPCs rejected with `NOT_LEADER` (counter)
+- `tsoracle.shutdown.watch_aborted.total` — a graceful shutdown had to forcibly abort the leader-watch task because it did not stop within `shutdown_grace`, almost always because a consensus-driver call (`load_high_water` / `persist_high_water`) was wedged; any non-zero value means a shutdown narrowly avoided a SIGKILL stall and warrants investigating driver latency (counter)
 
 The library is exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the [`Server`]. The example below wires Prometheus over an HTTP listener:
 

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -73,11 +73,21 @@ pub enum ServingState {
     Serving,
 }
 
+/// Default bound on how long a graceful shutdown waits for the leader-watch
+/// task to stop cooperatively before forcibly aborting it. The abort is a
+/// last-resort safety net for a consensus driver whose `load_high_water` /
+/// `persist_high_water` is wedged (the trait places no latency bound; see
+/// [`ConsensusDriver`]). Chosen to sit comfortably under a typical Kubernetes
+/// `terminationGracePeriodSeconds` (30s) so the abort, the tonic drain, and
+/// process exit all complete before the kubelet escalates to SIGKILL.
+const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(10);
+
 pub struct ServerBuilder {
     consensus: Option<Arc<dyn ConsensusDriver>>,
     clock: Option<Arc<dyn Clock>>,
     window_ahead: Duration,
     failover_advance: Duration,
+    shutdown_grace: Duration,
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
@@ -89,6 +99,7 @@ impl Default for ServerBuilder {
             clock: None,
             window_ahead: Duration::from_secs(3),
             failover_advance: Duration::from_secs(1),
+            shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: None,
         }
@@ -113,6 +124,25 @@ impl ServerBuilder {
         self
     }
 
+    /// Bound on how long a graceful shutdown waits for the leader-watch task to
+    /// stop cooperatively before forcibly aborting it.
+    ///
+    /// On shutdown the server drops the watch task's cancel signal and waits for
+    /// it to publish `NotServing` and return. That wait is normally
+    /// near-instant, but the task observes cancellation only at its `select!`
+    /// boundaries — never inside a fence attempt. A consensus driver whose
+    /// `load_high_water` / `persist_high_water` never returns (the trait places
+    /// no latency bound) would otherwise park the task mid-fence and block
+    /// process exit indefinitely, leading to a SIGKILL on a Kubernetes drain.
+    /// Once `shutdown_grace` elapses the server aborts the task so exit always
+    /// makes progress. Set this comfortably below your deployment's
+    /// `terminationGracePeriodSeconds`. Defaults to 10s. A value of zero aborts
+    /// immediately without waiting for a cooperative stop.
+    pub fn shutdown_grace(mut self, shutdown_grace: Duration) -> Self {
+        self.shutdown_grace = shutdown_grace;
+        self
+    }
+
     /// Configure TLS termination for this server. Applied inside
     /// [`Server::serve`], [`Server::serve_with_shutdown`], and
     /// [`Server::serve_with_listener`]. Not applied to [`Server::into_router`] —
@@ -132,6 +162,7 @@ impl ServerBuilder {
             clock,
             window_ahead: self.window_ahead,
             failover_advance: self.failover_advance,
+            shutdown_grace: self.shutdown_grace,
             core: ServingCore::new(),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: self.tls_config,
@@ -144,6 +175,9 @@ pub struct Server {
     pub(crate) clock: Arc<dyn Clock>,
     pub(crate) window_ahead: Duration,
     pub(crate) failover_advance: Duration,
+    /// Bound on the graceful-shutdown wait for the leader-watch task before a
+    /// forced abort. See [`ServerBuilder::shutdown_grace`].
+    pub(crate) shutdown_grace: Duration,
     /// Owns the allocator, serving-state channel, and both extension locks, with
     /// the lock-ordering and step-down invariants private behind its methods.
     pub(crate) core: ServingCore,
@@ -213,12 +247,17 @@ impl Server {
     /// That decode happens before the leader-watch task is spawned, so a failure
     /// leaves nothing running to clean up.
     pub fn into_router(self) -> Result<(Routes, WatchGuard), ServerError> {
+        // Read the `Copy` grace before `into_router_parts` consumes `self`, so
+        // the returned guard can bound its own shutdown wait identically to the
+        // `serve_*` paths.
+        let shutdown_grace = self.shutdown_grace;
         let (routes, cancel_tx, handle) = self.into_router_parts()?;
         Ok((
             routes,
             WatchGuard {
                 cancel_tx: Some(cancel_tx),
                 handle: Some(handle),
+                shutdown_grace,
             },
         ))
     }
@@ -306,7 +345,9 @@ impl Server {
     ///
     /// Three outcomes:
     /// 1. `shutdown` fires first → tonic drains in-flights and returns Ok.
-    ///    The watch handle is aborted; any error it had been about to return
+    ///    The watch task is then stopped cooperatively, bounded by
+    ///    `shutdown_grace` and forcibly aborted if it overruns (e.g. parked in a
+    ///    wedged consensus-driver call); any error it had been about to return
     ///    is forfeited (the process is shutting down anyway).
     /// 2. Watch returns `Ok(Err(e))` → poisoned state is already published;
     ///    `cancel_tx` triggers tonic's graceful shutdown; in-flight `GetTs`
@@ -325,6 +366,8 @@ impl Server {
         #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
         let tls_config = self.tls_config.clone();
 
+        // Read the `Copy` grace before `into_router_parts` consumes `self`.
+        let shutdown_grace = self.shutdown_grace;
         let (routes, watch_cancel_tx, watch_handle) = self.into_router_parts()?;
         let (combined_shutdown, cancel_tx) = combined_shutdown_with_cancel(shutdown);
 
@@ -337,7 +380,14 @@ impl Server {
             .add_routes(routes)
             .serve_with_shutdown(addr, combined_shutdown);
 
-        serve_inner(watch_cancel_tx, watch_handle, serve, cancel_tx).await
+        serve_inner(
+            watch_cancel_tx,
+            watch_handle,
+            serve,
+            cancel_tx,
+            shutdown_grace,
+        )
+        .await
     }
 
     /// Run the gRPC server on a caller-provided `TcpListener` until either
@@ -370,6 +420,8 @@ impl Server {
         #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
         let tls_config = self.tls_config.clone();
 
+        // Read the `Copy` grace before `into_router_parts` consumes `self`.
+        let shutdown_grace = self.shutdown_grace;
         let (routes, watch_cancel_tx, watch_handle) = self.into_router_parts()?;
         let (combined_shutdown, cancel_tx) = combined_shutdown_with_cancel(shutdown);
 
@@ -384,7 +436,14 @@ impl Server {
             .add_routes(routes)
             .serve_with_incoming_shutdown(incoming, combined_shutdown);
 
-        serve_inner(watch_cancel_tx, watch_handle, serve, cancel_tx).await
+        serve_inner(
+            watch_cancel_tx,
+            watch_handle,
+            serve,
+            cancel_tx,
+            shutdown_grace,
+        )
+        .await
     }
 }
 
@@ -406,6 +465,9 @@ pub struct WatchGuard {
     // signal: the task's `cancel` future resolves on sender-drop too.
     cancel_tx: Option<tokio::sync::oneshot::Sender<()>>,
     handle: Option<tokio::task::JoinHandle<Result<(), ServerError>>>,
+    /// Bound on the cooperative-stop wait in [`Self::shutdown`] before a forced
+    /// abort. Inherited from [`ServerBuilder::shutdown_grace`].
+    shutdown_grace: Duration,
 }
 
 impl WatchGuard {
@@ -417,11 +479,19 @@ impl WatchGuard {
     /// its own (driver error, stream EOF, or panic) the original outcome is
     /// surfaced verbatim: `Err(e)` or [`ServerError::WatchPanic`]. Either way
     /// serving state is `NotServing` once this returns.
+    ///
+    /// The cooperative wait is bounded by the configured
+    /// [`ServerBuilder::shutdown_grace`]: if the task is parked in a
+    /// consensus-driver call that never returns it is aborted once the grace
+    /// elapses (still reported as `Ok(())`), so an embedder's shutdown can never
+    /// wedge behind a hung driver.
     pub async fn shutdown(mut self) -> Result<(), ServerError> {
         // Dropping the sender fires the task's cancel future.
         self.cancel_tx.take();
         match self.handle.take() {
-            Some(handle) => join_to_server_result(handle.await),
+            Some(mut handle) => join_to_server_result(
+                await_watch_within_grace(&mut handle, self.shutdown_grace).await,
+            ),
             None => Ok(()),
         }
     }
@@ -483,6 +553,49 @@ fn combined_shutdown_with_cancel(
     (combined_shutdown, cancel_tx)
 }
 
+/// Wait for the leader-watch task to stop cooperatively, but no longer than
+/// `grace`, then forcibly abort it if it is still running.
+///
+/// The watch task observes its cancel signal only at the `select!` boundaries
+/// in [`crate::fence::run_leader_watch`], never inside a fence attempt. A
+/// consensus driver whose `load_high_water` / `persist_high_water` never
+/// returns (the trait places no latency bound; see
+/// [`tsoracle_consensus::ConsensusDriver`]) therefore parks the task upstream
+/// of any cancel-observing await, so dropping the cancel sender cannot stop it.
+/// Left unbounded, the shutdown wait would block process exit until the kubelet
+/// escalates to SIGKILL on a drain. Bounding the wait by `grace` and aborting
+/// on expiry guarantees forward progress: `tokio` tears a suspended task (and
+/// the wedged driver future it holds) down at the abort, dropping its
+/// drain-barrier guard.
+///
+/// Returns the task's join result. A clean cooperative stop forwards its real
+/// outcome verbatim; an aborted task surfaces as a cancelled `JoinError`, which
+/// [`join_to_server_result`] maps to `Ok(())` — the stop was requested, so a
+/// forced abort during shutdown is not an error. A `grace` of zero aborts
+/// immediately (the `timeout` future is already elapsed on first poll).
+async fn await_watch_within_grace(
+    watch_handle: &mut tokio::task::JoinHandle<Result<(), ServerError>>,
+    grace: Duration,
+) -> Result<Result<(), ServerError>, tokio::task::JoinError> {
+    match tokio::time::timeout(grace, &mut *watch_handle).await {
+        Ok(join_result) => join_result,
+        Err(_elapsed) => {
+            #[cfg(feature = "metrics")]
+            metrics::counter!("tsoracle.shutdown.watch_aborted.total").increment(1);
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                grace_ms = grace.as_millis() as u64,
+                "leader-watch task did not stop within the shutdown grace; aborting it (a consensus-driver call likely exceeded its latency bound)"
+            );
+            watch_handle.abort();
+            // Reap the aborted task so its Drop (releasing any held drain-barrier
+            // guard) runs before we report shutdown complete. Bounded: an aborted
+            // task resolves at its next poll.
+            (&mut *watch_handle).await
+        }
+    }
+}
+
 /// Drive the gRPC `serve_future` against the leader-watch task, shared by
 /// [`Server::serve_with_shutdown`] and [`Server::serve_with_listener`].
 ///
@@ -499,12 +612,14 @@ fn combined_shutdown_with_cancel(
 /// [`WatchGuard`] holds for embedders); dropping it stops the task. Taking the
 /// raw parts rather than a `WatchGuard` keeps this path free of the guard's
 /// `Option` fields — neither the watch handle nor the cancel sender is optional
-/// here.
+/// here. `shutdown_grace` bounds the user-shutdown arm's wait for the watch task
+/// (see [`await_watch_within_grace`]).
 async fn serve_inner<S>(
     watch_cancel_tx: tokio::sync::oneshot::Sender<()>,
     mut watch_handle: tokio::task::JoinHandle<Result<(), ServerError>>,
     serve_future: S,
     tonic_cancel_tx: tokio::sync::oneshot::Sender<()>,
+    shutdown_grace: Duration,
 ) -> Result<(), ServerError>
 where
     S: Future<Output = Result<(), tonic::transport::Error>>,
@@ -531,16 +646,21 @@ where
         serve_result = &mut serve_future => {
             // User shutdown fired (or our cancel — but watch arm has
             // `biased` priority, so reaching here means user shutdown).
-            // Stop the watch task cooperatively rather than with a hard
-            // abort: dropping its cancel sender resolves the task's cancel
-            // future, and we await the task so it never gets torn down
-            // mid-fence while holding `extension_gate.write()`. The wait is
-            // bounded — the cancel arms in `run_leader_watch` fire even when
-            // a fence is stuck retrying a transient error. The task's own
-            // outcome is a clean `Ok(())` (we asked it to stop) and is not
-            // surfaced; the user-requested shutdown result wins.
+            // Prefer a cooperative stop: dropping the cancel sender resolves
+            // the task's cancel future so it stops at its next `select!`
+            // boundary, having published `NotServing` and never torn down
+            // mid-fence while holding `extension_gate.write()`. But a
+            // cooperative stop is only observed at those boundaries, never
+            // inside a fence attempt — a consensus-driver call that never
+            // returns (the trait places no latency bound) would park the task
+            // upstream of any cancel point and block process exit until a
+            // kubelet SIGKILL. `await_watch_within_grace` therefore bounds the
+            // wait by `shutdown_grace` and aborts the task if it overruns. The
+            // task's own outcome (a clean `Ok(())` on cooperative stop, a
+            // cancelled `JoinError` on abort) is discarded; the user-requested
+            // shutdown result wins.
             drop(watch_cancel_tx);
-            let _ = (&mut watch_handle).await;
+            let _ = await_watch_within_grace(&mut watch_handle, shutdown_grace).await;
             serve_result?;
             Ok(())
         }

--- a/crates/tsoracle-server/tests/serve_shutdown.rs
+++ b/crates/tsoracle-server/tests/serve_shutdown.rs
@@ -28,7 +28,24 @@ use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::{Epoch, SystemClock};
-use tsoracle_server::{Server, ServerError, test_fakes::InMemoryDriver};
+use tsoracle_server::{
+    Server, ServerError,
+    test_fakes::{InMemoryDriver, StallableDriver},
+};
+
+/// Spin until the leader-watch fence has entered `persist_high_water` (and, with
+/// the driver stalled from call index 0, is now parked there). Polling the
+/// driver's call counter makes the "watch task is wedged mid-fence" precondition
+/// deterministic rather than timing-dependent.
+async fn wait_until_persist_started(driver: &StallableDriver) {
+    for _ in 0..2_000 {
+        if driver.persist_call_count() >= 1 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("fence never reached persist_high_water within the polling window");
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn serve_with_listener_returns_ok_when_user_shutdown_fires() {
@@ -176,6 +193,88 @@ async fn serve_with_listener_translates_watch_panic_to_server_error() {
         }
         other => panic!("expected WatchPanic, got {other:?}"),
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn serve_returns_within_grace_when_a_driver_call_hangs() {
+    // Regression for the shutdown-stall hazard: the leader-watch fence observes
+    // its cooperative-cancel signal only at `select!` boundaries, never inside a
+    // fence attempt. A `persist_high_water` that never returns (the driver trait
+    // places no latency bound) therefore parks the watch task upstream of any
+    // cancel-observing await, so dropping the cancel sender cannot stop it. Left
+    // unbounded, `serve_inner` would block process exit until the kubelet
+    // escalates to SIGKILL. With a configured `shutdown_grace`, the serve path
+    // must abort the wedged task once the grace elapses and return promptly.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+    let driver = Arc::new(StallableDriver::new());
+    // Stall every persist from call index 0: the fence's own persist wedges.
+    driver.stall_from(0);
+    driver.become_leader(Epoch(1));
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .clock(Arc::new(SystemClock))
+        .shutdown_grace(Duration::from_millis(200))
+        .build()
+        .unwrap();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let serve_task = tokio::spawn(async move {
+        server
+            .serve_with_listener(listener, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    // The fence must be parked in the stalled persist before we ask to stop, so
+    // the cancel genuinely arrives while a driver call is in flight.
+    wait_until_persist_started(&driver).await;
+    shutdown_tx.send(()).unwrap();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(3), serve_task)
+        .await
+        .expect("serve must return after the grace elapses even though the driver is wedged")
+        .expect("spawned task panicked");
+    assert!(
+        outcome.is_ok(),
+        "a shutdown that forcibly aborts a wedged watch task reports Ok, got {outcome:?}"
+    );
+
+    // Release the held persist so the (now-aborted) future tears down cleanly.
+    driver.release();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watch_guard_shutdown_returns_within_grace_when_a_driver_call_hangs() {
+    // The embedder-facing analogue: `WatchGuard::shutdown` awaits the same watch
+    // task. A wedged `persist_high_water` must not block an embedder's shutdown
+    // either — the grace bounds the cooperative wait, then the task is aborted.
+    let driver = Arc::new(StallableDriver::new());
+    driver.stall_from(0);
+    driver.become_leader(Epoch(1));
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .clock(Arc::new(SystemClock))
+        .shutdown_grace(Duration::from_millis(200))
+        .build()
+        .unwrap();
+
+    let (_routes, guard) = server.into_router().expect("into_router must succeed");
+
+    wait_until_persist_started(&driver).await;
+
+    let outcome = tokio::time::timeout(Duration::from_secs(3), guard.shutdown())
+        .await
+        .expect("WatchGuard::shutdown must return after the grace elapses even when wedged");
+    assert!(
+        outcome.is_ok(),
+        "a forced abort on shutdown reports Ok (the stop was requested), got {outcome:?}"
+    );
+
+    driver.release();
 }
 
 /// Driver whose `leadership_events()` stream resolves to `None` immediately,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,6 +30,7 @@ Default is 1 second. On leadership gain, the new leader first computes `serving_
 - `tsoracle.leader_transition.fence_latency` — duration of the failover fence (histogram, seconds)
 - `tsoracle.leader_transition.fence_transient_retries.total` — fence retried a transient consensus error during failover (counter)
 - `tsoracle.not_leader.total` — RPCs rejected with `NOT_LEADER` (counter)
+- `tsoracle.shutdown.watch_aborted.total` — a graceful shutdown had to forcibly abort the leader-watch task because it did not stop within `shutdown_grace`, almost always because a consensus-driver call (`load_high_water` / `persist_high_water`) was wedged; any non-zero value means a shutdown narrowly avoided a SIGKILL stall and warrants investigating driver latency (counter)
 
 **Paxos consensus signals** (emitted by `tsoracle-driver-paxos` / `tsoracle-paxos-toolkit` when their `metrics` feature is enabled)
 


### PR DESCRIPTION
## Problem

The user-shutdown arm of `serve_inner` dropped the leader-watch task's cancel sender and then awaited the task **unbounded**. But `fence::run_leader_watch` observes its cancel signal only at its two `select!` boundaries — the event wait and the transient-retry backoff — **never inside a fence attempt**. A `load_high_water` / `persist_high_water` that never returns (the `ConsensusDriver` trait placed no latency bound) therefore parks the watch task upstream of any cancel-observing await, so dropping the sender cannot stop it. Process exit then blocks until the kubelet escalates to **SIGKILL** on a drain. The prior comment claiming the wait "is bounded — the cancel arms fire even when a fence is stuck retrying" held only for the retry-backoff path, not for a single hung call.

## Fix

- New `await_watch_within_grace(handle, grace)`: waits at most `shutdown_grace` for the task to stop cooperatively, then aborts it (emitting `tsoracle.shutdown.watch_aborted.total` + a warning) so exit always makes progress. An aborted task surfaces as a cancelled `JoinError`, which `join_to_server_result` maps to `Ok(())` — the stop was requested. Wired into **both** `serve_inner` and the embedder-facing `WatchGuard::shutdown`, which had the identical unbounded `handle.await`. Dropping a `WatchGuard` is unchanged (still a detached cooperative cancel).
- Because the tonic drain has already completed before this arm runs, the wait is purely additive and near-instant in the normal case; the grace only elapses on a genuinely wedged driver.
- The grace is configurable via `ServerBuilder::shutdown_grace`, defaulting to **10s** — comfortably under a typical Kubernetes `terminationGracePeriodSeconds` (30s).
- Documented the matching `ConsensusDriver` contract: implementations must be cancel-safe (a dropped in-flight future must not corrupt durable state; a late-committing persist is safe under monotonic-advance) and should prefer returning `TransientDriver` over blocking indefinitely, since the fence retry loop is cancel-observant.
- Cataloged the new counter in `operations.md`.

## Tests

Two regression tests drive a stalled `persist_high_water` (via the existing `StallableDriver`) through both the `serve_*` and `WatchGuard::shutdown` paths and assert each returns promptly once the grace elapses. Both were confirmed to fail (hang to the outer timeout) before the fix and pass after.

## Verification

- `tsoracle-server` full suite (`test-support,metrics,yieldpoints,reflection`) and `tsoracle-consensus` tests/doctests pass.
- `cargo clippy -D warnings` clean on both crates; builds with tracing+metrics **off** (confirming the `cfg`-gated lines); whole workspace + all examples/benchmarks build; `cargo fmt --check` clean.

No breaking API changes: `shutdown_grace` is an additive builder method; `WatchGuard::shutdown`'s bounded-abort behavior is a bug fix.