### PR TITLE
docs(server): resolve broken intra-doc link to Server in operations guide

### DIFF
--- a/crates/tsoracle-server/src/docs/operations.md
+++ b/crates/tsoracle-server/src/docs/operations.md
@@ -70,3 +70,5 @@ The consensus driver owns the mapping from consensus leader identity to tsoracle
 **HA via your own consensus:** N nodes (typically 3 or 5), each running `tsoracle serve` embedded in a binary that supplies a custom `ConsensusDriver` over your consensus library. Clients configure all N endpoints. Leader handles GetTs; followers redirect.
 
 **Sharded TSO domains:** for systems wanting separate monotonic sequences per keyspace, run one tsoracle cluster per shard. The library has no opinion on sharding.
+
+[`Server`]: crate::Server

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -50,7 +50,7 @@ Default is 1 second. On leadership gain, the new leader first computes `serving_
 - `tsoracle.client.driver.queue_depth` — waiter-queue size inside the coalescing driver task (gauge). Updated after every enqueue and after each dispatch drain.
 - `tsoracle.client.driver.in_flight` — 0 or 1 indicating whether the driver currently has an outgoing batch in flight (gauge)
 
-Both libraries are exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the [`Server`] or [`Client`]. The example below wires Prometheus over an HTTP listener for a process that hosts either side:
+Both libraries are exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the `Server` or `Client`. The example below wires Prometheus over an HTTP listener for a process that hosts either side:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
## Problem

`crates/tsoracle-server/src/docs/operations.md` is included as the rustdoc for `crate::docs::operations` (via `#[doc = include_str!]` in `docs/mod.rs`). It referenced the server type as a bare `` [`Server`] `` shortcut link, but `Server` lives at the crate root, not in `docs::operations` — so rustdoc could not resolve it and emitted a `broken_intra_doc_links` warning.

## Fix

- Define the reference target as `` [`Server`]: crate::Server `` at the end of `operations.md`, matching the reference-style intra-doc link convention already used in the sibling `docs.md`. `cargo doc` with `-D warnings` now passes for `tsoracle-server`.
- The standalone book copy (`docs/operations.md`) carried the same `` [`Server`] `` plus a `` [`Client`] `` written as shortcut-reference links. That file is not compiled by rustdoc, so `crate::`-style targets do not apply and the brackets only rendered as literal text on GitHub. Replaced them with plain code spans (`` `Server` `` / `` `Client` ``).

## Verification

`RUSTDOCFLAGS="-D warnings" cargo doc -p tsoracle-server --no-deps --features "tracing,metrics,reflection"` builds with no warnings; whole-workspace build (incl. examples) clean; pre-commit fmt + clippy passed.