### PR TITLE
EKS e2e deploy tooling + graceful leadership handoff on shutdown

### DIFF
--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -37,3 +37,16 @@ kind delete cluster --name tsoracle-e2e
 ## Scope
 
 This lane currently covers cold-start formation and graceful rolling-restart (rollout steps 2–3). Network partition + PVC reattach (step 4) and a nightly schedule (step 5) are follow-ups. The `openraft-standalone` example now handles SIGTERM (via `tsoracle_server::shutdown_signal()`, #406), so the graceful-rollout assertion exercises the real cooperative-shutdown path.
+
+## Deploying to EKS (staging)
+
+The kind flow above is fully local. To deploy the same `openraft-standalone` cluster onto the real **staging** EKS cluster (arm64, real EBS) for a manual smoke test, the Kubernetes manifests live in the **infra** repo at `k8s/tsoracle-e2e/`; this repo only builds and pushes the images.
+
+Prerequisites: AWS credentials, the `staging` kube context, and the ECR repositories created once via `terraform apply` in `infra/terraform/shared-artifacts`.
+
+```sh
+# build + push the arm64 node and driver images to ECR
+./e2e/kube/push-to-ecr.sh
+```
+
+Then follow `infra/k8s/tsoracle-e2e/README.md` for apply, assertions, and teardown. Unlike the kind lane (side-loaded images, `imagePullPolicy: IfNotPresent`), the EKS overlay uses `imagePullPolicy: Always` against ECR.

--- a/e2e/kube/push-to-ecr.sh
+++ b/e2e/kube/push-to-ecr.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the arm64 node + driver images and push them to ECR for the EKS e2e
+# lane (the Kubernetes manifests live in the infra repo under k8s/tsoracle-e2e).
+# Run from the tsoracle repo root — both Dockerfiles compile Rust from this
+# build context.
+set -euo pipefail
+
+# Account and region are resolved from the caller's AWS context rather than
+# hardcoded, so this script carries no environment-specific identifiers.
+# Override either via the env if your shell default is not the target.
+AWS_REGION="${AWS_REGION:-$(aws configure get region)}"
+: "${AWS_REGION:?set AWS_REGION (no default region configured)}"
+ACCOUNT="${ACCOUNT:-$(aws sts get-caller-identity --query Account --output text)}"
+: "${ACCOUNT:?could not resolve AWS account id; set ACCOUNT}"
+TAG="${TAG:-$(git rev-parse --short HEAD)}"
+REG="${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$root"
+
+echo "== ecr login (${REG}) =="
+aws ecr get-login-password --region "$AWS_REGION" \
+    | docker login --username AWS --password-stdin "$REG"
+
+build_push() {
+    local name="$1" dockerfile="$2"
+    local repo="${REG}/prisma-risk/${name}"
+    echo "== build ${repo} (arm64, tags: ${TAG}, latest) =="
+    docker build --platform linux/arm64 -f "$dockerfile" \
+        -t "${repo}:${TAG}" -t "${repo}:latest" .
+    docker push "${repo}:${TAG}"
+    docker push "${repo}:latest"
+    echo "pushed ${repo}:${TAG}"
+}
+
+build_push tsoracle-e2e        e2e/kube/Dockerfile
+build_push tsoracle-e2e-driver e2e/kube/driver/Dockerfile
+
+echo
+echo "Pinned refs (for 'kustomize edit set image' / the driver sed in infra/k8s/tsoracle-e2e):"
+echo "  tsoracle-e2e=${REG}/prisma-risk/tsoracle-e2e:${TAG}"
+echo "  tsoracle-e2e-driver=${REG}/prisma-risk/tsoracle-e2e-driver:${TAG}"

--- a/examples/openraft-standalone/proto/raft.proto
+++ b/examples/openraft-standalone/proto/raft.proto
@@ -16,6 +16,7 @@ service RaftPeerService {
   rpc AppendEntries (RaftMessage) returns (RaftMessage);
   rpc Vote (RaftMessage) returns (RaftMessage);
   rpc Snapshot (stream SnapshotChunk) returns (RaftMessage);
+  rpc TransferLeader (RaftMessage) returns (RaftMessage);
 }
 
 message RaftMessage {

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -19,6 +19,7 @@
 //! `--bootstrap` flag goes on exactly one node at first cluster init.
 
 mod network;
+mod shutdown;
 
 use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
@@ -226,7 +227,15 @@ async fn main() -> anyhow::Result<()> {
         "tsoracle openraft node {} on http://{}",
         cli.id, cli.tso_addr
     );
-    tso.serve_with_shutdown(cli.tso_addr, tsoracle_server::shutdown_signal())
-        .await?;
+    // On drain, hand off leadership before the gRPC server stops accepting, so
+    // peers don't wait out an election timeout. Best-effort: if this node is
+    // not the leader (or the handoff times out) it simply drains normally.
+    let raft_for_shutdown = raft.clone();
+    let my_id = cli.id;
+    let shutdown = async move {
+        tsoracle_server::shutdown_signal().await;
+        shutdown::graceful_leader_handoff(&raft_for_shutdown, my_id).await;
+    };
+    tso.serve_with_shutdown(cli.tso_addr, shutdown).await?;
     Ok(())
 }

--- a/examples/openraft-standalone/src/network.rs
+++ b/examples/openraft-standalone/src/network.rs
@@ -38,7 +38,8 @@ use openraft::error::{NetworkError, RPCError, StreamingError, Unreachable};
 use openraft::errors::ReplicationClosed;
 use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
 use openraft::raft::{
-    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
+    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, TransferLeaderRequest,
+    VoteRequest, VoteResponse,
 };
 use openraft::type_config::alias::{SnapshotOf, VoteOf};
 use tokio::sync::Mutex;
@@ -205,6 +206,26 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
         Ok(body)
     }
 
+    /// Forward a leadership-transfer request to the target peer. openraft calls
+    /// this on the outgoing leader when `trigger().transfer_leader` fires; the
+    /// receiver hands the request to `Raft::handle_transfer_leader`. Without
+    /// this override the default no-op drops the request and leadership only
+    /// moves on the next election timeout.
+    async fn transfer_leader(
+        &mut self,
+        req: TransferLeaderRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<(), RPCError<TypeConfig>> {
+        let mut c = self.client().await?;
+        let payload =
+            postcard::to_stdvec(&req).map_err(|err| RPCError::Network(NetworkError::new(&err)))?;
+        if let Err(err) = c.transfer_leader(RaftMessage { payload }).await {
+            evict(&self.pool, self.target, &self.addr).await;
+            return Err(RPCError::Network(NetworkError::new(&err)));
+        }
+        Ok(())
+    }
+
     /// Send a snapshot to the target as a stream of `SnapshotChunk`s.
     ///
     /// Stream layout: one `header` chunk (postcard vote + postcard meta),
@@ -323,6 +344,22 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
         let payload =
             postcard::to_stdvec(&resp).map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(tonic::Response::new(RaftMessage { payload }))
+    }
+
+    async fn transfer_leader(
+        &self,
+        request: tonic::Request<RaftMessage>,
+    ) -> Result<tonic::Response<RaftMessage>, tonic::Status> {
+        let body: TransferLeaderRequest<TypeConfig> =
+            postcard::from_bytes(&request.into_inner().payload)
+                .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
+        self.raft
+            .handle_transfer_leader(body)
+            .await
+            .map_err(|e| tonic::Status::internal(e.to_string()))?;
+        Ok(tonic::Response::new(RaftMessage {
+            payload: Vec::new(),
+        }))
     }
 
     /// Reassemble a streamed snapshot and hand it to `install_full_snapshot`.

--- a/examples/openraft-standalone/src/shutdown.rs
+++ b/examples/openraft-standalone/src/shutdown.rs
@@ -1,0 +1,153 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Graceful leadership handoff on shutdown.
+//!
+//! When a node is asked to drain (SIGTERM under Kubernetes), the tso gRPC
+//! server stops accepting once the shutdown future resolves. If the node being
+//! drained is the raft leader, peers would otherwise wait out an election
+//! timeout before a successor emerges — a multi-second window where `GetTs`
+//! returns `NOT_LEADER`. Transferring leadership to an up-to-date voter first
+//! collapses that gap: the successor campaigns immediately, and the draining
+//! node redirects in-flight clients to it via the usual leader hint.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use openraft::Raft;
+use openraft::async_runtime::watch::WatchReceiver;
+
+use tsoracle_driver_openraft::TypeConfig;
+
+type NodeId = u64;
+
+/// Wall-clock ceiling on waiting for leadership to move after a transfer is
+/// triggered. Generous relative to a healthy campaign; if it elapses we drain
+/// anyway rather than block shutdown indefinitely.
+const HANDOFF_WAIT: Duration = Duration::from_secs(5);
+
+/// Choose the most caught-up voter other than `me` to receive leadership.
+///
+/// `matched` maps a peer's node id to its highest replicated (matched) log
+/// index; a voter missing from the map is treated as having replicated
+/// nothing. Picking the most caught-up voter lets the successor become leader
+/// without first catching up. Returns `None` when there is no other voter
+/// (e.g. a single-node cluster), in which case there is nothing to hand to.
+pub(crate) fn pick_handoff_target(
+    me: NodeId,
+    voters: &BTreeSet<NodeId>,
+    matched: &BTreeMap<NodeId, u64>,
+) -> Option<NodeId> {
+    voters
+        .iter()
+        .copied()
+        .filter(|id| *id != me)
+        .max_by_key(|id| matched.get(id).copied().unwrap_or(0))
+}
+
+/// If this node is the current leader, transfer leadership to the most
+/// caught-up voter and wait (bounded) for it to take over. Best-effort: any
+/// error or timeout falls through to a normal drain.
+pub(crate) async fn graceful_leader_handoff<SM>(raft: &Raft<TypeConfig, SM>, me: NodeId)
+where
+    SM: Send + Sync + 'static,
+{
+    if raft.current_leader().await != Some(me) {
+        return;
+    }
+
+    let (voters, matched) = {
+        let metrics = raft.metrics().borrow_watched().clone();
+        let voters: BTreeSet<NodeId> = metrics.membership_config.voter_ids().collect();
+        let matched: BTreeMap<NodeId, u64> = metrics
+            .replication
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|(id, log)| log.map(|log_id| (id, log_id.index)))
+            .collect();
+        (voters, matched)
+    };
+
+    let Some(target) = pick_handoff_target(me, &voters, &matched) else {
+        return;
+    };
+
+    tracing::info!(target, "transferring leadership before drain");
+    if let Err(error) = raft.trigger().transfer_leader(target).await {
+        tracing::warn!(
+            ?error,
+            "leadership transfer failed; draining without handoff"
+        );
+        return;
+    }
+
+    let moved = tokio::time::timeout(HANDOFF_WAIT, async {
+        while raft.current_leader().await == Some(me) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+    if moved.is_err() {
+        tracing::warn!("leadership did not move within the handoff window; draining anyway");
+    } else {
+        tracing::info!(target, "leadership handed off; draining");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn voters(ids: &[NodeId]) -> BTreeSet<NodeId> {
+        ids.iter().copied().collect()
+    }
+
+    #[test]
+    fn picks_the_most_caught_up_follower() {
+        let v = voters(&[1, 2, 3]);
+        // Node 1 is the leader; node 3 has replicated further than node 2.
+        let matched = BTreeMap::from([(2, 40), (3, 70)]);
+        assert_eq!(pick_handoff_target(1, &v, &matched), Some(3));
+    }
+
+    #[test]
+    fn excludes_self_even_when_most_caught_up() {
+        let v = voters(&[1, 2, 3]);
+        // The leader (1) has the highest index but must never pick itself.
+        let matched = BTreeMap::from([(1, 100), (2, 40), (3, 30)]);
+        assert_eq!(pick_handoff_target(1, &v, &matched), Some(2));
+    }
+
+    #[test]
+    fn treats_missing_replication_as_zero() {
+        let v = voters(&[1, 2, 3]);
+        // No replication info at all: still returns *a* voter (not None), so a
+        // handoff is attempted rather than skipped.
+        let matched = BTreeMap::new();
+        assert!(matches!(pick_handoff_target(1, &v, &matched), Some(2 | 3)));
+    }
+
+    #[test]
+    fn single_voter_cluster_has_no_target() {
+        let v = voters(&[1]);
+        assert_eq!(pick_handoff_target(1, &v, &BTreeMap::new()), None);
+    }
+
+    #[test]
+    fn ignores_non_voter_progress() {
+        // A learner (id 9) is the most caught up but is not a voter, so it is
+        // never chosen.
+        let v = voters(&[1, 2]);
+        let matched = BTreeMap::from([(2, 10), (9, 999)]);
+        assert_eq!(pick_handoff_target(1, &v, &matched), Some(2));
+    }
+}


### PR DESCRIPTION
## Summary

- **EKS deploy tooling** (`e2e/kube/push-to-ecr.sh` + an "EKS (staging)" section in `e2e/kube/README.md`): builds the `openraft-standalone` node image and the assertion driver image for `linux/arm64` and pushes both to ECR, so the cluster can be deployed to a real EKS StatefulSet for a manual smoke test. The Kubernetes manifests themselves live in the infra repo (`k8s/tsoracle-e2e`).
- **Graceful leadership handoff on SIGTERM** in the `openraft-standalone` example: on drain, if the node is the current leader it transfers leadership to the most caught-up voter *before* the gRPC server stops accepting, instead of letting peers wait out an election timeout. This wires a `TransferLeader` RPC into the peer transport (openraft's default `RaftNetworkV2::transfer_leader` is a no-op that drops the request) and sequences the handoff into the shutdown future.

## Why

Deploying the cluster to a real EBS-backed EKS StatefulSet surfaced a rolling-restart availability gap the in-process and kind harnesses structurally cannot reach: every leader restart cost an election-timeout window of `NOT_LEADER` errors, stretched on EBS by slower pod turnover. Measured across a rolling restart of a 3-node cluster:

| | failed / total GetTs | rate | NOT_LEADER | monotonicity violations |
| --- | --- | --- | --- | --- |
| before | 361 / 46,108 | 0.78% | 348 | 0 |
| after | 3 / 39,045 | 0.0077% | 0 | 0 |

A ~100x reduction, with `NOT_LEADER` (the leadership-churn signature) eliminated. The 3 residual errors are transient transport timeouts — an in-flight call to the specific pod being torn down — and are tracked as a follow-up.

## Test plan

- [x] `cargo test -p example-openraft-standalone` — 10 unit tests (incl. `pick_handoff_target` selection logic: most-caught-up voter, excludes self, single-node no-op, ignores non-voters) + the SIGTERM integration test
- [x] `cargo clippy -p example-openraft-standalone --all-targets` — clean
- [x] Manual EKS soak across a rolling restart (3-node, arm64, gp3 EBS) — before/after table above

## Follow-up

- Mask the residual ~3 transient timeouts (in-flight call dropped when its bound pod is torn down) via client retry-on-timeout across endpoints during the restart window.