### PR TITLE
refactor(server): consolidate consensus-error classification into one classifier

### DIFF
--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 
 use tsoracle_consensus::{ConsensusError, LeaderState};
 
+use crate::persist_disposition::{PersistDisposition, classify};
 use crate::server::{Server, ServerError};
 
 // Fence retry tuning for the volatile post-election window. When a fence hits
@@ -234,61 +235,84 @@ pub(crate) async fn run_leader_watch(
                                 .record(fence_started_at.elapsed().as_secs_f64());
                             break;
                         }
-                        // Leadership moved under us. Already NotServing; await the
-                        // next leadership event rather than retrying a persist that
-                        // can only keep failing at this epoch.
-                        Err(ServerError::Consensus(
-                            ConsensusError::NotLeader { .. } | ConsensusError::Fenced { .. },
-                        )) => {
-                            server.core.publish_not_serving(None, None);
-                            break;
-                        }
-                        // Recoverable driver hiccup. Retry, but race the backoff
-                        // against the leadership stream so a genuine transition is
-                        // observed instead of spun past.
-                        Err(ServerError::Consensus(ConsensusError::TransientDriver(_source))) => {
-                            transient_retries += 1;
-                            #[cfg(feature = "metrics")]
-                            metrics::counter!(
-                                "tsoracle.leader_transition.fence_transient_retries.total"
-                            )
-                            .increment(1);
-                            #[cfg(feature = "tracing")]
-                            if warn_on_stuck_fence(transient_retries) {
-                                tracing::warn!(
-                                    error = %_source,
-                                    retries = transient_retries,
-                                    "fence still retrying a transient consensus error; serving is paused while this node remains leader"
-                                );
-                            }
-                            let backoff = core::cmp::min(
-                                FENCE_RETRY_BASE
-                                    .saturating_mul(1u32 << (transient_retries - 1).min(16)),
-                                FENCE_RETRY_CAP,
-                            );
-                            tokio::select! {
-                                // Bias toward cancel so a stop requested while
-                                // a fence is stuck retrying a transient error
-                                // is honored rather than spun past.
-                                biased;
-                                _ = &mut cancel => {
-                                    server.core.step_down(None, None);
-                                    return Ok(());
+                        // A consensus error (from load_high_water or
+                        // persist_high_water) routes through the shared
+                        // classifier; the fence then applies its *own* policy to
+                        // each disposition. The extend path
+                        // (`service::extend_window`) maps these same dispositions
+                        // differently — that deliberate divergence is now explicit
+                        // at the two call sites instead of duplicated as variant
+                        // matches.
+                        Err(ServerError::Consensus(consensus_error)) => {
+                            match classify(consensus_error) {
+                                // Leadership moved under us. Already NotServing via
+                                // enter_fencing; republish it (no hint — the fence
+                                // has no caller to redirect, it just awaits the next
+                                // leadership event) and stop retrying a persist that
+                                // can only keep failing at this epoch. `fenced_by` is
+                                // unused here for that reason.
+                                PersistDisposition::SteppedDown { .. } => {
+                                    server.core.publish_not_serving(None, None);
+                                    break;
                                 }
-                                _ = tokio::time::sleep(backoff) => {}
-                                next = stream.next() => {
-                                    match next {
-                                        Some(evt) => {
-                                            pending = Some(evt);
-                                            break;
+                                // Recoverable driver hiccup. Retry, but race the
+                                // backoff against the leadership stream so a genuine
+                                // transition is observed instead of spun past.
+                                PersistDisposition::Transient(_source) => {
+                                    transient_retries += 1;
+                                    #[cfg(feature = "metrics")]
+                                    metrics::counter!(
+                                        "tsoracle.leader_transition.fence_transient_retries.total"
+                                    )
+                                    .increment(1);
+                                    #[cfg(feature = "tracing")]
+                                    if warn_on_stuck_fence(transient_retries) {
+                                        tracing::warn!(
+                                            error = %_source,
+                                            retries = transient_retries,
+                                            "fence still retrying a transient consensus error; serving is paused while this node remains leader"
+                                        );
+                                    }
+                                    let backoff = core::cmp::min(
+                                        FENCE_RETRY_BASE.saturating_mul(
+                                            1u32 << (transient_retries - 1).min(16),
+                                        ),
+                                        FENCE_RETRY_CAP,
+                                    );
+                                    tokio::select! {
+                                        // Bias toward cancel so a stop requested
+                                        // while a fence is stuck retrying a transient
+                                        // error is honored rather than spun past.
+                                        biased;
+                                        _ = &mut cancel => {
+                                            server.core.step_down(None, None);
+                                            return Ok(());
                                         }
-                                        None => return Err(ServerError::WatchStreamClosed),
+                                        _ = tokio::time::sleep(backoff) => {}
+                                        next = stream.next() => {
+                                            match next {
+                                                Some(evt) => {
+                                                    pending = Some(evt);
+                                                    break;
+                                                }
+                                                None => return Err(ServerError::WatchStreamClosed),
+                                            }
+                                        }
                                     }
                                 }
+                                // Permanent fault: fail fast so into_router poisons
+                                // serving state and stops serving. Reconstitute the
+                                // original error as the propagated cause.
+                                PersistDisposition::Permanent(source) => {
+                                    return Err(ServerError::Consensus(
+                                        ConsensusError::PermanentDriver(source),
+                                    ));
+                                }
                             }
                         }
-                        // Permanent fault or allocator invariant: fail fast so
-                        // into_router poisons serving state and stops serving.
+                        // A non-consensus fault (e.g. a Core allocator invariant
+                        // from seed_on_leadership_gained): never recoverable here,
+                        // so fail fast and let into_router poison serving state.
                         Err(e) => return Err(e),
                     }
                 }

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -17,6 +17,7 @@
 
 mod fence;
 mod leader_hint;
+mod persist_disposition;
 mod server;
 mod service;
 mod serving_core;

--- a/crates/tsoracle-server/src/persist_disposition.rs
+++ b/crates/tsoracle-server/src/persist_disposition.rs
@@ -1,0 +1,140 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Shared classification of a consensus persist/load failure into the
+//! policy-neutral [`PersistDisposition`] categories the server acts on.
+//!
+//! Two sites react to a `ConsensusError` from the consensus driver: the
+//! request-path window extension ([`service::extend_window`]) and the
+//! leadership fence ([`fence::run_leader_watch`]). Their *policies* diverge —
+//! the extend path surfaces a transient fault to the caller immediately and a
+//! permanent one as `INTERNAL`, while the fence retries a transient fault with
+//! backoff and treats a permanent one as fatal — but the *classification* that
+//! feeds those policies is identical. [`classify`] owns that classification in
+//! one place; each site then maps a `PersistDisposition` to its own action, so
+//! the divergence is explicit at the call sites rather than smeared across two
+//! near-identical `match` blocks. A fifth `ConsensusError` variant becomes one
+//! edit here plus a compiler-forced arm at each site.
+//!
+//! [`service::extend_window`]: crate::service
+//! [`fence::run_leader_watch`]: crate::fence
+
+use tsoracle_consensus::ConsensusError;
+use tsoracle_core::Epoch;
+
+/// The policy-neutral category of a consensus persist/load failure.
+///
+/// This deliberately collapses `ConsensusError::Fenced` and
+/// `ConsensusError::NotLeader` into the single [`SteppedDown`] category: both
+/// mean "leadership moved under us, abandon this epoch", and both call sites
+/// react identically (step down to `NotServing`). The only thing they differ on
+/// — the epoch to advertise in a leader hint — is preserved in `fenced_by`, so
+/// nothing is lost by the collapse.
+///
+/// [`SteppedDown`]: PersistDisposition::SteppedDown
+#[derive(Debug)]
+pub(crate) enum PersistDisposition {
+    /// Leadership moved under us (`Fenced` or `NotLeader`). `fenced_by` is the
+    /// epoch that fenced us when the driver named it: `Fenced` reports it as
+    /// `current`; `NotLeader` exposes none. The extend path threads it into the
+    /// `NOT_LEADER` hint so the client can validate its next leader; the fence
+    /// path ignores it (it republishes `NotServing` without a hint and awaits
+    /// the next leadership event).
+    SteppedDown { fenced_by: Option<Epoch> },
+    /// A recoverable driver fault: storage I/O hiccup, peer transport flap,
+    /// momentary quorum loss. The caller MAY retry. Carries the boxed source so
+    /// the call site can format the original `persist: {source}` message.
+    Transient(Box<dyn std::error::Error + Send + Sync>),
+    /// A permanent driver fault: read-only filesystem, corruption, gone storage
+    /// device, invariant violation. The caller MUST NOT silently retry. Carries
+    /// the boxed source for the same reason as [`Transient`].
+    ///
+    /// [`Transient`]: PersistDisposition::Transient
+    Permanent(Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Classify a consensus persist/load failure into its policy-neutral
+/// [`PersistDisposition`].
+///
+/// Takes the error by value so the `Transient` / `Permanent` categories can
+/// move the boxed source out of the `ConsensusError` rather than cloning it
+/// (the source is a `Box<dyn Error>`, which is not `Clone`), letting each call
+/// site format the original source text.
+pub(crate) fn classify(error: ConsensusError) -> PersistDisposition {
+    match error {
+        ConsensusError::Fenced { current, .. } => PersistDisposition::SteppedDown {
+            fenced_by: Some(current),
+        },
+        ConsensusError::NotLeader { .. } => PersistDisposition::SteppedDown { fenced_by: None },
+        ConsensusError::TransientDriver(source) => PersistDisposition::Transient(source),
+        ConsensusError::PermanentDriver(source) => PersistDisposition::Permanent(source),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fenced_carries_the_current_epoch_into_the_hint() {
+        // Fenced names the epoch that fenced us as `current`; classify must
+        // surface it so the extend path can advertise it in the NOT_LEADER
+        // hint. The `expected` field is irrelevant to the disposition.
+        let disposition = classify(ConsensusError::Fenced {
+            expected: Epoch(1),
+            current: Epoch(2),
+        });
+        assert!(matches!(
+            disposition,
+            PersistDisposition::SteppedDown {
+                fenced_by: Some(Epoch(2))
+            }
+        ));
+    }
+
+    #[test]
+    fn not_leader_steps_down_without_an_epoch() {
+        // NotLeader carries `observed`, but the persist path does NOT propagate
+        // it into the hint (see #244 / the churn test) — so the disposition
+        // deliberately drops it, yielding fenced_by: None even when observed is
+        // Some.
+        let disposition = classify(ConsensusError::NotLeader {
+            observed: Some(Epoch(7)),
+        });
+        assert!(matches!(
+            disposition,
+            PersistDisposition::SteppedDown { fenced_by: None }
+        ));
+    }
+
+    #[test]
+    fn transient_preserves_the_source_text() {
+        let disposition = classify(ConsensusError::TransientDriver(Box::new(
+            std::io::Error::other("flap"),
+        )));
+        match disposition {
+            PersistDisposition::Transient(source) => assert_eq!(source.to_string(), "flap"),
+            other => panic!("expected Transient, got a different disposition: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn permanent_preserves_the_source_text() {
+        let disposition = classify(ConsensusError::PermanentDriver(Box::new(
+            std::io::Error::other("corrupted"),
+        )));
+        match disposition {
+            PersistDisposition::Permanent(source) => assert_eq!(source.to_string(), "corrupted"),
+            other => panic!("expected Permanent, got a different disposition: {other:?}"),
+        }
+    }
+}

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
-use tsoracle_consensus::ConsensusError;
 #[cfg(feature = "metrics")]
 use tsoracle_core::IgnoreReason;
 use tsoracle_core::{CommitOutcome, CoreError, Epoch};
@@ -23,6 +22,7 @@ use tsoracle_proto::v1::{
 };
 
 use crate::leader_hint::not_leader_status;
+use crate::persist_disposition::{PersistDisposition, classify};
 use crate::server::{Server, ServingState};
 
 /// Convert an optional leader epoch into the nested wire form carried by
@@ -257,37 +257,40 @@ impl TsoServiceImpl {
         }
         let actual = match persist_outcome {
             Ok(v) => v,
-            // NotLeader / Fenced are authoritative proof from the consensus
-            // driver that this node's epoch is stale. Step down immediately
-            // — letting subsequent try_grant calls keep serving from a
-            // fenced epoch, even briefly, is the wrong tradeoff for a TSO.
-            // The step_down helper clears the allocator and publishes
-            // NotServing under the single transition API; leader_hint_from
-            // then snapshots that freshly-published state for the redirect.
-            //
-            // Fenced names the epoch that fenced us as `current`; publish it
-            // so the NOT_LEADER hint carries an epoch the client can validate
-            // its next leader against. NotLeader during persist exposes no
-            // such epoch here, so its hint omits one.
-            Err(ConsensusError::Fenced { current, .. }) => {
-                self.server.core.step_down(None, Some(current));
-                return Err(not_leader_status(leader_hint_from(&self.server)));
-            }
-            Err(ConsensusError::NotLeader { .. }) => {
-                self.server.core.step_down(None, None);
-                return Err(not_leader_status(leader_hint_from(&self.server)));
-            }
-            // Transient driver failure: storage hiccup, peer transport flap,
-            // quorum momentarily lost. Tell the client it MAY retry.
-            Err(ConsensusError::TransientDriver(e)) => {
-                return Err(Status::unavailable(format!("persist: {e}")));
-            }
-            // Permanent driver failure: read-only filesystem, corruption,
-            // gone storage device, invariant violation. Surface honestly so
-            // clients do not silently retry into a tarpit.
-            Err(ConsensusError::PermanentDriver(e)) => {
-                return Err(Status::internal(format!("persist: {e}")));
-            }
+            // Route the failure through the shared classifier and apply the
+            // *extend path's* policy to each disposition. The fence path
+            // (`fence::run_leader_watch`) maps the same dispositions
+            // differently — that divergence is the whole point of factoring
+            // the classification out: it now lives at these two call sites
+            // explicitly rather than as two near-identical variant matches.
+            Err(error) => match classify(error) {
+                // Leadership moved under us — authoritative proof this node's
+                // epoch is stale. Step down immediately: letting subsequent
+                // try_grant calls keep serving from a fenced epoch, even
+                // briefly, is the wrong tradeoff for a TSO. step_down clears
+                // the allocator and publishes NotServing under the single
+                // transition API; leader_hint_from then snapshots that
+                // freshly-published state for the redirect. `fenced_by` is the
+                // epoch the client can validate its next leader against —
+                // present for Fenced, absent for NotLeader.
+                PersistDisposition::SteppedDown { fenced_by } => {
+                    self.server.core.step_down(None, fenced_by);
+                    return Err(not_leader_status(leader_hint_from(&self.server)));
+                }
+                // Transient driver failure: storage hiccup, peer transport
+                // flap, quorum momentarily lost. Tell the client it MAY retry;
+                // do NOT step down — there is no proof the epoch is stale.
+                PersistDisposition::Transient(source) => {
+                    return Err(Status::unavailable(format!("persist: {source}")));
+                }
+                // Permanent driver failure: read-only filesystem, corruption,
+                // gone storage device, invariant violation. Surface honestly
+                // so clients do not silently retry into a tarpit; do NOT step
+                // down — the driver is sick, not fenced.
+                PersistDisposition::Permanent(source) => {
+                    return Err(Status::internal(format!("persist: {source}")));
+                }
+            },
         };
         let commit_outcome = self
             .server


### PR DESCRIPTION
## Problem

The server has two sites that react to a `ConsensusError` from the consensus driver, and both classified the same four variants (`Fenced`, `NotLeader`, `TransientDriver`, `PermanentDriver`) — independently, with **divergent policy**:

- **`service::extend_window`** (request path): on a transient fault, surface `UNAVAILABLE` to the caller immediately; on a permanent fault, surface `INTERNAL`. Either way the node keeps serving.
- **`fence::run_leader_watch`** (leadership transition): on a transient fault, retry with capped backoff while racing the leadership stream; on a permanent fault, fail fast so `into_router` poisons serving state.

The classification knowledge was split across two near-identical `match` blocks, so adding a fifth `ConsensusError` variant meant editing both, and the policy divergence was implicit.

## Change

Introduce a small shared module `persist_disposition` with:

- `PersistDisposition` — the policy-neutral category of a persist/load failure.
- `classify(ConsensusError) -> PersistDisposition` — the single owner of the variant→category mapping.

Both sites now call `classify(...)` and map the resulting disposition to **their own** policy, so the divergence is explicit and co-located at each call site rather than smeared across two variant matches. A fifth `ConsensusError` variant is now one edit in `classify` plus a compiler-forced arm at each site.

`PersistDisposition` deliberately collapses `Fenced` and `NotLeader` into a single `SteppedDown { fenced_by: Option<Epoch> }`: both sites step down on either, differing only in the epoch advertised in the leader hint (`Fenced` names `current`; `NotLeader` exposes none), which the field preserves. `classify` takes the error by value so `Transient`/`Permanent` move the boxed source out (it isn't `Clone`), letting each site keep its exact `persist: {source}` message.

## Behavior

Unchanged. The existing `leadership_churn` integration suite pins both paths (Fenced-carries-epoch hint, NotLeader-no-epoch, transient/permanent stay-serving, watch-death poisoning); four new unit tests cover the `classify` mapping directly.

## Verification

- `cargo clippy -p tsoracle-server --all-features --all-targets` — clean
- `cargo test --workspace --all-features` — 124 test binaries OK, 0 failed
- `cargo build --workspace --examples --all-features` — clean