### PR TITLE
fix(paxos): seed barrier-nonce recovery from the durable log, not the non-synced decided_idx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "tracing-subscriber",
  "tsoracle-consensus",
  "tsoracle-core",
+ "tsoracle-failpoint",
  "tsoracle-paxos-toolkit",
  "tsoracle-yieldpoint",
 ]

--- a/crates/tsoracle-driver-paxos/Cargo.toml
+++ b/crates/tsoracle-driver-paxos/Cargo.toml
@@ -14,6 +14,7 @@ default          = ["rocksdb-storage"]
 rocksdb-storage  = ["tsoracle-paxos-toolkit/rocksdb-storage"]
 yieldpoints      = ["tsoracle-yieldpoint/yieldpoints"]
 metrics          = ["dep:metrics", "tsoracle-paxos-toolkit/metrics"]
+failpoints       = ["tsoracle-paxos-toolkit/failpoints", "tsoracle-failpoint/failpoints"]
 
 [dependencies]
 async-trait          = { workspace = true }
@@ -40,4 +41,10 @@ rocksdb          = { workspace = true }
 tempfile         = { workspace = true }
 tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 tracing-subscriber = { workspace = true }
+tsoracle-failpoint = { workspace = true }
 tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "0.2.3", features = ["rocksdb-storage", "test-fakes"] }
+
+[[test]]
+name              = "recovery_failpoints"
+path              = "tests/recovery_failpoints.rs"
+required-features = ["failpoints", "rocksdb-storage"]

--- a/crates/tsoracle-driver-paxos/src/lib.rs
+++ b/crates/tsoracle-driver-paxos/src/lib.rs
@@ -27,7 +27,7 @@ pub use driver::PaxosDriver;
 pub use log_entry::{HighWaterCommand, HighWaterSnapshot};
 pub use snapshot_policy::SnapshotPolicy;
 pub use standalone::{AlreadyRunning, BuilderError, StandaloneHost, StandaloneHostBuilder};
-pub use state_machine::{ApplyState, drain_decided_into, maybe_snapshot};
+pub use state_machine::{ApplyState, drain_decided_into, max_logged_barrier_seq, maybe_snapshot};
 /// Re-export of the cross-backend advance payload that [`HighWaterCommand::Advance`]
 /// wraps, so consumers can build commands without depending on `tsoracle-consensus`.
 pub use tsoracle_consensus::AdvancePayload;

--- a/crates/tsoracle-driver-paxos/src/standalone.rs
+++ b/crates/tsoracle-driver-paxos/src/standalone.rs
@@ -105,30 +105,38 @@ where
         let mut runner = PaxosRunner::new(omnipaxos.clone(), my_node_id, peers, tick_interval);
         let leader_subscriber = runner.take_leader_subscriber();
 
-        // Resume the barrier-nonce counter above any seq this node already
-        // used in a prior process lifetime. `barrier_seq` is process-local
-        // and resets to 0 on restart, but the `applied_barriers` ledger is
-        // durable — restored from decided-log replay and snapshot transfer.
-        // `current_high_water` waits for `applied_barrier_seq(self) >=
-        // minted_seq`; minting from 0 would hand back a seq a recovered
-        // `(self, old_seq)` entry already satisfies, letting the read return
-        // before its own barrier is applied and seeding the new leader's
-        // allocator below the prior ceiling. Folding the recovered decided
-        // suffix here learns this node's highest durable seq and lifts the
-        // counter above it, so a freshly minted seq can only be satisfied by
-        // this lifetime's own barrier.
+        // Resume the barrier-nonce counter above any seq this node already used
+        // in a prior process lifetime. `barrier_seq` is process-local and
+        // resets to 0 on restart; `current_high_water` waits for
+        // `applied_barrier_seq(self) >= minted_seq`, so minting from 0 would
+        // hand back a seq a recovered `(self, old_seq)` entry already satisfies,
+        // letting the read return before its own barrier is applied and seeding
+        // the new leader's allocator below the prior ceiling.
         //
-        // The same recovery fold also yields the recovered decided index, which
-        // seeds `apply_cursor`: whichever drive path runs (sync stepping or the
-        // spawned apply task) resumes from where this fold left off rather than
-        // re-draining the whole decided log from 0. The fold is idempotent (max
-        // over advances and per-node seqs), so the worst the old cursor-from-0
-        // behaviour did was redundant work; seeding the cursor here removes that
-        // O(decided-log) startup cost on long-lived nodes.
+        // The seed is the highest `(self, seq)` recoverable from the *durable
+        // log* — see [`max_logged_barrier_seq`]. It deliberately does NOT come
+        // from the recovered decided fold (`applied_barrier_seq` after
+        // `recover`): `set_decided_idx` is a non-synced write, so a crash can
+        // recover a `decided_idx` below a barrier that is still durably logged.
+        // A decided-only seed would miss that barrier, yet the apply task will
+        // fold it once the decision is re-confirmed — reopening the exact
+        // false-satisfy this counter exists to prevent. Scanning the accepted
+        // suffix instead bounds the nonce above every barrier the log can still
+        // surface, lost `decided_idx` or not.
+        //
+        // The recovery fold still runs, for the other recovered state it is the
+        // right source for: the in-memory high-water, the `applied_barriers`
+        // ledger, and the recovered decided index that seeds `apply_cursor` so
+        // whichever drive path runs (sync stepping or the spawned apply task)
+        // resumes from where the fold left off rather than re-draining the
+        // decided log from 0. The fold is idempotent (max over advances and
+        // per-node seqs), so the worst the old cursor-from-0 behaviour did was
+        // redundant work; seeding the cursor here removes that O(decided-log)
+        // startup cost on long-lived nodes.
         let engine = ApplyEngine::new(policy);
         let mut recovery_cursor = 0u64;
         engine.recover(&omnipaxos, &mut recovery_cursor);
-        let recovered_seq = engine.applied_barrier_seq(my_node_id);
+        let recovered_seq = crate::state_machine::max_logged_barrier_seq(&omnipaxos, my_node_id);
 
         Self {
             omnipaxos,
@@ -656,6 +664,91 @@ mod tests {
             *host.apply_cursor.lock(),
             recovered_decided,
             "apply cursor must be seeded at the recovered decided index, not re-drained from 0",
+        );
+    }
+
+    /// A node that crashes after a `Barrier` is fsynced into the log but
+    /// before the *non-synced* `set_decided_idx` write that records its
+    /// decision recovers a `decided_idx` below that barrier. The barrier still
+    /// lives in the durable log; only the decided-index bump was lost. Seeding
+    /// the barrier-nonce counter from the recovered decided fold would learn
+    /// nothing about that barrier's seq, so a freshly minted post-restart nonce
+    /// could collide with it — and the recovered `(self, seq)` would falsely
+    /// satisfy the new read before its own barrier was folded. The seed must
+    /// instead come from the actual durable log contents, so the next nonce is
+    /// strictly greater than any `(self, seq)` the log can still surface.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn barrier_seq_seed_survives_a_lost_decided_suffix() {
+        use omnipaxos::ballot_leader_election::Ballot;
+        use omnipaxos::storage::Storage as _;
+        use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+        use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
+
+        const MY_NODE: u64 = 1;
+        const DURABLE_BARRIER_SEQ: u64 = 9;
+
+        // Stage the post-crash storage shape directly. A promise must be
+        // present or OmniPaxos's failure-recovery load treats the store as
+        // empty and ignores the staged log and decided index.
+        let mut storage = MemStorage::<HighWaterCommand>::new();
+        storage
+            .set_promise(Ballot::with(1, 1, 0, MY_NODE))
+            .expect("set promise");
+        storage
+            .append_entries(vec![
+                HighWaterCommand::Advance(AdvancePayload { at_least: 100 }),
+                HighWaterCommand::Barrier {
+                    node: MY_NODE,
+                    seq: DURABLE_BARRIER_SEQ,
+                },
+            ])
+            .expect("append durable log");
+        // decided_idx covers only the Advance at index 0; the barrier at index
+        // 1 is durably logged but its decided bump was the write that was lost.
+        storage
+            .set_decided_idx(1)
+            .expect("persist stale decided idx");
+
+        let cluster_config = ClusterConfig {
+            configuration_id: 1,
+            nodes: vec![1, 2, 3],
+            flexible_quorum: None,
+        };
+        let server_config = ServerConfig {
+            pid: MY_NODE,
+            ..Default::default()
+        };
+        let omnipaxos = OmniPaxosConfig {
+            cluster_config,
+            server_config,
+        }
+        .build(storage)
+        .expect("build omnipaxos over staged storage");
+        let handle = Arc::new(Mutex::new(omnipaxos));
+
+        // The decided view really does hide the barrier: the old decided-fold
+        // seed would have learned nothing about seq 9.
+        assert_eq!(
+            handle.lock().get_decided_idx(),
+            1,
+            "fixture must keep the barrier past the recovered decided_idx",
+        );
+
+        let host = StandaloneHost::new(
+            handle,
+            MY_NODE,
+            Vec::new(),
+            Duration::from_millis(2),
+            SnapshotPolicy::disabled(),
+            DEFAULT_BARRIER_TIMEOUT,
+        );
+
+        let seed = host.barrier_seq.load(Ordering::SeqCst);
+        assert!(
+            seed >= DURABLE_BARRIER_SEQ,
+            "seed {seed} must cover the durable barrier seq {DURABLE_BARRIER_SEQ}, \
+             so the next minted nonce ({}) cannot collide with a recovered barrier",
+            seed + 1,
         );
     }
 

--- a/crates/tsoracle-driver-paxos/src/state_machine.rs
+++ b/crates/tsoracle-driver-paxos/src/state_machine.rs
@@ -176,6 +176,65 @@ where
     decided_idx
 }
 
+/// Highest `Barrier { node, seq }` sequence `node` has ever appended that is
+/// still recoverable from the durable log — scanned across the snapshotted
+/// prefix and the *entire accepted suffix*, not just the decided prefix.
+///
+/// This is the recovery seed for the host's barrier-nonce counter, and it must
+/// not be derived from `decided_idx`. Log entries are fsynced on append
+/// (`batch_sync`), but `set_decided_idx` is not (`batch_async`), so a crash can
+/// recover a `decided_idx` below a barrier that is in fact durably logged. That
+/// barrier is invisible to a decided-only fold (`read_decided_suffix` /
+/// `applied_barrier_seq`) yet the apply task will still fold it once the
+/// cluster re-confirms the decision — at which point a nonce minted from the
+/// under-counted seed could be falsely satisfied by it before the read's own
+/// barrier is folded. Scanning the accepted suffix instead yields a ceiling
+/// that survives a lost `decided_idx`: every `(node, seq)` the log can still
+/// surface is `<=` the seed, so the next minted nonce is strictly greater.
+///
+/// Including not-yet-decided entries can only raise the seed, never lower it.
+/// A higher seed is always safe — the nonce is an opaque monotonic counter, so
+/// skipping values is harmless — whereas a lower one reopens the collision. An
+/// undecided entry that a later leader truncates simply leaves a gap in the
+/// nonce space, which costs nothing.
+pub fn max_logged_barrier_seq<S>(
+    omnipaxos: &Arc<Mutex<OmniPaxos<HighWaterCommand, S>>>,
+    node: u64,
+) -> u64
+where
+    S: Storage<HighWaterCommand> + Send + 'static,
+{
+    // `read_entries(..)` spans `0..accepted_idx`: a leading `Snapshotted` entry
+    // when a prefix has been compacted, then every accepted entry — `Decided`
+    // up to `decided_idx` and `Undecided` above it. All three carry the durable
+    // command, so the same `(node, seq)` fold covers each.
+    let entries = omnipaxos.lock().read_entries(..);
+    let mut max_seq = 0u64;
+    for entry in entries.into_iter().flatten() {
+        match entry {
+            LogEntry::Decided(HighWaterCommand::Barrier {
+                node: appended,
+                seq,
+            })
+            | LogEntry::Undecided(HighWaterCommand::Barrier {
+                node: appended,
+                seq,
+            }) => {
+                if appended == node {
+                    max_seq = max_seq.max(seq);
+                }
+            }
+            LogEntry::Snapshotted(snapshotted) => {
+                if let Some(seq) = snapshotted.snapshot.applied_barriers.get(&node) {
+                    max_seq = max_seq.max(*seq);
+                }
+            }
+            _ => {}
+        }
+    }
+    max_seq
+}
+
 /// Maybe trigger a snapshot via the given policy. Called by the host's
 /// apply task after each successful drain.
 pub fn maybe_snapshot<S>(
@@ -582,6 +641,96 @@ mod drain_tests {
             3,
             "the second drain must NOT re-apply already-cursored entries",
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn max_logged_barrier_seq_is_zero_on_an_empty_log() {
+        let mut cluster = build_cluster(3);
+        drive_to_leader_election(&mut cluster).await;
+        // Nothing appended: the accepted suffix is empty, so there is no seq to
+        // recover and the seed starts the nonce counter at 0.
+        assert_eq!(max_logged_barrier_seq(&leader_handle(&cluster), 1), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn max_logged_barrier_seq_is_scoped_to_the_queried_node() {
+        let mut cluster = build_cluster(3);
+        drive_to_leader_election(&mut cluster).await;
+        {
+            let leader = leader_handle(&cluster);
+            let mut handle = leader.lock();
+            handle
+                .append(HighWaterCommand::Barrier { node: 1, seq: 5 })
+                .expect("append");
+            handle
+                .append(HighWaterCommand::Barrier { node: 2, seq: 9 })
+                .expect("append");
+        }
+        drive_until(
+            &mut cluster,
+            |state| {
+                state
+                    .nodes
+                    .iter()
+                    .all(|node| node.omnipaxos.lock().get_decided_idx() >= 2)
+            },
+            500,
+        )
+        .await;
+
+        let handle = leader_handle(&cluster);
+        // The ceiling is per-appending-node: node 2's higher seq must not lift
+        // node 1's seed, or two nodes' independent counters would trample.
+        assert_eq!(max_logged_barrier_seq(&handle, 1), 5);
+        assert_eq!(max_logged_barrier_seq(&handle, 2), 9);
+        assert_eq!(max_logged_barrier_seq(&handle, 3), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn max_logged_barrier_seq_recovers_a_compacted_barrier_from_the_snapshot() {
+        let mut cluster = build_cluster(3);
+        drive_to_leader_election(&mut cluster).await;
+        {
+            let leader = leader_handle(&cluster);
+            let mut handle = leader.lock();
+            handle
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 10 }))
+                .expect("append");
+            handle
+                .append(HighWaterCommand::Barrier { node: 1, seq: 4 })
+                .expect("append");
+            handle
+                .append(HighWaterCommand::Advance(AdvancePayload { at_least: 20 }))
+                .expect("append");
+        }
+        drive_until(
+            &mut cluster,
+            |state| {
+                state
+                    .nodes
+                    .iter()
+                    .all(|node| node.omnipaxos.lock().get_decided_idx() >= 3)
+            },
+            500,
+        )
+        .await;
+
+        // Compact past the barrier so its only durable trace is the snapshot's
+        // per-node ledger, not a live log entry.
+        let handle = leader_handle(&cluster);
+        handle
+            .lock()
+            .snapshot(Some(2), false)
+            .expect("snapshot up to the decided index");
+        assert!(
+            handle.lock().get_compacted_idx() >= 2,
+            "the barrier at index 1 must be compacted away",
+        );
+
+        // The scan must still recover it through the `Snapshotted` ledger;
+        // otherwise an idle node whose barriers were all compacted would
+        // re-seed its nonce from 0 and reopen the false-satisfy.
+        assert_eq!(max_logged_barrier_seq(&handle, 1), 4);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/tsoracle-driver-paxos/tests/recovery_failpoints.rs
+++ b/crates/tsoracle-driver-paxos/tests/recovery_failpoints.rs
@@ -1,0 +1,141 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Recovery behaviour under a lost non-synced storage write.
+//!
+//! `set_decided_idx` is a `batch_async` (non-synced) write, while log appends
+//! are `batch_sync` (fsynced). A crash can therefore recover a `decided_idx`
+//! below a `Barrier` that is still durably in the log. The barrier-nonce
+//! recovery seed must survive that: it is scanned from the durable log
+//! contents, not from the recovered `decided_idx`.
+
+#![cfg(all(feature = "failpoints", feature = "rocksdb-storage"))]
+
+use std::sync::Arc;
+
+use omnipaxos::ballot_leader_election::Ballot;
+use omnipaxos::storage::Storage as _;
+use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
+use parking_lot::Mutex;
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use tempfile::TempDir;
+use tsoracle_driver_paxos::{
+    AdvancePayload, ApplyState, HighWaterCommand, drain_decided_into, max_logged_barrier_seq,
+};
+use tsoracle_paxos_toolkit::storage::RocksdbStorage;
+
+const CF: &str = "tso_paxos_recovery";
+
+/// Failpoints live in the process-global `fail` registry, so serialize the
+/// tests in this binary; `parking_lot::Mutex` is non-poisoning so a failing
+/// test can't cascade into its siblings.
+static FAILPOINT_TEST_SERIAL: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+fn open_db(dir: &TempDir) -> Arc<DB> {
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let cf = ColumnFamilyDescriptor::new(CF, Options::default());
+    Arc::new(DB::open_cf_descriptors(&opts, dir.path(), vec![cf]).expect("open db"))
+}
+
+/// A barrier fsynced into the log, then a lost `set_decided_idx` bump, must
+/// still be recoverable as the barrier-nonce seed — proving the seed is derived
+/// from the durable log and not from the non-synced `decided_idx`.
+///
+/// The assertions contrast the two candidate seed sources against the same
+/// recovered store: the decided-only fold (the previous seed) under-counts to
+/// 0, while the accepted-suffix scan recovers the barrier's true sequence.
+#[test]
+fn lost_decided_idx_write_leaves_barrier_recoverable_from_durable_log() {
+    let _serial = FAILPOINT_TEST_SERIAL.lock();
+    const MY_NODE: u64 = 1;
+    const DURABLE_BARRIER_SEQ: u64 = 9;
+
+    let dir = TempDir::new().unwrap();
+
+    // Prior lifetime: durably log an Advance and this node's Barrier, record
+    // the Advance as decided, then lose the decided-index bump that would have
+    // recorded the Barrier's decision — exactly a truncated non-synced tail.
+    {
+        let mut storage: RocksdbStorage<HighWaterCommand> =
+            RocksdbStorage::open_in(open_db(&dir), CF).expect("open_in");
+        storage
+            .set_promise(Ballot::with(1, 1, 0, MY_NODE))
+            .expect("set promise");
+        storage
+            .append_entries(vec![
+                HighWaterCommand::Advance(AdvancePayload { at_least: 100 }),
+                HighWaterCommand::Barrier {
+                    node: MY_NODE,
+                    seq: DURABLE_BARRIER_SEQ,
+                },
+            ])
+            .expect("append durable log");
+        // The Advance's decision persists (index 0 decided).
+        storage.set_decided_idx(1).expect("persist decided idx 1");
+        // The Barrier's decision bump is the write the crash drops.
+        tsoracle_failpoint::fail::cfg("paxos_toolkit::storage::async_write", "return").unwrap();
+        let lost = storage.set_decided_idx(2);
+        tsoracle_failpoint::fail::remove("paxos_toolkit::storage::async_write");
+        assert!(
+            lost.is_err(),
+            "the failpoint must drop the decided-index bump"
+        );
+    }
+
+    // Restart: reopen the durable store and rebuild OmniPaxos over it.
+    let storage: RocksdbStorage<HighWaterCommand> =
+        RocksdbStorage::open_in(open_db(&dir), CF).expect("reopen");
+    let cluster_config = ClusterConfig {
+        configuration_id: 1,
+        nodes: vec![1, 2, 3],
+        flexible_quorum: None,
+    };
+    let server_config = ServerConfig {
+        pid: MY_NODE,
+        ..Default::default()
+    };
+    let omnipaxos = OmniPaxosConfig {
+        cluster_config,
+        server_config,
+    }
+    .build(storage)
+    .expect("build over recovered storage");
+    let handle = Arc::new(Mutex::new(omnipaxos));
+
+    // The lost write left `decided_idx` stale-low: the barrier sits past it.
+    assert_eq!(
+        handle.lock().get_decided_idx(),
+        1,
+        "the dropped bump must leave decided_idx recovered below the barrier",
+    );
+
+    // The decided-only fold — the previous seed source — cannot see the
+    // barrier, so it would have under-counted the nonce ceiling to 0.
+    let state = ApplyState::new();
+    let mut cursor = 0u64;
+    drain_decided_into(&handle, &mut cursor, &state);
+    assert_eq!(
+        state.applied_barrier_seq(MY_NODE),
+        0,
+        "the decided fold misses the barrier stranded in the lost suffix",
+    );
+
+    // The durable-log scan — the seed the host now uses — recovers it, so a
+    // freshly minted post-restart nonce will exceed it.
+    assert_eq!(
+        max_logged_barrier_seq(&handle, MY_NODE),
+        DURABLE_BARRIER_SEQ,
+        "the accepted-suffix scan recovers the barrier despite the lost decided_idx",
+    );
+}

--- a/crates/tsoracle-driver-paxos/tests/restart_barrier_seq.rs
+++ b/crates/tsoracle-driver-paxos/tests/restart_barrier_seq.rs
@@ -74,9 +74,10 @@ async fn recovered_barrier_ledger_does_not_satisfy_a_fresh_read_after_restart() 
     assert!(reader_decided_before >= 8);
 
     // Phase B: stop the follower and rebuild it from disk. Its `barrier_seq`
-    // resets to 0 in construction, but `new()` folds the recovered suffix and
-    // resumes the counter to the durable ledger's `reader -> 7`; the recovered
-    // high-water is 100. Stepping the cluster lets the rebuilt node fold.
+    // resets to 0 in construction, but `new()` resumes the counter to `reader
+    // -> 7` by scanning the durable log for this node's highest barrier seq,
+    // while the recovery fold restores the high-water to 100. Stepping the
+    // cluster lets the rebuilt node fold.
     cluster.stop_node(reader_id).await;
     cluster.rebuild_rocksdb_node(reader_id);
     assert_eq!(


### PR DESCRIPTION
## Problem

`StandaloneHost::new` resumed `barrier_seq` from the recovered **decided fold** — `applied_barrier_seq(self)` over `[0, decided_idx)`. The two facts `load_cache` rebuilds on restart carry different durability guarantees: `real_log_len` comes from fsynced (`batch_sync`) appends, while `decided_idx` comes from a **non-synced** `batch_async` write (`set_decided_idx`). A crash that loses that write recovers a `decided_idx` *below* a `Barrier { node: self, seq }` that is still durably in the log.

That barrier is invisible to the decided fold, yet the apply task folds it once the cluster re-confirms the decision. So a freshly minted post-restart nonce could be falsely satisfied by the recovered `(self, seq)` *before the read's own barrier is folded* — the exact linearizability hazard the per-node nonce exists to close, reopened across a restart. The old recovery comment claimed to prevent this while relying on `decided_idx` durability it explicitly disclaimed.

## Fix

Derive the seed from the durable log, not the meta counter. New `max_logged_barrier_seq(omnipaxos, node)` scans the **entire accepted suffix** via `read_entries(..)` (`0..accepted_idx`, where `accepted_idx = compacted_idx + real_log_len` is rebuilt from the fsynced `get_log_len`), folding:

- `Decided` / `Undecided` `Barrier { node: self }` entries, and
- the leading `Snapshotted` entry's `applied_barriers` ledger (so an idle node whose barriers were all compacted away still re-seeds correctly).

`new` seeds `barrier_seq` from this. The recovery fold still runs for the in-memory high-water, the applied-barrier ledger, and the apply cursor.

Including not-yet-decided entries can only **raise** the seed, which is always safe: the nonce is an opaque monotonic counter, so skipped values are free, whereas a lower seed reopens the collision. A later-truncated undecided barrier simply leaves a harmless gap.

## Tests

- `barrier_seq_seed_survives_a_lost_decided_suffix` — in-crate wiring test; stages the lost-decided-suffix shape (durable `[Advance@0, Barrier@1]` with `decided_idx = 1`) and asserts the seed lifts the next nonce above the durable barrier. Verified red→green.
- Helper-branch tests: empty-log → 0, per-node scoping, and the compacted-snapshot path.
- `tests/recovery_failpoints.rs` — new failpoints binary that drops the real `set_decided_idx` write through the `paxos_toolkit::storage::async_write` failpoint, then asserts the decided fold misses the stranded barrier (`applied_barrier_seq == 0`) while the durable scan recovers it.

Adds a `failpoints` feature to `tsoracle-driver-paxos` (forwarding to `tsoracle-paxos-toolkit/failpoints` + `tsoracle-failpoint/failpoints`).

## Verification

- `cargo test -p tsoracle-driver-paxos --all-targets --features failpoints` → exit 0 (lib 55 + all integration binaries, 0 failures)
- `cargo clippy -p tsoracle-driver-paxos --all-targets --all-features -- -D warnings` → clean
- `cargo build --workspace --all-targets` → exit 0