### PR TITLE
refactor(core): extract validate_count to dedup the allocator count guard

### DIFF
--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -251,6 +251,24 @@ impl Allocator {
         }
     }
 
+    /// Shared count guard for `try_grant` and `would_grant`, kept here so the
+    /// two entry points cannot drift. The server's extension single-flight
+    /// relies on `would_grant(now_ms, count) == true` implying the retry
+    /// `try_grant(now_ms, count)` succeeds (see `service::extend_window`), so
+    /// the set of rejected counts must be identical on both paths — splitting
+    /// this check across both methods would let a future edit to one degrade
+    /// the recheck into a spurious consensus round-trip (or worse).
+    ///
+    /// `count == 0` reuses the oversized case's `InvalidCount(count)`; since
+    /// `count` is `0` there, the surfaced value matches the prior explicit
+    /// `InvalidCount(0)`.
+    fn validate_count(count: u32) -> Result<(), CoreError> {
+        if count == 0 || count > LOGICAL_MAX + 1 {
+            return Err(CoreError::InvalidCount(count));
+        }
+        Ok(())
+    }
+
     /// Single source of truth for the window-advance simulation and its bounds
     /// checks, shared by `try_grant` and `would_grant`. Pure: it takes the
     /// relevant state fields by value and mutates nothing, so a failed
@@ -305,12 +323,7 @@ impl Allocator {
     /// State is written back only on success: a failed grant (out-of-range or
     /// exhausted window) leaves `next_physical_ms`/`next_logical` untouched.
     pub fn try_grant(&mut self, now_ms: u64, count: u32) -> Result<WindowGrant, CoreError> {
-        if count == 0 {
-            return Err(CoreError::InvalidCount(0));
-        }
-        if count > LOGICAL_MAX + 1 {
-            return Err(CoreError::InvalidCount(count));
-        }
+        Self::validate_count(count)?;
         let State::Leader {
             epoch,
             committed_high_water,
@@ -348,7 +361,7 @@ impl Allocator {
     /// coarser predicate would risk false positives (skip the extension, then
     /// fail the outer retry) for requests whose `count` straddles the window edge.
     pub fn would_grant(&self, now_ms: u64, count: u32) -> bool {
-        if count == 0 || count > LOGICAL_MAX + 1 {
+        if Self::validate_count(count).is_err() {
             return false;
         }
         let State::Leader {


### PR DESCRIPTION
## What

Extract the allocator's count bounds check (`count == 0 || count > LOGICAL_MAX + 1`) into a single private `validate_count` helper, and route both `try_grant` and `would_grant` through it. The helper sits next to the existing `project_grant` helper that already centralizes the window-advance simulation shared by the two methods.

## Why

`would_grant` and `try_grant` each carried their own copy of the count guard. The server's extension single-flight (`service::extend_window`, `service.rs:219`) skips a consensus round-trip whenever `would_grant(now_ms, count)` returns true, trusting that the retry `try_grant(now_ms, count)` will then succeed. The count check was the one rejection rule duplicated verbatim across the two paths, so a future edit to one guard and not the other could drift their rejected-count sets apart — degrading the recheck into a spurious `INTERNAL` (or a skipped-then-failing extension) under load. Folding both into one function makes the rejected-count set identical by construction.

Low blast radius, but a real correctness-coupling: the codebase already extracted the harder exhaustion check (`project_grant`) for exactly this reason; this finishes the pattern for the count guard.

## Behavior

Unchanged. `try_grant`'s two former branches — `InvalidCount(0)` for zero and `InvalidCount(count)` for oversized — collapse into one `InvalidCount(count)`, which is byte-for-byte identical when `count` is `0`. `would_grant` still returns `false`, now via `.is_err()`.

## Verification

- `cargo test -p tsoracle-core` — all 33 allocator unit tests pass, including `try_grant_zero_count`, `try_grant_oversized_count`, and the coupling test `would_grant_matches_try_grant_outcome`, plus the `monotonicity` integration test.
- `cargo clippy -p tsoracle-core -p tsoracle-server --all-targets` — clean.