### PR TITLE
refactor(client): rename leader_resolved module to channel_pool

### DIFF
--- a/crates/tsoracle-client/src/channel_pool.rs
+++ b/crates/tsoracle-client/src/channel_pool.rs
@@ -29,7 +29,7 @@ use crate::transport::apply_endpoint_config;
 // `decode_leader_hint` helper now live in `tsoracle-proto` as the single
 // source of truth for the wire contract (the server inserts the trailer; this
 // client decodes it). Re-exported here so the retry loop's existing
-// `crate::leader_resolved::{LeaderHintLookup, decode_leader_hint}` import path
+// `crate::channel_pool::{LeaderHintLookup, decode_leader_hint}` import path
 // is unchanged.
 pub use tsoracle_proto::v1::{LeaderHintLookup, decode_leader_hint};
 

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -16,10 +16,10 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 mod budget;
+mod channel_pool;
 mod driver;
 mod driver_supervisor;
 mod error;
-mod leader_resolved;
 mod response;
 mod retry;
 mod retry_policy;
@@ -40,7 +40,7 @@ use tsoracle_core::{LOGICAL_MAX, Timestamp};
 /// slot and round-trip to learn the same thing from the server.
 pub(crate) const MAX_TIMESTAMPS_PER_RPC: u32 = LOGICAL_MAX + 1;
 
-use crate::leader_resolved::ChannelPool;
+use crate::channel_pool::ChannelPool;
 
 pub struct ClientBuilder {
     endpoints: Vec<String>,

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -78,8 +78,8 @@ use std::time::Duration;
 use tsoracle_core::Epoch;
 
 use crate::budget::{Budget, PairBudget};
+use crate::channel_pool::{ChannelPool, LeaderHintLookup, decode_leader_hint};
 use crate::error::ClientError;
-use crate::leader_resolved::{ChannelPool, LeaderHintLookup, decode_leader_hint};
 use crate::response::{TimestampRange, decode_get_ts_response};
 use crate::retry_policy::{is_transport_failure, jittered_backoff, should_backoff};
 use crate::worklist::Worklist;

--- a/crates/tsoracle-client/src/worklist.rs
+++ b/crates/tsoracle-client/src/worklist.rs
@@ -16,7 +16,7 @@
 //! push-front-on-hint steering so `crate::retry::issue_rpc` reads as a
 //! sequence of policy decisions rather than queue bookkeeping. The queue
 //! starts with the cached leader (if fresh) followed by the configured
-//! endpoints — see [`ChannelPool::iter_round_robin`](crate::leader_resolved::ChannelPool::iter_round_robin).
+//! endpoints — see [`ChannelPool::iter_round_robin`](crate::channel_pool::ChannelPool::iter_round_robin).
 //!
 //! A NOT_LEADER response carrying a usable [`LeaderHint`](tsoracle_proto::v1::LeaderHint)
 //! redirects the loop via [`Worklist::redirect_to`], which pushes the


### PR DESCRIPTION
## Summary

`leader_resolved.rs` no longer described what it owned. The module is the home of `ChannelPool` — the tonic `Channel` cache, LRU eviction of attacker-influenceable hint endpoints (issue #341), and round-robin iteration — alongside the leader cache. Renamed it to `channel_pool.rs` after the primary type it exports (addresses cleanup item L4).

## Changes

- `git mv leader_resolved.rs channel_pool.rs` (Git records a pure rename; `blame` / `log --follow` are preserved).
- `lib.rs` — `mod` declaration (kept the alphabetized `mod` list correct) and the `ChannelPool` import.
- `retry.rs` — the `{ChannelPool, LeaderHintLookup, decode_leader_hint}` import; rustfmt reordered it ahead of `crate::error` to keep the group sorted.
- `worklist.rs` — the `crate::channel_pool::ChannelPool::iter_round_robin` intra-doc link.
- `channel_pool.rs` — one in-file comment that cited the old import path.

The module body is otherwise unchanged.

## Why it's safe

Private module (`mod`, not `pub mod`), so there is **no public-API or semver impact** — nothing re-exports the module path.

## Verification

- `cargo build -p tsoracle-client` — clean
- `cargo test -p tsoracle-client` — 124 passed, 0 failed (incl. doc-test)
- `cargo doc --no-deps` with `-D rustdoc::broken_intra_doc_links` — clean (confirms the renamed doc link resolves)
- Pre-commit `cargo fmt --check` + `cargo clippy` across the workspace — clean