### PR TITLE
perf(server): add non-cloning is_serving() for the hot-path gate

### DIFF
--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -123,16 +123,13 @@ impl TsoService for TsoServiceImpl {
         #[cfg(feature = "metrics")]
         metrics::counter!("tsoracle.get_ts.requests.total").increment(1);
 
-        // Fast NOT_LEADER gate.
-        if let ServingState::NotServing {
-            leader_endpoint,
-            leader_epoch,
-        } = self.server.core.serving_state()
-        {
-            return Err(not_leader_status(LeaderHint {
-                leader_endpoint,
-                leader_epoch: wire_epoch(leader_epoch),
-            }));
+        // Fast NOT_LEADER gate. `is_serving` answers the gate without cloning a
+        // `ServingState`; only the rejected path re-reads (via `leader_hint_from`)
+        // to build the redirect hint. The two reads are not atomic, but the hint
+        // is best-effort either way — this mirrors the NotLeader arm below, which
+        // also re-reads after `try_grant`.
+        if !self.server.core.is_serving() {
+            return Err(not_leader_status(leader_hint_from(&self.server)));
         }
 
         // At most two attempts: the first may return WindowExhausted, in which

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -82,6 +82,16 @@ impl ServingCore {
         self.state_tx.borrow().clone()
     }
 
+    /// Non-cloning serving check for the hot-path NOT_LEADER gate. Borrows the
+    /// watch value and inspects the variant in place, where `serving_state`
+    /// would clone (and the caller then discard) a whole `ServingState`. The
+    /// gate only needs the yes/no answer; the rejected path re-reads through
+    /// `serving_state` to build the redirect hint, where cloning the
+    /// leader-endpoint `String` into the response is unavoidable regardless.
+    pub(crate) fn is_serving(&self) -> bool {
+        matches!(&*self.state_tx.borrow(), ServingState::Serving)
+    }
+
     pub(crate) fn publish_serving(&self) {
         self.state_tx.send_replace(ServingState::Serving);
     }
@@ -297,6 +307,30 @@ mod tests {
             Err(CoreError::NotLeader)
         ));
         assert!(!slot.would_grant(1, 1));
+    }
+
+    #[test]
+    fn is_serving_tracks_state_in_lockstep_with_serving_state() {
+        // The hot-path gate reads `is_serving` in place of cloning a
+        // `ServingState`; it must agree with `serving_state`'s variant across
+        // every transition. Fresh core is NotServing -> false; publish_serving
+        // -> true; step_down -> false again.
+        let core = ServingCore::new();
+        assert!(!core.is_serving(), "fresh core is NotServing");
+        assert!(matches!(
+            core.serving_state(),
+            ServingState::NotServing { .. }
+        ));
+
+        core.publish_serving();
+        assert!(
+            core.is_serving(),
+            "publish_serving must flip is_serving true"
+        );
+        assert!(matches!(core.serving_state(), ServingState::Serving));
+
+        core.step_down(Some("http://leader:9000".into()), Some(Epoch(1)));
+        assert!(!core.is_serving(), "step_down must flip is_serving false");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The fast `NOT_LEADER` gate in `get_ts` (`service.rs`) called `ServingCore::serving_state()`, which clones a whole `ServingState` out of the watch channel only to `match` on it and discard it. This adds a borrow-and-match `ServingCore::is_serving()` and uses it for the gate, so the serving path no longer materializes a value it throws away.

The rejected path keeps reading through `serving_state()` (via the existing `leader_hint_from` helper) because `LeaderHint` needs an owned leader-endpoint `String` for the response — that clone is unavoidable there. The two reads on the rejection path are not atomic, but the redirect hint is best-effort either way, and this mirrors the `NotLeader` arm below the gate that already re-reads after `try_grant`.

## Accuracy note on the original finding

The finding framed this as "clones an `Option<String>` on every gated request." That isn't what happens on the serving hot path:

- A healthy leader is `ServingState::Serving` — a fieldless variant. Derived `Clone` only clones the active variant's fields, so the per-request clone allocated no `String`; it was a discriminant copy.
- The `Option<String>` lives only in `NotServing` (the rejection path), where the `String` clone is required to build the response hint and is therefore unavoidable.

So the real benefit is (1) not materializing-then-discarding a `ServingState` on the serving path, and (2) clarity — the gate now reads as a boolean decision. It is not a per-request allocation win.

## Testing

- `cargo build -p tsoracle-server` — clean
- `cargo clippy -p tsoracle-server --all-features` — clean
- `cargo test --workspace` — passing, 0 failures
- New unit test `is_serving_tracks_state_in_lockstep_with_serving_state` asserts `is_serving()` agrees with `serving_state()`'s variant across `new → publish_serving → step_down`