### PR TITLE
feat(client): count waiters abandoned before delivery

### DIFF
--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -216,7 +216,8 @@ fn chunk_queue(queue: &mut VecDeque<Waiter>) -> Vec<(u32, VecDeque<Waiter>)> {
 
     while let Some(w) = queue.pop_front() {
         if w.count == 0 || w.count > MAX_TIMESTAMPS_PER_RPC {
-            let _ = w.respond.send(Err(ClientError::InvalidCount(w.count)));
+            let count = w.count;
+            reply_to_waiter(w, Err(ClientError::InvalidCount(count)));
             continue;
         }
         let fits = current_total
@@ -295,6 +296,33 @@ fn set_in_flight_gauge(state: u8) {
     let _ = state;
 }
 
+/// Hand one waiter its outcome over its `oneshot` channel.
+///
+/// `oneshot::Sender::send` fails only when the paired receiver has been
+/// dropped, which here means exactly one thing: the caller dropped its
+/// `Driver::request` future — a client-side timeout or cancellation — before
+/// the result arrived. There is nothing left to deliver, so dropping the
+/// outcome is correct; but the drop is counted via [`record_abandoned_waiter`]
+/// so a cancellation storm is observable instead of silently swallowed.
+/// Routing every delivery through this one helper also makes it structurally
+/// impossible to add a new send site that forgets the metric.
+#[inline]
+fn reply_to_waiter(waiter: Waiter, outcome: Result<Vec<Timestamp>, ClientError>) {
+    if waiter.respond.send(outcome).is_err() {
+        record_abandoned_waiter();
+    }
+}
+
+/// Count one waiter whose result could not be delivered because the caller
+/// already dropped its `Driver::request` future. Compiled away to a no-op
+/// without the `metrics` feature, matching the gauges above, so the hot path
+/// carries no recorder cost when no metrics feature is installed.
+#[inline]
+fn record_abandoned_waiter() {
+    #[cfg(feature = "metrics")]
+    metrics::counter!("tsoracle.client.driver.abandoned_waiters.total").increment(1);
+}
+
 /// Deliver one chunk's RPC outcome to its waiters.
 ///
 /// `expected` is the count the driver passed to the RPC. If the server
@@ -316,9 +344,10 @@ fn deliver(
                     range.count(),
                 );
                 while let Some(w) = waiters.pop_front() {
-                    let _ = w
-                        .respond
-                        .send(Err(ClientError::Rpc(tonic::Status::internal(msg.clone()))));
+                    reply_to_waiter(
+                        w,
+                        Err(ClientError::Rpc(tonic::Status::internal(msg.clone()))),
+                    );
                 }
                 return;
             }
@@ -331,12 +360,12 @@ fn deliver(
                     "chunk_queue established total == sum(count); a short slice means \
                      either chunk_queue or the response-length check above is wrong"
                 );
-                let _ = w.respond.send(Ok(slice));
+                reply_to_waiter(w, Ok(slice));
             }
         }
         Err(e) => {
             while let Some(w) = waiters.pop_front() {
-                let _ = w.respond.send(Err(clone_client_error(&e)));
+                reply_to_waiter(w, Err(clone_client_error(&e)));
             }
         }
     }
@@ -1008,6 +1037,79 @@ mod tests {
                     assert_eq!(total_rpc, total_requested, "rpc-side total {total_rpc} != requested {total_requested}");
                 });
             }
+        }
+    }
+
+    /// A failed `respond.send` — the caller dropped its `Driver::request`
+    /// future before the result arrived — must bump
+    /// `tsoracle.client.driver.abandoned_waiters.total`, so a cancellation
+    /// storm is observable rather than silently swallowed. A live receiver
+    /// must leave the counter untouched.
+    ///
+    /// The helper is driven directly on the test thread (not through a spawned
+    /// `driver_task`) because `metrics::with_local_recorder` installs a
+    /// *thread-local* recorder; an emission from another worker thread would
+    /// not be captured.
+    #[cfg(feature = "metrics")]
+    mod abandoned_waiter_metric {
+        use super::*;
+        use metrics_util::{
+            MetricKind,
+            debugging::{DebugValue, DebuggingRecorder},
+        };
+
+        type RecordedMetric = (
+            metrics_util::CompositeKey,
+            Option<metrics::Unit>,
+            Option<metrics::SharedString>,
+            DebugValue,
+        );
+
+        const METRIC: &str = "tsoracle.client.driver.abandoned_waiters.total";
+
+        fn counter(snapshot: &[RecordedMetric], name: &str) -> u64 {
+            for (composite, _unit, _desc, value) in snapshot {
+                if composite.kind() == MetricKind::Counter && composite.key().name() == name {
+                    if let DebugValue::Counter(n) = value {
+                        return *n;
+                    }
+                }
+            }
+            0
+        }
+
+        #[test]
+        fn dropped_receiver_increments_counter() {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                let (respond, rx) = oneshot::channel();
+                // The caller gave up: its receiver is gone before delivery.
+                drop(rx);
+                reply_to_waiter(Waiter { count: 1, respond }, Ok(Vec::new()));
+            });
+            assert_eq!(
+                counter(&snapshotter.snapshot().into_vec(), METRIC),
+                1,
+                "a send to a dropped receiver must count exactly one abandoned waiter",
+            );
+        }
+
+        #[test]
+        fn live_receiver_does_not_increment_counter() {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                // The receiver stays alive for the whole delivery, so the send
+                // succeeds and nothing is abandoned.
+                let (respond, _rx) = oneshot::channel();
+                reply_to_waiter(Waiter { count: 1, respond }, Ok(Vec::new()));
+            });
+            assert_eq!(
+                counter(&snapshotter.snapshot().into_vec(), METRIC),
+                0,
+                "a delivery to a live receiver must not count an abandoned waiter",
+            );
         }
     }
 }

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -17,6 +17,13 @@
 //! least once. Scenarios are sequenced inside one test binary because the
 //! `metrics` recorder slot is process-global; running each scenario as its
 //! own `#[tokio::test]` would race on `install()`.
+//!
+//! One documented client signal is deliberately not exercised here:
+//! `tsoracle.client.driver.abandoned_waiters.total` fires only when a caller
+//! drops its `get_ts()` future *after* the driver has dispatched but *before*
+//! delivery — a race that is timing-dependent to force end to end. It has
+//! deterministic unit coverage in `tsoracle_client::driver` instead, where the
+//! delivery helper is driven directly against a dropped receiver.
 
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -50,6 +50,7 @@ Default is 1 second. On leadership gain, the new leader first computes `serving_
 - `tsoracle.client.connect.failures.total` — connect attempts that returned an error (counter)
 - `tsoracle.client.driver.queue_depth` — waiter-queue size inside the coalescing driver task (gauge). Updated after every enqueue and after each dispatch drain.
 - `tsoracle.client.driver.in_flight` — 0 or 1 indicating whether the driver currently has an outgoing batch in flight (gauge)
+- `tsoracle.client.driver.abandoned_waiters.total` — waiters whose result could not be delivered because the caller dropped its `get_ts()` future (a client-side timeout or cancellation) before the driver finished delivering (counter). An occasional bump is benign; a sustained or spiking rate is a cancellation storm — callers are giving up before the oracle answers, usually because client deadlines are tighter than current end-to-end latency (correlate with `tsoracle.client.connect.duration` and the server's `get_ts` latency) or because a leader election is making requests time out (correlate with `tsoracle.client.not_leader.total` / `tsoracle.client.leader_pivots.total`).
 
 Both libraries are exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the `Server` or `Client`. The example below wires Prometheus over an HTTP listener for a process that hosts either side:
 


### PR DESCRIPTION
## What

The coalescing driver delivered every waiter's result with `let _ = respond.send(...)` at four sites in `tsoracle-client/src/driver.rs`. A `oneshot::Sender::send` fails **only** when the paired receiver has been dropped — which here means exactly one thing: the caller dropped its `Driver::request` future (a client-side timeout or cancellation) before the result arrived. Swallowing the outcome is correct, but it was completely **unmeasured**, so a cancellation storm left no signal at all (finding L5).

## Change

- Route all four delivery sites — success, protocol-violation fanout, error fanout, and the synchronous `InvalidCount` rejection — through a single `reply_to_waiter` helper that increments a new counter whenever the send fails. Centralizing delivery also makes it structurally impossible to add a new send site that forgets the metric.
- New counter **`tsoracle.client.driver.abandoned_waiters.total`**. A single unlabeled counter, matching the sibling driver signals (`queue_depth`, `in_flight`) and `connect.failures.total`. The helper mirrors the existing gauge helpers: feature-gated behind `metrics`, a no-op otherwise, and cheap on the hot path because the counter is only touched on the cold cancellation branch.
- Documented in `docs/operations.md` with operator guidance: correlate spikes with `connect.duration` / server `get_ts` latency (deadlines too tight) vs. `not_leader.total` / `leader_pivots.total` (leader election storm).

## Tests

- Two deterministic unit tests in `driver::tests` drive the synchronous `reply_to_waiter` helper directly against a dropped vs. live receiver, asserting the counter increments exactly once / not at all. The helper is exercised on the test thread rather than through a spawned `driver_task` because `metrics::with_local_recorder` installs a *thread-local* recorder that cannot observe an emission from another worker thread.
- The end-to-end metrics catalog test (`client_metrics.rs`) documents why this one signal is covered by unit tests rather than the catalog: forcing a caller to abandon a waiter *after* dispatch but *before* delivery end-to-end is timing-dependent and would be flaky.

## Verification

- `cargo test -p tsoracle-client --features metrics` → 126 passed (incl. the two new tests)
- `cargo test -p tsoracle-tests --features metrics --test client_metrics` → passed
- Default-feature build + `cargo clippy --features metrics --all-targets` clean
- Pre-commit `cargo fmt --check` + workspace `cargo clippy` clean