### PR TITLE
fix(server): enforce LeaderState::Follower driver contracts with a debug guard

### DIFF
--- a/crates/tsoracle-consensus/src/driver.rs
+++ b/crates/tsoracle-consensus/src/driver.rs
@@ -62,6 +62,15 @@ pub trait ConsensusDriver: Send + Sync + 'static {
     /// `tokio::sync::watch` + `tokio_stream::wrappers::WatchStream` satisfy this
     /// because the watch is seeded with an initial value the stream yields
     /// immediately.
+    ///
+    /// **Contract — `Follower` payload shape:** the `leader_endpoint` and
+    /// `leader_epoch` a driver places on [`LeaderState::Follower`] are
+    /// load-bearing for client redirects and carry their own rules — a
+    /// scheme-less `host:port` endpoint and a per-node non-decreasing epoch.
+    /// Violations are silent in production (dropped redirects); see the
+    /// `LeaderState::Follower` field docs for the full contract. The server's
+    /// leader-watch task `debug_assert!`s both in debug builds, so a
+    /// contract-violating driver trips loudly in its own tests.
     fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>>;
 
     /// Read the durably-persisted high-water.

--- a/crates/tsoracle-consensus/src/leadership.rs
+++ b/crates/tsoracle-consensus/src/leadership.rs
@@ -31,6 +31,24 @@ pub enum LeaderState {
     /// the leader's epoch (raft term) as observed by this follower, used by
     /// clients to reject a stale follower's lower-epoch redirect; `None` when
     /// the driver does not surface it.
+    ///
+    /// **Contract — endpoint shape:** `leader_endpoint`, when `Some`, MUST be a
+    /// scheme-less `host:port` (e.g. `leader:9000`, `10.0.0.7:50551`), never a
+    /// `http://...` or `https://...` URL. The follower-redirect path surfaces
+    /// this string to clients as a leader hint, and a TLS-configured client
+    /// *silently drops* any `http://` hint (`rejects_plaintext_hint`) to refuse
+    /// a transport downgrade — so a scheme-bearing endpoint makes this leader
+    /// unreachable via redirect, with only a log line as evidence. The shipped
+    /// drivers satisfy this by reading the operator-configured membership
+    /// service endpoint, which is itself contracted scheme-less.
+    ///
+    /// **Contract — epoch monotonicity:** `leader_epoch`, across successive
+    /// emissions from one node, MUST be non-decreasing. Clients gate redirects
+    /// on it (`compare_and_set_leader`): a hint whose epoch cannot outrank the
+    /// cached leader is dropped, so a regressing epoch makes clients drop valid
+    /// redirects (or, the other way, admit a stale one). Raft/Paxos terms are
+    /// monotonic per node, so the shipped drivers satisfy this by construction;
+    /// `None` (an epoch-less hint) is always permitted and gates nothing.
     Follower {
         leader_endpoint: Option<String>,
         leader_epoch: Option<Epoch>,
@@ -53,7 +71,7 @@ mod tests {
         assert_eq!(l1, LeaderState::Leader { epoch: Epoch(1) });
 
         let f_known = LeaderState::Follower {
-            leader_endpoint: Some("http://node-2".into()),
+            leader_endpoint: Some("node-2".into()),
             leader_epoch: Some(Epoch(4)),
         };
         let f_unknown = LeaderState::Follower {
@@ -67,7 +85,7 @@ mod tests {
         // Epoch participates in equality so the watch-debounce re-emits on a
         // follower-side epoch change, not just an endpoint change.
         let f_epoch_5 = LeaderState::Follower {
-            leader_endpoint: Some("http://node-2".into()),
+            leader_endpoint: Some("node-2".into()),
             leader_epoch: Some(Epoch(5)),
         };
         assert_ne!(f_known, f_epoch_5, "epoch must discriminate followers");

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -189,14 +189,14 @@ mod tests {
                 2u64,
                 crate::type_config::OpenraftPeer {
                     addr: "node-2:50052".into(),
-                    service_endpoint: "http://node-2:50051".into(),
+                    service_endpoint: "node-2:50051".into(),
                 },
             )),
         });
         assert_eq!(
             state,
             LeaderState::Follower {
-                leader_endpoint: Some("http://node-2:50051".into()),
+                leader_endpoint: Some("node-2:50051".into()),
                 leader_epoch: Some(Epoch(4)),
             }
         );

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
@@ -112,13 +112,13 @@ mod tests {
     fn leader_is_other_emits_follower_with_endpoint() {
         let peers = vec![TsoPeer {
             node_id: 2,
-            endpoint: "http://node-2:50051".into(),
+            endpoint: "node-2:50051".into(),
         }];
         let state = LeadershipState::from_omnipaxos(1, Some(2), Some(Epoch(7)), &peers);
         assert_eq!(
             state.to_consensus(),
             LeaderState::Follower {
-                leader_endpoint: Some("http://node-2:50051".into()),
+                leader_endpoint: Some("node-2:50051".into()),
                 leader_epoch: None,
             },
         );

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tsoracle_consensus::{ConsensusError, LeaderState};
+use tsoracle_core::Epoch;
 
 use crate::persist_disposition::{PersistDisposition, classify};
 use crate::server::{Server, ServerError};
@@ -65,6 +66,65 @@ fn warn_on_stuck_fence(transient_retries: u32) -> bool {
             == 0
 }
 
+/// Whether `endpoint` is a scheme-less `host:port` — the shape
+/// `LeaderState::Follower::leader_endpoint` is contracted to carry.
+///
+/// Match shape mirrors the client's `normalize_uri` / `rejects_plaintext_hint`:
+/// ASCII-lowercase `http://` and `https://` prefixes. An uppercase variant
+/// would already fail to parse downstream, so checking the lowercase form is
+/// sufficient.
+fn endpoint_is_scheme_less(endpoint: &str) -> bool {
+    !endpoint.starts_with("http://") && !endpoint.starts_with("https://")
+}
+
+/// Debug-only guard that a driver-surfaced [`LeaderState`] honors the two
+/// `LeaderState::Follower` contracts (see [`tsoracle_consensus::LeaderState`]):
+///
+///   * `leader_endpoint` is a scheme-less `host:port`. A scheme-bearing hint is
+///     silently dropped by the client's `rejects_plaintext_hint` under TLS, so
+///     a contract-violating driver makes that leader unreachable via redirect.
+///   * `leader_epoch` is non-decreasing across emissions. The client's
+///     monotone-forward gate (`compare_and_set_leader`) drops a hint that
+///     cannot outrank the cached leader, so a regressing epoch makes clients
+///     drop valid redirects.
+///
+/// Compiled out in release builds (`debug_assert!`), so it costs nothing in
+/// production and fires only in a driver author's own test suite — turning a
+/// silent production trap into a loud test-time failure. `last_epoch` carries
+/// the highest epoch observed so far across the watch loop; `None` epochs
+/// (epoch-less paxos hints, `Unknown`) are a documented valid case and advance
+/// nothing.
+fn debug_assert_leader_state_contract(evt: &LeaderState, last_epoch: &mut Option<Epoch>) {
+    if let LeaderState::Follower {
+        leader_endpoint: Some(endpoint),
+        ..
+    } = evt
+    {
+        debug_assert!(
+            endpoint_is_scheme_less(endpoint),
+            "consensus driver surfaced a scheme-bearing leader_endpoint ({endpoint:?}); \
+             LeaderState::Follower::leader_endpoint must be a scheme-less host:port — \
+             the TLS client silently drops http(s):// hints to avoid transport downgrade",
+        );
+    }
+    let epoch = match evt {
+        LeaderState::Leader { epoch } => Some(*epoch),
+        LeaderState::Follower { leader_epoch, .. } => *leader_epoch,
+        LeaderState::Unknown => None,
+    };
+    if let Some(epoch) = epoch {
+        if let Some(prev) = *last_epoch {
+            debug_assert!(
+                epoch >= prev,
+                "consensus driver surfaced a leader_epoch that regressed \
+                 ({epoch:?} < {prev:?}); LeaderState epochs must be non-decreasing — \
+                 the client's monotone-forward leader cache drops lower-epoch redirects",
+            );
+        }
+        *last_epoch = Some(epoch);
+    }
+}
+
 pub(crate) async fn run_leader_watch(
     server: Arc<Server>,
     cancel: impl std::future::Future<Output = ()>,
@@ -73,6 +133,10 @@ pub(crate) async fn run_leader_watch(
     // A leadership event observed while a fence is mid-retry is stashed here and
     // dispatched on the next iteration instead of being awaited fresh.
     let mut pending: Option<LeaderState> = None;
+    // Highest leader epoch observed so far, threaded through the debug-only
+    // driver-contract guard below. Carries no production behavior; the guard's
+    // `debug_assert!`s compile out in release.
+    let mut last_epoch: Option<Epoch> = None;
     // Cooperative cancellation (see `Server::into_router` / `WatchGuard`).
     // Pinned once and observed only at the `select!` boundaries below — the
     // event wait and the transient-retry backoff — never inside a fence
@@ -100,6 +164,11 @@ pub(crate) async fn run_leader_watch(
                 }
             }
         };
+        // Debug-only driver-contract check: a scheme-bearing leader_endpoint or
+        // a regressing leader_epoch is a silent trap in production (dropped
+        // redirects) but a loud failure in a driver author's test suite. Costs
+        // nothing in release — the asserts compile out.
+        debug_assert_leader_state_contract(&evt, &mut last_epoch);
         // `tsoracle.leader_transition.total` is emitted per-arm *after* that
         // arm's safety state change (clear/publish), never here before the
         // `match`. The counter answers "how often is leadership churning"; one
@@ -342,4 +411,74 @@ pub(crate) async fn run_leader_watch(
     // termination always routes through the poisoning branch in `into_router`
     // and is observable to callers of `serve_with_*`. See #72.
     Err(ServerError::WatchStreamClosed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsoracle_core::Epoch;
+
+    #[test]
+    fn bare_host_port_is_scheme_less() {
+        assert!(endpoint_is_scheme_less("leader:9000"));
+        assert!(endpoint_is_scheme_less("10.9.8.7:50551"));
+        assert!(endpoint_is_scheme_less("node-2"));
+    }
+
+    #[test]
+    fn http_and_https_are_not_scheme_less() {
+        assert!(!endpoint_is_scheme_less("http://leader:9000"));
+        assert!(!endpoint_is_scheme_less("https://leader:9000"));
+    }
+
+    #[test]
+    fn monotone_sequence_with_bare_endpoints_passes_guard() {
+        let mut last_epoch = None;
+        for evt in [
+            LeaderState::Unknown,
+            LeaderState::Leader { epoch: Epoch(5) },
+            LeaderState::Follower {
+                leader_endpoint: Some("leader:9000".into()),
+                leader_epoch: Some(Epoch(5)),
+            },
+            LeaderState::Follower {
+                leader_endpoint: None,
+                leader_epoch: None,
+            },
+            LeaderState::Leader { epoch: Epoch(6) },
+        ] {
+            debug_assert_leader_state_contract(&evt, &mut last_epoch);
+        }
+        assert_eq!(last_epoch, Some(Epoch(6)));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "scheme-less host:port")]
+    fn scheme_bearing_follower_endpoint_trips_guard() {
+        let mut last_epoch = None;
+        let evt = LeaderState::Follower {
+            leader_endpoint: Some("http://leader:9000".into()),
+            leader_epoch: Some(Epoch(1)),
+        };
+        debug_assert_leader_state_contract(&evt, &mut last_epoch);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "leader_epoch that regressed")]
+    fn regressing_epoch_trips_guard() {
+        let mut last_epoch = None;
+        debug_assert_leader_state_contract(
+            &LeaderState::Leader { epoch: Epoch(7) },
+            &mut last_epoch,
+        );
+        debug_assert_leader_state_contract(
+            &LeaderState::Follower {
+                leader_endpoint: Some("leader:9000".into()),
+                leader_epoch: Some(Epoch(6)),
+            },
+            &mut last_epoch,
+        );
+    }
 }

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -41,6 +41,14 @@ use tonic::transport::{Endpoint, Server as TonicServer};
 
 use crate::{Server, ServerError, ServingState};
 
+#[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+use crate::leader_hint::not_leader_status;
+#[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+use tsoracle_proto::v1::{
+    GetTsRequest, GetTsResponse, LeaderHint,
+    tso_service_server::{TsoService, TsoServiceServer},
+};
+
 /// A running [`Server`] with its captured bind address, observable
 /// [`ServingState`], a graceful-shutdown signal, and the spawned task's
 /// `JoinHandle`.
@@ -253,4 +261,63 @@ pub async fn wait_for_grpc_handshake_tls(
             }
         }
     }
+}
+
+/// A minimal [`TsoService`] that always rejects with `NOT_LEADER`, carrying a
+/// well-formed leader-hint trailer pointing at `hint_endpoint`. Booted over TLS
+/// by [`boot_fixed_hint_server_tls`].
+///
+/// Exists so TLS client tests can simulate a misconfigured or adversarial peer
+/// that surfaces a plaintext `http://` leader hint *at the wire* — the input a
+/// TLS-configured client must refuse to follow. Injecting the trailer here
+/// bypasses a real server's leader-watch path, whose debug guard (correctly)
+/// rejects a scheme-bearing `leader_endpoint` as a driver-contract violation;
+/// the behaviour under test is the *client's* downgrade defence, not the
+/// server's contract enforcement. The trailer is produced by the production
+/// [`not_leader_status`] encoder, so it is byte-identical to a real rejection.
+#[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+struct FixedHintService {
+    hint_endpoint: String,
+}
+
+#[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+#[tonic::async_trait]
+impl TsoService for FixedHintService {
+    async fn get_ts(
+        &self,
+        _request: tonic::Request<GetTsRequest>,
+    ) -> Result<tonic::Response<GetTsResponse>, tonic::Status> {
+        Err(not_leader_status(LeaderHint {
+            leader_endpoint: Some(self.hint_endpoint.clone()),
+            leader_epoch: None,
+        }))
+    }
+}
+
+/// Bind a TLS gRPC peer on `127.0.0.1:0` that always replies `NOT_LEADER` with a
+/// leader-hint trailer pointing at `hint_endpoint`, and return its address. The
+/// spawned task is detached and lives until the test process exits. See
+/// [`FixedHintService`] for why tests inject the hint here rather than through a
+/// real server's leader-watch path.
+#[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
+pub async fn boot_fixed_hint_server_tls(
+    hint_endpoint: String,
+    tls_config: tonic::transport::ServerTlsConfig,
+) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind 127.0.0.1:0 for fixed-hint TLS server");
+    let addr = listener
+        .local_addr()
+        .expect("local_addr for fixed-hint TLS server");
+    let server = TonicServer::builder()
+        .tls_config(tls_config)
+        .expect("fixed-hint server tls config")
+        .add_service(TsoServiceServer::new(FixedHintService { hint_endpoint }));
+    tokio::spawn(async move {
+        let _ = server
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await;
+    });
+    addr
 }

--- a/crates/tsoracle-server/tests/leader_watch.rs
+++ b/crates/tsoracle-server/tests/leader_watch.rs
@@ -325,7 +325,7 @@ async fn leader_watch_propagates_follower_epoch_into_serving_state() {
     let watch_server = server.clone();
     let watch_handle = tokio::spawn(async move { watch_server.run_leader_watch_for_tests().await });
 
-    driver.become_follower_with_epoch(Some("http://leader:9000".into()), Some(Epoch(7)));
+    driver.become_follower_with_epoch(Some("leader:9000".into()), Some(Epoch(7)));
 
     let mut state_rx = server.subscribe();
     let snapshot = timeout(Duration::from_secs(1), async {
@@ -349,7 +349,7 @@ async fn leader_watch_propagates_follower_epoch_into_serving_state() {
             leader_endpoint,
             leader_epoch,
         } => {
-            assert_eq!(leader_endpoint.as_deref(), Some("http://leader:9000"));
+            assert_eq!(leader_endpoint.as_deref(), Some("leader:9000"));
             assert_eq!(leader_epoch, Some(Epoch(7)));
         }
         other => panic!("expected NotServing, got {other:?}"),

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -187,7 +187,7 @@ async fn emits_documented_client_signals_end_to_end() {
     let mut booted_a = boot_server(server_a).await;
     let mut booted_b = boot_server(server_b).await;
     driver_b.become_leader(Epoch(1));
-    driver_a.become_follower(Some(format!("http://{}", booted_b.addr)));
+    driver_a.become_follower(Some(booted_b.addr.to_string()));
     wait_until_serving(&mut booted_b.state_rx).await;
     wait_until(&mut booted_a.state_rx, |s| {
         matches!(

--- a/crates/tsoracle-tests/tests/client_tls.rs
+++ b/crates/tsoracle-tests/tests/client_tls.rs
@@ -24,7 +24,8 @@ use tsoracle_core::Epoch;
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::InMemoryDriver;
 use tsoracle_server::test_support::{
-    boot_server, wait_for_grpc_handshake, wait_for_grpc_handshake_tls, wait_until_serving,
+    boot_fixed_hint_server_tls, boot_server, wait_for_grpc_handshake, wait_for_grpc_handshake_tls,
+    wait_until_serving,
 };
 
 struct CertBundle {
@@ -355,16 +356,17 @@ async fn leader_hint_rejects_plaintext_under_tls_config() {
         .expect("plaintext leader ready");
 
     let plaintext_endpoint = format!("http://127.0.0.1:{}", booted_plaintext.addr.port());
-    let follower_driver = Arc::new(InMemoryDriver::new());
-    follower_driver.become_follower(Some(plaintext_endpoint.clone()));
-    let follower = Server::builder()
-        .consensus_driver(follower_driver.clone())
-        .tls_config(server_tls_config(&bundle))
-        .build()
-        .expect("follower build");
-    let booted_follower = boot_server(follower).await;
+    // Inject the adversarial plaintext hint at the wire via a fake TLS peer
+    // rather than through a real follower's leader-watch path. Surfacing a
+    // scheme-bearing `leader_endpoint` is a driver-contract violation the
+    // server-side debug guard rejects (see `fence::debug_assert_leader_state_contract`),
+    // but the behaviour under test here is the *client's* refusal to follow
+    // such a hint, so the misbehaving peer is simulated directly. The trailer
+    // is byte-identical to a real NOT_LEADER rejection.
+    let follower_addr =
+        boot_fixed_hint_server_tls(plaintext_endpoint.clone(), server_tls_config(&bundle)).await;
     wait_for_grpc_handshake_tls(
-        booted_follower.addr,
+        follower_addr,
         client_tls_config_with_ca(&bundle),
         Duration::from_secs(5),
     )
@@ -373,7 +375,7 @@ async fn leader_hint_rejects_plaintext_under_tls_config() {
 
     let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
         "127.0.0.1:{}",
-        booted_follower.addr.port()
+        follower_addr.port()
     )])
     .tls_config(client_tls_config_with_ca(&bundle))
     .build()
@@ -394,7 +396,8 @@ async fn leader_hint_rejects_plaintext_under_tls_config() {
 
     drop(client);
     booted_plaintext.shutdown().await.expect("plaintext exit");
-    booted_follower.shutdown().await.expect("follower exit");
+    // The follower is a detached fake-peer task (no shutdown handle); it dies
+    // with the test runtime.
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Finding L8

`LeaderState::Follower.leader_endpoint: Option<String>` and `leader_epoch: Option<Epoch>` carry two **driver contracts that nothing enforced**:

- **Endpoint shape** — must be a scheme-less `host:port`. A TLS-configured client *silently drops* any `http://` leader hint (`rejects_plaintext_hint`) to refuse a transport downgrade, so a scheme-bearing endpoint makes that leader unreachable via redirect, with only a log line as evidence.
- **Epoch monotonicity** — must be per-node non-decreasing. The client's monotone-forward leader cache (`compare_and_set_leader`) drops a hint that cannot outrank the cached leader, so a regressing epoch makes clients drop valid redirects (or admit a stale one).

The shipped openraft/paxos drivers honor both by construction (raft term / paxos ballot, membership service endpoint), so the contracts were fine for shipped drivers but a **silent trap for a third-party driver**.

## Fix

1. **Make the contracts explicit.** `**Contract —**` rustdoc on `LeaderState::Follower` and a pointer from `ConsensusDriver::leadership_events()`, matching the style already used on the trait's high-water methods. Client guards are referenced by symbol name so the docs survive file moves.
2. **Turn the silent trap into a loud one.** `debug_assert_leader_state_contract` is called once per observed event in `run_leader_watch`. The `debug_assert!`s compile out in release (**zero production behavior change**) and fire in a driver author's own test suite.
3. **Correct contract-violating fixtures** the guard surfaced — the guarded-path tests plus the reference-example mapping unit tests (consensus/paxos/openraft) a third-party author would copy.

## Notable design decision

The TLS security test `leader_hint_rejects_plaintext_under_tls_config` *deliberately* drives a follower to surface an `http://` hint to verify the client **drops** that plaintext redirect — which the new guard (correctly) rejects when routed through a real follower's leader-watch path. The adversarial hint is now injected **at the wire** via a new `test_support::boot_fixed_hint_server_tls` fake peer (a minimal TLS `TsoService` returning a byte-faithful trailer from the production `not_leader_status` encoder). The guard stays intact, the client-side assertion is preserved exactly, and the misbehaving peer is modeled more faithfully (a crafted trailer rather than an honest server in an invalid state). The helper lives in `test_support` to reuse the encoder and avoid adding `prost`/`tokio-stream` deps to `tsoracle-tests`.

## Verification

- `cargo test --workspace --all-features` — green (the cross-crate fixture conflicts only surfaced here, not per-crate)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- New fence unit tests, including `should_panic` coverage for a scheme-bearing endpoint and a regressing epoch