### PR TITLE
feat(standalone): TLS/mTLS for peer transport + client API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3233,6 +3233,7 @@ dependencies = [
  "futures",
  "humantime",
  "parking_lot",
+ "rcgen",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,6 +3236,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "tsoracle-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,7 @@ dependencies = [
  "parking_lot",
  "postcard",
  "prost",
+ "rcgen",
  "rocksdb",
  "tempfile",
  "thiserror",

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -39,6 +39,7 @@ tsoracle-driver-file = { path = "../tsoracle-driver-file", version = "0.1.7" }
 async-trait        = { workspace = true }
 futures            = { workspace = true }
 parking_lot        = { workspace = true }
+rcgen              = { workspace = true }
 tokio-stream       = { workspace = true }
 tempfile           = { workspace = true }
 tokio              = { workspace = true, features = ["process"] }

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -27,6 +27,7 @@ clap                  = { workspace = true }
 tokio                 = { workspace = true, features = ["signal"] }
 tracing               = { workspace = true }
 tracing-subscriber    = { workspace = true }
+tonic                 = { workspace = true, features = ["tls-aws-lc"] }
 tsoracle-core         = { path = "../tsoracle-core", version = "0.2.2" }
 tsoracle-server       = { path = "../tsoracle-server", version = "0.2.5" }
 tsoracle-standalone   = { path = "../tsoracle-standalone", version = "0.1.0", default-features = false }

--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -30,7 +30,7 @@ pub struct Cli {
 pub enum Cmd {
     /// Run the timestamp oracle server with a selected driver.
     #[command(subcommand)]
-    Serve(ServeCmd),
+    Serve(Box<ServeCmd>),
     /// Initialize a fresh file-driver state directory at a seeded high-water.
     Init(InitArgs),
 }
@@ -60,6 +60,15 @@ pub struct CommonServeArgs {
     /// Log level.
     #[arg(long, default_value = "info")]
     pub log: String,
+    /// PEM server certificate chain for the client gRPC API (enables TLS).
+    #[arg(long)]
+    pub tls_cert: Option<std::path::PathBuf>,
+    /// PEM private key for `--tls-cert`.
+    #[arg(long)]
+    pub tls_key: Option<std::path::PathBuf>,
+    /// PEM CA to verify CLIENT certificates (enables client mTLS on the API).
+    #[arg(long)]
+    pub tls_client_ca: Option<std::path::PathBuf>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -96,6 +105,15 @@ pub struct OpenraftArgs {
     pub election_min_ms: u64,
     #[arg(long, default_value = "2000")]
     pub election_max_ms: u64,
+    /// PEM node certificate for the peer transport (enables peer mTLS; needs all three).
+    #[arg(long)]
+    pub peer_tls_cert: Option<std::path::PathBuf>,
+    /// PEM private key for `--peer-tls-cert`.
+    #[arg(long)]
+    pub peer_tls_key: Option<std::path::PathBuf>,
+    /// PEM CA (cluster-dedicated) to verify connecting peers.
+    #[arg(long)]
+    pub peer_tls_ca: Option<std::path::PathBuf>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -119,6 +137,15 @@ pub struct PaxosArgs {
     pub data_dir: PathBuf,
     #[arg(long, value_parser = parse_duration, default_value = "20ms")]
     pub tick_interval: Duration,
+    /// PEM node certificate for the peer transport (enables peer mTLS; needs all three).
+    #[arg(long)]
+    pub peer_tls_cert: Option<std::path::PathBuf>,
+    /// PEM private key for `--peer-tls-cert`.
+    #[arg(long)]
+    pub peer_tls_key: Option<std::path::PathBuf>,
+    /// PEM CA (cluster-dedicated) to verify connecting peers.
+    #[arg(long)]
+    pub peer_tls_ca: Option<std::path::PathBuf>,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -117,6 +117,7 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         election_min_ms: args.election_min_ms,
                         election_max_ms: args.election_max_ms,
                     },
+                    peer_tls: None,
                 });
                 run_serve(args.common, cfg).await
             }
@@ -138,6 +139,7 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         .map_err(anyhow::Error::msg)?,
                     data_dir: args.data_dir,
                     tick_interval: args.tick_interval,
+                    peer_tls: None,
                 });
                 run_serve(args.common, cfg).await
             }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
         Some(Cmd::Init(args)) => run_init(args.state_dir, args.seed_physical_ms),
-        Some(Cmd::Serve(serve)) => dispatch_serve(serve).await,
+        Some(Cmd::Serve(serve)) => dispatch_serve(*serve).await,
         // Bare `tsoracle` defaults to `serve file` when file is compiled in.
         None => {
             #[cfg(feature = "file")]
@@ -117,7 +117,11 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         election_min_ms: args.election_min_ms,
                         election_max_ms: args.election_max_ms,
                     },
-                    peer_tls: None,
+                    peer_tls: peer_tls_config(
+                        args.peer_tls_cert,
+                        args.peer_tls_key,
+                        args.peer_tls_ca,
+                    )?,
                 });
                 run_serve(args.common, cfg).await
             }
@@ -139,7 +143,11 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         .map_err(anyhow::Error::msg)?,
                     data_dir: args.data_dir,
                     tick_interval: args.tick_interval,
-                    peer_tls: None,
+                    peer_tls: peer_tls_config(
+                        args.peer_tls_cert,
+                        args.peer_tls_key,
+                        args.peer_tls_ca,
+                    )?,
                 });
                 run_serve(args.common, cfg).await
             }
@@ -168,6 +176,57 @@ fn run_init(_state_dir: std::path::PathBuf, _seed_physical_ms: u64) -> Result<()
     Err(not_compiled_in("file"))
 }
 
+/// Assemble the client-API server TLS config from flags (server-auth + optional
+/// client mTLS). `Ok(None)` when no TLS flags are given (plaintext). Eagerly
+/// validated: `from_pem` is lazy and the server applies tls only inside serve()
+/// (after bind + "serving on"), so we dry-run the acceptor build here.
+fn client_tls_config(
+    common: &CommonServeArgs,
+) -> anyhow::Result<Option<tonic::transport::ServerTlsConfig>> {
+    match (&common.tls_cert, &common.tls_key) {
+        (None, None) => {
+            if common.tls_client_ca.is_some() {
+                anyhow::bail!("--tls-client-ca requires --tls-cert and --tls-key");
+            }
+            Ok(None)
+        }
+        (Some(cert), Some(key)) => {
+            let cert_pem =
+                std::fs::read(cert).with_context(|| format!("read {}", cert.display()))?;
+            let key_pem = std::fs::read(key).with_context(|| format!("read {}", key.display()))?;
+            let mut tls = tonic::transport::ServerTlsConfig::new()
+                .identity(tonic::transport::Identity::from_pem(&cert_pem, &key_pem));
+            if let Some(ca) = &common.tls_client_ca {
+                let ca_pem = std::fs::read(ca).with_context(|| format!("read {}", ca.display()))?;
+                tls = tls.client_ca_root(tonic::transport::Certificate::from_pem(&ca_pem));
+            }
+            tonic::transport::Server::builder()
+                .tls_config(tls.clone())
+                .context("invalid client-API TLS configuration")?;
+            Ok(Some(tls))
+        }
+        _ => anyhow::bail!("--tls-cert and --tls-key must be provided together"),
+    }
+}
+
+/// Assemble the peer `PeerTlsConfig` from the all-or-nothing flag trio.
+#[cfg(any(feature = "openraft", feature = "paxos"))]
+fn peer_tls_config(
+    cert: Option<std::path::PathBuf>,
+    key: Option<std::path::PathBuf>,
+    ca: Option<std::path::PathBuf>,
+) -> anyhow::Result<Option<tsoracle_standalone::PeerTlsConfig>> {
+    match (cert, key, ca) {
+        (None, None, None) => Ok(None),
+        (Some(cert), Some(key), Some(ca)) => {
+            Ok(Some(tsoracle_standalone::PeerTlsConfig { cert, key, ca }))
+        }
+        _ => anyhow::bail!(
+            "--peer-tls-cert, --peer-tls-key, and --peer-tls-ca must all be set together"
+        ),
+    }
+}
+
 async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_new(&common.log).unwrap_or_else(|_| EnvFilter::new("info")))
@@ -177,12 +236,15 @@ async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
         .await
         .context("driver bootstrap")?;
     let drain = node.take_drain();
-    let server = Server::builder()
+    let tls = client_tls_config(&common)?;
+    let mut builder = Server::builder()
         .consensus_driver(node.driver.clone())
         .window_ahead(common.window_ahead)
-        .failover_advance(common.failover_advance)
-        .build()
-        .context("server build")?;
+        .failover_advance(common.failover_advance);
+    if let Some(tls) = tls {
+        builder = builder.tls_config(tls);
+    }
+    let server = builder.build().context("server build")?;
 
     let listener = tokio::net::TcpListener::bind(common.listen)
         .await

--- a/crates/tsoracle-bin/tests/smoke.rs
+++ b/crates/tsoracle-bin/tests/smoke.rs
@@ -10,6 +10,7 @@
 //  https://github.com/prisma-risk/tsoracle
 //
 
+use std::path::PathBuf;
 use std::time::Instant;
 use std::{io, net::SocketAddr, time::Duration};
 use tempfile::tempdir;
@@ -229,6 +230,175 @@ async fn serve_openraft_single_node_serves_after_bootstrap() {
     wait_until_responsive(&client, Duration::from_secs(15))
         .await
         .expect("openraft node never became responsive after starting to accept");
+
+    let ts1 = client.get_ts().await.unwrap();
+    let ts2 = client.get_ts().await.unwrap();
+    assert!(ts2 > ts1, "ts2 {ts2:?} > ts1 {ts1:?}");
+
+    child.kill().await.unwrap();
+}
+
+struct ServerCerts {
+    cert: PathBuf,
+    key: PathBuf,
+    ca_path: PathBuf,
+    ca_pem: String,
+}
+
+/// Mint a self-signed CA and a server leaf cert (SANs: `localhost` + `127.0.0.1`),
+/// write them into `dir`, and return the paths + the CA PEM string.
+fn write_server_certs(dir: &std::path::Path) -> ServerCerts {
+    use rcgen::{
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+        KeyUsagePurpose,
+    };
+
+    let ca_key = KeyPair::generate().expect("ca keypair");
+    let mut ca_params =
+        CertificateParams::new(vec!["tsoracle-smoke-ca".to_string()]).expect("ca params");
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let ca_cert = ca_params.self_signed(&ca_key).expect("ca self-sign");
+
+    let server_key = KeyPair::generate().expect("server keypair");
+    let mut server_params =
+        CertificateParams::new(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("server params");
+    server_params
+        .distinguished_name
+        .push(DnType::CommonName, "localhost");
+    server_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let server_cert = server_params
+        .signed_by(&server_key, &ca_cert, &ca_key)
+        .expect("server sign");
+
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+    let ca_path = dir.join("ca.pem");
+    let ca_pem = ca_cert.pem();
+    std::fs::write(&cert_path, server_cert.pem()).expect("write cert.pem");
+    std::fs::write(&key_path, server_key.serialize_pem()).expect("write key.pem");
+    std::fs::write(&ca_path, &ca_pem).expect("write ca.pem");
+
+    ServerCerts {
+        cert: cert_path,
+        key: key_path,
+        ca_path,
+        ca_pem,
+    }
+}
+
+/// The file driver starts up, serves its client gRPC API over TLS (server-auth),
+/// and a TLS-configured client can issue `get_ts` successfully.
+#[tokio::test]
+async fn serve_file_with_client_tls_serves_over_tls() {
+    let binary_path = env!("CARGO_BIN_EXE_tsoracle");
+    let certdir = tempdir().unwrap();
+    let certs = write_server_certs(certdir.path());
+    let state_dir = tempdir().unwrap();
+    let listen_addr = bind_unused().await;
+
+    let mut child = Command::new(binary_path)
+        .arg("serve")
+        .arg("file")
+        .arg("--listen")
+        .arg(listen_addr.to_string())
+        .arg("--state-dir")
+        .arg(state_dir.path())
+        .arg("--tls-cert")
+        .arg(&certs.cert)
+        .arg("--tls-key")
+        .arg(&certs.key)
+        .arg("--log")
+        .arg("warn")
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+
+    let readiness = wait_until_accepting(listen_addr, Duration::from_secs(10));
+    tokio::pin!(readiness);
+    tokio::select! {
+        r = &mut readiness => r.expect("binary did not start accepting connections"),
+        c = child.wait() => panic!("binary exited before accepting connections: {c:?}"),
+    }
+
+    let tls = tonic::transport::ClientTlsConfig::new()
+        .ca_certificate(tonic::transport::Certificate::from_pem(&certs.ca_pem))
+        .domain_name("localhost");
+    let client = tsoracle_client::ClientBuilder::endpoints(vec![format!(
+        "localhost:{}",
+        listen_addr.port()
+    )])
+    .tls_config(tls)
+    .build()
+    .await
+    .expect("client build");
+
+    wait_until_responsive(&client, Duration::from_secs(5))
+        .await
+        .expect("server never became responsive after TLS handshake");
+    assert!(client.get_ts().await.is_ok());
+    child.kill().await.unwrap();
+}
+
+/// A single-node openraft cluster with peer mTLS configured on the raft
+/// transport binds and serves timestamps normally (a single node never dials
+/// a peer, so this proves the peer-TLS server binds without error and the
+/// node still elects itself and serves the client API).
+#[cfg(feature = "openraft")]
+#[tokio::test]
+async fn serve_openraft_with_peer_mtls_boots_and_serves() {
+    let binary_path = env!("CARGO_BIN_EXE_tsoracle");
+    let certdir = tempdir().unwrap();
+    let certs = write_server_certs(certdir.path());
+    let raft_dir = tempdir().unwrap();
+    let listen_addr = bind_unused().await;
+    let raft_addr = bind_unused().await;
+
+    let mut child = Command::new(binary_path)
+        .arg("serve")
+        .arg("openraft")
+        .arg("--id")
+        .arg("1")
+        .arg("--listen")
+        .arg(listen_addr.to_string())
+        .arg("--raft-addr")
+        .arg(raft_addr.to_string())
+        .arg("--raft-dir")
+        .arg(raft_dir.path())
+        .arg("--bootstrap")
+        .arg("--members")
+        .arg(format!("1={raft_addr}/{listen_addr}"))
+        .arg("--peer-tls-cert")
+        .arg(&certs.cert)
+        .arg("--peer-tls-key")
+        .arg(&certs.key)
+        .arg("--peer-tls-ca")
+        .arg(&certs.ca_path)
+        .arg("--log")
+        .arg("warn")
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+
+    let readiness = wait_until_accepting(listen_addr, Duration::from_secs(15));
+    tokio::pin!(readiness);
+    tokio::select! {
+        result = &mut readiness => {
+            result.expect("binary did not start accepting connections");
+        }
+        child_result = child.wait() => {
+            let status = child_result.expect("wait on child failed");
+            panic!("binary exited before accepting connections: status={status}");
+        }
+    }
+
+    let client = Client::connect(vec![listen_addr.to_string()])
+        .await
+        .unwrap();
+    wait_until_responsive(&client, Duration::from_secs(15))
+        .await
+        .expect("openraft node with peer mTLS never became responsive");
 
     let ts1 = client.get_ts().await.unwrap();
     let ts2 = client.get_ts().await.unwrap();

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -15,12 +15,14 @@ openraft = [
     "dep:tsoracle-driver-openraft", "dep:tsoracle-openraft-toolkit",
     "dep:openraft", "dep:rocksdb", "dep:tonic", "dep:tonic-prost",
     "dep:prost", "dep:postcard", "dep:tokio-stream", "dep:async-trait", "dep:futures",
+    "tonic/tls-aws-lc",
 ]
 paxos    = [
     "dep:tsoracle-driver-paxos", "dep:tsoracle-paxos-toolkit",
     "dep:omnipaxos", "dep:rocksdb", "dep:tonic", "dep:tonic-prost",
     "dep:prost", "dep:postcard", "dep:parking_lot", "dep:tokio-stream",
     "dep:async-trait",
+    "tonic/tls-aws-lc",
 ]
 
 [dependencies]
@@ -61,5 +63,6 @@ postcard    = { workspace = true, optional = true }
 tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
+rcgen    = { workspace = true }
 tempfile = { workspace = true }
 tokio    = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/tsoracle-standalone/src/config.rs
+++ b/crates/tsoracle-standalone/src/config.rs
@@ -45,6 +45,19 @@ pub struct FileConfig {
     pub state_dir: PathBuf,
 }
 
+/// mTLS material for the peer transport (PEM file paths, read at build()).
+/// Presence on a driver config turns the peer transport into mutual TLS:
+/// `cert`/`key` is this node's identity (used as both the peer-server identity
+/// and the peer-client identity when dialing); `ca` verifies connecting peers.
+/// The CA MUST be cluster-dedicated — anyone holding a cert it signed can join
+/// replication.
+#[derive(Debug, Clone)]
+pub struct PeerTlsConfig {
+    pub cert: PathBuf,
+    pub key: PathBuf,
+    pub ca: PathBuf,
+}
+
 #[derive(Debug, Clone)]
 pub struct OpenraftConfig {
     pub id: u64,
@@ -55,6 +68,7 @@ pub struct OpenraftConfig {
     /// (membership recovers from raft state, #408).
     pub initial_membership: Option<BTreeMap<u64, MemberAddr>>,
     pub tuning: RaftTuning,
+    pub peer_tls: Option<PeerTlsConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -68,6 +82,7 @@ pub struct PaxosConfig {
     pub tso_peers: BTreeMap<u64, String>,
     pub data_dir: PathBuf,
     pub tick_interval: Duration,
+    pub peer_tls: Option<PeerTlsConfig>,
 }
 
 pub enum DriverConfig {

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -111,7 +111,12 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         .map_err(|e| StandaloneError::Config(e.to_string()))?,
     );
 
-    let network = PeerFactory::new();
+    let peer_tls = match &cfg.peer_tls {
+        Some(p) => Some(crate::peer_tls::build_peer_tls(p)?),
+        None => None,
+    };
+
+    let network = PeerFactory::new(peer_tls.as_ref().map(|m| m.client.clone()));
     let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
         cfg.id,
         config,
@@ -132,15 +137,28 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
     let peer_service = peer_server(raft.clone())
         .max_decoding_message_size(MAX_PEER_MESSAGE_BYTES)
         .max_encoding_message_size(MAX_PEER_MESSAGE_BYTES);
+    let mut builder = tonic::transport::Server::builder()
+        .max_concurrent_streams(MAX_CONCURRENT_STREAMS)
+        .max_frame_size(MAX_FRAME_SIZE);
+    if let Some(material) = &peer_tls {
+        builder = builder
+            .tls_config(material.server.clone())
+            .map_err(|source| StandaloneError::Tls {
+                path: cfg
+                    .peer_tls
+                    .as_ref()
+                    .map(|p| p.cert.clone())
+                    .unwrap_or_default(),
+                source: Box::new(source),
+            })?;
+    }
+    let router = builder.add_service(peer_service);
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
     let join = tokio::spawn(async move {
         let shutdown = async {
             let _ = cancel_rx.await;
         };
-        if let Err(e) = tonic::transport::Server::builder()
-            .max_concurrent_streams(MAX_CONCURRENT_STREAMS)
-            .max_frame_size(MAX_FRAME_SIZE)
-            .add_service(peer_service)
+        if let Err(e) = router
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
             .await
         {

--- a/crates/tsoracle-standalone/src/drivers/openraft/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/network.rs
@@ -498,6 +498,206 @@ pub fn server<SM: Send + Sync + 'static>(
 }
 
 #[cfg(test)]
+mod tls_tests {
+    use super::*;
+    use crate::config::PeerTlsConfig;
+    use crate::peer_tls::build_peer_tls;
+    use std::sync::Arc;
+    use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+
+    // --- cert helpers (rcgen 0.13) ---
+    struct Certs {
+        ca_pem: String,
+        node_cert: String,
+        node_key: String,
+        other_leaf_cert: String,
+        other_leaf_key: String,
+    }
+
+    fn mint() -> Certs {
+        use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+        let mk_ca = |name: &str| {
+            let key = KeyPair::generate().unwrap();
+            let mut p = CertificateParams::new(vec![name.to_string()]).unwrap();
+            p.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+            let cert = p.self_signed(&key).unwrap();
+            (cert, key)
+        };
+        let (ca, ca_key) = mk_ca("tso-ca");
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf_params =
+            CertificateParams::new(vec!["localhost".to_string(), "127.0.0.1".to_string()]).unwrap();
+        let leaf = leaf_params.signed_by(&leaf_key, &ca, &ca_key).unwrap();
+        let (other_ca, other_ca_key) = mk_ca("other-ca");
+        let other_key = KeyPair::generate().unwrap();
+        let other_params = CertificateParams::new(vec!["127.0.0.1".to_string()]).unwrap();
+        let other_leaf = other_params
+            .signed_by(&other_key, &other_ca, &other_ca_key)
+            .unwrap();
+        Certs {
+            ca_pem: ca.pem(),
+            node_cert: leaf.pem(),
+            node_key: leaf_key.serialize_pem(),
+            other_leaf_cert: other_leaf.pem(),
+            other_leaf_key: other_key.serialize_pem(),
+        }
+    }
+
+    fn node_material(c: &Certs, dir: &std::path::Path) -> crate::peer_tls::PeerTlsMaterial {
+        let cert = dir.join("n.crt");
+        let key = dir.join("n.key");
+        let ca = dir.join("ca.crt");
+        std::fs::write(&cert, &c.node_cert).unwrap();
+        std::fs::write(&key, &c.node_key).unwrap();
+        std::fs::write(&ca, &c.ca_pem).unwrap();
+        build_peer_tls(&PeerTlsConfig { cert, key, ca }).unwrap()
+    }
+
+    // Minimal stub server (handlers never called — only the TLS handshake is).
+    #[derive(Clone)]
+    struct Stub;
+
+    #[tonic::async_trait]
+    impl proto::raft_peer_service_server::RaftPeerService for Stub {
+        async fn append_entries(
+            &self,
+            _: tonic::Request<proto::RaftMessage>,
+        ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+            Err(tonic::Status::unimplemented("stub"))
+        }
+        async fn vote(
+            &self,
+            _: tonic::Request<proto::RaftMessage>,
+        ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+            Err(tonic::Status::unimplemented("stub"))
+        }
+        async fn snapshot(
+            &self,
+            _: tonic::Request<tonic::Streaming<proto::SnapshotChunk>>,
+        ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+            Err(tonic::Status::unimplemented("stub"))
+        }
+        async fn transfer_leader(
+            &self,
+            _: tonic::Request<proto::RaftMessage>,
+        ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+            Err(tonic::Status::unimplemented("stub"))
+        }
+    }
+
+    async fn spawn_stub(server_tls: tonic::transport::ServerTlsConfig) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .tls_config(server_tls)
+                .unwrap()
+                .add_service(proto::raft_peer_service_server::RaftPeerServiceServer::new(
+                    Stub,
+                ))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        addr
+    }
+
+    fn make_net(addr: std::net::SocketAddr, tls: Option<ClientTlsConfig>) -> PeerNetwork {
+        PeerNetwork {
+            target: 2,
+            addr: addr.to_string(),
+            pool: Arc::new(Mutex::new(HashMap::new())),
+            tls,
+        }
+    }
+
+    // `Channel::connect()` is lazy — the TLS handshake happens on the first RPC.
+    // We therefore attempt a real RPC (append_entries) and check whether it fails
+    // at the transport level (tonic Status) vs. at the stub handler (Unimplemented).
+    // A successful mTLS handshake produces Unimplemented; a rejected one produces
+    // a connection-level error (Unavailable / Unknown).
+    async fn probe(net: PeerNetwork) -> tonic::Code {
+        match net.client().await {
+            Err(_) => tonic::Code::Unavailable,
+            Ok(mut c) => {
+                match c
+                    .append_entries(tonic::Request::new(proto::RaftMessage {
+                        payload: Vec::new(),
+                    }))
+                    .await
+                {
+                    Ok(_) => tonic::Code::Ok,
+                    Err(s) => s.code(),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_node_cert_connects() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        // Stub returns Unimplemented — handshake succeeded.
+        assert_eq!(
+            probe(make_net(addr, Some(m.client.clone()))).await,
+            tonic::Code::Unimplemented
+        );
+    }
+
+    #[tokio::test]
+    async fn no_client_cert_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        let no_id = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(&c.ca_pem))
+            .domain_name("localhost");
+        let code = probe(make_net(addr, Some(no_id))).await;
+        assert_ne!(
+            code,
+            tonic::Code::Unimplemented,
+            "server must reject a client with no cert"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_ca_client_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        let wrong = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(&c.ca_pem))
+            .identity(Identity::from_pem(&c.other_leaf_cert, &c.other_leaf_key))
+            .domain_name("localhost");
+        let code = probe(make_net(addr, Some(wrong))).await;
+        assert_ne!(
+            code,
+            tonic::Code::Unimplemented,
+            "server must reject a cert from a foreign CA"
+        );
+    }
+
+    #[tokio::test]
+    async fn plaintext_against_tls_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        let code = probe(make_net(addr, None)).await;
+        assert_ne!(
+            code,
+            tonic::Code::Unimplemented,
+            "plaintext must not reach a TLS-only server"
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/crates/tsoracle-standalone/src/drivers/openraft/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/network.rs
@@ -43,7 +43,7 @@ use openraft::raft::{
 };
 use openraft::type_config::alias::{SnapshotOf, VoteOf};
 use tokio::sync::Mutex;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, ClientTlsConfig};
 
 use tsoracle_driver_openraft::{OpenraftPeer as Node, TypeConfig};
 type NodeId = u64;
@@ -107,19 +107,15 @@ async fn evict<V>(pool: &Arc<Mutex<HashMap<(NodeId, String), V>>>, target: NodeI
 
 pub struct PeerFactory {
     pool: Pool,
+    tls: Option<ClientTlsConfig>,
 }
 
 impl PeerFactory {
-    pub fn new() -> Self {
+    pub fn new(tls: Option<ClientTlsConfig>) -> Self {
         Self {
             pool: Arc::new(Mutex::new(HashMap::new())),
+            tls,
         }
-    }
-}
-
-impl Default for PeerFactory {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -131,6 +127,7 @@ impl RaftNetworkFactory<TypeConfig> for PeerFactory {
             target,
             addr: node.addr.clone(),
             pool: self.pool.clone(),
+            tls: self.tls.clone(),
         }
     }
 }
@@ -143,6 +140,7 @@ pub struct PeerNetwork {
     target: NodeId,
     addr: String,
     pool: Pool,
+    tls: Option<ClientTlsConfig>,
 }
 
 impl PeerNetwork {
@@ -155,10 +153,21 @@ impl PeerNetwork {
                 return Ok(client.clone());
             }
         }
-        let url = format!("http://{}", self.addr);
-        let client = RaftPeerServiceClient::connect(url)
-            .await
-            .map_err(|err| RPCError::Unreachable(Unreachable::new(&err)))?;
+        let channel = match &self.tls {
+            Some(tls) => Channel::from_shared(format!("https://{}", self.addr))
+                .map_err(|err| RPCError::Unreachable(Unreachable::new(&err)))?
+                .tls_config(tls.clone())
+                .map_err(|err| RPCError::Unreachable(Unreachable::new(&err)))?
+                .connect()
+                .await
+                .map_err(|err| RPCError::Unreachable(Unreachable::new(&err)))?,
+            None => Channel::from_shared(format!("http://{}", self.addr))
+                .map_err(|err| RPCError::Unreachable(Unreachable::new(&err)))?
+                .connect()
+                .await
+                .map_err(|err| RPCError::Unreachable(Unreachable::new(&err)))?,
+        };
+        let client = RaftPeerServiceClient::new(channel);
         self.pool.lock().await.insert(key, client.clone());
         Ok(client)
     }

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -46,6 +46,11 @@ fn open_rocksdb(dir: &std::path::Path) -> Result<Arc<DB>, StandaloneError> {
 }
 
 pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, StandaloneError> {
+    let peer_tls = match &cfg.peer_tls {
+        Some(p) => Some(crate::peer_tls::build_peer_tls(p)?),
+        None => None,
+    };
+
     // Validate self identity (spec: Lifecycle): a node absent from its own
     // ClusterConfig.nodes can never be elected.
     if !cfg.peers.contains_key(&cfg.node_id) {
@@ -95,13 +100,26 @@ pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, Standalo
             source,
         })?;
     let peer_service = peer_server(omnipaxos.clone());
+    let mut builder = tonic::transport::Server::builder();
+    if let Some(material) = &peer_tls {
+        builder = builder
+            .tls_config(material.server.clone())
+            .map_err(|source| StandaloneError::Tls {
+                path: cfg
+                    .peer_tls
+                    .as_ref()
+                    .map(|p| p.cert.clone())
+                    .unwrap_or_default(),
+                source: Box::new(source),
+            })?;
+    }
+    let router = builder.add_service(peer_service);
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
     let join = tokio::spawn(async move {
         let shutdown = async {
             let _ = cancel_rx.await;
         };
-        if let Err(err) = tonic::transport::Server::builder()
-            .add_service(peer_service)
+        if let Err(err) = router
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
             .await
         {
@@ -115,7 +133,7 @@ pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, Standalo
         .filter(|(id, _)| **id != cfg.node_id)
         .map(|(id, endpoint)| TsoPeer {
             node_id: *id,
-            endpoint: format!("http://{endpoint}"),
+            endpoint: endpoint.clone(),
         })
         .collect();
     let mut host = StandaloneHost::builder()
@@ -130,7 +148,10 @@ pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, Standalo
         .take_leader_subscriber()
         .ok_or_else(|| StandaloneError::Bootstrap("leader subscriber unavailable".into()))?;
 
-    let sink = Arc::new(PeerSink::new(cfg.peers.into_iter().collect()));
+    let sink = Arc::new(PeerSink::new(
+        cfg.peers.into_iter().collect(),
+        peer_tls.as_ref().map(|m| m.client.clone()),
+    ));
     host.start(sink)
         .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?;
 

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -159,6 +159,7 @@ mod tests {
             tso_peers: BTreeMap::new(),
             data_dir: std::path::PathBuf::from("/this/path/must/not/be/touched"),
             tick_interval: Duration::from_millis(20),
+            peer_tls: None,
         };
         match build_paxos(cfg).await {
             Err(StandaloneError::Config(_)) => {}

--- a/crates/tsoracle-standalone/src/drivers/paxos/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/network.rs
@@ -156,3 +156,179 @@ where
 {
     PaxosPeerServiceServer::new(PaxosPeerServiceImpl { omnipaxos })
 }
+
+#[cfg(test)]
+mod tls_tests {
+    use super::*;
+    use crate::config::PeerTlsConfig;
+    use crate::peer_tls::build_peer_tls;
+    use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+
+    // --- cert helpers (rcgen 0.13) ---
+    struct Certs {
+        ca_pem: String,
+        node_cert: String,
+        node_key: String,
+        other_leaf_cert: String,
+        other_leaf_key: String,
+    }
+
+    fn mint() -> Certs {
+        use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+        let mk_ca = |name: &str| {
+            let key = KeyPair::generate().unwrap();
+            let mut p = CertificateParams::new(vec![name.to_string()]).unwrap();
+            p.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+            let cert = p.self_signed(&key).unwrap();
+            (cert, key)
+        };
+        let (ca, ca_key) = mk_ca("tso-ca");
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf_params =
+            CertificateParams::new(vec!["localhost".to_string(), "127.0.0.1".to_string()]).unwrap();
+        let leaf = leaf_params.signed_by(&leaf_key, &ca, &ca_key).unwrap();
+        let (other_ca, other_ca_key) = mk_ca("other-ca");
+        let other_key = KeyPair::generate().unwrap();
+        let other_params = CertificateParams::new(vec!["127.0.0.1".to_string()]).unwrap();
+        let other_leaf = other_params
+            .signed_by(&other_key, &other_ca, &other_ca_key)
+            .unwrap();
+        Certs {
+            ca_pem: ca.pem(),
+            node_cert: leaf.pem(),
+            node_key: leaf_key.serialize_pem(),
+            other_leaf_cert: other_leaf.pem(),
+            other_leaf_key: other_key.serialize_pem(),
+        }
+    }
+
+    fn node_material(c: &Certs, dir: &std::path::Path) -> crate::peer_tls::PeerTlsMaterial {
+        let cert = dir.join("n.crt");
+        let key = dir.join("n.key");
+        let ca = dir.join("ca.crt");
+        std::fs::write(&cert, &c.node_cert).unwrap();
+        std::fs::write(&key, &c.node_key).unwrap();
+        std::fs::write(&ca, &c.ca_pem).unwrap();
+        build_peer_tls(&PeerTlsConfig { cert, key, ca }).unwrap()
+    }
+
+    // Minimal stub server (handlers never called — only the TLS handshake is).
+    #[derive(Clone)]
+    struct Stub;
+
+    #[tonic::async_trait]
+    impl proto::paxos_peer_service_server::PaxosPeerService for Stub {
+        async fn send(
+            &self,
+            _: tonic::Request<proto::PaxosMessage>,
+        ) -> Result<tonic::Response<proto::Ack>, tonic::Status> {
+            Ok(tonic::Response::new(proto::Ack {}))
+        }
+    }
+
+    async fn spawn_stub(server_tls: tonic::transport::ServerTlsConfig) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .tls_config(server_tls)
+                .unwrap()
+                .add_service(proto::paxos_peer_service_server::PaxosPeerServiceServer::new(Stub))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        addr
+    }
+
+    fn make_sink(addr: std::net::SocketAddr, tls: Option<ClientTlsConfig>) -> PeerSink {
+        PeerSink::new(
+            std::collections::HashMap::from([(2u64, addr.to_string())]),
+            tls,
+        )
+    }
+
+    // `Channel::connect()` is lazy — the TLS handshake happens on the first RPC.
+    // We issue a real `send` RPC to force the handshake and check the status code.
+    // A successful mTLS handshake produces Ok (the stub returns Ack {}); a rejected
+    // handshake means `client()` returns None after the failed dial.
+    async fn probe(sink: PeerSink) -> tonic::Code {
+        match sink.client(2).await {
+            None => tonic::Code::Unavailable,
+            Some(mut c) => {
+                match c
+                    .send(tonic::Request::new(proto::PaxosMessage {
+                        payload: Vec::new(),
+                    }))
+                    .await
+                {
+                    Ok(_) => tonic::Code::Ok,
+                    Err(s) => s.code(),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_node_cert_connects() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        // Stub returns Ok(Ack {}) — handshake succeeded.
+        assert_eq!(
+            probe(make_sink(addr, Some(m.client.clone()))).await,
+            tonic::Code::Ok
+        );
+    }
+
+    #[tokio::test]
+    async fn no_client_cert_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        let no_id = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(&c.ca_pem))
+            .domain_name("localhost");
+        let code = probe(make_sink(addr, Some(no_id))).await;
+        assert_ne!(
+            code,
+            tonic::Code::Ok,
+            "server must reject a client with no cert"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_ca_client_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        let wrong = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(&c.ca_pem))
+            .identity(Identity::from_pem(&c.other_leaf_cert, &c.other_leaf_key))
+            .domain_name("localhost");
+        let code = probe(make_sink(addr, Some(wrong))).await;
+        assert_ne!(
+            code,
+            tonic::Code::Ok,
+            "server must reject a cert from a foreign CA"
+        );
+    }
+
+    #[tokio::test]
+    async fn plaintext_against_tls_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = mint();
+        let m = node_material(&c, dir.path());
+        let addr = spawn_stub(m.server.clone()).await;
+        let code = probe(make_sink(addr, None)).await;
+        assert_ne!(
+            code,
+            tonic::Code::Ok,
+            "plaintext must not reach a TLS-only server"
+        );
+    }
+}

--- a/crates/tsoracle-standalone/src/drivers/paxos/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/network.rs
@@ -29,7 +29,7 @@ use omnipaxos::messages::Message;
 use omnipaxos::storage::Storage;
 use parking_lot::Mutex;
 use tokio::sync::Mutex as AsyncMutex;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::warn;
 use tsoracle_driver_paxos::HighWaterCommand;
 use tsoracle_paxos_toolkit::lifecycle::MessageSink;
@@ -47,13 +47,15 @@ use proto::{Ack, PaxosMessage};
 pub struct PeerSink {
     addrs: Arc<HashMap<u64, String>>,
     pool: AsyncMutex<HashMap<u64, PaxosPeerServiceClient<Channel>>>,
+    tls: Option<ClientTlsConfig>,
 }
 
 impl PeerSink {
-    pub fn new(addrs: HashMap<u64, String>) -> Self {
+    pub fn new(addrs: HashMap<u64, String>, tls: Option<ClientTlsConfig>) -> Self {
         Self {
             addrs: Arc::new(addrs),
             pool: AsyncMutex::new(HashMap::new()),
+            tls,
         }
     }
 
@@ -63,9 +65,25 @@ impl PeerSink {
             return Some(client.clone());
         }
         let endpoint = self.addrs.get(&target)?;
-        let url = format!("http://{endpoint}");
-        match PaxosPeerServiceClient::connect(url).await {
-            Ok(client) => {
+        let channel = match &self.tls {
+            Some(tls) => {
+                tonic::transport::Channel::from_shared(format!("https://{endpoint}"))
+                    .ok()?
+                    .tls_config(tls.clone())
+                    .ok()?
+                    .connect()
+                    .await
+            }
+            None => {
+                tonic::transport::Channel::from_shared(format!("http://{endpoint}"))
+                    .ok()?
+                    .connect()
+                    .await
+            }
+        };
+        match channel {
+            Ok(channel) => {
+                let client = PaxosPeerServiceClient::new(channel);
                 pool.insert(target, client.clone());
                 Some(client)
             }

--- a/crates/tsoracle-standalone/src/error.rs
+++ b/crates/tsoracle-standalone/src/error.rs
@@ -32,4 +32,10 @@ pub enum StandaloneError {
     Bootstrap(Box<dyn std::error::Error + Send + Sync>),
     #[error("invalid configuration: {0}")]
     Config(String),
+    #[error("failed to load TLS material from {path}: {source}")]
+    Tls {
+        path: std::path::PathBuf,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -22,7 +22,8 @@ use tsoracle_consensus::ConsensusDriver;
 
 mod config;
 pub use config::{
-    DriverConfig, FileConfig, MemberAddr, OpenraftConfig, PaxosConfig, RaftTuning, parse_peer_map,
+    DriverConfig, FileConfig, MemberAddr, OpenraftConfig, PaxosConfig, PeerTlsConfig, RaftTuning,
+    parse_peer_map,
 };
 
 mod drivers;

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -37,6 +37,9 @@ pub use error::StandaloneError;
 mod transport;
 pub use transport::TransportHandle;
 
+#[cfg(any(feature = "openraft", feature = "paxos"))]
+pub(crate) mod peer_tls;
+
 /// A constructed, running standalone node: the consensus driver plus the
 /// background peer-transport task (if any). The caller (the bin) owns the
 /// client-facing `tsoracle_server::Server`; this type owns only the driver

--- a/crates/tsoracle-standalone/src/peer_tls.rs
+++ b/crates/tsoracle-standalone/src/peer_tls.rs
@@ -1,0 +1,137 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//
+//  Copyright (c) 2026 Prisma Risk
+//  Licensed under the Apache License, Version 2.0
+//  https://github.com/prisma-risk/tsoracle
+//
+
+//! Builds and eagerly validates the TLS configs for the peer transport.
+
+use tonic::transport::{Certificate, ClientTlsConfig, Endpoint, Identity, ServerTlsConfig};
+
+use crate::config::PeerTlsConfig;
+use crate::error::StandaloneError;
+
+/// Validated TLS material for one node's peer transport. The same node identity
+/// is used both as the peer-server identity and (for mTLS) the peer-client
+/// identity when dialing other nodes.
+pub(crate) struct PeerTlsMaterial {
+    pub server: ServerTlsConfig,
+    pub client: ClientTlsConfig,
+}
+
+fn read(path: &std::path::Path) -> Result<Vec<u8>, StandaloneError> {
+    std::fs::read(path).map_err(|source| StandaloneError::Tls {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })
+}
+
+/// Read the PEM trio and build the peer mTLS server + client configs, eagerly
+/// validating BOTH so a bad cert/key/CA fails at build() rather than on first
+/// dial. `tonic`'s `Identity/Certificate::from_pem` are lazy (just wrap bytes);
+/// the cryptographic parse happens when the acceptor/connector is materialized,
+/// so we force that here via `Server`/`Endpoint` dry-runs (no socket touched).
+pub(crate) fn build_peer_tls(cfg: &PeerTlsConfig) -> Result<PeerTlsMaterial, StandaloneError> {
+    let cert = read(&cfg.cert)?;
+    let key = read(&cfg.key)?;
+    let ca = read(&cfg.ca)?;
+
+    let identity = Identity::from_pem(&cert, &key);
+    let ca_cert = Certificate::from_pem(&ca);
+
+    let server = ServerTlsConfig::new()
+        .identity(identity.clone())
+        .client_ca_root(ca_cert.clone());
+    let client = ClientTlsConfig::new()
+        .ca_certificate(ca_cert)
+        .identity(identity);
+
+    // Eager validation (force the lazy parse before bind/spawn):
+    // server side — building the acceptor parses the identity + client CA.
+    tonic::transport::Server::builder()
+        .tls_config(server.clone())
+        .map_err(|source| StandaloneError::Tls {
+            path: cfg.cert.clone(),
+            source: Box::new(source),
+        })?;
+    // client side — building the connector parses the CA + client identity.
+    Endpoint::from_static("https://127.0.0.1:65535")
+        .tls_config(client.clone())
+        .map_err(|source| StandaloneError::Tls {
+            path: cfg.cert.clone(),
+            source: Box::new(source),
+        })?;
+
+    Ok(PeerTlsMaterial { server, client })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PeerTlsConfig;
+
+    // rcgen 0.13 API (mirrors examples/tls-mtls/src/certs.rs): KeyPair::generate,
+    // CertificateParams::{self_signed, signed_by}, cert.pem(), key.serialize_pem().
+    fn write_node_certs(dir: &std::path::Path) -> PeerTlsConfig {
+        use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+        let ca_key = KeyPair::generate().unwrap();
+        let mut ca_params = CertificateParams::new(vec!["tso-ca".to_string()]).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let node_key = KeyPair::generate().unwrap();
+        let node_params = CertificateParams::new(vec!["127.0.0.1".to_string()]).unwrap();
+        let node_cert = node_params.signed_by(&node_key, &ca_cert, &ca_key).unwrap();
+
+        let cert = dir.join("node.crt");
+        let key = dir.join("node.key");
+        let ca = dir.join("ca.crt");
+        std::fs::write(&cert, node_cert.pem()).unwrap();
+        std::fs::write(&key, node_key.serialize_pem()).unwrap();
+        std::fs::write(&ca, ca_cert.pem()).unwrap();
+        PeerTlsConfig { cert, key, ca }
+    }
+
+    #[tokio::test]
+    async fn valid_trio_builds_both_configs() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_node_certs(dir.path());
+        let mat = build_peer_tls(&cfg).expect("valid trio must build");
+        // Confirm the material fields are populated (used by Tasks 3–6).
+        let _ = mat.server;
+        let _ = mat.client;
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_a_tls_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = write_node_certs(dir.path());
+        cfg.cert = dir.path().join("does-not-exist.crt");
+        // PeerTlsMaterial is not Debug, so don't use unwrap_err().
+        let err = match build_peer_tls(&cfg) {
+            Ok(_) => panic!("expected a Tls error"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, StandaloneError::Tls { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn invalid_pem_is_a_tls_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = write_node_certs(dir.path());
+        let garbage = dir.path().join("garbage.crt");
+        std::fs::write(&garbage, b"not a pem").unwrap();
+        cfg.cert = garbage;
+        let err = match build_peer_tls(&cfg) {
+            Ok(_) => panic!("expected a Tls error"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, StandaloneError::Tls { .. }), "got {err:?}");
+    }
+}

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -101,6 +101,7 @@ mod openraft_driver {
                 election_min_ms: 150,
                 election_max_ms: 300,
             },
+            peer_tls: None,
         }
     }
 
@@ -154,6 +155,7 @@ mod openraft_driver {
             bootstrap: true,
             initial_membership: None,
             tuning: RaftTuning::default(),
+            peer_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -178,6 +180,7 @@ mod openraft_driver {
             bootstrap: false,
             initial_membership: Some(members),
             tuning: RaftTuning::default(),
+            peer_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -202,6 +205,7 @@ mod openraft_driver {
             bootstrap: true,
             initial_membership: Some(members),
             tuning: RaftTuning::default(),
+            peer_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -268,6 +272,7 @@ mod paxos_driver {
             tso_peers,
             data_dir: dir.path().join("paxos"),
             tick_interval: Duration::from_millis(20),
+            peer_tls: None,
         };
 
         let mut node = build(DriverConfig::Paxos(cfg))
@@ -293,6 +298,7 @@ mod paxos_driver {
             tso_peers: BTreeMap::new(),
             data_dir: std::path::PathBuf::from("/this/path/must/not/be/touched"),
             tick_interval: Duration::from_millis(20),
+            peer_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Paxos(cfg)).await,
@@ -319,6 +325,7 @@ mod paxos_driver {
             tso_peers: BTreeMap::new(),
             data_dir: dir.path().join("paxos"),
             tick_interval: Duration::from_millis(20),
+            peer_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Paxos(cfg)).await,

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<()> {
         bootstrap: cli.bootstrap,
         initial_membership: members,
         tuning: RaftTuning::default(),
+        peer_tls: None,
     });
     let mut node = build(cfg).await?;
     let drain = node.take_drain();

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -20,7 +20,9 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result};
 use clap::Parser;
 use tsoracle_server::Server;
-use tsoracle_standalone::{DriverConfig, MemberAddr, OpenraftConfig, RaftTuning, build};
+use tsoracle_standalone::{
+    DriverConfig, MemberAddr, OpenraftConfig, PeerTlsConfig, RaftTuning, build,
+};
 
 #[derive(Parser, Debug)]
 #[command(name = "openraft-standalone")]
@@ -38,6 +40,12 @@ struct Cli {
     /// id=raft_host:port/service_host:port,... (only with --bootstrap)
     #[arg(long)]
     members: Option<String>,
+    #[arg(long)]
+    peer_tls_cert: Option<std::path::PathBuf>,
+    #[arg(long)]
+    peer_tls_key: Option<std::path::PathBuf>,
+    #[arg(long)]
+    peer_tls_ca: Option<std::path::PathBuf>,
 }
 
 fn parse_members(input: &str) -> Result<BTreeMap<u64, MemberAddr>> {
@@ -62,6 +70,13 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
     let cli = Cli::parse();
     let members = cli.members.as_deref().map(parse_members).transpose()?;
+    let peer_tls = match (cli.peer_tls_cert, cli.peer_tls_key, cli.peer_tls_ca) {
+        (None, None, None) => None,
+        (Some(cert), Some(key), Some(ca)) => Some(PeerTlsConfig { cert, key, ca }),
+        _ => {
+            anyhow::bail!("--peer-tls-cert, --peer-tls-key, --peer-tls-ca must all be set together")
+        }
+    };
     let cfg = DriverConfig::Openraft(OpenraftConfig {
         id: cli.id,
         raft_addr: cli.raft_addr,
@@ -69,7 +84,7 @@ async fn main() -> Result<()> {
         bootstrap: cli.bootstrap,
         initial_membership: members,
         tuning: RaftTuning::default(),
-        peer_tls: None,
+        peer_tls,
     });
     let mut node = build(cfg).await?;
     let drain = node.take_drain();

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use anyhow::{Error, Result};
 use clap::Parser;
 use tsoracle_server::Server;
-use tsoracle_standalone::{DriverConfig, PaxosConfig, build, parse_peer_map};
+use tsoracle_standalone::{DriverConfig, PaxosConfig, PeerTlsConfig, build, parse_peer_map};
 
 #[derive(Parser, Debug)]
 #[command(name = "paxos-standalone")]
@@ -34,12 +34,25 @@ struct Cli {
     tso_peers: String,
     #[arg(long)]
     data_dir: std::path::PathBuf,
+    #[arg(long)]
+    peer_tls_cert: Option<std::path::PathBuf>,
+    #[arg(long)]
+    peer_tls_key: Option<std::path::PathBuf>,
+    #[arg(long)]
+    peer_tls_ca: Option<std::path::PathBuf>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
     let cli = Cli::parse();
+    let peer_tls = match (cli.peer_tls_cert, cli.peer_tls_key, cli.peer_tls_ca) {
+        (None, None, None) => None,
+        (Some(cert), Some(key), Some(ca)) => Some(PeerTlsConfig { cert, key, ca }),
+        _ => {
+            anyhow::bail!("--peer-tls-cert, --peer-tls-key, --peer-tls-ca must all be set together")
+        }
+    };
     let cfg = DriverConfig::Paxos(PaxosConfig {
         node_id: cli.node_id,
         peer_listen: cli.listen,
@@ -47,7 +60,7 @@ async fn main() -> Result<()> {
         tso_peers: parse_peer_map(&cli.tso_peers).map_err(Error::msg)?,
         data_dir: cli.data_dir,
         tick_interval: Duration::from_millis(20),
-        peer_tls: None,
+        peer_tls,
     });
     let mut node = build(cfg).await?;
     let drain = node.take_drain();

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -47,6 +47,7 @@ async fn main() -> Result<()> {
         tso_peers: parse_peer_map(&cli.tso_peers).map_err(Error::msg)?,
         data_dir: cli.data_dir,
         tick_interval: Duration::from_millis(20),
+        peer_tls: None,
     });
     let mut node = build(cfg).await?;
     let drain = node.take_drain();


### PR DESCRIPTION
## Summary

Adds TLS to both network surfaces of a standalone tsoracle node: **mutual TLS on the openraft/paxos peer transport** (closing the previously-unauthenticated plaintext peer socket) and **TLS on the client-facing gRPC API** (server-auth + optional client mTLS). Configured via per-surface PEM-path flags.

Sub-project 2 of the standalone roadmap (follows #438). Authentication modes follow the cross-industry consensus (etcd / CockroachDB / Consul): peer transport = plaintext-or-mTLS; client API = server-auth + optional client mTLS; configurable, not mandatory.

## What changed

- **Peer mTLS (`tsoracle-standalone`)** — `PeerTlsConfig { cert, key, ca }` on the openraft/paxos driver configs. When set, the peer server requires + verifies client certs (`client_ca_root`) and the peer *clients* (`PeerNetwork` / `PeerSink`) dial `https://` presenting the node identity. A `build_peer_tls` helper builds and **eagerly validates** both the server and client TLS configs at `build()` (tonic's `Identity/Certificate::from_pem` are lazy, so without a dry-run a bad cert would only fail on first dial — possibly never on a single node); failures surface as `StandaloneError::Tls` before the listener binds. Peer authorization is CA-based, so the peer CA must be **cluster-dedicated** (documented on the flags).
- **Client-API TLS (bin)** — `--tls-cert`/`--tls-key` enable server-auth TLS; `--tls-client-ca` adds client mTLS. Built into `Server::builder().tls_config(...)` (eagerly validated). No flags ⇒ plaintext (for proxy/mesh-fronted deployments).
- **Per-surface flags** — client: `--tls-cert/-key/-client-ca`; peer (openraft/paxos): `--peer-tls-cert/-key/-ca` (all-or-nothing), with validation. Examples gained `--peer-tls-*` pass-through.
- **Fix: scheme-less Paxos leader hints** — Paxos wrapped `tso_peers` endpoints in `http://`, but TLS clients drop wire-supplied `http://` hints to prevent transport downgrade, so a TLS client redirected by a Paxos follower couldn't reach the leader. Hints are now scheme-less (matching openraft's `service_endpoint`); the client prepends the scheme from its own config.

## Tests

- **Peer mTLS handshake** (raft + paxos, in-crate, driving the real peer clients): valid cert connects; no-cert / wrong-CA / plaintext-against-TLS are rejected. (`Channel::connect()` is lazy, so the tests issue a real RPC to force the handshake and assert accept/reject.)
- Eager-validation unit tests (missing/invalid PEM ⇒ build-time error).
- Bin smoke: `serve file --tls-cert/-key` served + queried by a TLS client; single-node `serve openraft --peer-tls-*` boots and serves.
- Full workspace test suite, feature matrix (file/openraft/paxos/default for crate + bin), and `clippy --all-targets --all-features -D warnings` all green.

## Notes for reviewers

- Peer authorization is CA-only (any cert chaining to the configured peer CA is accepted) — hence the cluster-dedicated-CA requirement. SAN/identity-to-membership binding, SNI override, and hot cert reload are deferred (restart-to-rotate is cheap given the graceful leadership handoff from #438/#423).
- Client-API TLS is driver-agnostic (one `run_serve` path), so it's covered once via the file driver rather than per-driver. OmniPaxos cannot run single-node, so multi-node paxos redirect-under-TLS is exercised in the kind e2e lane, not a unit test.
