### PR TITLE
fix(stress): surface scheme-less paxos leader hints in the topology fixture

### DIFF
--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -165,6 +165,29 @@ fn paxos_config(node_id: u64, cluster: &ClusterConfig) -> OmniPaxosConfig {
     }
 }
 
+/// Build the toolkit peer list for node `my_id`: every *other* node paired with
+/// its service endpoint.
+///
+/// The endpoint must be a **scheme-less** `host:port`. `StandaloneHost` surfaces
+/// it verbatim as `LeaderState::Follower::leader_endpoint`, which the server's
+/// `run_leader_watch` guard requires to be scheme-less (a `http(s)://` hint is
+/// silently dropped by a TLS client's redirect path, so a follower would point
+/// clients at an unreachable leader). A `SocketAddr`'s `Display` is exactly that
+/// shape; the in-process `MeshSink` routes by node id, so this string is only
+/// ever used as a leader hint, never dialed. See
+/// `build_toolkit_peers_yields_scheme_less_endpoints`.
+#[allow(dead_code)]
+fn build_toolkit_peers(tso_endpoints: &[(u64, SocketAddr)], my_id: u64) -> Vec<TsoPeer> {
+    tso_endpoints
+        .iter()
+        .filter(|(peer_id, _)| *peer_id != my_id)
+        .map(|(peer_id, peer_addr)| TsoPeer {
+            node_id: *peer_id,
+            endpoint: peer_addr.to_string(),
+        })
+        .collect()
+}
+
 /// `MessageSink` that routes outbound paxos messages back through the
 /// shared `MemNetwork`. Lifted from `examples/paxos-embedded`.
 #[allow(dead_code)]
@@ -259,14 +282,7 @@ impl PaxosTopology {
             });
 
             // ---- StandaloneHost ----
-            let toolkit_peers: Vec<TsoPeer> = tso_endpoints
-                .iter()
-                .filter(|(peer_id, _)| *peer_id != id)
-                .map(|(peer_id, peer_addr)| TsoPeer {
-                    node_id: *peer_id,
-                    endpoint: format!("http://{peer_addr}"),
-                })
-                .collect();
+            let toolkit_peers = build_toolkit_peers(&tso_endpoints, id);
             let mut host = StandaloneHost::builder()
                 .omnipaxos(omnipaxos.clone())
                 .my_node_id(id)
@@ -517,6 +533,38 @@ impl ChaosController for PaxosController {
 mod tests {
     use super::*;
     use std::time::Instant as StdInstant;
+
+    // The follower-redirect contract this guards is enforced at runtime only by
+    // a `debug_assert` in the server's `run_leader_watch`, which fires solely
+    // when a follower has observed a *stable* leader long enough to surface its
+    // hint. On a fast host the chaos tests finish before that happens, so the
+    // guard's coverage is timing-dependent (it slipped through once, surfacing
+    // as a slow-CI-only flake). This test pins the contract at the construction
+    // site instead — fully deterministic, independent of leader-election timing.
+    #[test]
+    fn build_toolkit_peers_yields_scheme_less_endpoints() {
+        let tso_endpoints: Vec<(u64, SocketAddr)> = vec![
+            (1, "127.0.0.1:5001".parse().unwrap()),
+            (2, "127.0.0.1:5002".parse().unwrap()),
+            (3, "127.0.0.1:5003".parse().unwrap()),
+        ];
+
+        let peers = build_toolkit_peers(&tso_endpoints, 2);
+
+        assert_eq!(peers.len(), 2, "a node must not list itself as a peer");
+        assert!(
+            peers.iter().all(|peer| peer.node_id != 2),
+            "node 2 must be filtered from its own peer list, got {peers:?}"
+        );
+        for peer in &peers {
+            assert!(
+                !peer.endpoint.starts_with("http://") && !peer.endpoint.starts_with("https://"),
+                "peer leader_endpoint must be a scheme-less host:port (a TLS client \
+                 drops http(s):// hints); got {:?}",
+                peer.endpoint
+            );
+        }
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn spawn_3_nodes_reports_endpoints_and_leader() {


### PR DESCRIPTION
## Problem

The `topology::paxos::tests::kill_leader_triggers_reelection` test flaked on CI (observed on the PR #443 run, which is itself an openraft-only change — the failure is unrelated and pre-existing). Two symptoms appeared together:

- a `debug_assert` panic at `fence.rs:103` — *"consensus driver surfaced a scheme-bearing leader_endpoint (`http://...`)"*; and
- a 30s re-election timeout with every node stuck at `leader=1`.

## Root cause (single)

The paxos stress topology built its toolkit peers with an `http://`-schemed endpoint. `StandaloneHost` surfaces that verbatim as `LeaderState::Follower::leader_endpoint`, which violates the scheme-less `host:port` contract the server's `run_leader_watch` guard enforces (added in #439 — a TLS client silently drops `http(s)://` redirect hints to avoid a transport downgrade). This was one of the "scattered `http://` fixtures" #439 flagged; it was missed. The raft topology dodged it by using an empty `service_endpoint`.

### Why both a panic *and* a re-election timeout, from one cause

1. Once a follower observes a stable leader, it surfaces `Follower{Some("http://...")}` → the guard's `debug_assert` panics the `run_leader_watch` task.
2. The watch task is `catch_unwind`+`resume_unwind`; `serve_inner`'s biased watch arm fires and `serve_with_listener` **returns** `Err(WatchPanic)` (it does not unwind).
3. The topology's server task logs and returns → the moved `Server` drops → `PaxosDriver` → `StandaloneHost` → `PaxosRunner::Drop` signals shutdown → that node's OmniPaxos tick task **stops**.
4. Under slow CI the spawn→`kill_leader` window is long enough for *both* followers to settle, panic, and lose their tick tasks before the kill → no quorum → re-election never completes. On a fast host the test finishes before any follower settles, so it only flaked under CI timing.

## Fix

Extract the peer construction into `build_toolkit_peers`, emitting a scheme-less `host:port` (`SocketAddr`'s `Display`). The in-process `MeshSink` routes by node id, so this string is only ever used as a leader hint, never dialed — safe to make scheme-less. Removing the panic removes the consensus teardown, so both symptoms are resolved.

## Regression guard

The runtime `debug_assert` only fires when a follower has observed a *stable* leader long enough to surface its hint, which is timing-dependent (it slipped through once as a slow-CI-only flake). A convergence-wait in the test cannot fix this: the leader-event channel is a coalescing `watch::channel`, so consensus-leader unanimity does not imply the watch loop has *consumed* a `Follower{Some}` value. So the contract is pinned at the construction site instead — `build_toolkit_peers_yields_scheme_less_endpoints` is fully deterministic and independent of leader-election timing.

## Verification

- Full `stress` lib suite (`--all-features`): 125 passed, 0 failed.
- `kill_leader_triggers_reelection`: green.
- The new unit test fails deterministically (3/3, ~0ms) when `http://` is reintroduced, and passes with the fix.
- `cargo clippy -p stress --all-features --all-targets`: clean.