### PR TITLE
fix(deploy): require peer mTLS or explicit opt-in for HA Helm deployments

### DIFF
--- a/deploy/charts/tsoracle/templates/NOTES.txt
+++ b/deploy/charts/tsoracle/templates/NOTES.txt
@@ -15,3 +15,16 @@ TLS is enabled. The Secret {{ .Values.tls.secretName | quote }} must contain:
 Peer connections between replicas require a CA shared across all nodes.
 Do not reuse a public CA here — provision a dedicated internal CA.
 {{- end }}
+{{- if and (ne .Values.driver "file") (not .Values.tls.enabled) }}
+
+WARNING: peer consensus traffic is UNAUTHENTICATED PLAINTEXT (tls.enabled=false,
+tls.allowInsecurePeer=true). Any pod that can reach port {{ .Values.ports.peer }} can inject
+raft/paxos RPCs and disrupt leadership, quorum, or timestamp ordering.
+{{- if .Values.networkPolicy.enabled }}
+A NetworkPolicy restricts the peer port to sibling replicas, but enable peer mTLS
+(tls.enabled=true with tls.secretName) before running this in production.
+{{- else }}
+networkPolicy.enabled=false — there is NO network restriction on the peer port.
+Enable peer mTLS or a NetworkPolicy before exposing this beyond a trusted network.
+{{- end }}
+{{- end }}

--- a/deploy/charts/tsoracle/templates/_helpers.tpl
+++ b/deploy/charts/tsoracle/templates/_helpers.tpl
@@ -9,5 +9,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "tsoracle.validate" -}}
 {{- if not (has .Values.driver (list "file" "openraft" "paxos")) }}{{ fail "driver must be file, openraft, or paxos" }}{{- end }}
 {{- if and .Values.tls.enabled (not .Values.tls.secretName) }}{{ fail "tls.enabled requires tls.secretName" }}{{- end }}
+{{- if and (ne .Values.driver "file") (not .Values.tls.enabled) (not .Values.tls.allowInsecurePeer) }}{{ fail "driver=openraft/paxos exposes a consensus peer port that runs unauthenticated plaintext when tls.enabled=false; set tls.enabled=true with tls.secretName to enable peer mTLS, or set tls.allowInsecurePeer=true to intentionally deploy plaintext consensus (e.g. dev/test behind a NetworkPolicy)" }}{{- end }}
 {{- if and (eq .Values.driver "file") (gt (int .Values.replicas) 1) }}{{ fail "driver=file is single-node; set replicas: 1" }}{{- end }}
 {{- end -}}

--- a/deploy/charts/tsoracle/templates/networkpolicy.yaml
+++ b/deploy/charts/tsoracle/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.networkPolicy.enabled (ne .Values.driver "file") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tsoracle.peerService" . }}
+  labels:
+    {{- include "tsoracle.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tsoracle
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: tsoracle
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: peer
+    - ports:
+        - protocol: TCP
+          port: tso
+{{- end }}

--- a/deploy/charts/tsoracle/tests/render.sh
+++ b/deploy/charts/tsoracle/tests/render.sh
@@ -4,22 +4,24 @@
 set -eu
 chart="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 
-# openraft => StatefulSet + headless svc + PDB
-out=$(helm template t "$chart" --set driver=openraft)
+# openraft => StatefulSet + headless svc + PDB + NetworkPolicy
+out=$(helm template t "$chart" --set driver=openraft,tls.allowInsecurePeer=true)
 echo "$out" | grep -q "kind: StatefulSet" || { echo "openraft: missing StatefulSet"; exit 1; }
 echo "$out" | grep -q "kind: PodDisruptionBudget" || { echo "openraft: missing PDB"; exit 1; }
 echo "$out" | grep -q "clusterIP: None" || { echo "openraft: missing headless Service"; exit 1; }
+echo "$out" | grep -q "kind: NetworkPolicy" || { echo "openraft: missing NetworkPolicy"; exit 1; }
 
 # paxos => same HA shape
-helm template t "$chart" --set driver=paxos | grep -q "kind: StatefulSet" || { echo "paxos: missing StatefulSet"; exit 1; }
+helm template t "$chart" --set driver=paxos,tls.allowInsecurePeer=true | grep -q "kind: StatefulSet" || { echo "paxos: missing StatefulSet"; exit 1; }
 
-# file => Deployment + PVC, no StatefulSet, no headless svc (replicas=1 to pass the guard)
+# file => Deployment + PVC, no StatefulSet, no headless svc, no NetworkPolicy (replicas=1 to pass the guard)
 out=$(helm template t "$chart" --set driver=file,replicas=1)
 echo "$out" | grep -q "kind: Deployment" || { echo "file: missing Deployment"; exit 1; }
 echo "$out" | grep -q "kind: PersistentVolumeClaim" || { echo "file: missing PVC"; exit 1; }
 if echo "$out" | grep -q "kind: StatefulSet"; then echo "file: must NOT have StatefulSet"; exit 1; fi
+if echo "$out" | grep -q "kind: NetworkPolicy"; then echo "file: must NOT have NetworkPolicy"; exit 1; fi
 
-# tls on => secret volume mount path present
+# tls on => secret volume mount path present, and no allowInsecurePeer needed
 helm template t "$chart" --set driver=openraft,tls.enabled=true,tls.secretName=certs | grep -q "/etc/tsoracle/tls" \
     || { echo "tls: missing mount"; exit 1; }
 
@@ -33,8 +35,25 @@ if helm template t "$chart" --set driver=openraft,tls.enabled=true >/dev/null 2>
     echo "tls-without-secret guard missing"; exit 1
 fi
 
+# invariant: HA driver with TLS off and no opt-out must FAIL (no unauthenticated peer port by default)
+if helm template t "$chart" --set driver=openraft >/dev/null 2>&1; then
+    echo "insecure-peer guard missing (openraft)"; exit 1
+fi
+if helm template t "$chart" --set driver=paxos >/dev/null 2>&1; then
+    echo "insecure-peer guard missing (paxos)"; exit 1
+fi
+
+# opt-out: allowInsecurePeer renders but still ships a NetworkPolicy by default
+helm template t "$chart" --set driver=openraft,tls.allowInsecurePeer=true | grep -q "kind: NetworkPolicy" \
+    || { echo "allowInsecurePeer: NetworkPolicy not emitted"; exit 1; }
+
+# networkPolicy.enabled=false suppresses the policy
+if helm template t "$chart" --set driver=openraft,tls.allowInsecurePeer=true,networkPolicy.enabled=false | grep -q "kind: NetworkPolicy"; then
+    echo "networkPolicy.enabled=false still emitted a NetworkPolicy"; exit 1
+fi
+
 # storageClassName must NOT be emitted as empty string (would bind the "" class)
-if helm template t "$chart" --set driver=openraft | grep -q 'storageClassName: ""'; then
+if helm template t "$chart" --set driver=openraft,tls.allowInsecurePeer=true | grep -q 'storageClassName: ""'; then
     echo "empty storageClassName emitted"; exit 1
 fi
 

--- a/deploy/charts/tsoracle/values.yaml
+++ b/deploy/charts/tsoracle/values.yaml
@@ -11,6 +11,9 @@ tls:
   enabled: false
   secretName: ""            # Secret with tls.crt / tls.key / ca.crt; mounted at /etc/tsoracle/tls
   clientMtls: false         # also require client certs on the client API
+  allowInsecurePeer: false  # HA drivers refuse to render with tls.enabled=false unless this is set
+networkPolicy:
+  enabled: true             # HA only; restrict the peer consensus port to sibling replicas
 server:
   windowAhead: 3s
   failoverAdvance: 1s


### PR DESCRIPTION
## Problem

The Helm chart introduced in #447 defaults the HA path (`driver: openraft`, 3 replicas) to `tls.enabled: false`. In that default state the entrypoint passes no peer TLS flags, binds the consensus peer listener to `0.0.0.0`, and the headless Service publishes the peer port cluster-wide. The peer transport falls back to plaintext HTTP when no peer TLS material is configured (`crates/tsoracle-standalone/src/drivers/openraft/{mod.rs,network.rs}`), so the default `helm install` stands up a cluster speaking **unauthenticated plaintext** raft/paxos RPCs reachable by any pod on the cluster network. Because the consensus layer is the integrity boundary for high-water advancement and leadership, spoofed peer traffic can force elections, disrupt quorum, or advance consensus state — violating the oracle's gap-free ordering guarantee.

This addresses a security finding against commit `12dfa54`. The transport's plaintext fallback is intentional library behavior; the issue is purely that the chart chose an insecure default. The fix lives entirely in the deployment artifacts.

## Approach

Secure-by-default with an explicit, acknowledged opt-out — rather than a blanket hard-fail that would break local/kind/dev where certs are friction.

- **Render-time guard** (`_helpers.tpl`): `driver=openraft|paxos` with `tls.enabled=false` now fails to render unless `tls.allowInsecurePeer=true` is set explicitly. You can no longer get plaintext consensus by accident — only on purpose.
- **NetworkPolicy** (`networkpolicy.yaml`, `networkPolicy.enabled` default `true`, HA only): restricts the peer port to sibling replicas as defense-in-depth, independent of TLS. Only `Ingress` is constrained so peers can still dial each other; the client port stays open to all sources.
- **NOTES.txt**: prints an explicit plaintext-consensus warning whenever an HA deployment runs with TLS off, and notes whether the NetworkPolicy is active.

## Behavior matrix

| Invocation | Result |
| --- | --- |
| `--set driver=openraft` (default TLS off) | **render blocked** with an actionable message |
| `--set driver=openraft,tls.enabled=true,tls.secretName=certs` | renders, peer mTLS on, NetworkPolicy present, no warning |
| `--set driver=openraft,tls.allowInsecurePeer=true` | renders plaintext, NetworkPolicy present, warning printed |
| `--set driver=openraft,tls.allowInsecurePeer=true,networkPolicy.enabled=false` | renders, no NetworkPolicy, stronger warning |
| `--set driver=file,replicas=1` | unaffected (no peer port, no NetworkPolicy) |

## Testing

`deploy/charts/tsoracle/tests/render.sh` extended with the new invariants (guard fires for openraft and paxos, opt-out renders with a NetworkPolicy, `networkPolicy.enabled=false` suppresses it, TLS path needs no opt-out). Verified locally with helm v4.1.4: `helm lint` clean and the render smoke test passes.
