### PR TITLE
feat(codec): add VersionedCodec trait and framed encode/decode helpers

### DIFF
--- a/crates/tsoracle-codec/src/lib.rs
+++ b/crates/tsoracle-codec/src/lib.rs
@@ -27,6 +27,11 @@ use std::io;
 
 use serde::{Serialize, de::DeserializeOwned};
 
+mod versioned;
+pub use versioned::{
+    VersionedCodec, decode_framed, decode_postcard_exact, encode_framed, encode_postcard,
+};
+
 /// Failure modes of the version-prefixed postcard codec.
 ///
 /// `Encode` and `Decode` are kept distinct so a caller can tell which
@@ -54,6 +59,18 @@ pub enum CodecError {
     /// overwrite that left stale tail bytes — rather than a clean record.
     #[error("trailing bytes: {extra} unconsumed after a valid body")]
     TrailingBytes { extra: usize },
+    /// The leading version byte was outside the reader's supported range
+    /// `[min, max]`. Distinct from [`CodecError::Version`] (which a single-version
+    /// reader returns); a multi-version reader uses this to fail loudly on a
+    /// version it has no parser for.
+    #[error("version unsupported: {actual} outside readable range [{min}, {max}]")]
+    VersionUnsupported { min: u8, max: u8, actual: u8 },
+    /// Down-conversion was asked to encode state not representable at `version`
+    /// (a feature-gate violation: a field/behavior introduced at a later version
+    /// is set while encoding an older layout). Fail-loud rather than silently
+    /// dropping the value.
+    #[error("value not representable at version {version}")]
+    NotRepresentable { version: u8 },
 }
 
 /// Encode `value` as `[version | postcard(value)]`.
@@ -111,10 +128,12 @@ pub fn decode<T: DeserializeOwned>(expected_version: u8, bytes: &[u8]) -> Result
 /// enum and so does not use this.)
 pub fn codec_io_error(context: &str, err: CodecError) -> io::Error {
     match err {
-        version_mismatch @ CodecError::Version { .. } => io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("{context}: {version_mismatch}"),
-        ),
+        foreign_version @ (CodecError::Version { .. } | CodecError::VersionUnsupported { .. }) => {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("{context}: {foreign_version}"),
+            )
+        }
         other => io::Error::other(format!("{context}: {other}")),
     }
 }
@@ -228,6 +247,33 @@ mod tests {
         let io_err = codec_io_error("vote decode", CodecError::Empty);
         assert_ne!(io_err.kind(), io::ErrorKind::InvalidData);
         assert!(io_err.to_string().starts_with("vote decode: "));
+    }
+
+    #[test]
+    fn codec_io_error_maps_version_unsupported_to_invalid_data() {
+        // A multi-version reader's foreign-version rejection must carry the same
+        // `InvalidData` contract as the single-version `Version` mismatch, so the
+        // openraft storage layer can still detect a foreign schema version.
+        let err = CodecError::VersionUnsupported {
+            min: 3,
+            max: 3,
+            actual: 7,
+        };
+        let io_err = codec_io_error("log decode", err);
+        assert_eq!(io_err.kind(), io::ErrorKind::InvalidData);
+        assert!(io_err.to_string().starts_with("log decode: "));
+    }
+
+    #[test]
+    fn codec_io_error_maps_not_representable_to_other_kind() {
+        // An encode-side feature-gate violation is not a foreign-format read, so
+        // it must not masquerade as the `InvalidData` reserved for that case.
+        let io_err = codec_io_error(
+            "snapshot encode",
+            CodecError::NotRepresentable { version: 1 },
+        );
+        assert_ne!(io_err.kind(), io::ErrorKind::InvalidData);
+        assert!(io_err.to_string().starts_with("snapshot encode: "));
     }
 
     use proptest::prelude::*;

--- a/crates/tsoracle-codec/src/versioned.rs
+++ b/crates/tsoracle-codec/src/versioned.rs
@@ -1,0 +1,386 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Versioned codec seam. A [`VersionedCodec`] type can be decoded from any
+//! supported version (up-converting older layouts into the current in-memory
+//! type) and encoded at any active version (down-converting the current type
+//! into an older layout). [`encode_framed`] / [`decode_framed`] add and validate
+//! the leading version byte; [`encode_postcard`] / [`decode_postcard_exact`] are
+//! the DRY per-version body building blocks implementors call.
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::CodecError;
+
+/// A type whose persisted and on-wire representation is versioned.
+///
+/// `decode_version` up-converts an older layout into the current in-memory type;
+/// `encode_version` down-converts the current type into the layout of a given
+/// (possibly older) version. Implementors typically `match` on the version,
+/// routing to a per-version struct via [`decode_postcard_exact`] /
+/// [`encode_postcard`] and a `From` conversion. Both methods operate on the
+/// bare body (the bytes after the version prefix); framing is handled by
+/// [`encode_framed`] / [`decode_framed`].
+pub trait VersionedCodec: Sized {
+    /// Decode a `body` known to be `version` into the current type.
+    fn decode_version(version: u8, body: &[u8]) -> Result<Self, CodecError>;
+
+    /// Encode `self` as the body layout of `version`.
+    fn encode_version(&self, version: u8) -> Result<Vec<u8>, CodecError>;
+}
+
+/// Encode `value` as `[version | body]`, where `body` is `value`'s layout at
+/// `version` (see [`VersionedCodec::encode_version`]).
+pub fn encode_framed<T: VersionedCodec>(version: u8, value: &T) -> Result<Vec<u8>, CodecError> {
+    let body = value.encode_version(version)?;
+    let mut out = Vec::with_capacity(1 + body.len());
+    out.push(version);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Decode a `[version | body]` payload, rejecting a version outside the reader's
+/// supported range `[min_version, max_version]` with [`CodecError::VersionUnsupported`]
+/// before any body parse. An in-range version is dispatched to
+/// [`VersionedCodec::decode_version`], up-converting older layouts into the
+/// current type.
+pub fn decode_framed<T: VersionedCodec>(
+    min_version: u8,
+    max_version: u8,
+    bytes: &[u8],
+) -> Result<T, CodecError> {
+    let (first, body) = bytes.split_first().ok_or(CodecError::Empty)?;
+    let version = *first;
+    if version < min_version || version > max_version {
+        return Err(CodecError::VersionUnsupported {
+            min: min_version,
+            max: max_version,
+            actual: version,
+        });
+    }
+    T::decode_version(version, body)
+}
+
+/// Serialize `value` to a bare postcard body (no version prefix). Used by
+/// [`VersionedCodec::encode_version`] implementations per version.
+pub fn encode_postcard<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
+    postcard::to_stdvec(value).map_err(CodecError::Encode)
+}
+
+/// Deserialize a bare postcard body, rejecting surplus trailing bytes. A
+/// versioned format that exists to catch drift treats trailing garbage as
+/// corruption (e.g. a partial overwrite), not a clean record. Used by
+/// [`VersionedCodec::decode_version`] implementations per version.
+pub fn decode_postcard_exact<T: DeserializeOwned>(body: &[u8]) -> Result<T, CodecError> {
+    let (value, remainder) = postcard::take_from_bytes(body).map_err(CodecError::Decode)?;
+    if !remainder.is_empty() {
+        return Err(CodecError::TrailingBytes {
+            extra: remainder.len(),
+        });
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Body {
+        idx: u64,
+        name: String,
+    }
+
+    // Current in-memory type. `color` is added at v2 and, per the design's
+    // representability rule, is feature-gated off (None) until the active write
+    // version reaches 2, so down-conversion to v1 is always lossless.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Widget {
+        id: u64,
+        label: String,
+        color: Option<String>,
+    }
+
+    // v1 on-disk/wire layout: no `color`.
+    #[derive(Serialize, Deserialize)]
+    struct WidgetV1 {
+        id: u64,
+        label: String,
+    }
+
+    // v2 layout: includes `color`.
+    #[derive(Serialize, Deserialize)]
+    struct WidgetV2 {
+        id: u64,
+        label: String,
+        color: Option<String>,
+    }
+
+    impl From<WidgetV1> for Widget {
+        fn from(widget: WidgetV1) -> Self {
+            Widget {
+                id: widget.id,
+                label: widget.label,
+                color: None,
+            }
+        }
+    }
+
+    impl From<WidgetV2> for Widget {
+        fn from(widget: WidgetV2) -> Self {
+            Widget {
+                id: widget.id,
+                label: widget.label,
+                color: widget.color,
+            }
+        }
+    }
+
+    const WIDGET_MIN: u8 = 1;
+    const WIDGET_MAX: u8 = 2;
+
+    impl VersionedCodec for Widget {
+        fn decode_version(version: u8, body: &[u8]) -> Result<Self, CodecError> {
+            match version {
+                1 => decode_postcard_exact::<WidgetV1>(body).map(Into::into),
+                2 => decode_postcard_exact::<WidgetV2>(body).map(Into::into),
+                other => Err(CodecError::VersionUnsupported {
+                    min: WIDGET_MIN,
+                    max: WIDGET_MAX,
+                    actual: other,
+                }),
+            }
+        }
+
+        fn encode_version(&self, version: u8) -> Result<Vec<u8>, CodecError> {
+            match version {
+                1 => {
+                    // v1 has no `color`. If it is set (a feature-gate violation —
+                    // `color` belongs to v2+), fail loudly rather than silently
+                    // drop it. encode_version returns Result precisely for this.
+                    if self.color.is_some() {
+                        return Err(CodecError::NotRepresentable { version: 1 });
+                    }
+                    encode_postcard(&WidgetV1 {
+                        id: self.id,
+                        label: self.label.clone(),
+                    })
+                }
+                2 => encode_postcard(&WidgetV2 {
+                    id: self.id,
+                    label: self.label.clone(),
+                    color: self.color.clone(),
+                }),
+                other => Err(CodecError::VersionUnsupported {
+                    min: WIDGET_MIN,
+                    max: WIDGET_MAX,
+                    actual: other,
+                }),
+            }
+        }
+    }
+
+    #[test]
+    fn postcard_body_roundtrips() {
+        let original = Body {
+            idx: 7,
+            name: "ts".into(),
+        };
+        let bytes = encode_postcard(&original).expect("encode");
+        let decoded: Body = decode_postcard_exact(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn postcard_body_rejects_trailing_bytes() {
+        let mut bytes = encode_postcard(&Body {
+            idx: 1,
+            name: "x".into(),
+        })
+        .expect("encode");
+        bytes.extend_from_slice(&[0xAB, 0xCD]);
+        assert!(matches!(
+            decode_postcard_exact::<Body>(&bytes),
+            Err(CodecError::TrailingBytes { extra: 2 })
+        ));
+    }
+
+    #[test]
+    fn version_unsupported_carries_range_and_actual() {
+        let err = CodecError::VersionUnsupported {
+            min: 1,
+            max: 2,
+            actual: 9,
+        };
+        assert_eq!(
+            err.to_string(),
+            "version unsupported: 9 outside readable range [1, 2]"
+        );
+    }
+
+    #[test]
+    fn not_representable_names_the_version() {
+        let err = CodecError::NotRepresentable { version: 1 };
+        assert_eq!(err.to_string(), "value not representable at version 1");
+    }
+
+    #[test]
+    fn trait_encode_decode_roundtrips_each_version() {
+        let widget = Widget {
+            id: 42,
+            label: "tso".into(),
+            color: Some("amber".into()),
+        };
+        let body_v2 = widget.encode_version(2).expect("encode v2");
+        let decoded_v2 = Widget::decode_version(2, &body_v2).expect("decode v2");
+        assert_eq!(widget, decoded_v2);
+
+        let gated = Widget {
+            id: 7,
+            label: "old".into(),
+            color: None,
+        };
+        let body_v1 = gated.encode_version(1).expect("encode v1");
+        let decoded_v1 = Widget::decode_version(1, &body_v1).expect("decode v1");
+        assert_eq!(gated, decoded_v1);
+    }
+
+    #[test]
+    fn down_convert_rejects_non_representable_state() {
+        // A v2-only field (color) set while encoding the v1 layout must fail
+        // loud, not silently drop — in release builds too.
+        let widget = Widget {
+            id: 1,
+            label: "x".into(),
+            color: Some("blue".into()),
+        };
+        assert!(matches!(
+            widget.encode_version(1),
+            Err(CodecError::NotRepresentable { version: 1 })
+        ));
+    }
+
+    #[test]
+    fn encode_framed_prepends_version_and_matches_body() {
+        let widget = Widget {
+            id: 5,
+            label: "z".into(),
+            color: None,
+        };
+        let framed = encode_framed(1, &widget).expect("encode_framed v1");
+        assert_eq!(framed[0], 1, "leading byte is the version");
+        // The remainder must equal the bare v1 body — proving no `color` byte
+        // leaks into the v1 layout (down-conversion is lossless).
+        let expected_body = widget.encode_version(1).expect("encode v1 body");
+        assert_eq!(&framed[1..], expected_body.as_slice());
+    }
+
+    #[test]
+    fn decode_framed_dispatches_and_up_converts() {
+        // A record written at v1 (no color) decodes into the current type with
+        // color defaulted to None.
+        let v1_body = encode_postcard(&WidgetV1 {
+            id: 9,
+            label: "old".into(),
+        })
+        .expect("body");
+        let mut framed = vec![1u8];
+        framed.extend_from_slice(&v1_body);
+        let widget: Widget = decode_framed(WIDGET_MIN, WIDGET_MAX, &framed).expect("decode v1");
+        assert_eq!(
+            widget,
+            Widget {
+                id: 9,
+                label: "old".into(),
+                color: None
+            }
+        );
+    }
+
+    #[test]
+    fn decode_framed_roundtrips_current_version() {
+        let widget = Widget {
+            id: 1,
+            label: "now".into(),
+            color: Some("red".into()),
+        };
+        let framed = encode_framed(2, &widget).expect("encode");
+        let back: Widget = decode_framed(WIDGET_MIN, WIDGET_MAX, &framed).expect("decode");
+        assert_eq!(widget, back);
+    }
+
+    #[test]
+    fn decode_framed_rejects_out_of_range_version() {
+        let framed = [3u8, 0x00];
+        let err = decode_framed::<Widget>(WIDGET_MIN, WIDGET_MAX, &framed).expect_err("reject");
+        assert!(matches!(
+            err,
+            CodecError::VersionUnsupported {
+                min: 1,
+                max: 2,
+                actual: 3
+            }
+        ));
+    }
+
+    #[test]
+    fn decode_framed_rejects_below_range_version() {
+        let framed = [0u8, 0x00];
+        let err = decode_framed::<Widget>(WIDGET_MIN, WIDGET_MAX, &framed).expect_err("reject");
+        assert!(matches!(
+            err,
+            CodecError::VersionUnsupported {
+                min: 1,
+                max: 2,
+                actual: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn decode_framed_rejects_empty() {
+        let err = decode_framed::<Widget>(WIDGET_MIN, WIDGET_MAX, &[]).expect_err("reject");
+        assert!(matches!(err, CodecError::Empty));
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        // For any widget with color gated off, framing at v1 then decoding
+        // returns the original; framing at v2 with any color round-trips too.
+        #[test]
+        fn framed_roundtrips_any(id in any::<u64>(), label in any::<String>(), color in any::<Option<String>>()) {
+            let gated = Widget { id, label: label.clone(), color: None };
+            let framed_v1 = encode_framed(1, &gated).unwrap();
+            let back_v1: Widget = decode_framed(WIDGET_MIN, WIDGET_MAX, &framed_v1).unwrap();
+            prop_assert_eq!(gated, back_v1);
+
+            let full = Widget { id, label, color };
+            let framed_v2 = encode_framed(2, &full).unwrap();
+            let back_v2: Widget = decode_framed(WIDGET_MIN, WIDGET_MAX, &framed_v2).unwrap();
+            prop_assert_eq!(full, back_v2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a symmetric multi-version codec seam to `tsoracle-codec` so types whose on-disk and on-wire layout evolves can be read from any supported version (up-convert) and written at any active version (down-convert), with fail-loud rejection of out-of-range versions on read and fail-loud rejection of non-representable down-conversions on write.

**Purely additive.** The existing single-version `encode` / `decode` and their callers are untouched. No production call site changes.

## New public surface (in `tsoracle-codec`)

`````rust
pub trait VersionedCodec: Sized {
    fn decode_version(version: u8, body: &[u8]) -> Result<Self, CodecError>;
    fn encode_version(&self, version: u8) -> Result<Vec<u8>, CodecError>;
}
pub fn encode_framed<T: VersionedCodec>(version: u8, value: &T) -> Result<Vec<u8>, CodecError>;
pub fn decode_framed<T: VersionedCodec>(min_version: u8, max_version: u8, bytes: &[u8]) -> Result<T, CodecError>;
pub fn encode_postcard<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError>;
pub fn decode_postcard_exact<T: DeserializeOwned>(body: &[u8]) -> Result<T, CodecError>;
// New CodecError variants:
//   VersionUnsupported { min: u8, max: u8, actual: u8 }  -> codec_io_error => InvalidData
//   NotRepresentable   { version: u8 }                   -> codec_io_error => Other
`````

### Design notes

- `encode_framed` / `decode_framed` add and validate the leading version byte. `encode_postcard` / `decode_postcard_exact` are DRY per-version body building blocks implementors call from inside the `match version` of their `decode_version` / `encode_version`. `decode_postcard_exact` rejects surplus trailing bytes (a versioned format that exists to catch drift treats trailing garbage as corruption).
- `CodecError::VersionUnsupported` is the multi-version analogue of `CodecError::Version` (single-version). `codec_io_error` maps both to `io::ErrorKind::InvalidData` so the openraft storage layer keeps its ability to distinguish a foreign schema version after it adopts `decode_framed`.
- `CodecError::NotRepresentable` is the encode-side feature-gate violation (a field/behavior introduced at a later version is set while encoding an older layout). Fail-loud rather than silently dropping; maps to `Other`, not `InvalidData`, because it is not a foreign-format read.

## Test plan

- [x] `cargo test -p tsoracle-codec` — 24 codec tests pass (existing 9 plus 15 new), including a proptest covering framed round-trip at both fixture versions
- [x] `cargo test --workspace` — all crates pass; the change is additive so no pre-existing tests are affected
- [x] `cargo build --workspace --all-features` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `python3 scripts/check-ts-header.py` — all 254 headers OK (the new `versioned.rs` carries the canonical short header)

Covered by the new inline tests in `versioned.rs`:
- Per-version body round-trip + surplus-trailing-byte rejection
- `Display` strings and `codec_io_error` mapping for both new error variants
- Two-version `Widget` fixture (`color` added at v2) exercising the trait via `encode_version` / `decode_version` and the `From` up-convert path
- Fail-loud negative test: encoding `Widget { color: Some(_) }` at v1 returns `NotRepresentable { version: 1 }` (representability rule, exercised in release builds too)
- `encode_framed` prepends the version byte and matches the bare v1 body (proves down-conversion is byte-identical to the bare body)
- `decode_framed` dispatches in-range and up-converts a v1 record into the current type; rejects above-range, below-range, and empty input