### PR TITLE
chore(ci): use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token` deprecated the `app-id` input in favor of `client-id`. The release-plz workflow runs were surfacing the deprecation warning on every release-plz PR cycle and release publish.
- Renames `app-id` → `client-id` in both jobs (`release` and `release-pr`). The action accepts either the App ID or the Client ID value under the new input, so the `RELEASE_PLZ_APP_ID` secret keeps working unchanged — no secret rotation required.
- Action pin (`bcd2ba49…` / v3.2.0) already supports `client-id`; this is an input-level rename, not a version bump.

## Post-merge follow-ups

- [ ] Confirm the next release-plz workflow run on `main` no longer logs `Input 'app-id' has been deprecated`.
- [ ] Confirm the `app-token` step still mints a token (no auth failures on the `release-pr` job's next scheduled trigger).