### PR TITLE
feat(openraft-toolkit): route RocksdbLogStore log/meta/snapshot codec through LogStoreCodec provider seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3337,6 +3337,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tsoracle-codec",
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-openraft-toolkit",

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -41,6 +41,7 @@ serde              = { workspace = true }
 thiserror          = { workspace = true }
 tokio              = { workspace = true }
 tracing            = { workspace = true }
+tsoracle-codec     = { workspace = true }
 tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.9", features = ["serde"] }
 tsoracle-core      = { path = "../tsoracle-core", version = "0.2.4" }
 

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod driver;
 pub mod host;
+pub mod log_codec;
 pub mod log_entry;
 pub mod snapshot_store;
 pub mod standalone;
@@ -36,6 +37,7 @@ pub mod type_config;
 
 pub use driver::OpenraftDriver;
 pub use host::OpenraftHighWaterHost;
+pub use log_codec::OpenraftLogCodec;
 pub use log_entry::HighWaterCommand;
 #[cfg(feature = "rocksdb-snapshot-store")]
 pub use snapshot_store::RocksdbSnapshotStore;

--- a/crates/tsoracle-driver-openraft/src/log_codec.rs
+++ b/crates/tsoracle-driver-openraft/src/log_codec.rs
@@ -1,0 +1,120 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Concrete [`LogStoreCodec`] provider for this driver's [`TypeConfig`].
+//!
+//! The orphan rule forbids implementing `tsoracle_codec::VersionedCodec` for
+//! openraft's `Entry`/`Vote`/`LogId` directly (foreign trait, foreign types),
+//! so the toolkit exposes the local [`LogStoreCodec`] provider trait and this
+//! driver supplies the marker that implements it. The v4 arms postcard each
+//! openraft value whole via `encode_postcard`/`decode_postcard_exact`,
+//! byte-identical to the toolkit's [`tsoracle_openraft_toolkit::DefaultLogStoreCodec`] —
+//! `RocksdbLogStore` frames the version byte, this provider only handles the
+//! body.
+
+use tsoracle_codec::{CodecError, decode_postcard_exact, encode_postcard};
+use tsoracle_openraft_toolkit::LogStoreCodec;
+
+use crate::type_config::{OpenraftLogId, OpenraftVote, TypeConfig};
+
+/// The [`LogStoreCodec`] provider this driver wires into `RocksdbLogStore`.
+///
+/// Zero-sized type-level marker. Behavior-preserving: every body is the same
+/// whole-value postcard the store wrote before the seam existed.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpenraftLogCodec;
+
+impl LogStoreCodec<TypeConfig> for OpenraftLogCodec {
+    fn encode_entry(
+        _version: u8,
+        entry: &<TypeConfig as openraft::RaftTypeConfig>::Entry,
+    ) -> Result<Vec<u8>, CodecError> {
+        encode_postcard(entry)
+    }
+
+    fn decode_entry(
+        _version: u8,
+        body: &[u8],
+    ) -> Result<<TypeConfig as openraft::RaftTypeConfig>::Entry, CodecError> {
+        decode_postcard_exact(body)
+    }
+
+    fn encode_vote(_version: u8, vote: &OpenraftVote) -> Result<Vec<u8>, CodecError> {
+        encode_postcard(vote)
+    }
+
+    fn decode_vote(_version: u8, body: &[u8]) -> Result<OpenraftVote, CodecError> {
+        decode_postcard_exact(body)
+    }
+
+    fn encode_log_id(_version: u8, log_id: &OpenraftLogId) -> Result<Vec<u8>, CodecError> {
+        encode_postcard(log_id)
+    }
+
+    fn decode_log_id(_version: u8, body: &[u8]) -> Result<OpenraftLogId, CodecError> {
+        decode_postcard_exact(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::log_entry::HighWaterCommand;
+    use tsoracle_consensus::AdvancePayload;
+
+    #[test]
+    fn entry_body_matches_raw_postcard() {
+        // The driver provider must agree byte-for-byte with raw postcard (and
+        // therefore with the toolkit DefaultLogStoreCodec), proving the seam is
+        // behavior-preserving.
+        let lid = openraft::testing::log_id::<TypeConfig>(1, 1, 1);
+        let entry: <TypeConfig as openraft::RaftTypeConfig>::Entry =
+            openraft::entry::RaftEntry::new_normal(
+                lid,
+                HighWaterCommand::Advance(AdvancePayload { at_least: 5 }),
+            );
+        let via_provider =
+            <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_entry(4, &entry).unwrap();
+        let raw = postcard::to_stdvec(&entry).unwrap();
+        assert_eq!(via_provider, raw);
+    }
+
+    #[test]
+    fn vote_body_matches_raw_postcard() {
+        let vote: OpenraftVote = openraft::Vote::new_committed(7, 3);
+        let via_provider =
+            <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_vote(4, &vote).unwrap();
+        assert_eq!(via_provider, postcard::to_stdvec(&vote).unwrap());
+        let back: OpenraftVote =
+            <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::decode_vote(4, &via_provider).unwrap();
+        assert_eq!(back, vote);
+    }
+
+    #[test]
+    fn log_id_body_matches_raw_postcard() {
+        let log_id: OpenraftLogId = openraft::testing::log_id::<TypeConfig>(2, 1, 9);
+        let via_provider =
+            <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_log_id(4, &log_id).unwrap();
+        assert_eq!(via_provider, postcard::to_stdvec(&log_id).unwrap());
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -57,7 +57,10 @@ use openraft::type_config::alias::{LogIdOf, SnapshotMetaOf, SnapshotOf, StoredMe
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
-use tsoracle_openraft_toolkit::{SCHEMA_VERSION, codec_io_error, decode, encode};
+use tsoracle_codec::{
+    VersionedCodec, decode_framed, decode_postcard_exact, encode_framed, encode_postcard,
+};
+use tsoracle_openraft_toolkit::{SCHEMA_VERSION, codec_io_error};
 
 use crate::log_entry::HighWaterCommand;
 use crate::snapshot_store::{InMemorySnapshotStore, SnapshotStore};
@@ -94,6 +97,56 @@ pub struct HighWaterStateMachineSnapshot {
 struct PersistedSnapshot {
     meta: SnapMeta,
     data: Vec<u8>,
+}
+
+impl VersionedCodec for HighWaterStateMachineSnapshot {
+    fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
+        match version {
+            // v4: whole-value postcard, byte-identical to the pre-seam frame.
+            // P2 adds older/newer arms here as the layout evolves.
+            v if v == SCHEMA_VERSION => decode_postcard_exact(body),
+            other => Err(tsoracle_codec::CodecError::VersionUnsupported {
+                min: SCHEMA_VERSION,
+                max: SCHEMA_VERSION,
+                actual: other,
+            }),
+        }
+    }
+
+    fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
+        match version {
+            v if v == SCHEMA_VERSION => encode_postcard(self),
+            other => Err(tsoracle_codec::CodecError::VersionUnsupported {
+                min: SCHEMA_VERSION,
+                max: SCHEMA_VERSION,
+                actual: other,
+            }),
+        }
+    }
+}
+
+impl VersionedCodec for PersistedSnapshot {
+    fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
+        match version {
+            v if v == SCHEMA_VERSION => decode_postcard_exact(body),
+            other => Err(tsoracle_codec::CodecError::VersionUnsupported {
+                min: SCHEMA_VERSION,
+                max: SCHEMA_VERSION,
+                actual: other,
+            }),
+        }
+    }
+
+    fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
+        match version {
+            v if v == SCHEMA_VERSION => encode_postcard(self),
+            other => Err(tsoracle_codec::CodecError::VersionUnsupported {
+                min: SCHEMA_VERSION,
+                max: SCHEMA_VERSION,
+                actual: other,
+            }),
+        }
+    }
 }
 
 /// Mutable core guarded by a single mutex. `parking_lot::Mutex` because the
@@ -204,10 +257,12 @@ impl HighWaterStateMachine {
             current_snapshot: None,
         };
         if let Some(bytes) = store.load()? {
-            let persisted: PersistedSnapshot = decode(SCHEMA_VERSION, &bytes)
-                .map_err(|e| codec_io_error("persisted snapshot envelope decode", e))?;
-            let payload: HighWaterStateMachineSnapshot = decode(SCHEMA_VERSION, &persisted.data)
-                .map_err(|e| codec_io_error("persisted snapshot payload decode", e))?;
+            let persisted: PersistedSnapshot =
+                decode_framed(SCHEMA_VERSION, SCHEMA_VERSION, &bytes)
+                    .map_err(|e| codec_io_error("persisted snapshot envelope decode", e))?;
+            let payload: HighWaterStateMachineSnapshot =
+                decode_framed(SCHEMA_VERSION, SCHEMA_VERSION, &persisted.data)
+                    .map_err(|e| codec_io_error("persisted snapshot payload decode", e))?;
             core.current_value = payload.current_value;
             core.last_applied = payload.last_applied;
             core.last_membership = payload.last_membership;
@@ -315,7 +370,7 @@ impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
                 last_membership: core.last_membership.clone(),
                 snapshot_id,
             };
-            let bytes = encode(SCHEMA_VERSION, &payload)
+            let bytes = encode_framed(SCHEMA_VERSION, &payload)
                 .map_err(|e| codec_io_error("snapshot payload serialize", e))?;
             (bytes, meta)
         };
@@ -324,7 +379,7 @@ impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
             meta: meta.clone(),
             data: snapshot_payload.clone(),
         };
-        let envelope = encode(SCHEMA_VERSION, &persisted)
+        let envelope = encode_framed(SCHEMA_VERSION, &persisted)
             .map_err(|e| codec_io_error("snapshot envelope serialize", e))?;
         // Persist + publish through the monotone, serialized commit path. The
         // store write happens BEFORE `current_snapshot` is updated, so a
@@ -411,8 +466,9 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
         snapshot: SnapData,
     ) -> Result<(), io::Error> {
         let bytes = snapshot.into_inner();
-        let payload: HighWaterStateMachineSnapshot = decode(SCHEMA_VERSION, &bytes)
-            .map_err(|e| codec_io_error("snapshot payload decode", e))?;
+        let payload: HighWaterStateMachineSnapshot =
+            decode_framed(SCHEMA_VERSION, SCHEMA_VERSION, &bytes)
+                .map_err(|e| codec_io_error("snapshot payload decode", e))?;
 
         // `meta.last_log_id` is read back by `get_current_snapshot` while
         // `payload.last_applied` is read back by `applied_state`. `build_snapshot`
@@ -436,7 +492,7 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
             meta: meta.clone(),
             data: bytes.clone(),
         };
-        let envelope = encode(SCHEMA_VERSION, &persisted)
+        let envelope = encode_framed(SCHEMA_VERSION, &persisted)
             .map_err(|e| codec_io_error("snapshot envelope serialize", e))?;
         // Persist, apply the snapshot's state, and publish atomically through
         // the monotone, serialized commit path — the same one `build_snapshot`
@@ -1126,10 +1182,56 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_payload_versioned_codec_matches_legacy_frame() {
+        use tsoracle_codec::{decode_framed, encode_framed};
+        // The framed bytes through the new VersionedCodec seam must equal the
+        // legacy `tsoracle_openraft_toolkit::encode(SCHEMA_VERSION, ..)` frame —
+        // proving the on-disk format did not move.
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 7,
+            last_applied: None,
+            last_membership: StoredMembership::default(),
+        };
+        let via_seam = encode_framed(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
+            .expect("encode_framed");
+        let legacy =
+            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
+                .expect("legacy encode");
+        assert_eq!(via_seam, legacy);
+        assert_eq!(via_seam, vec![4, 7, 0, 0, 0, 0]);
+
+        let back: HighWaterStateMachineSnapshot = decode_framed(
+            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            &via_seam,
+        )
+        .expect("decode_framed");
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn snapshot_payload_versioned_codec_rejects_foreign_version() {
+        use tsoracle_codec::{CodecError, decode_framed};
+        let framed = vec![0xFFu8, 7, 0, 0, 0, 0];
+        let err = decode_framed::<HighWaterStateMachineSnapshot>(
+            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            &framed,
+        )
+        .expect_err("must reject");
+        assert!(matches!(
+            err,
+            CodecError::VersionUnsupported { actual: 0xFF, .. }
+        ));
+    }
+
+    #[test]
     fn snapshot_payload_pins_v4_layout() {
-        // Hand-built v4 frame: [SCHEMA_VERSION | postcard(payload)]. The leading
-        // byte advanced 3 -> 4 when OpenraftPeer gained the admin_endpoint field
-        // (a breaking on-disk change for membership); the postcard body is
+        use tsoracle_codec::encode_framed;
+        // Hand-built v4 frame: [SCHEMA_VERSION | postcard(payload)], now produced
+        // through the VersionedCodec seam that build_snapshot uses. Leading byte
+        // advanced 3 -> 4 when OpenraftPeer gained the admin_endpoint field (a
+        // breaking on-disk change for membership); the postcard body is
         // unchanged. Body [7, 0, 0, 0, 0] = current_value 7, last_applied None,
         // then default StoredMembership (None log id + empty configs + empty
         // nodes). Reordering or inserting a field changes these bytes and trips
@@ -1140,44 +1242,53 @@ mod tests {
             last_membership: StoredMembership::default(),
         };
         let framed =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
-                .expect("encode");
+            encode_framed(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload).expect("encode");
         assert_eq!(framed, vec![4, 7, 0, 0, 0, 0]);
     }
 
     #[test]
     fn log_entry_pins_v4_layout() {
-        // The bytes RocksdbLogStore<TypeConfig> persists per entry: the v4
+        use crate::log_codec::OpenraftLogCodec;
+        use tsoracle_openraft_toolkit::LogStoreCodec;
+        // The bytes RocksdbLogStore<TypeConfig> persists per entry: SCHEMA_VERSION
+        // byte (prepended by the store) + OpenraftLogCodec entry body — the v4
         // frame around a Normal entry carrying Advance(AdvancePayload { at_least: 5 })
-        // at log id (term 1, node 1, index 1). Leading byte 4 is SCHEMA_VERSION;
-        // body [1,1,1,1,0,5] = leader (term 1, node 1), index 1,
-        // EntryPayload::Normal tag (1), Advance variant (0), at_least 5 —
-        // byte-identical to the pre-v4 layout.
+        // at log id (term 1, node 1, index 1). Body [1,1,1,1,0,5] = leader
+        // (term 1, node 1), index 1, EntryPayload::Normal tag (1), Advance
+        // variant (0), at_least 5 — byte-identical to the pre-seam layout.
         let lid = openraft::testing::log_id::<TypeConfig>(1, 1, 1);
         let entry: EntryOf<TypeConfig> = EntryOf::<TypeConfig>::new_normal(
             lid,
             HighWaterCommand::Advance(AdvancePayload { at_least: 5 }),
         );
-        let framed =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &entry)
-                .expect("encode");
+        let body = <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_entry(
+            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            &entry,
+        )
+        .expect("encode entry body");
+        let mut framed = vec![tsoracle_openraft_toolkit::SCHEMA_VERSION];
+        framed.extend_from_slice(&body);
         assert_eq!(framed, vec![4, 1, 1, 1, 1, 0, 5]);
     }
 
     #[test]
     fn meta_vote_pins_v4_layout() {
-        // The bytes RocksdbLogStore<TypeConfig> now persists in the meta column
-        // for a Vote — historically a bare, unversioned postcard blob, now the
-        // same [SCHEMA_VERSION | postcard] frame as the log column. This is the
-        // recovery-critical field (term/leader-election safety) the framing
-        // protects: a foreign version loud-rejects instead of misdecoding. Body
-        // [7, 3, 1] = leader (term 7, node 3), committed flag true; leading byte
-        // 4 is SCHEMA_VERSION. A layout change to Vote trips this test.
+        use crate::log_codec::OpenraftLogCodec;
+        use tsoracle_openraft_toolkit::LogStoreCodec;
+        // The bytes RocksdbLogStore<TypeConfig> persists in the meta column for a
+        // Vote: SCHEMA_VERSION byte + OpenraftLogCodec vote body. Body [7, 3, 1] =
+        // leader (term 7, node 3), committed flag true. A layout change to Vote
+        // trips this test. This is the recovery-critical field the framing
+        // protects: a foreign version loud-rejects instead of misdecoding.
         let vote: openraft::type_config::alias::VoteOf<TypeConfig> =
             openraft::Vote::new_committed(7, 3);
-        let framed =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &vote)
-                .expect("encode");
+        let body = <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_vote(
+            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            &vote,
+        )
+        .expect("encode vote body");
+        let mut framed = vec![tsoracle_openraft_toolkit::SCHEMA_VERSION];
+        framed.extend_from_slice(&body);
         assert_eq!(framed, vec![4, 7, 3, 1]);
     }
 

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -48,7 +48,8 @@ use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tempfile::TempDir;
 use tokio::time::Instant;
 use tsoracle_driver_openraft::{
-    HighWaterStateMachine, OpenraftDriver, OpenraftPeer, StandaloneHost, TypeConfig,
+    HighWaterStateMachine, OpenraftDriver, OpenraftLogCodec, OpenraftPeer, StandaloneHost,
+    TypeConfig,
 };
 use tsoracle_openraft_toolkit::test_fakes::{MemNetwork, PartitionController};
 use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
@@ -195,10 +196,11 @@ fn open_rocksdb(dir: &TempDir) -> Arc<DB> {
 fn open_log_and_snapshot_stores(
     db: Arc<DB>,
 ) -> (
-    RocksdbLogStore<TypeConfig, Flat>,
+    RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec>,
     Arc<dyn tsoracle_driver_openraft::SnapshotStore>,
 ) {
-    let log_store = RocksdbLogStore::open(db.clone(), LOG_CF, META_CF, Flat).unwrap();
+    let log_store: RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec> =
+        RocksdbLogStore::open(db.clone(), LOG_CF, META_CF, Flat).unwrap();
     let snapshot_store: Arc<dyn tsoracle_driver_openraft::SnapshotStore> =
         Arc::new(tsoracle_driver_openraft::RocksdbSnapshotStore::open(db, SNAP_CF).unwrap());
     (log_store, snapshot_store)

--- a/crates/tsoracle-driver-openraft/tests/snapshot_restart.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_restart.rs
@@ -51,7 +51,7 @@ use openraft::{Config, SnapshotPolicy};
 use tokio::time::timeout;
 use tsoracle_consensus::{ConsensusDriver, LeaderState};
 use tsoracle_core::Epoch;
-use tsoracle_driver_openraft::TypeConfig;
+use tsoracle_driver_openraft::{OpenraftLogCodec, TypeConfig};
 use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
 
 use common::{TestCluster, build_single_node_with_config, reopen_node_with_config};
@@ -124,7 +124,7 @@ async fn snapshot_persists_across_restart_when_log_is_purged() {
     // — the recovered SM would just rebuild from log replay. Open a separate
     // log-store view on the same `Arc<DB>` so we can inspect `get_log_state`
     // without disturbing the running raft.
-    let log_inspector: RocksdbLogStore<TypeConfig, Flat> =
+    let log_inspector: RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec> =
         RocksdbLogStore::open(nodes[0].db.clone(), "raft_log", "raft_meta", Flat).unwrap();
     timeout(Duration::from_secs(5), async {
         let mut inspector = log_inspector;

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -47,7 +47,9 @@ use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 use tempfile::TempDir;
 use tokio::time::timeout;
 use tsoracle_driver_openraft::AdvancePayload;
-use tsoracle_driver_openraft::{HighWaterCommand, HighWaterStateMachine, OpenraftPeer, TypeConfig};
+use tsoracle_driver_openraft::{
+    HighWaterCommand, HighWaterStateMachine, OpenraftLogCodec, OpenraftPeer, TypeConfig,
+};
 use tsoracle_openraft_toolkit::test_fakes::MemNetwork;
 use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
 
@@ -74,7 +76,7 @@ fn snapshot_aggressive_config() -> Arc<Config> {
     )
 }
 
-fn open_log_store(dir: &TempDir) -> RocksdbLogStore<TypeConfig, Flat> {
+fn open_log_store(dir: &TempDir) -> RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec> {
     let mut opts = Options::default();
     opts.create_if_missing(true);
     opts.create_missing_column_families(true);

--- a/crates/tsoracle-openraft-toolkit/src/codec_provider.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec_provider.rs
@@ -1,0 +1,173 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Orphan-rule seam between the toolkit's generic `RocksdbLogStore` and the
+//! concrete openraft types it persists.
+//!
+//! The toolkit cannot `impl tsoracle_codec::VersionedCodec` for openraft's
+//! `Entry`/`Vote`/`LogId` (both the trait and the types are foreign here), and
+//! neither can a driver. So the toolkit defines this *toolkit-local* provider
+//! trait; a driver supplies a local marker type that implements it (satisfying
+//! the orphan rule), and `RocksdbLogStore<C, K, Codec>` dispatches the *body*
+//! codec through it. The toolkit keeps ownership of the version-byte framing
+//! (see `super::encode_entry_record` / `super::decode_entry_record` and the
+//! vote/log-id analogues), so the provider only ever sees and returns the bare
+//! postcard body — never the leading version byte.
+//!
+//! [`DefaultLogStoreCodec`] is the behavior-preserving default: it postcards
+//! each value whole, exactly as the pre-seam codec did, and is the default
+//! `Codec` type parameter so existing call sites compile unchanged.
+
+use openraft::RaftTypeConfig;
+use openraft::type_config::alias::LogIdOf;
+use openraft::type_config::alias::VoteOf;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tsoracle_codec::{CodecError, decode_postcard_exact, encode_postcard};
+
+/// Provider of the *body* codec for the three openraft types `RocksdbLogStore`
+/// persists: the log `Entry`, the `Vote`, and the `LogId` meta singletons.
+///
+/// Every method operates on the bare body (the bytes after the leading version
+/// byte); the toolkit adds and validates that version byte itself. `version` is
+/// passed through so a provider can dispatch a per-version body layout in a
+/// later phase; in P1b the only version in play is the current `SCHEMA_VERSION`.
+///
+/// The methods take no `self`: a `Codec` is a pure type-level marker selected
+/// at the `RocksdbLogStore<C, K, Codec>` type parameter, never an instance.
+pub trait LogStoreCodec<C: RaftTypeConfig> {
+    /// Encode a log `Entry` body at `version`.
+    fn encode_entry(version: u8, entry: &C::Entry) -> Result<Vec<u8>, CodecError>;
+    /// Decode a log `Entry` body known to be `version`.
+    fn decode_entry(version: u8, body: &[u8]) -> Result<C::Entry, CodecError>;
+    /// Encode a `Vote` body at `version`.
+    fn encode_vote(version: u8, vote: &VoteOf<C>) -> Result<Vec<u8>, CodecError>;
+    /// Decode a `Vote` body known to be `version`.
+    fn decode_vote(version: u8, body: &[u8]) -> Result<VoteOf<C>, CodecError>;
+    /// Encode a `LogId` body at `version`.
+    fn encode_log_id(version: u8, log_id: &LogIdOf<C>) -> Result<Vec<u8>, CodecError>;
+    /// Decode a `LogId` body known to be `version`.
+    fn decode_log_id(version: u8, body: &[u8]) -> Result<LogIdOf<C>, CodecError>;
+}
+
+/// The default, behavior-preserving [`LogStoreCodec`]: whole-value postcard for
+/// every type, identical bytes to the pre-seam `encode_record`/`decode_record`.
+///
+/// Zero-sized; it exists only as the default `Codec` type parameter of
+/// [`super::RocksdbLogStore`] so the toolkit's own consumers and tests need no
+/// change. `version` is accepted for trait-shape symmetry but ignored — there
+/// is a single body layout in P1b.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultLogStoreCodec;
+
+impl<C> LogStoreCodec<C> for DefaultLogStoreCodec
+where
+    C: RaftTypeConfig,
+    C::Entry: Serialize + DeserializeOwned,
+    VoteOf<C>: Serialize + DeserializeOwned,
+    LogIdOf<C>: Serialize + DeserializeOwned,
+{
+    fn encode_entry(_version: u8, entry: &C::Entry) -> Result<Vec<u8>, CodecError> {
+        encode_postcard(entry)
+    }
+    fn decode_entry(_version: u8, body: &[u8]) -> Result<C::Entry, CodecError> {
+        decode_postcard_exact(body)
+    }
+    fn encode_vote(_version: u8, vote: &VoteOf<C>) -> Result<Vec<u8>, CodecError> {
+        encode_postcard(vote)
+    }
+    fn decode_vote(_version: u8, body: &[u8]) -> Result<VoteOf<C>, CodecError> {
+        decode_postcard_exact(body)
+    }
+    fn encode_log_id(_version: u8, log_id: &LogIdOf<C>) -> Result<Vec<u8>, CodecError> {
+        encode_postcard(log_id)
+    }
+    fn decode_log_id(_version: u8, body: &[u8]) -> Result<LogIdOf<C>, CodecError> {
+        decode_postcard_exact(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::declare_raft_types_ext;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ProbePeer {
+        addr: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ProbeData {
+        n: u64,
+    }
+
+    impl std::fmt::Display for ProbeData {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ProbeData({})", self.n)
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ProbeApplied;
+
+    declare_raft_types_ext! {
+        pub ProbeConfig:
+            Node            = ProbePeer,
+            AppData         = ProbeData,
+            AppDataResponse = ProbeApplied,
+            SnapshotData    = std::io::Cursor<Vec<u8>>,
+    }
+
+    #[test]
+    fn default_codec_vote_body_matches_raw_postcard() {
+        // The provider must emit the SAME bytes the pre-seam codec did: a bare
+        // whole-value postcard, no version byte. This is the behavior-preserving
+        // contract of `DefaultLogStoreCodec`.
+        let vote: VoteOf<ProbeConfig> = openraft::Vote::new_committed(7, 3);
+        let via_provider =
+            <DefaultLogStoreCodec as LogStoreCodec<ProbeConfig>>::encode_vote(3, &vote)
+                .expect("encode vote");
+        let raw = postcard::to_stdvec(&vote).expect("raw postcard");
+        assert_eq!(via_provider, raw);
+        let back: VoteOf<ProbeConfig> =
+            <DefaultLogStoreCodec as LogStoreCodec<ProbeConfig>>::decode_vote(3, &via_provider)
+                .expect("decode vote");
+        assert_eq!(back, vote);
+    }
+
+    #[test]
+    fn default_codec_rejects_trailing_bytes() {
+        // Inherits `decode_postcard_exact`'s trailing-byte rejection, matching
+        // the old `decode_record` corruption contract.
+        let vote: VoteOf<ProbeConfig> = openraft::Vote::new_committed(1, 1);
+        let mut body =
+            <DefaultLogStoreCodec as LogStoreCodec<ProbeConfig>>::encode_vote(3, &vote).unwrap();
+        body.extend_from_slice(&[0xAB, 0xCD]);
+        assert!(matches!(
+            <DefaultLogStoreCodec as LogStoreCodec<ProbeConfig>>::decode_vote(3, &body),
+            Err(CodecError::TrailingBytes { extra: 2 })
+        ));
+    }
+}

--- a/crates/tsoracle-openraft-toolkit/src/lib.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lib.rs
@@ -28,6 +28,7 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod codec;
+pub mod codec_provider;
 pub mod macros;
 
 #[cfg(feature = "rocksdb-log-store")]
@@ -39,6 +40,7 @@ pub mod lifecycle;
 pub mod test_fakes;
 
 pub use codec::{CodecError, SCHEMA_VERSION, codec_io_error, decode, encode};
+pub use codec_provider::{DefaultLogStoreCodec, LogStoreCodec};
 pub use lifecycle::{
     BootstrapError, BootstrapMode, LeadershipState, MembershipError, add_learner, bootstrap,
     change_membership, join, leadership_events, leadership_events_from_metrics,
@@ -48,3 +50,19 @@ pub use lifecycle::{
 pub use log_store::{
     Flat, GroupPrefixed, KeySpace, MetaLabel, RocksdbLogStore, RocksdbLogStoreError,
 };
+
+#[cfg(all(test, feature = "rocksdb-log-store"))]
+mod reexport_tests {
+    #[test]
+    fn seam_items_are_reachable_from_crate_root() {
+        // Compile-time reachability: name the re-exported items. (A type-level
+        // assertion; the driver imports both from the crate root.)
+        fn _assert_reachable<C, Codec>()
+        where
+            C: openraft::RaftTypeConfig,
+            Codec: crate::LogStoreCodec<C>,
+        {
+        }
+        let _ = std::any::type_name::<crate::DefaultLogStoreCodec>();
+    }
+}

--- a/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
@@ -26,42 +26,92 @@
 //! The meta CF holds four small openraft values: current vote, last-committed
 //! log id, last-purged log id, last-applied membership. Each is keyed by a
 //! [`MetaLabel`](super::MetaLabel) via the active [`KeySpace`](super::KeySpace).
-//! These helpers frame values with the same `[SCHEMA_VERSION | postcard]` codec
-//! the log column uses ([`super::encode_record`] / [`super::decode_record`]), so
-//! a recovery-critical meta record (Vote/Committed/LastPurged) loud-rejects on a
-//! version mismatch instead of misdecoding silently. rocksdb errors are mapped
-//! to [`io::Error`] to match the storage trait surface.
+//! The vote and log-id helpers frame their values through the toolkit's
+//! provider-backed record helpers ([`super::encode_vote_record`] /
+//! [`super::decode_vote_record`] and the log-id analogues), so a
+//! recovery-critical meta record loud-rejects on a version mismatch instead of
+//! misdecoding silently. rocksdb errors are mapped to [`io::Error`] to match
+//! the storage trait surface.
 
+use openraft::RaftTypeConfig;
+use openraft::type_config::alias::{LogIdOf, VoteOf};
 use rocksdb::{BoundColumnFamily, DB, WriteBatch};
-use serde::{Serialize, de::DeserializeOwned};
 use std::io;
 use std::sync::Arc;
 
-use super::key_space::{KeySpace, MetaLabel};
-use super::{decode_record, encode_record};
+use crate::codec_provider::LogStoreCodec;
 
-pub(super) fn read<T: DeserializeOwned, K: KeySpace>(
+use super::key_space::{KeySpace, MetaLabel};
+use super::{decode_log_id_record, decode_vote_record, encode_log_id_record, encode_vote_record};
+
+pub(super) fn read_vote<C, K, Codec>(
     db: &DB,
     cf: &Arc<BoundColumnFamily<'_>>,
     keys: &K,
     label: MetaLabel,
-) -> io::Result<Option<T>> {
+) -> io::Result<Option<VoteOf<C>>>
+where
+    C: RaftTypeConfig,
+    K: KeySpace,
+    Codec: LogStoreCodec<C>,
+{
     let key = keys.meta_key(label);
     match db.get_pinned_cf(cf, &key).map_err(io::Error::other)? {
-        Some(bytes) => Ok(Some(decode_record(&bytes)?)),
+        Some(bytes) => Ok(Some(decode_vote_record::<C, Codec>(&bytes)?)),
         None => Ok(None),
     }
 }
 
-pub(super) fn put<T: Serialize, K: KeySpace>(
+pub(super) fn read_log_id<C, K, Codec>(
+    db: &DB,
+    cf: &Arc<BoundColumnFamily<'_>>,
+    keys: &K,
+    label: MetaLabel,
+) -> io::Result<Option<LogIdOf<C>>>
+where
+    C: RaftTypeConfig,
+    K: KeySpace,
+    Codec: LogStoreCodec<C>,
+{
+    let key = keys.meta_key(label);
+    match db.get_pinned_cf(cf, &key).map_err(io::Error::other)? {
+        Some(bytes) => Ok(Some(decode_log_id_record::<C, Codec>(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+pub(super) fn put_vote<C, K, Codec>(
     batch: &mut WriteBatch,
     cf: &Arc<BoundColumnFamily<'_>>,
     keys: &K,
     label: MetaLabel,
-    value: &T,
-) -> io::Result<()> {
+    value: &VoteOf<C>,
+) -> io::Result<()>
+where
+    C: RaftTypeConfig,
+    K: KeySpace,
+    Codec: LogStoreCodec<C>,
+{
     let key = keys.meta_key(label);
-    let bytes = encode_record(value)?;
+    let bytes = encode_vote_record::<C, Codec>(value)?;
+    batch.put_cf(cf, &key, &bytes);
+    Ok(())
+}
+
+pub(super) fn put_log_id<C, K, Codec>(
+    batch: &mut WriteBatch,
+    cf: &Arc<BoundColumnFamily<'_>>,
+    keys: &K,
+    label: MetaLabel,
+    value: &LogIdOf<C>,
+) -> io::Result<()>
+where
+    C: RaftTypeConfig,
+    K: KeySpace,
+    Codec: LogStoreCodec<C>,
+{
+    let key = keys.meta_key(label);
+    let bytes = encode_log_id_record::<C, Codec>(value)?;
     batch.put_cf(cf, &key, &bytes);
     Ok(())
 }
@@ -74,4 +124,75 @@ pub(super) fn delete<K: KeySpace>(
 ) {
     let key = keys.meta_key(label);
     batch.delete_cf(cf, &key);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::declare_raft_types_ext;
+    use crate::log_store::{DefaultLogStoreCodec, Flat, KeySpace, MetaLabel};
+    use openraft::type_config::alias::VoteOf;
+    use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+    use serde::{Deserialize, Serialize};
+    use tempfile::TempDir;
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct MetaPeer {
+        addr: String,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct MetaData {
+        v: u64,
+    }
+    impl std::fmt::Display for MetaData {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MetaData({})", self.v)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct MetaApplied;
+
+    declare_raft_types_ext! {
+        pub MetaConfig:
+            Node            = MetaPeer,
+            AppData         = MetaData,
+            AppDataResponse = MetaApplied,
+            SnapshotData    = std::io::Cursor<Vec<u8>>,
+    }
+
+    #[test]
+    fn meta_vote_roundtrips_through_provider_with_version_byte() {
+        let dir = TempDir::new().unwrap();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let cfs = vec![ColumnFamilyDescriptor::new("meta", Options::default())];
+        let db = DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap();
+        let keys = Flat;
+        let cf = db.cf_handle("meta").unwrap();
+
+        let vote: VoteOf<MetaConfig> = openraft::Vote::new_committed(7, 3);
+        let mut batch = rocksdb::WriteBatch::default();
+        put_vote::<MetaConfig, Flat, DefaultLogStoreCodec>(
+            &mut batch,
+            &cf,
+            &keys,
+            MetaLabel::Vote,
+            &vote,
+        )
+        .unwrap();
+        db.write(batch).unwrap();
+
+        // On-disk leading byte is SCHEMA_VERSION.
+        let raw = db
+            .get_cf(&cf, keys.meta_key(MetaLabel::Vote))
+            .unwrap()
+            .unwrap();
+        assert_eq!(raw[0], crate::codec::SCHEMA_VERSION);
+
+        let back: Option<VoteOf<MetaConfig>> =
+            read_vote::<MetaConfig, Flat, DefaultLogStoreCodec>(&db, &cf, &keys, MetaLabel::Vote)
+                .unwrap();
+        assert_eq!(back, Some(vote));
+    }
 }

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -26,6 +26,7 @@
 pub mod key_space;
 mod meta;
 
+pub use crate::codec_provider::{DefaultLogStoreCodec, LogStoreCodec};
 pub use key_space::{Flat, GroupPrefixed, KeySpace, MetaLabel};
 
 use thiserror::Error;
@@ -62,8 +63,6 @@ use openraft::storage::RaftLogStorage;
 use openraft::type_config::alias::LogIdOf;
 use openraft::type_config::alias::VoteOf;
 use rocksdb::{BoundColumnFamily, DB, IteratorMode, WriteBatch, WriteOptions};
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 
 /// RocksDB-backed `RaftLogStorage` implementation.
 ///
@@ -72,6 +71,11 @@ use serde::de::DeserializeOwned;
 /// - `K`: the active [`KeySpace`] — [`Flat`] for single-group deployments,
 ///   [`GroupPrefixed`] for multi-group deployments that multiplex N raft
 ///   instances onto shared column families.
+/// - `Codec`: the [`LogStoreCodec`] body provider. The toolkit owns the
+///   leading version-byte framing; this codec produces and consumes only the
+///   bare body. Defaults to [`DefaultLogStoreCodec`], a behavior-preserving
+///   whole-value postcard provider, so toolkit-internal call sites compile
+///   unchanged. Drivers supply their own marker to satisfy the orphan rule.
 ///
 /// `Arc<DB>` is `Clone`, so the store can be cloned cheaply to satisfy
 /// `RaftLogStorage::LogReader = Self`. All rocksdb operations take `&DB`, so
@@ -80,22 +84,26 @@ use serde::de::DeserializeOwned;
 ///
 /// Construct via [`RocksdbLogStore::open`], which validates that the two
 /// column-family names you pass already exist on the database.
-pub struct RocksdbLogStore<C, K>
+pub struct RocksdbLogStore<C, K, Codec = DefaultLogStoreCodec>
 where
     C: RaftTypeConfig,
     K: KeySpace,
+    Codec: 'static,
 {
     db: Arc<DB>,
     log_cf: String,
     meta_cf: String,
     keys: K,
-    _phantom: PhantomData<C>,
+    // `fn() -> Codec` is a type-level marker that's always `Send + Sync` no
+    // matter what `Codec` is — the struct holds no actual `Codec` value.
+    _phantom: PhantomData<(C, fn() -> Codec)>,
 }
 
-impl<C, K> RocksdbLogStore<C, K>
+impl<C, K, Codec> RocksdbLogStore<C, K, Codec>
 where
     C: RaftTypeConfig,
     K: KeySpace,
+    Codec: 'static,
 {
     /// Open a log store on top of an already-opened `DB`. Both column families
     /// must already exist; `open_cf_descriptors` should have created them when
@@ -162,10 +170,11 @@ where
     }
 }
 
-impl<C, K> Clone for RocksdbLogStore<C, K>
+impl<C, K, Codec> Clone for RocksdbLogStore<C, K, Codec>
 where
     C: RaftTypeConfig,
     K: KeySpace,
+    Codec: 'static,
 {
     fn clone(&self) -> Self {
         Self {
@@ -178,10 +187,11 @@ where
     }
 }
 
-impl<C, K> fmt::Debug for RocksdbLogStore<C, K>
+impl<C, K, Codec> fmt::Debug for RocksdbLogStore<C, K, Codec>
 where
     C: RaftTypeConfig,
     K: KeySpace,
+    Codec: 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RocksdbLogStore")
@@ -206,23 +216,111 @@ fn range_boundary<RB: RangeBounds<u64>>(range: RB) -> (u64, u64) {
     (start, end)
 }
 
-/// Encode a log record as `[SCHEMA_VERSION | postcard(value)]`.
-fn encode_record<T: Serialize>(value: &T) -> io::Result<Vec<u8>> {
-    crate::codec::encode(crate::codec::SCHEMA_VERSION, value)
-        .map_err(|err| crate::codec::codec_io_error("log-store record encode", err))
+/// Prepend the toolkit's version byte to a provider-produced body.
+///
+/// The toolkit owns framing; `Codec` owns the body. In P1b the write version is
+/// the single `SCHEMA_VERSION`; P2 replaces it with the active write version.
+fn frame_with_version(version: u8, body: Vec<u8>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + body.len());
+    out.push(version);
+    out.extend_from_slice(&body);
+    out
 }
 
-/// Decode a record framed by [`encode_record`], rejecting a foreign version.
-fn decode_record<T: DeserializeOwned>(bytes: &[u8]) -> io::Result<T> {
-    crate::codec::decode(crate::codec::SCHEMA_VERSION, bytes)
+/// Split a framed record into `(version, body)`, rejecting an out-of-range
+/// version before any body parse. In P1b the readable range is the single
+/// `SCHEMA_VERSION`; P2 widens this to `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
+fn unframe_with_version(bytes: &[u8]) -> io::Result<(u8, &[u8])> {
+    let (first, body) = bytes.split_first().ok_or_else(|| {
+        crate::codec::codec_io_error("log-store record decode", crate::codec::CodecError::Empty)
+    })?;
+    let version = *first;
+    if version != crate::codec::SCHEMA_VERSION {
+        return Err(crate::codec::codec_io_error(
+            "log-store record decode",
+            crate::codec::CodecError::Version {
+                expected: crate::codec::SCHEMA_VERSION,
+                actual: version,
+            },
+        ));
+    }
+    Ok((version, body))
+}
+
+/// Encode a log `Entry` as `[SCHEMA_VERSION | Codec::encode_entry(..)]`.
+fn encode_entry_record<C, Codec>(entry: &C::Entry) -> io::Result<Vec<u8>>
+where
+    C: RaftTypeConfig,
+    Codec: LogStoreCodec<C>,
+{
+    let version = crate::codec::SCHEMA_VERSION;
+    let body = Codec::encode_entry(version, entry)
+        .map_err(|err| crate::codec::codec_io_error("log-store record encode", err))?;
+    Ok(frame_with_version(version, body))
+}
+
+/// Decode a log `Entry` framed by [`encode_entry_record`], rejecting a foreign version.
+fn decode_entry_record<C, Codec>(bytes: &[u8]) -> io::Result<C::Entry>
+where
+    C: RaftTypeConfig,
+    Codec: LogStoreCodec<C>,
+{
+    let (version, body) = unframe_with_version(bytes)?;
+    Codec::decode_entry(version, body)
         .map_err(|err| crate::codec::codec_io_error("log-store record decode", err))
 }
 
-impl<C, K> RocksdbLogStore<C, K>
+/// Encode a `Vote` as `[SCHEMA_VERSION | Codec::encode_vote(..)]`.
+fn encode_vote_record<C, Codec>(vote: &VoteOf<C>) -> io::Result<Vec<u8>>
+where
+    C: RaftTypeConfig,
+    Codec: LogStoreCodec<C>,
+{
+    let version = crate::codec::SCHEMA_VERSION;
+    let body = Codec::encode_vote(version, vote)
+        .map_err(|err| crate::codec::codec_io_error("log-store record encode", err))?;
+    Ok(frame_with_version(version, body))
+}
+
+/// Decode a `Vote` framed by [`encode_vote_record`], rejecting a foreign version.
+fn decode_vote_record<C, Codec>(bytes: &[u8]) -> io::Result<VoteOf<C>>
+where
+    C: RaftTypeConfig,
+    Codec: LogStoreCodec<C>,
+{
+    let (version, body) = unframe_with_version(bytes)?;
+    Codec::decode_vote(version, body)
+        .map_err(|err| crate::codec::codec_io_error("log-store record decode", err))
+}
+
+/// Encode a `LogId` as `[SCHEMA_VERSION | Codec::encode_log_id(..)]`.
+fn encode_log_id_record<C, Codec>(log_id: &LogIdOf<C>) -> io::Result<Vec<u8>>
+where
+    C: RaftTypeConfig,
+    Codec: LogStoreCodec<C>,
+{
+    let version = crate::codec::SCHEMA_VERSION;
+    let body = Codec::encode_log_id(version, log_id)
+        .map_err(|err| crate::codec::codec_io_error("log-store record encode", err))?;
+    Ok(frame_with_version(version, body))
+}
+
+/// Decode a `LogId` framed by [`encode_log_id_record`], rejecting a foreign version.
+fn decode_log_id_record<C, Codec>(bytes: &[u8]) -> io::Result<LogIdOf<C>>
+where
+    C: RaftTypeConfig,
+    Codec: LogStoreCodec<C>,
+{
+    let (version, body) = unframe_with_version(bytes)?;
+    Codec::decode_log_id(version, body)
+        .map_err(|err| crate::codec::codec_io_error("log-store record decode", err))
+}
+
+impl<C, K, Codec> RocksdbLogStore<C, K, Codec>
 where
     C: RaftTypeConfig,
     K: KeySpace,
-    C::Entry: Serialize + DeserializeOwned,
+    Codec: LogStoreCodec<C> + 'static,
 {
     /// Scan the log CF in reverse and return the highest-index `LogId`, or
     /// `None` if the log range is empty. The full log id (not just the index)
@@ -247,16 +345,16 @@ where
         if &*k < lo.as_slice() {
             return Ok(None);
         }
-        let entry: C::Entry = decode_record(&v)?;
+        let entry: C::Entry = decode_entry_record::<C, Codec>(&v)?;
         Ok(Some(entry.log_id()))
     }
 }
 
-impl<C, K> RaftLogReader<C> for RocksdbLogStore<C, K>
+impl<C, K, Codec> RaftLogReader<C> for RocksdbLogStore<C, K, Codec>
 where
     C: RaftTypeConfig,
     K: KeySpace,
-    C::Entry: Serialize + DeserializeOwned,
+    Codec: LogStoreCodec<C> + 'static,
 {
     async fn try_get_log_entries<RB>(&mut self, range: RB) -> Result<Vec<C::Entry>, io::Error>
     where
@@ -284,7 +382,7 @@ where
             if &*k >= end_key.as_slice() {
                 break;
             }
-            let entry: C::Entry = decode_record(&v)?;
+            let entry: C::Entry = decode_entry_record::<C, Codec>(&v)?;
             out.push(entry);
         }
         Ok(out)
@@ -292,15 +390,15 @@ where
 
     async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, io::Error> {
         let cf = self.meta_cf_handle();
-        meta::read::<VoteOf<C>, K>(&self.db, &cf, &self.keys, MetaLabel::Vote)
+        meta::read_vote::<C, K, Codec>(&self.db, &cf, &self.keys, MetaLabel::Vote)
     }
 }
 
-impl<C, K> RaftLogStorage<C> for RocksdbLogStore<C, K>
+impl<C, K, Codec> RaftLogStorage<C> for RocksdbLogStore<C, K, Codec>
 where
     C: RaftTypeConfig,
     K: KeySpace,
-    C::Entry: Serialize + DeserializeOwned,
+    Codec: LogStoreCodec<C> + 'static,
 {
     type LogReader = Self;
 
@@ -310,8 +408,12 @@ where
 
     async fn get_log_state(&mut self) -> Result<LogState<C>, io::Error> {
         let cf_meta = self.meta_cf_handle();
-        let last_purged_log_id: Option<LogIdOf<C>> =
-            meta::read::<LogIdOf<C>, K>(&self.db, &cf_meta, &self.keys, MetaLabel::LastPurged)?;
+        let last_purged_log_id: Option<LogIdOf<C>> = meta::read_log_id::<C, K, Codec>(
+            &self.db,
+            &cf_meta,
+            &self.keys,
+            MetaLabel::LastPurged,
+        )?;
 
         let last_in_log = self.last_log_id_in_cf()?;
         let last_log_id = last_in_log.or_else(|| last_purged_log_id.clone());
@@ -325,7 +427,7 @@ where
     async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), io::Error> {
         let cf_meta = self.meta_cf_handle();
         let mut batch = WriteBatch::default();
-        meta::put::<VoteOf<C>, K>(&mut batch, &cf_meta, &self.keys, MetaLabel::Vote, vote)?;
+        meta::put_vote::<C, K, Codec>(&mut batch, &cf_meta, &self.keys, MetaLabel::Vote, vote)?;
         // fsync: the vote must be durable before it is acknowledged, or a crash
         // could let this node vote twice in one term and split the cluster.
         let wo = Self::write_sync_opts();
@@ -337,7 +439,7 @@ where
         let cf_meta = self.meta_cf_handle();
         let mut batch = WriteBatch::default();
         match committed {
-            Some(committed) => meta::put::<LogIdOf<C>, K>(
+            Some(committed) => meta::put_log_id::<C, K, Codec>(
                 &mut batch,
                 &cf_meta,
                 &self.keys,
@@ -355,7 +457,7 @@ where
 
     async fn read_committed(&mut self) -> Result<Option<LogIdOf<C>>, io::Error> {
         let cf_meta = self.meta_cf_handle();
-        meta::read::<LogIdOf<C>, K>(&self.db, &cf_meta, &self.keys, MetaLabel::Committed)
+        meta::read_log_id::<C, K, Codec>(&self.db, &cf_meta, &self.keys, MetaLabel::Committed)
     }
 
     async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), io::Error>
@@ -368,7 +470,7 @@ where
         for entry in entries {
             let (_leader, idx) = entry.log_id_parts();
             let key = self.keys.log_key(idx);
-            let value = encode_record(&entry)?;
+            let value = encode_entry_record::<C, Codec>(&entry)?;
             batch.put_cf(&cf_log, &key, &value);
         }
 
@@ -442,7 +544,7 @@ where
         };
         batch.delete_range_cf(&cf_log, &lo, &end_key);
 
-        meta::put::<LogIdOf<C>, K>(
+        meta::put_log_id::<C, K, Codec>(
             &mut batch,
             &cf_meta,
             &self.keys,
@@ -526,34 +628,71 @@ mod range_boundary_tests {
 
 #[cfg(test)]
 mod record_codec_tests {
-    use super::{decode_record, encode_record};
+    use super::{decode_entry_record, encode_entry_record};
+    use crate::codec::SCHEMA_VERSION;
+    use crate::declare_raft_types_ext;
+    use crate::log_store::DefaultLogStoreCodec;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct Rec {
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct RecPeer {
+        addr: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct RecData {
         v: u64,
     }
 
-    #[test]
-    fn encode_record_stamps_schema_version_and_roundtrips() {
-        let bytes = encode_record(&Rec { v: 5 }).expect("encode");
-        assert_eq!(bytes[0], crate::codec::SCHEMA_VERSION);
-        let back: Rec = decode_record(&bytes).expect("decode");
-        assert_eq!(back, Rec { v: 5 });
+    impl std::fmt::Display for RecData {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "RecData({})", self.v)
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct RecApplied;
+
+    declare_raft_types_ext! {
+        pub RecConfig:
+            Node            = RecPeer,
+            AppData         = RecData,
+            AppDataResponse = RecApplied,
+            SnapshotData    = std::io::Cursor<Vec<u8>>,
+    }
+
+    type RecEntry = openraft::type_config::alias::EntryOf<RecConfig>;
+
+    fn sample_entry() -> RecEntry {
+        let lid = openraft::testing::log_id::<RecConfig>(1, 1, 1);
+        openraft::entry::RaftEntry::new_normal(lid, RecData { v: 5 })
     }
 
     #[test]
-    fn decode_record_rejects_foreign_version() {
+    fn encode_entry_record_stamps_schema_version_and_roundtrips() {
+        let entry = sample_entry();
+        let bytes = encode_entry_record::<RecConfig, DefaultLogStoreCodec>(&entry).expect("encode");
+        assert_eq!(bytes[0], SCHEMA_VERSION);
+        let back: RecEntry =
+            decode_entry_record::<RecConfig, DefaultLogStoreCodec>(&bytes).expect("decode");
+        // Compare via re-encode: EntryOf is not PartialEq across all type params.
+        let reencoded =
+            encode_entry_record::<RecConfig, DefaultLogStoreCodec>(&back).expect("re-encode");
+        assert_eq!(bytes, reencoded);
+    }
+
+    #[test]
+    fn decode_entry_record_rejects_foreign_version() {
         // A 0xFF-framed record must surface as InvalidData rather than a
-        // successful-but-wrong decode.
-        let err = decode_record::<Rec>(&[0xFF, 5]).expect_err("must reject");
+        // successful-but-wrong decode, exactly as the old free function did.
+        let err = decode_entry_record::<RecConfig, DefaultLogStoreCodec>(&[0xFF, 5])
+            .expect_err("must reject");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]
     fn schema_version_is_four() {
-        // Pinned so a future layout change re-confirms the bump deliberately;
-        // v4 widened the openraft driver's OpenraftPeer with admin_endpoint.
+        // Pinned so a future layout change re-confirms the bump deliberately.
         assert_eq!(crate::codec::SCHEMA_VERSION, 4);
     }
 }

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -33,8 +33,8 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
 use tsoracle_consensus::ConsensusDriver;
 use tsoracle_driver_openraft::{
-    HighWaterStateMachine, OpenraftDriver, OpenraftPeer, RocksdbSnapshotStore, SnapshotStore,
-    StandaloneHost, TypeConfig,
+    HighWaterStateMachine, OpenraftDriver, OpenraftLogCodec, OpenraftPeer, RocksdbSnapshotStore,
+    SnapshotStore, StandaloneHost, TypeConfig,
 };
 use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
 
@@ -94,12 +94,13 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         source: Box::new(source),
     })?;
     let db = open_rocksdb(&cfg.raft_dir)?;
-    let log_store = RocksdbLogStore::open(db.clone(), LOG_CF, META_CF, Flat).map_err(|e| {
-        StandaloneError::Storage {
-            path: cfg.raft_dir.clone(),
-            source: Box::new(e),
-        }
-    })?;
+    let log_store: RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec> =
+        RocksdbLogStore::open(db.clone(), LOG_CF, META_CF, Flat).map_err(|e| {
+            StandaloneError::Storage {
+                path: cfg.raft_dir.clone(),
+                source: Box::new(e),
+            }
+        })?;
     let snapshot_store: Arc<dyn SnapshotStore> =
         Arc::new(RocksdbSnapshotStore::open(db, SNAP_CF).map_err(|e| {
             StandaloneError::Storage {


### PR DESCRIPTION
## Summary

Wire the openraft toolkit and the openraft driver through the `VersionedCodec` seam introduced in #454 so log/meta/snapshot (de)serialization routes through a versioned body provider, with the toolkit owning the leading version-byte framing.

**No on-disk byte changes.** `SCHEMA_VERSION` stays `4` and every body is byte-for-byte identical to the pre-seam postcard frame. The `*_pins_v4_layout` tests guard sameness; they now go through the new seam and still assert the same `vec![4, ..]` bytes.

## Orphan-rule seam (two halves)

The orphan rule blocks `impl tsoracle_codec::VersionedCodec for openraft::Entry` (both foreign here). The seam therefore has two halves.

1. **Toolkit-generic openraft types** (`C::Entry`, `VoteOf<C>`, `LogIdOf<C>`): the toolkit defines a toolkit-local provider trait `LogStoreCodec<C>` (six `(version, &T)` / `(version, &[u8])` body methods), a behavior-preserving `DefaultLogStoreCodec` impl (whole-value postcard), and the driver supplies a local marker `OpenraftLogCodec` to satisfy the orphan rule. `RocksdbLogStore<C, K, Codec = DefaultLogStoreCodec>` gains the `Codec` parameter — defaulted to keep the ~40 internal `<TestTypeConfig, …>` sites compiling unchanged, threaded explicitly at the four driver-side sites.

2. **Driver-local snapshot types** (`HighWaterStateMachineSnapshot`, `PersistedSnapshot`): the driver `impl tsoracle_codec::VersionedCodec` directly. The six `state_machine.rs` snapshot codec sites (`with_store` envelope+payload decode at 207/209; `build_snapshot` payload+envelope encode at 318/327; `install_snapshot` payload decode + envelope encode at 414/439) move from `decode(SCHEMA_VERSION, ..)` / `encode(SCHEMA_VERSION, ..)` to `decode_framed(SCHEMA_VERSION, SCHEMA_VERSION, ..)` / `encode_framed(SCHEMA_VERSION, ..)`.

## Toolkit changes

- `tsoracle-openraft-toolkit::codec_provider` (new, **top-level — NOT gated by `rocksdb-log-store`** since the trait has no rocksdb dep): the `LogStoreCodec` trait + `DefaultLogStoreCodec`.
- `RocksdbLogStore<C, K, Codec>` gains a `Codec: 'static` type parameter, defaulted to `DefaultLogStoreCodec`. `PhantomData<(C, fn() -> Codec)>` keeps the struct `Send + Sync` regardless of `Codec`'s thread-safety. The codec bound lives on the impls that actually dispatch, not on the struct, so `open` / `Clone` / `Debug` stay codec-bound-free.
- `encode_record`/`decode_record` replaced by six version-parameterized, provider-backed helpers (`encode_entry_record`/`decode_entry_record` and the vote/log-id analogues) + `frame_with_version`/`unframe_with_version`. The toolkit owns the version byte; the provider owns the body. P1b's range check is a single-version equality against `SCHEMA_VERSION` (a degenerate one-element range a later phase widens to `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`).
- `meta::read`/`put` split into `read_vote`/`read_log_id`/`put_vote`/`put_log_id` per-type helpers, each routed through the matching record helper.
- Crate-root re-exports added for `LogStoreCodec` and `DefaultLogStoreCodec` (un-gated so a default-feature driver can name the trait without pulling rocksdb).

## Driver changes

- New `tsoracle-driver-openraft::log_codec::OpenraftLogCodec` provider implementing `LogStoreCodec<TypeConfig>`. `tsoracle-codec` added to the driver's dependencies.
- `impl VersionedCodec for HighWaterStateMachineSnapshot` and `for PersistedSnapshot` — v4 arms call `encode_postcard`/`decode_postcard_exact` (byte-identical to the pre-seam frame); foreign versions return `CodecError::VersionUnsupported` (mapping to `InvalidData` via the extended `codec_io_error` from #454).
- All four driver-side `RocksdbLogStore` construction sites annotated to pin `OpenraftLogCodec` explicitly: production (`tsoracle-standalone/src/drivers/openraft/mod.rs:97`) plus three driver test sites (`tests/common/mod.rs`, `tests/snapshot_transfer.rs`, `tests/snapshot_restart.rs`).
- The three `*_pins_v4_layout` tests re-asserted through the new seam — same `vec![4, ..]` bytes through `encode_framed` / `OpenraftLogCodec`, proving the on-disk format did not move.

## Behavior preservation

Every body arm is whole-value `encode_postcard`/`decode_postcard_exact`, byte-identical to today's `postcard::to_stdvec`/`take_from_bytes`. Asserted byte-for-byte by:

- `default_codec_vote_body_matches_raw_postcard` (toolkit default codec equals raw postcard)
- the three driver `*_body_matches_raw_postcard` tests (`OpenraftLogCodec` equals raw postcard)
- `snapshot_payload_versioned_codec_matches_legacy_frame` (new seam equals the legacy `encode(SCHEMA_VERSION, ..)` frame)
- the three `*_pins_v4_layout` tests (exact `vec![4, ..]` bytes through the new seam)

The toolkit's real-rocksdb integration tests (default codec) and the driver's `snapshot_restart`/`snapshot_transfer` tests (`OpenraftLogCodec`) exercise write-then-read-back end-to-end against real rocksdb — the strongest cross-process check that the bytes did not move.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo build --workspace --all-features` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo build -p tsoracle-openraft-toolkit --no-default-features` — clean (`codec_provider` lives at the toolkit's top level, NOT under `rocksdb-log-store`, so the driver can import `LogStoreCodec` without pulling rocksdb)
- [x] `cargo fmt --check` — clean
- [x] `python3 scripts/check-ts-header.py` — all headers OK