### PR TITLE
feat(openraft-toolkit): ActiveWriteVersion cell and version constants

### DIFF
--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -65,6 +65,18 @@ impl StandaloneHost {
             state_machine,
         }
     }
+
+    /// The format version this node currently emits (stamps onto persisted
+    /// records, snapshots, and — in a later phase — peer RPC payloads). Reads
+    /// the shared
+    /// [`ActiveWriteVersion`](tsoracle_openraft_toolkit::ActiveWriteVersion)
+    /// cell via the state machine, which shares the one cell with the log
+    /// store. In this release it is always
+    /// [`BASELINE_WRITE_VERSION`](tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION);
+    /// a successful activation apply (later phase) advances it.
+    pub fn active_write_version(&self) -> u8 {
+        self.state_machine.active_write_version()
+    }
 }
 
 #[async_trait]
@@ -195,5 +207,28 @@ mod tests {
             classify_client_write_error(err),
             ConsensusError::TransientDriver(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn host_active_write_version_delegates_to_the_shared_cell() {
+        // StandaloneHost surfaces the SM's shared cell. Assert the delegation
+        // target (the SM accessor) behaves; the host's accessor is a thin
+        // pass-through to it. Building a full `Raft` in a unit test is heavy
+        // and the live-host tests live in the integration harness; the
+        // _assert_signature line below also gives compile-time evidence that
+        // the host's accessor exists with the right signature.
+        let cell = tsoracle_openraft_toolkit::ActiveWriteVersion::default();
+        let store: std::sync::Arc<dyn crate::snapshot_store::SnapshotStore> =
+            std::sync::Arc::new(crate::snapshot_store::InMemorySnapshotStore::new());
+        let state_machine =
+            HighWaterStateMachine::with_store_and_active_version(store, cell.clone()).expect("sm");
+        assert_eq!(
+            state_machine.active_write_version(),
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION
+        );
+        cell.set(7);
+        assert_eq!(state_machine.active_write_version(), 7);
+        // Compile-time guard that the host accessor exists and returns u8:
+        let _assert_signature: fn(&StandaloneHost) -> u8 = StandaloneHost::active_write_version;
     }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -28,7 +28,7 @@
 //! State is one `u64` plus the openraft-required apply-progress metadata
 //! (`last_applied`, `last_membership`). Snapshots are encoded with the toolkit's
 //! version-prefixed codec ([`tsoracle_openraft_toolkit::encode`] /
-//! [`tsoracle_openraft_toolkit::decode`] at [`SCHEMA_VERSION`]) — a leading
+//! [`tsoracle_openraft_toolkit::decode`] at the active write version) — a leading
 //! version byte followed by the postcard body — written through to a
 //! [`SnapshotStore`] so they survive a
 //! process restart. The default store is in-memory
@@ -60,7 +60,10 @@ use serde::{Deserialize, Serialize};
 use tsoracle_codec::{
     VersionedCodec, decode_framed, decode_postcard_exact, encode_framed, encode_postcard,
 };
-use tsoracle_openraft_toolkit::{SCHEMA_VERSION, codec_io_error};
+use tsoracle_openraft_toolkit::{
+    ActiveWriteVersion, BASELINE_WRITE_VERSION, MAX_READABLE_VERSION, MIN_READABLE_VERSION,
+    codec_io_error,
+};
 
 use crate::log_entry::HighWaterCommand;
 use crate::snapshot_store::{InMemorySnapshotStore, SnapshotStore};
@@ -73,9 +76,10 @@ type SnapData = Cursor<Vec<u8>>;
 type StoredMem = StoredMembershipOf<TypeConfig>;
 
 /// Snapshot payload. The persisted/streamed bytes are version-framed as
-/// `[SCHEMA_VERSION | postcard(Self)]`, so decode them through the toolkit codec
-/// ([`tsoracle_openraft_toolkit::decode`] with [`SCHEMA_VERSION`]) rather than
-/// raw `postcard::from_bytes`.
+/// `[active write version | postcard(Self)]`, so decode them through the
+/// toolkit `decode_framed` over the readable range
+/// `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]` rather than raw
+/// `postcard::from_bytes`.
 ///
 /// Exposed at the crate root so callers building tooling around the snapshot
 /// format (e.g. inspectors, migration tools) can decode it without re-deriving
@@ -89,10 +93,10 @@ pub struct HighWaterStateMachineSnapshot {
 
 /// On-disk envelope written to the [`SnapshotStore`]: pairs the openraft
 /// snapshot meta with the version-framed payload, where `data` holds
-/// `[SCHEMA_VERSION | postcard(HighWaterStateMachineSnapshot)]`. Kept private —
-/// embedders that need to inspect persisted snapshots decode the inner `data`
-/// blob through the toolkit codec ([`tsoracle_openraft_toolkit::decode`] with
-/// [`SCHEMA_VERSION`]).
+/// `[active write version | postcard(HighWaterStateMachineSnapshot)]`. Kept
+/// private — embedders that need to inspect persisted snapshots decode the
+/// inner `data` blob through the toolkit `decode_framed` over the readable
+/// range.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PersistedSnapshot {
     meta: SnapMeta,
@@ -102,12 +106,14 @@ struct PersistedSnapshot {
 impl VersionedCodec for HighWaterStateMachineSnapshot {
     fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
         match version {
-            // v4: whole-value postcard, byte-identical to the pre-seam frame.
-            // P2 adds older/newer arms here as the layout evolves.
-            v if v == SCHEMA_VERSION => decode_postcard_exact(body),
+            // v4 (BASELINE_WRITE_VERSION): whole-value postcard, byte-identical
+            // to the pre-seam frame. Later phases add older/newer arms here as
+            // the layout evolves and MIN_READABLE_VERSION/MAX_READABLE_VERSION
+            // widen.
+            v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
-                min: SCHEMA_VERSION,
-                max: SCHEMA_VERSION,
+                min: MIN_READABLE_VERSION,
+                max: MAX_READABLE_VERSION,
                 actual: other,
             }),
         }
@@ -115,10 +121,10 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
 
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
-            v if v == SCHEMA_VERSION => encode_postcard(self),
+            v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
-                min: SCHEMA_VERSION,
-                max: SCHEMA_VERSION,
+                min: MIN_READABLE_VERSION,
+                max: MAX_READABLE_VERSION,
                 actual: other,
             }),
         }
@@ -128,10 +134,10 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
 impl VersionedCodec for PersistedSnapshot {
     fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
         match version {
-            v if v == SCHEMA_VERSION => decode_postcard_exact(body),
+            v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
-                min: SCHEMA_VERSION,
-                max: SCHEMA_VERSION,
+                min: MIN_READABLE_VERSION,
+                max: MAX_READABLE_VERSION,
                 actual: other,
             }),
         }
@@ -139,10 +145,10 @@ impl VersionedCodec for PersistedSnapshot {
 
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
-            v if v == SCHEMA_VERSION => encode_postcard(self),
+            v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
-                min: SCHEMA_VERSION,
-                max: SCHEMA_VERSION,
+                min: MIN_READABLE_VERSION,
+                max: MAX_READABLE_VERSION,
                 actual: other,
             }),
         }
@@ -201,6 +207,12 @@ pub struct HighWaterStateMachine {
     /// `core` precisely so the hot `apply` path never serializes against
     /// snapshot I/O — `core` is never held across `store.save`.
     persist: Arc<Mutex<()>>,
+    /// Shared active write version: the version this SM stamps onto snapshots
+    /// it builds and installs. Shares the one cell with the log store (and,
+    /// in a later phase, the wire sender) so all writers emit the same
+    /// version. Mutated only by a successful activation apply (later phase);
+    /// defaults to BASELINE.
+    active_write_version: ActiveWriteVersion,
 }
 
 impl Clone for HighWaterStateMachine {
@@ -209,6 +221,7 @@ impl Clone for HighWaterStateMachine {
             core: Arc::clone(&self.core),
             store: Arc::clone(&self.store),
             persist: Arc::clone(&self.persist),
+            active_write_version: self.active_write_version.clone(),
         }
     }
 }
@@ -249,6 +262,18 @@ impl HighWaterStateMachine {
     /// index 0, and the state machine must already cover those purged entries
     /// or openraft will panic during recovery.
     pub fn with_store(store: Arc<dyn SnapshotStore>) -> io::Result<Self> {
+        Self::with_store_and_active_version(store, ActiveWriteVersion::default())
+    }
+
+    /// Build a state machine backed by `store`, sharing `active_write_version`
+    /// with the log store (and, in a later phase, the wire sender). Bootstrap
+    /// constructs and seeds the cell once, then threads the same clone here
+    /// and into the log store; non-bootstrap callers use
+    /// [`with_store`](Self::with_store), which supplies a fresh BASELINE cell.
+    pub fn with_store_and_active_version(
+        store: Arc<dyn SnapshotStore>,
+        active_write_version: ActiveWriteVersion,
+    ) -> io::Result<Self> {
         let mut core = Core {
             current_value: 0,
             last_applied: None,
@@ -258,10 +283,10 @@ impl HighWaterStateMachine {
         };
         if let Some(bytes) = store.load()? {
             let persisted: PersistedSnapshot =
-                decode_framed(SCHEMA_VERSION, SCHEMA_VERSION, &bytes)
+                decode_framed(MIN_READABLE_VERSION, MAX_READABLE_VERSION, &bytes)
                     .map_err(|e| codec_io_error("persisted snapshot envelope decode", e))?;
             let payload: HighWaterStateMachineSnapshot =
-                decode_framed(SCHEMA_VERSION, SCHEMA_VERSION, &persisted.data)
+                decode_framed(MIN_READABLE_VERSION, MAX_READABLE_VERSION, &persisted.data)
                     .map_err(|e| codec_io_error("persisted snapshot payload decode", e))?;
             core.current_value = payload.current_value;
             core.last_applied = payload.last_applied;
@@ -275,7 +300,13 @@ impl HighWaterStateMachine {
             core: Arc::new(Mutex::new(core)),
             store,
             persist: Arc::new(Mutex::new(())),
+            active_write_version,
         })
+    }
+
+    /// The version this SM currently stamps onto snapshots.
+    pub fn active_write_version(&self) -> u8 {
+        self.active_write_version.get()
     }
 
     /// Read the current high-water value without going through raft.
@@ -370,7 +401,7 @@ impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
                 last_membership: core.last_membership.clone(),
                 snapshot_id,
             };
-            let bytes = encode_framed(SCHEMA_VERSION, &payload)
+            let bytes = encode_framed(self.active_write_version.get(), &payload)
                 .map_err(|e| codec_io_error("snapshot payload serialize", e))?;
             (bytes, meta)
         };
@@ -379,7 +410,7 @@ impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
             meta: meta.clone(),
             data: snapshot_payload.clone(),
         };
-        let envelope = encode_framed(SCHEMA_VERSION, &persisted)
+        let envelope = encode_framed(self.active_write_version.get(), &persisted)
             .map_err(|e| codec_io_error("snapshot envelope serialize", e))?;
         // Persist + publish through the monotone, serialized commit path. The
         // store write happens BEFORE `current_snapshot` is updated, so a
@@ -467,7 +498,7 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
     ) -> Result<(), io::Error> {
         let bytes = snapshot.into_inner();
         let payload: HighWaterStateMachineSnapshot =
-            decode_framed(SCHEMA_VERSION, SCHEMA_VERSION, &bytes)
+            decode_framed(MIN_READABLE_VERSION, MAX_READABLE_VERSION, &bytes)
                 .map_err(|e| codec_io_error("snapshot payload decode", e))?;
 
         // `meta.last_log_id` is read back by `get_current_snapshot` while
@@ -492,7 +523,7 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
             meta: meta.clone(),
             data: bytes.clone(),
         };
-        let envelope = encode_framed(SCHEMA_VERSION, &persisted)
+        let envelope = encode_framed(self.active_write_version.get(), &persisted)
             .map_err(|e| codec_io_error("snapshot envelope serialize", e))?;
         // Persist, apply the snapshot's state, and publish atomically through
         // the monotone, serialized commit path — the same one `build_snapshot`
@@ -666,9 +697,11 @@ mod tests {
 
         let snap = sm.build_snapshot().await.expect("build_snapshot");
         let bytes = snap.snapshot.into_inner();
-        let payload: HighWaterStateMachineSnapshot =
-            tsoracle_openraft_toolkit::decode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &bytes)
-                .expect("decode snapshot");
+        let payload: HighWaterStateMachineSnapshot = tsoracle_openraft_toolkit::decode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &bytes,
+        )
+        .expect("decode snapshot");
         assert_eq!(payload.current_value, 500);
         assert_eq!(payload.last_applied.map(|l| l.index), Some(1));
     }
@@ -699,9 +732,11 @@ mod tests {
             last_applied: Some(log_id(5)),
             last_membership: StoredMem::default(),
         };
-        let bytes =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
-                .expect("serialize payload");
+        let bytes = tsoracle_openraft_toolkit::encode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &payload,
+        )
+        .expect("serialize payload");
 
         let meta = SnapMeta {
             last_log_id: payload.last_applied,
@@ -798,6 +833,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn state_machine_defaults_to_baseline_active_write_version() {
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        let sm = HighWaterStateMachine::with_store(store).expect("with_store");
+        assert_eq!(
+            sm.active_write_version(),
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION
+        );
+    }
+
+    #[tokio::test]
+    async fn state_machine_reads_the_same_shared_cell() {
+        // The SM and the log store hold clones of ONE cell. A set() on the
+        // cell (a later phase's activation apply will do this) is observed
+        // identically by every clone.
+        let cell = tsoracle_openraft_toolkit::ActiveWriteVersion::default();
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        let sm = HighWaterStateMachine::with_store_and_active_version(store, cell.clone())
+            .expect("with_store_and_active_version");
+        assert_eq!(
+            sm.active_write_version(),
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION
+        );
+        cell.set(7);
+        assert_eq!(sm.active_write_version(), 7);
+    }
+
+    #[tokio::test]
     async fn begin_receiving_snapshot_returns_empty_cursor() {
         // openraft hands the returned cursor to the snapshot-receiving network
         // path; the contract is "empty, writable buffer." Anything non-empty
@@ -833,9 +895,11 @@ mod tests {
             meta: SnapMeta::default(),
             data: b"not a postcard payload".to_vec(),
         };
-        let bytes =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &envelope)
-                .unwrap();
+        let bytes = tsoracle_openraft_toolkit::encode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &envelope,
+        )
+        .unwrap();
         let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
         store.save(&bytes).unwrap();
         let Err(err) = HighWaterStateMachine::with_store(store) else {
@@ -854,9 +918,11 @@ mod tests {
             last_applied: Some(log_id(10)),
             last_membership: StoredMem::default(),
         };
-        let bytes =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
-                .unwrap();
+        let bytes = tsoracle_openraft_toolkit::encode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &payload,
+        )
+        .unwrap();
         let meta = SnapMeta {
             last_log_id: payload.last_applied,
             last_membership: payload.last_membership.clone(),
@@ -882,9 +948,11 @@ mod tests {
             last_applied: Some(last_applied),
             last_membership: StoredMem::default(),
         };
-        let bytes =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
-                .expect("serialize payload");
+        let bytes = tsoracle_openraft_toolkit::encode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &payload,
+        )
+        .expect("serialize payload");
         let meta = SnapMeta {
             last_log_id: payload.last_applied,
             last_membership: payload.last_membership.clone(),
@@ -1015,7 +1083,7 @@ mod tests {
 
         let (stale_meta, stale_data) = install_payload(50, log_id(5));
         let envelope = tsoracle_openraft_toolkit::encode(
-            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &PersistedSnapshot {
                 meta: stale_meta.clone(),
                 data: stale_data.clone(),
@@ -1066,9 +1134,11 @@ mod tests {
             last_applied: Some(log_id(5)),
             last_membership: StoredMem::default(),
         };
-        let bytes =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
-                .expect("serialize payload");
+        let bytes = tsoracle_openraft_toolkit::encode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &payload,
+        )
+        .expect("serialize payload");
 
         let meta = SnapMeta {
             last_log_id: Some(log_id(6)),
@@ -1185,24 +1255,26 @@ mod tests {
     fn snapshot_payload_versioned_codec_matches_legacy_frame() {
         use tsoracle_codec::{decode_framed, encode_framed};
         // The framed bytes through the new VersionedCodec seam must equal the
-        // legacy `tsoracle_openraft_toolkit::encode(SCHEMA_VERSION, ..)` frame —
+        // legacy `tsoracle_openraft_toolkit::encode(BASELINE_WRITE_VERSION, ..)` frame —
         // proving the on-disk format did not move.
         let payload = HighWaterStateMachineSnapshot {
             current_value: 7,
             last_applied: None,
             last_membership: StoredMembership::default(),
         };
-        let via_seam = encode_framed(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
+        let via_seam = encode_framed(tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION, &payload)
             .expect("encode_framed");
-        let legacy =
-            tsoracle_openraft_toolkit::encode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload)
-                .expect("legacy encode");
+        let legacy = tsoracle_openraft_toolkit::encode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &payload,
+        )
+        .expect("legacy encode");
         assert_eq!(via_seam, legacy);
         assert_eq!(via_seam, vec![4, 7, 0, 0, 0, 0]);
 
         let back: HighWaterStateMachineSnapshot = decode_framed(
-            tsoracle_openraft_toolkit::SCHEMA_VERSION,
-            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &via_seam,
         )
         .expect("decode_framed");
@@ -1214,8 +1286,8 @@ mod tests {
         use tsoracle_codec::{CodecError, decode_framed};
         let framed = vec![0xFFu8, 7, 0, 0, 0, 0];
         let err = decode_framed::<HighWaterStateMachineSnapshot>(
-            tsoracle_openraft_toolkit::SCHEMA_VERSION,
-            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &framed,
         )
         .expect_err("must reject");
@@ -1228,21 +1300,24 @@ mod tests {
     #[test]
     fn snapshot_payload_pins_v4_layout() {
         use tsoracle_codec::encode_framed;
-        // Hand-built v4 frame: [SCHEMA_VERSION | postcard(payload)], now produced
-        // through the VersionedCodec seam that build_snapshot uses. Leading byte
-        // advanced 3 -> 4 when OpenraftPeer gained the admin_endpoint field (a
-        // breaking on-disk change for membership); the postcard body is
-        // unchanged. Body [7, 0, 0, 0, 0] = current_value 7, last_applied None,
-        // then default StoredMembership (None log id + empty configs + empty
-        // nodes). Reordering or inserting a field changes these bytes and trips
-        // this test, forcing a SCHEMA_VERSION bump.
+        // Hand-built v4 frame: [BASELINE_WRITE_VERSION | postcard(payload)],
+        // now produced through the VersionedCodec seam that build_snapshot
+        // uses. Leading byte advanced 3 -> 4 when OpenraftPeer gained the
+        // admin_endpoint field (a breaking on-disk change for membership);
+        // the postcard body is unchanged. Body [7, 0, 0, 0, 0] =
+        // current_value 7, last_applied None, then default StoredMembership
+        // (None log id + empty configs + empty nodes). Reordering or
+        // inserting a field changes these bytes and trips this test, forcing
+        // a deliberate version bump (a future evolution would advance
+        // MAX_READABLE_VERSION + BASELINE_WRITE_VERSION through an
+        // activation barrier rather than the historical stop-the-world bump).
         let payload = HighWaterStateMachineSnapshot {
             current_value: 7,
             last_applied: None,
             last_membership: StoredMembership::default(),
         };
-        let framed =
-            encode_framed(tsoracle_openraft_toolkit::SCHEMA_VERSION, &payload).expect("encode");
+        let framed = encode_framed(tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION, &payload)
+            .expect("encode");
         assert_eq!(framed, vec![4, 7, 0, 0, 0, 0]);
     }
 
@@ -1250,9 +1325,10 @@ mod tests {
     fn log_entry_pins_v4_layout() {
         use crate::log_codec::OpenraftLogCodec;
         use tsoracle_openraft_toolkit::LogStoreCodec;
-        // The bytes RocksdbLogStore<TypeConfig> persists per entry: SCHEMA_VERSION
-        // byte (prepended by the store) + OpenraftLogCodec entry body — the v4
-        // frame around a Normal entry carrying Advance(AdvancePayload { at_least: 5 })
+        // The bytes RocksdbLogStore<TypeConfig> persists per entry: the
+        // active write version byte (prepended by the store) +
+        // OpenraftLogCodec entry body — the v4 frame around a Normal entry
+        // carrying Advance(AdvancePayload { at_least: 5 })
         // at log id (term 1, node 1, index 1). Body [1,1,1,1,0,5] = leader
         // (term 1, node 1), index 1, EntryPayload::Normal tag (1), Advance
         // variant (0), at_least 5 — byte-identical to the pre-seam layout.
@@ -1262,11 +1338,11 @@ mod tests {
             HighWaterCommand::Advance(AdvancePayload { at_least: 5 }),
         );
         let body = <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_entry(
-            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &entry,
         )
         .expect("encode entry body");
-        let mut framed = vec![tsoracle_openraft_toolkit::SCHEMA_VERSION];
+        let mut framed = vec![tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION];
         framed.extend_from_slice(&body);
         assert_eq!(framed, vec![4, 1, 1, 1, 1, 0, 5]);
     }
@@ -1276,18 +1352,18 @@ mod tests {
         use crate::log_codec::OpenraftLogCodec;
         use tsoracle_openraft_toolkit::LogStoreCodec;
         // The bytes RocksdbLogStore<TypeConfig> persists in the meta column for a
-        // Vote: SCHEMA_VERSION byte + OpenraftLogCodec vote body. Body [7, 3, 1] =
+        // Vote: active write version byte + OpenraftLogCodec vote body. Body [7, 3, 1] =
         // leader (term 7, node 3), committed flag true. A layout change to Vote
         // trips this test. This is the recovery-critical field the framing
         // protects: a foreign version loud-rejects instead of misdecoding.
         let vote: openraft::type_config::alias::VoteOf<TypeConfig> =
             openraft::Vote::new_committed(7, 3);
         let body = <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_vote(
-            tsoracle_openraft_toolkit::SCHEMA_VERSION,
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &vote,
         )
         .expect("encode vote body");
-        let mut framed = vec![tsoracle_openraft_toolkit::SCHEMA_VERSION];
+        let mut framed = vec![tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION];
         framed.extend_from_slice(&body);
         assert_eq!(framed, vec![4, 7, 3, 1]);
     }

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -47,7 +47,10 @@ use crate::log_entry::HighWaterCommand;
 ///   Empty means "no admin redirect available for this node".
 ///
 /// Widening this struct changes the postcard layout of membership log entries
-/// and therefore requires a `tsoracle_openraft_toolkit::SCHEMA_VERSION` bump.
+/// and therefore requires growing `tsoracle_openraft_toolkit::MAX_READABLE_VERSION`
+/// and advancing `BASELINE_WRITE_VERSION` through an activation barrier (the
+/// historical fix was a global stop-the-world bump; the format-migration
+/// design replaces that with a rolling upgrade).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenraftPeer {
     pub addr: String,
@@ -107,15 +110,15 @@ pub type OpenraftEntry = openraft::type_config::alias::EntryOf<TypeConfig>;
 /// column family on recovery.
 ///
 /// Like the log and snapshot records, the meta singletons are persisted under
-/// the `[SCHEMA_VERSION | postcard]` frame (the meta column was brought under it
-/// in `SCHEMA_VERSION` v2) — see `log_store::meta::read`, which routes
-/// `VoteOf<C>` (label `Vote`) and `LogIdOf<C>` (labels `Committed` and
-/// `LastPurged`) through `log_store::decode_record`, so a foreign version
+/// the `[active write version | postcard]` frame (the meta column was brought
+/// under it in v2) — see `log_store::meta::read`, which routes `VoteOf<C>`
+/// (label `Vote`) and `LogIdOf<C>` (labels `Committed` and `LastPurged`)
+/// through the toolkit's record helpers, so an out-of-range version
 /// loud-rejects instead of silently misdecoding the recovery-critical vote.
 /// Exposed only so the fuzz harness can reconstruct that framed decode
-/// (`tsoracle_openraft_toolkit::decode::<_>(SCHEMA_VERSION, ..)`) against the
-/// concrete meta types; hidden from the public API because nothing else should
-/// depend on the meta representation.
+/// (`tsoracle_openraft_toolkit::decode::<_>(BASELINE_WRITE_VERSION, ..)`)
+/// against the concrete meta types; hidden from the public API because nothing
+/// else should depend on the meta representation.
 #[doc(hidden)]
 pub type OpenraftVote = openraft::type_config::alias::VoteOf<TypeConfig>;
 
@@ -165,7 +168,8 @@ mod tests {
         // Pins the postcard field order (addr, service_endpoint, admin_endpoint)
         // that membership log entries embed. A reorder or inserted field changes
         // these bytes and trips this test, guarding the membership record layout
-        // the SCHEMA_VERSION frame versions. postcard encodes each String as a
+        // the active write version frame versions. postcard encodes each String
+        // as a
         // varint length prefix followed by its UTF-8 bytes.
         let peer = OpenraftPeer {
             addr: "a:1".into(),

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -28,30 +28,174 @@
 //! sides of an upgrade run mixed versions briefly.
 //!
 //! The framing itself lives in the shared [`tsoracle_codec`] crate, re-used
-//! verbatim by the paxos toolkit. Only [`SCHEMA_VERSION`] is owned here, so
-//! this toolkit's wire/on-disk format versions independently of the others.
+//! verbatim by the paxos toolkit. The version constants ([`MIN_READABLE_VERSION`],
+//! [`MAX_READABLE_VERSION`], [`BASELINE_WRITE_VERSION`]) and the runtime
+//! [`ActiveWriteVersion`] cell are owned here, so this toolkit's wire/on-disk
+//! format versions independently of the others.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 pub use tsoracle_codec::{CodecError, codec_io_error, decode, encode};
 
-/// On-disk/wire schema version stamped as the leading byte of every framed
-/// snapshot, log entry, and storage record produced by this toolkit. Bump
-/// when a persisted struct's postcard layout changes in a
-/// backward-incompatible way (field reorder/insert/remove), or when the set of
-/// framed records changes; a stale reader then fails loudly with
-/// [`CodecError::Version`] instead of misdecoding.
+/// Oldest on-disk/wire format version this binary still ships a parser for.
+/// The decode side (disk now, peer RPC in P3) accepts any version in the
+/// inclusive range `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`. Under the
+/// never-remove decoder policy this only ever stays put or moves down; it never
+/// rises. Seeded at the feature baseline (4): the historical 1->2->3->4 bumps
+/// were stop-the-world, so no pre-v4 on-disk data can rolling-coexist in any
+/// cluster this feature touches. A future release may lower it (re-adding
+/// older parsers) if a real pre-v4 rolling-read need ever surfaces.
+pub const MIN_READABLE_VERSION: u8 = 4;
+
+/// Newest on-disk/wire format version this binary has a parser for. Only ever
+/// grows. Decode accepts `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
+pub const MAX_READABLE_VERSION: u8 = 4;
+
+// Compile-time guard: the readable range must be non-empty (`MIN <= MAX`) or
+// every decode rejects every record. Catches a future inverted-constants edit
+// at build time rather than at test runtime.
+const _: () = assert!(MIN_READABLE_VERSION <= MAX_READABLE_VERSION);
+
+/// Default active write version — the single version this node emits before any
+/// activation barrier advances it. It is independent of [`MIN_READABLE_VERSION`]
+/// and is the assumed version of any unframed legacy peer payload (P3). Held at
+/// runtime in an [`ActiveWriteVersion`] cell that defaults to this value; the
+/// cell only ever advances via a successful, committed activation apply (P5),
+/// so in this release every framed record still leads with this byte.
+pub const BASELINE_WRITE_VERSION: u8 = 4;
+
+/// Process-shared, runtime-mutable active write version.
 ///
-/// v2 brought the log-store meta column (Vote/Committed/LastPurged) under this
-/// same frame — it was previously persisted as bare, unversioned postcard, so a
-/// v1 store's meta records read against this version loud-reject rather than
-/// risk a silent misdecode of the recovery-critical vote.
+/// A thin newtype over `Arc<AtomicU8>` so the three writers — the log store
+/// (stamps appended records), the state machine (stamps snapshots), and the peer
+/// RPC sender (P3) — share **one** cell, the single source of truth for "the
+/// version this node currently emits". Constructed once at bootstrap, seeded by
+/// [`recover_active_write_version`], and cloned (cheap refcount bump) into each
+/// writer. It is mutated only by a successful, committed activation apply (P5);
+/// in this release it never leaves [`BASELINE_WRITE_VERSION`].
 ///
-/// v3 widened the openraft driver's `OpenraftPeer` membership node (a
-/// `service_endpoint` field beside `addr`), changing the postcard layout of
-/// membership log entries. The bump is global to this toolkit, so a v2 store's
-/// records — for any config, not just the standalone driver — loud-reject when
-/// read against v3 rather than risk a silent misdecode.
+/// There is deliberately no persisted copy of this value. The state machine
+/// reaches storage only through its opaque snapshot store and cannot write the
+/// log store's meta column family, and a separate non-synced counter would
+/// reintroduce the barrier-seq durability hazard. Durability comes from the raft
+/// log (a committed `SetFormatVersion` entry is fsynced and re-applied
+/// deterministically on restart) and the snapshot's leading frame byte; recovery
+/// re-seeds the cell from that durable evidence via [`recover_active_write_version`].
+#[derive(Clone, Debug)]
+pub struct ActiveWriteVersion(Arc<AtomicU8>);
+
+impl ActiveWriteVersion {
+    /// Construct a cell holding `version`.
+    pub fn new(version: u8) -> Self {
+        Self(Arc::new(AtomicU8::new(version)))
+    }
+
+    /// The version this node currently emits.
+    pub fn get(&self) -> u8 {
+        self.0.load(Ordering::Acquire)
+    }
+
+    /// Set the active write version. Called only by a successful activation
+    /// apply (P5); `Release` pairs with the `Acquire` in [`get`](Self::get) so a
+    /// writer that observes the new version also observes everything sequenced
+    /// before the activation. Not exposed as a CAS in P2 because no concurrent
+    /// mutator exists yet; P5 may revisit if it needs a compare-and-set.
+    pub fn set(&self, version: u8) {
+        self.0.store(version, Ordering::Release);
+    }
+}
+
+impl Default for ActiveWriteVersion {
+    /// A fresh cell at [`BASELINE_WRITE_VERSION`]. Used by the default log-store
+    /// and state-machine constructors (and tests) that do not run the bootstrap
+    /// recovery seed; behavior is then identical to a pre-feature node.
+    fn default() -> Self {
+        Self::new(BASELINE_WRITE_VERSION)
+    }
+}
+
+/// Compute the bootstrap seed for the [`ActiveWriteVersion`] cell from
+/// fsync-durable lower bounds.
 ///
-/// v4 widened `OpenraftPeer` further with an `admin_endpoint` field, changing
-/// the postcard layout of membership log entries again. A v3 store's records
-/// loud-reject when read against v4 rather than risk a silent misdecode.
-pub const SCHEMA_VERSION: u8 = 4;
+/// Returns `max(BASELINE_WRITE_VERSION, snapshot_leading_byte?,
+/// highest_log_record_byte?)`. Both inputs are `Option` because a fresh store
+/// has neither a persisted snapshot nor any log record. Taking the max of
+/// durably-*written* evidence is monotone and safe: a rejected or no-op
+/// activation never caused any record to be written at the higher version, so it
+/// cannot be resurrected here, and a node never recovers a version below what it
+/// actually emitted.
+///
+/// This deliberately does NOT read any meta-CF counter and does NOT inspect the
+/// mere presence of a committed `SetFormatVersion` log entry. Durability of an
+/// activation is the raft log itself (the entry is fsynced and re-applied
+/// deterministically on restart, re-establishing the cell through P5's apply) and
+/// the snapshot's leading frame byte (snapshots are encoded at the active write
+/// version, carrying it across log purge). This mirrors the project's barrier-seq
+/// rule: a safety-critical recovery value derives from fsynced written state, not
+/// a non-synced side counter or unapplied log presence.
+pub fn recover_active_write_version(
+    snapshot_leading_byte: Option<u8>,
+    highest_log_record_byte: Option<u8>,
+) -> u8 {
+    BASELINE_WRITE_VERSION
+        .max(snapshot_leading_byte.unwrap_or(BASELINE_WRITE_VERSION))
+        .max(highest_log_record_byte.unwrap_or(BASELINE_WRITE_VERSION))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_constants_are_at_the_v4_baseline() {
+        assert_eq!(MIN_READABLE_VERSION, 4);
+        assert_eq!(MAX_READABLE_VERSION, 4);
+        assert_eq!(BASELINE_WRITE_VERSION, 4);
+    }
+
+    #[test]
+    fn active_write_version_defaults_to_baseline() {
+        let cell = ActiveWriteVersion::default();
+        assert_eq!(cell.get(), BASELINE_WRITE_VERSION);
+    }
+
+    #[test]
+    fn active_write_version_new_seeds_the_given_version() {
+        let cell = ActiveWriteVersion::new(5);
+        assert_eq!(cell.get(), 5);
+    }
+
+    #[test]
+    fn active_write_version_set_is_visible_through_a_clone() {
+        let writer = ActiveWriteVersion::default();
+        let reader = writer.clone();
+        writer.set(7);
+        assert_eq!(reader.get(), 7);
+        assert_eq!(writer.get(), 7);
+    }
+
+    #[test]
+    fn recover_returns_baseline_with_no_durable_evidence() {
+        assert_eq!(
+            recover_active_write_version(None, None),
+            BASELINE_WRITE_VERSION
+        );
+    }
+
+    #[test]
+    fn recover_takes_the_max_of_present_lower_bounds() {
+        assert_eq!(recover_active_write_version(Some(5), None), 5);
+        assert_eq!(recover_active_write_version(None, Some(6)), 6);
+        assert_eq!(recover_active_write_version(Some(5), Some(6)), 6);
+        assert_eq!(recover_active_write_version(Some(7), Some(5)), 7);
+    }
+
+    #[test]
+    fn recover_never_drops_below_baseline() {
+        assert_eq!(
+            recover_active_write_version(Some(1), Some(2)),
+            BASELINE_WRITE_VERSION
+        );
+    }
+}

--- a/crates/tsoracle-openraft-toolkit/src/codec_provider.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec_provider.rs
@@ -50,8 +50,9 @@ use tsoracle_codec::{CodecError, decode_postcard_exact, encode_postcard};
 ///
 /// Every method operates on the bare body (the bytes after the leading version
 /// byte); the toolkit adds and validates that version byte itself. `version` is
-/// passed through so a provider can dispatch a per-version body layout in a
-/// later phase; in P1b the only version in play is the current `SCHEMA_VERSION`.
+/// passed through so a provider can dispatch a per-version body layout as the
+/// readable range widens; today the only version in play is the current
+/// [`BASELINE_WRITE_VERSION`](crate::codec::BASELINE_WRITE_VERSION).
 ///
 /// The methods take no `self`: a `Codec` is a pure type-level marker selected
 /// at the `RocksdbLogStore<C, K, Codec>` type parameter, never an instance.

--- a/crates/tsoracle-openraft-toolkit/src/lib.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lib.rs
@@ -39,7 +39,10 @@ pub mod lifecycle;
 #[cfg(any(test, feature = "test-fakes"))]
 pub mod test_fakes;
 
-pub use codec::{CodecError, SCHEMA_VERSION, codec_io_error, decode, encode};
+pub use codec::{
+    ActiveWriteVersion, BASELINE_WRITE_VERSION, CodecError, MAX_READABLE_VERSION,
+    MIN_READABLE_VERSION, codec_io_error, decode, encode, recover_active_write_version,
+};
 pub use codec_provider::{DefaultLogStoreCodec, LogStoreCodec};
 pub use lifecycle::{
     BootstrapError, BootstrapMode, LeadershipState, MembershipError, add_learner, bootstrap,

--- a/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
@@ -29,8 +29,10 @@
 //! The vote and log-id helpers frame their values through the toolkit's
 //! provider-backed record helpers ([`super::encode_vote_record`] /
 //! [`super::decode_vote_record`] and the log-id analogues), so a
-//! recovery-critical meta record loud-rejects on a version mismatch instead of
-//! misdecoding silently. rocksdb errors are mapped to [`io::Error`] to match
+//! recovery-critical meta record loud-rejects on an out-of-range version
+//! instead of misdecoding silently. The write version comes from the store's
+//! shared [`ActiveWriteVersion`](crate::codec::ActiveWriteVersion) cell,
+//! supplied by the caller. rocksdb errors are mapped to [`io::Error`] to match
 //! the storage trait surface.
 
 use openraft::RaftTypeConfig;
@@ -85,6 +87,7 @@ pub(super) fn put_vote<C, K, Codec>(
     cf: &Arc<BoundColumnFamily<'_>>,
     keys: &K,
     label: MetaLabel,
+    version: u8,
     value: &VoteOf<C>,
 ) -> io::Result<()>
 where
@@ -93,7 +96,7 @@ where
     Codec: LogStoreCodec<C>,
 {
     let key = keys.meta_key(label);
-    let bytes = encode_vote_record::<C, Codec>(value)?;
+    let bytes = encode_vote_record::<C, Codec>(version, value)?;
     batch.put_cf(cf, &key, &bytes);
     Ok(())
 }
@@ -103,6 +106,7 @@ pub(super) fn put_log_id<C, K, Codec>(
     cf: &Arc<BoundColumnFamily<'_>>,
     keys: &K,
     label: MetaLabel,
+    version: u8,
     value: &LogIdOf<C>,
 ) -> io::Result<()>
 where
@@ -111,7 +115,7 @@ where
     Codec: LogStoreCodec<C>,
 {
     let key = keys.meta_key(label);
-    let bytes = encode_log_id_record::<C, Codec>(value)?;
+    let bytes = encode_log_id_record::<C, Codec>(version, value)?;
     batch.put_cf(cf, &key, &bytes);
     Ok(())
 }
@@ -178,17 +182,20 @@ mod tests {
             &cf,
             &keys,
             MetaLabel::Vote,
+            crate::codec::BASELINE_WRITE_VERSION,
             &vote,
         )
         .unwrap();
         db.write(batch).unwrap();
 
-        // On-disk leading byte is SCHEMA_VERSION.
+        // On-disk leading byte is the BASELINE_WRITE_VERSION the caller passed
+        // in (the same version the production log store reads from its shared
+        // ActiveWriteVersion cell).
         let raw = db
             .get_cf(&cf, keys.meta_key(MetaLabel::Vote))
             .unwrap()
             .unwrap();
-        assert_eq!(raw[0], crate::codec::SCHEMA_VERSION);
+        assert_eq!(raw[0], crate::codec::BASELINE_WRITE_VERSION);
 
         let back: Option<VoteOf<MetaConfig>> =
             read_vote::<MetaConfig, Flat, DefaultLogStoreCodec>(&db, &cf, &keys, MetaLabel::Vote)

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -36,8 +36,8 @@ use thiserror::Error;
 /// Construction (`open`) only fails when a named column family is absent;
 /// every later storage operation reports through `io::Error` to match the
 /// `RaftLogStorage` trait surface (decode/version failures route through the
-/// `[SCHEMA_VERSION | postcard]` codec, surfacing a foreign version as
-/// `InvalidData`).
+/// `[active write version | postcard]` codec, surfacing an out-of-range version
+/// as `InvalidData`).
 #[derive(Debug, Error)]
 pub enum RocksdbLogStoreError {
     #[error("column family `{0}` not found")]
@@ -94,6 +94,12 @@ where
     log_cf: String,
     meta_cf: String,
     keys: K,
+    /// Shared active write version: supplies the `version` argument every record
+    /// encode stamps. Constructed once at bootstrap and shared with the state
+    /// machine (and, in P3, the wire sender) so all writers emit the same
+    /// version. Defaults to a fresh `BASELINE_WRITE_VERSION` cell for
+    /// constructors that do not run the bootstrap recovery seed.
+    active_write_version: crate::codec::ActiveWriteVersion,
     // `fn() -> Codec` is a type-level marker that's always `Send + Sync` no
     // matter what `Codec` is — the struct holds no actual `Codec` value.
     _phantom: PhantomData<(C, fn() -> Codec)>,
@@ -125,8 +131,29 @@ where
             log_cf,
             meta_cf,
             keys,
+            active_write_version: crate::codec::ActiveWriteVersion::default(),
             _phantom: PhantomData,
         })
+    }
+
+    /// Replace the store's active-write-version cell with a shared one.
+    ///
+    /// Bootstrap constructs a single
+    /// [`ActiveWriteVersion`](crate::codec::ActiveWriteVersion), seeds it via
+    /// [`recover_active_write_version`](crate::codec::recover_active_write_version),
+    /// and threads the same cell here and into the state machine so both stamp
+    /// writes from one source of truth.
+    pub fn with_active_write_version(
+        mut self,
+        active_write_version: crate::codec::ActiveWriteVersion,
+    ) -> Self {
+        self.active_write_version = active_write_version;
+        self
+    }
+
+    /// The version this store currently stamps onto appended records.
+    pub fn active_write_version(&self) -> u8 {
+        self.active_write_version.get()
     }
 
     #[expect(
@@ -182,6 +209,7 @@ where
             log_cf: self.log_cf.clone(),
             meta_cf: self.meta_cf.clone(),
             keys: self.keys.clone(),
+            active_write_version: self.active_write_version.clone(),
             _phantom: PhantomData,
         }
     }
@@ -198,6 +226,7 @@ where
             .field("log_cf", &self.log_cf)
             .field("meta_cf", &self.meta_cf)
             .field("keys", &self.keys)
+            .field("active_write_version", &self.active_write_version.get())
             .finish()
     }
 }
@@ -218,8 +247,9 @@ fn range_boundary<RB: RangeBounds<u64>>(range: RB) -> (u64, u64) {
 
 /// Prepend the toolkit's version byte to a provider-produced body.
 ///
-/// The toolkit owns framing; `Codec` owns the body. In P1b the write version is
-/// the single `SCHEMA_VERSION`; P2 replaces it with the active write version.
+/// The toolkit owns framing; `Codec` owns the body. The `version` argument is
+/// the active write version supplied by the caller (the log store reads it from
+/// its [`ActiveWriteVersion`](crate::codec::ActiveWriteVersion) cell).
 fn frame_with_version(version: u8, body: Vec<u8>) -> Vec<u8> {
     let mut out = Vec::with_capacity(1 + body.len());
     out.push(version);
@@ -228,18 +258,20 @@ fn frame_with_version(version: u8, body: Vec<u8>) -> Vec<u8> {
 }
 
 /// Split a framed record into `(version, body)`, rejecting an out-of-range
-/// version before any body parse. In P1b the readable range is the single
-/// `SCHEMA_VERSION`; P2 widens this to `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
+/// version before any body parse. Accepts any version in the inclusive readable
+/// range `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`; the returned `version`
+/// is the leading byte, dispatched to a per-version body parser by the codec.
 fn unframe_with_version(bytes: &[u8]) -> io::Result<(u8, &[u8])> {
     let (first, body) = bytes.split_first().ok_or_else(|| {
         crate::codec::codec_io_error("log-store record decode", crate::codec::CodecError::Empty)
     })?;
     let version = *first;
-    if version != crate::codec::SCHEMA_VERSION {
+    if version < crate::codec::MIN_READABLE_VERSION || version > crate::codec::MAX_READABLE_VERSION
+    {
         return Err(crate::codec::codec_io_error(
             "log-store record decode",
             crate::codec::CodecError::Version {
-                expected: crate::codec::SCHEMA_VERSION,
+                expected: crate::codec::MAX_READABLE_VERSION,
                 actual: version,
             },
         ));
@@ -247,19 +279,19 @@ fn unframe_with_version(bytes: &[u8]) -> io::Result<(u8, &[u8])> {
     Ok((version, body))
 }
 
-/// Encode a log `Entry` as `[SCHEMA_VERSION | Codec::encode_entry(..)]`.
-fn encode_entry_record<C, Codec>(entry: &C::Entry) -> io::Result<Vec<u8>>
+/// Encode a log `Entry` as `[version | Codec::encode_entry(version, ..)]`.
+fn encode_entry_record<C, Codec>(version: u8, entry: &C::Entry) -> io::Result<Vec<u8>>
 where
     C: RaftTypeConfig,
     Codec: LogStoreCodec<C>,
 {
-    let version = crate::codec::SCHEMA_VERSION;
     let body = Codec::encode_entry(version, entry)
         .map_err(|err| crate::codec::codec_io_error("log-store record encode", err))?;
     Ok(frame_with_version(version, body))
 }
 
-/// Decode a log `Entry` framed by [`encode_entry_record`], rejecting a foreign version.
+/// Decode a log `Entry` framed by [`encode_entry_record`], rejecting an
+/// out-of-range version.
 fn decode_entry_record<C, Codec>(bytes: &[u8]) -> io::Result<C::Entry>
 where
     C: RaftTypeConfig,
@@ -270,19 +302,19 @@ where
         .map_err(|err| crate::codec::codec_io_error("log-store record decode", err))
 }
 
-/// Encode a `Vote` as `[SCHEMA_VERSION | Codec::encode_vote(..)]`.
-fn encode_vote_record<C, Codec>(vote: &VoteOf<C>) -> io::Result<Vec<u8>>
+/// Encode a `Vote` as `[version | Codec::encode_vote(version, ..)]`.
+fn encode_vote_record<C, Codec>(version: u8, vote: &VoteOf<C>) -> io::Result<Vec<u8>>
 where
     C: RaftTypeConfig,
     Codec: LogStoreCodec<C>,
 {
-    let version = crate::codec::SCHEMA_VERSION;
     let body = Codec::encode_vote(version, vote)
         .map_err(|err| crate::codec::codec_io_error("log-store record encode", err))?;
     Ok(frame_with_version(version, body))
 }
 
-/// Decode a `Vote` framed by [`encode_vote_record`], rejecting a foreign version.
+/// Decode a `Vote` framed by [`encode_vote_record`], rejecting an out-of-range
+/// version.
 fn decode_vote_record<C, Codec>(bytes: &[u8]) -> io::Result<VoteOf<C>>
 where
     C: RaftTypeConfig,
@@ -293,19 +325,19 @@ where
         .map_err(|err| crate::codec::codec_io_error("log-store record decode", err))
 }
 
-/// Encode a `LogId` as `[SCHEMA_VERSION | Codec::encode_log_id(..)]`.
-fn encode_log_id_record<C, Codec>(log_id: &LogIdOf<C>) -> io::Result<Vec<u8>>
+/// Encode a `LogId` as `[version | Codec::encode_log_id(version, ..)]`.
+fn encode_log_id_record<C, Codec>(version: u8, log_id: &LogIdOf<C>) -> io::Result<Vec<u8>>
 where
     C: RaftTypeConfig,
     Codec: LogStoreCodec<C>,
 {
-    let version = crate::codec::SCHEMA_VERSION;
     let body = Codec::encode_log_id(version, log_id)
         .map_err(|err| crate::codec::codec_io_error("log-store record encode", err))?;
     Ok(frame_with_version(version, body))
 }
 
-/// Decode a `LogId` framed by [`encode_log_id_record`], rejecting a foreign version.
+/// Decode a `LogId` framed by [`encode_log_id_record`], rejecting an
+/// out-of-range version.
 fn decode_log_id_record<C, Codec>(bytes: &[u8]) -> io::Result<LogIdOf<C>>
 where
     C: RaftTypeConfig,
@@ -347,6 +379,35 @@ where
         }
         let entry: C::Entry = decode_entry_record::<C, Codec>(&v)?;
         Ok(Some(entry.log_id()))
+    }
+
+    /// The highest format-version leading byte among durably-stored log records,
+    /// or `None` if the log is empty. One of the fsync-durable lower bounds
+    /// [`recover_active_write_version`](crate::codec::recover_active_write_version)
+    /// takes the max of when bootstrap seeds the shared cell.
+    ///
+    /// Reads only each record's leading byte (no postcard body parse), so a
+    /// record from any version in the readable range contributes its byte
+    /// without needing its parser. Bounded by `lo` like [`last_log_id_in_cf`]:
+    /// for `GroupPrefixed` the reverse iterator can walk into a neighbouring
+    /// group's bytes, so any key below `lo` ends the scan.
+    pub fn highest_log_record_version(&self) -> io::Result<Option<u8>> {
+        let cf = self.log_cf_handle();
+        let (lo, hi) = self.keys.log_range();
+        let it = self
+            .db
+            .iterator_cf(&cf, IteratorMode::From(&hi, rocksdb::Direction::Reverse));
+        let mut highest: Option<u8> = None;
+        for item in it {
+            let (key, value) = item.map_err(io::Error::other)?;
+            if &*key < lo.as_slice() {
+                break;
+            }
+            if let Some(&leading) = value.first() {
+                highest = Some(highest.map_or(leading, |current| current.max(leading)));
+            }
+        }
+        Ok(highest)
     }
 }
 
@@ -427,7 +488,14 @@ where
     async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), io::Error> {
         let cf_meta = self.meta_cf_handle();
         let mut batch = WriteBatch::default();
-        meta::put_vote::<C, K, Codec>(&mut batch, &cf_meta, &self.keys, MetaLabel::Vote, vote)?;
+        meta::put_vote::<C, K, Codec>(
+            &mut batch,
+            &cf_meta,
+            &self.keys,
+            MetaLabel::Vote,
+            self.active_write_version.get(),
+            vote,
+        )?;
         // fsync: the vote must be durable before it is acknowledged, or a crash
         // could let this node vote twice in one term and split the cluster.
         let wo = Self::write_sync_opts();
@@ -444,6 +512,7 @@ where
                 &cf_meta,
                 &self.keys,
                 MetaLabel::Committed,
+                self.active_write_version.get(),
                 &committed,
             )?,
             None => meta::delete::<K>(&mut batch, &cf_meta, &self.keys, MetaLabel::Committed),
@@ -467,10 +536,11 @@ where
     {
         let cf_log = self.log_cf_handle();
         let mut batch = WriteBatch::default();
+        let write_version = self.active_write_version.get();
         for entry in entries {
             let (_leader, idx) = entry.log_id_parts();
             let key = self.keys.log_key(idx);
-            let value = encode_entry_record::<C, Codec>(&entry)?;
+            let value = encode_entry_record::<C, Codec>(write_version, &entry)?;
             batch.put_cf(&cf_log, &key, &value);
         }
 
@@ -549,6 +619,7 @@ where
             &cf_meta,
             &self.keys,
             MetaLabel::LastPurged,
+            self.active_write_version.get(),
             &log_id,
         )?;
 
@@ -629,7 +700,7 @@ mod range_boundary_tests {
 #[cfg(test)]
 mod record_codec_tests {
     use super::{decode_entry_record, encode_entry_record};
-    use crate::codec::SCHEMA_VERSION;
+    use crate::codec::{BASELINE_WRITE_VERSION, MAX_READABLE_VERSION, MIN_READABLE_VERSION};
     use crate::declare_raft_types_ext;
     use crate::log_store::DefaultLogStoreCodec;
     use serde::{Deserialize, Serialize};
@@ -669,30 +740,122 @@ mod record_codec_tests {
     }
 
     #[test]
-    fn encode_entry_record_stamps_schema_version_and_roundtrips() {
+    fn encode_entry_record_stamps_baseline_version_and_roundtrips() {
         let entry = sample_entry();
-        let bytes = encode_entry_record::<RecConfig, DefaultLogStoreCodec>(&entry).expect("encode");
-        assert_eq!(bytes[0], SCHEMA_VERSION);
+        let bytes =
+            encode_entry_record::<RecConfig, DefaultLogStoreCodec>(BASELINE_WRITE_VERSION, &entry)
+                .expect("encode");
+        assert_eq!(bytes[0], BASELINE_WRITE_VERSION);
         let back: RecEntry =
             decode_entry_record::<RecConfig, DefaultLogStoreCodec>(&bytes).expect("decode");
         // Compare via re-encode: EntryOf is not PartialEq across all type params.
         let reencoded =
-            encode_entry_record::<RecConfig, DefaultLogStoreCodec>(&back).expect("re-encode");
+            encode_entry_record::<RecConfig, DefaultLogStoreCodec>(BASELINE_WRITE_VERSION, &back)
+                .expect("re-encode");
         assert_eq!(bytes, reencoded);
     }
 
     #[test]
-    fn decode_entry_record_rejects_foreign_version() {
+    fn decode_entry_record_rejects_out_of_range_version() {
         // A 0xFF-framed record must surface as InvalidData rather than a
-        // successful-but-wrong decode, exactly as the old free function did.
+        // successful-but-wrong decode.
         let err = decode_entry_record::<RecConfig, DefaultLogStoreCodec>(&[0xFF, 5])
             .expect_err("must reject");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]
-    fn schema_version_is_four() {
-        // Pinned so a future layout change re-confirms the bump deliberately.
-        assert_eq!(crate::codec::SCHEMA_VERSION, 4);
+    fn version_constants_are_at_four() {
+        assert_eq!(BASELINE_WRITE_VERSION, 4);
+        assert_eq!(MIN_READABLE_VERSION, 4);
+        assert_eq!(MAX_READABLE_VERSION, 4);
+    }
+}
+
+#[cfg(test)]
+mod active_write_version_wiring_tests {
+    use super::*;
+    use crate::codec::ActiveWriteVersion;
+    use crate::declare_raft_types_ext;
+    use crate::log_store::{DefaultLogStoreCodec, Flat};
+    use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+    use serde::{Deserialize, Serialize};
+    use tempfile::TempDir;
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct WirePeer {
+        addr: String,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct WireData {
+        v: u64,
+    }
+    impl std::fmt::Display for WireData {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "WireData({})", self.v)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct WireApplied;
+
+    declare_raft_types_ext! {
+        pub WireConfig:
+            Node            = WirePeer,
+            AppData         = WireData,
+            AppDataResponse = WireApplied,
+            SnapshotData    = std::io::Cursor<Vec<u8>>,
+    }
+
+    fn open_empty_store() -> (
+        RocksdbLogStore<WireConfig, Flat, DefaultLogStoreCodec>,
+        TempDir,
+    ) {
+        let dir = TempDir::new().unwrap();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let cfs = vec![
+            ColumnFamilyDescriptor::new("log", Options::default()),
+            ColumnFamilyDescriptor::new("meta", Options::default()),
+        ];
+        let db = Arc::new(DB::open_cf_descriptors(&opts, dir.path(), cfs).unwrap());
+        let store: RocksdbLogStore<WireConfig, Flat, DefaultLogStoreCodec> =
+            RocksdbLogStore::open(db, "log", "meta", Flat).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn highest_log_record_version_is_none_for_empty_log() {
+        let (store, _guard) = open_empty_store();
+        assert_eq!(store.highest_log_record_version().expect("scan"), None);
+    }
+
+    #[tokio::test]
+    async fn log_store_stamps_appended_records_at_the_shared_cell_version() {
+        // The store reads the SHARED cell for its write version. With a default
+        // (baseline) cell, appended records lead with BASELINE_WRITE_VERSION,
+        // and the scan that bootstrap uses reports that same byte back.
+        use openraft::storage::{IOFlushed, RaftLogStorage};
+
+        let cell = ActiveWriteVersion::default();
+        let (mut store, _guard) = open_empty_store();
+        store = store.with_active_write_version(cell.clone());
+
+        let lid = openraft::testing::log_id::<WireConfig>(1, 1, 1);
+        let entry: openraft::type_config::alias::EntryOf<WireConfig> =
+            openraft::entry::RaftEntry::new_normal(lid, WireData { v: 5 });
+        store
+            .append(std::iter::once(entry), IOFlushed::noop())
+            .await
+            .expect("append");
+        assert_eq!(
+            store.highest_log_record_version().expect("scan"),
+            Some(crate::codec::BASELINE_WRITE_VERSION)
+        );
+
+        // And the cell is the single source of truth: log store reports the
+        // same version the cell holds.
+        assert_eq!(store.active_write_version(), cell.get());
+        assert_eq!(cell.get(), crate::codec::BASELINE_WRITE_VERSION);
     }
 }

--- a/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/log_store_basic.rs
@@ -98,7 +98,7 @@ async fn save_and_read_vote_roundtrips() {
 // yet historically persisted them as bare `postcard` with no version frame —
 // unlike every other persisted blob in the store. After a layout-changing
 // upgrade an unframed `Vote` would misdecode silently instead of loud-rejecting.
-// This pins the on-disk meta record to the same `[SCHEMA_VERSION | postcard]`
+// This pins the on-disk meta record to the same `[active write version | postcard]`
 // frame the log column uses: a save_vote must persist a version-prefixed record
 // that decodes back through the toolkit's public codec.
 #[tokio::test]
@@ -118,11 +118,11 @@ async fn save_vote_persists_version_framed_meta() {
 
     assert_eq!(
         raw[0],
-        tsoracle_openraft_toolkit::SCHEMA_VERSION,
-        "meta record must be framed with the leading schema-version byte",
+        tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+        "meta record must be framed with the active-write-version byte",
     );
     let decoded: Vote<TestLeaderId> =
-        tsoracle_openraft_toolkit::decode(tsoracle_openraft_toolkit::SCHEMA_VERSION, &raw)
+        tsoracle_openraft_toolkit::decode(tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION, &raw)
             .expect("framed vote must decode through the toolkit codec");
     assert_eq!(decoded, vote);
 }
@@ -184,12 +184,12 @@ async fn save_committed_with_none_clears_existing_record() {
     assert!(store.read_committed().await.unwrap().is_none());
 }
 
-// A meta record written under a foreign schema version must loud-reject on
-// read rather than misdecode silently against the current struct layout. This
-// is the core safety property the version frame buys: an upgrade that changed
+// A meta record written under an out-of-range version must loud-reject on read
+// rather than misdecode silently against the current struct layout. This is
+// the core safety property the version frame buys: an upgrade that changed
 // the `Vote` layout would otherwise risk corrupting term/leader-election
-// safety. The injected record carries a `0xFF` version byte (never our
-// `SCHEMA_VERSION`), so `read_vote` must surface `InvalidData`.
+// safety. The injected record carries a `0xFF` version byte (outside the
+// readable range), so `read_vote` must surface `InvalidData`.
 #[tokio::test]
 async fn read_vote_rejects_foreign_version_meta() {
     let dir = TempDir::new().unwrap();
@@ -216,22 +216,27 @@ async fn read_vote_rejects_foreign_version_meta() {
     );
 }
 
-// A meta record carrying the CURRENT schema version but an undecodable body
-// must surface as a generic `io::Error` — the non-`Version` arm of
-// `codec_io_error` — distinct from the `InvalidData` a version *mismatch*
-// yields. The foreign-version test above pins the `Version` arm; this pins its
+// A meta record carrying an IN-RANGE version but an undecodable body must
+// surface as a generic `io::Error` — the non-`Version` arm of
+// `codec_io_error` — distinct from the `InvalidData` a version mismatch
+// yields. The out-of-range test above pins the `Version` arm; this pins its
 // sibling, so a future edit that collapses the two error kinds is caught.
 #[tokio::test]
 async fn read_vote_surfaces_corrupt_body_as_generic_io_error() {
     let dir = TempDir::new().unwrap();
     let db = open_db(&dir);
 
-    // Correct leading version byte, but no decodable `Vote` body behind it, so
-    // the codec fails at `take_from_bytes` rather than the version check.
+    // Correct (in-range) leading version byte, but no decodable `Vote` body
+    // behind it, so the codec fails at `take_from_bytes` rather than the
+    // version check.
     let key = Flat.meta_key(MetaLabel::Vote);
     let cf = db.cf_handle(META_CF).unwrap();
-    db.put_cf(&cf, &key, [tsoracle_openraft_toolkit::SCHEMA_VERSION])
-        .unwrap();
+    db.put_cf(
+        &cf,
+        &key,
+        [tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION],
+    )
+    .unwrap();
 
     let mut store: RocksdbLogStore<TestTypeConfig, Flat> =
         RocksdbLogStore::open(Arc::clone(&db), LOG_CF, META_CF, Flat).unwrap();

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -36,7 +36,9 @@ use tsoracle_driver_openraft::{
     HighWaterStateMachine, OpenraftDriver, OpenraftLogCodec, OpenraftPeer, RocksdbSnapshotStore,
     SnapshotStore, StandaloneHost, TypeConfig,
 };
-use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
+use tsoracle_openraft_toolkit::{
+    ActiveWriteVersion, Flat, RocksdbLogStore, recover_active_write_version,
+};
 
 use crate::config::OpenraftConfig;
 use crate::error::StandaloneError;
@@ -108,8 +110,33 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
                 source: Box::new(e),
             }
         })?);
-    let state_machine = HighWaterStateMachine::with_store(snapshot_store)
+
+    // Seed the single, process-shared active-write-version cell from
+    // fsync-durable evidence. NO meta key is read: durability of any
+    // activation is the raft log (deterministically re-applied on restart)
+    // plus the snapshot's leading frame byte; the cell is just the runtime
+    // holder. Recovery takes the max of the baseline, the persisted snapshot's
+    // leading version byte, and the highest version byte among durable log
+    // records — never below what this node actually wrote.
+    let snapshot_leading_byte = snapshot_store
+        .load()
+        .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?
+        .as_deref()
+        .and_then(|bytes| bytes.first().copied());
+    let highest_log_record_byte = log_store
+        .highest_log_record_version()
         .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?;
+    let active_write_version = ActiveWriteVersion::new(recover_active_write_version(
+        snapshot_leading_byte,
+        highest_log_record_byte,
+    ));
+
+    // Thread the SAME cell into both writers: the log store stamps appended
+    // records, the state machine stamps snapshots, both reading this one cell.
+    let log_store = log_store.with_active_write_version(active_write_version.clone());
+    let state_machine =
+        HighWaterStateMachine::with_store_and_active_version(snapshot_store, active_write_version)
+            .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?;
     let state_machine_for_host = state_machine.clone();
 
     let config = Arc::new(

--- a/fuzz/fuzz_targets/codec_roundtrip.rs
+++ b/fuzz/fuzz_targets/codec_roundtrip.rs
@@ -25,15 +25,17 @@
 
 use libfuzzer_sys::fuzz_target;
 use tsoracle_driver_openraft::HighWaterStateMachineSnapshot;
-use tsoracle_openraft_toolkit::{SCHEMA_VERSION, decode, encode};
+use tsoracle_openraft_toolkit::{BASELINE_WRITE_VERSION, decode, encode};
 
 // Reverse-roundtrip property for the version-framed openraft snapshot codec.
-// The snapshot is persisted and streamed as `[SCHEMA_VERSION | postcard(..)]`
-// (see `state_machine.rs`, written with `encode` and read with `decode`), so
-// the bytes that reach `decode` on `install_snapshot` / store load come from a
-// peer or disk. Beyond "does not panic" (covered by `snapshot_payload_decode`),
-// we assert the codec is a stable canonical form: decoding then re-encoding
-// then decoding again must reproduce the same value.
+// The snapshot is persisted and streamed as
+// `[active write version | postcard(..)]` (see `state_machine.rs`, written
+// with `encode` and read with `decode`), so the bytes that reach `decode` on
+// `install_snapshot` / store load come from a peer or disk. Beyond "does not
+// panic" (covered by `snapshot_payload_decode`), we assert the codec is a
+// stable canonical form: decoding then re-encoding then decoding again must
+// reproduce the same value. The target pins the baseline byte; per-version
+// range fuzzing is a later phase per the format-migration testing strategy.
 //
 // The property is value equality, not byte equality:
 //   - `postcard::from_bytes` ignores trailing bytes, so `re-encode == input`
@@ -42,12 +44,13 @@ use tsoracle_openraft_toolkit::{SCHEMA_VERSION, decode, encode};
 //     equality is well-defined here; byte equality of two re-encodings would
 //     still be the wrong assertion to bake in as the general contract.
 fuzz_target!(|data: &[u8]| {
-    let Ok(value) = decode::<HighWaterStateMachineSnapshot>(SCHEMA_VERSION, data) else {
+    let Ok(value) = decode::<HighWaterStateMachineSnapshot>(BASELINE_WRITE_VERSION, data) else {
         return;
     };
-    let reencoded = encode(SCHEMA_VERSION, &value).expect("re-encoding a decoded value must succeed");
-    let roundtripped: HighWaterStateMachineSnapshot = decode(SCHEMA_VERSION, &reencoded)
-        .expect("re-encoded bytes must decode");
+    let reencoded =
+        encode(BASELINE_WRITE_VERSION, &value).expect("re-encoding a decoded value must succeed");
+    let roundtripped: HighWaterStateMachineSnapshot =
+        decode(BASELINE_WRITE_VERSION, &reencoded).expect("re-encoded bytes must decode");
     assert_eq!(
         value, roundtripped,
         "codec is not a stable canonical form: decode -> encode -> decode changed the value"

--- a/fuzz/fuzz_targets/openraft_entry_decode.rs
+++ b/fuzz/fuzz_targets/openraft_entry_decode.rs
@@ -25,7 +25,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use tsoracle_driver_openraft::OpenraftEntry;
-use tsoracle_openraft_toolkit::{SCHEMA_VERSION, decode};
+use tsoracle_openraft_toolkit::{BASELINE_WRITE_VERSION, decode};
 
 // Adversarial-bytes safety for the full openraft log record. The log store
 // reads `[version | postcard(Entry<TypeConfig>)]` from the log column family
@@ -39,5 +39,5 @@ use tsoracle_openraft_toolkit::{SCHEMA_VERSION, decode};
 // variable-length `EntryPayload::Membership(Membership<C>)` variant, which the
 // inner-command target never reaches.
 fuzz_target!(|data: &[u8]| {
-    let _ = decode::<OpenraftEntry>(SCHEMA_VERSION, data);
+    let _ = decode::<OpenraftEntry>(BASELINE_WRITE_VERSION, data);
 });

--- a/fuzz/fuzz_targets/openraft_meta_decode.rs
+++ b/fuzz/fuzz_targets/openraft_meta_decode.rs
@@ -25,26 +25,28 @@
 
 use libfuzzer_sys::fuzz_target;
 use tsoracle_driver_openraft::{OpenraftLogId, OpenraftVote};
-use tsoracle_openraft_toolkit::{SCHEMA_VERSION, decode};
+use tsoracle_openraft_toolkit::{BASELINE_WRITE_VERSION, decode};
 
 // Adversarial-bytes safety for the openraft meta column family. On every node
 // restart the log store reads three singletons back from the meta CF via
 // `log_store::meta::read`, which routes them through the same
 // `[version_byte | postcard(body)]` frame as the log and snapshot records (the
-// meta column was brought under the frame in `SCHEMA_VERSION` v2): the current
-// `Vote` (label `Vote`) and a `LogId` for the `Committed` and `LastPurged`
-// labels. A panic decoding any of them crashes startup.
+// meta column was brought under the frame in v2): the current `Vote` (label
+// `Vote`) and a `LogId` for the `Committed` and `LastPurged` labels. A panic
+// decoding any of them crashes startup. The target pins the baseline byte;
+// per-version range fuzzing is a later phase per the format-migration testing
+// strategy.
 //
 // Mirrors `toolkit_codec_decode`'s split between the framing and the postcard
-// body: `decode::<T>(SCHEMA_VERSION, data)` drives the expected-version path
-// (the one `meta::read` takes), while `decode::<T>(data[0], data)` escapes the
-// version gate so the postcard decoder sees the whole body for any leading
-// byte. Distinct from `toolkit_codec_decode` in the concrete types it
-// exercises — the two the meta CF actually holds, including the
-// variable-length `LogId`.
+// body: `decode::<T>(BASELINE_WRITE_VERSION, data)` drives the
+// expected-version path (the one `meta::read` takes), while
+// `decode::<T>(data[0], data)` escapes the version gate so the postcard
+// decoder sees the whole body for any leading byte. Distinct from
+// `toolkit_codec_decode` in the concrete types it exercises — the two the
+// meta CF actually holds, including the variable-length `LogId`.
 fuzz_target!(|data: &[u8]| {
-    let _ = decode::<OpenraftVote>(SCHEMA_VERSION, data);
-    let _ = decode::<OpenraftLogId>(SCHEMA_VERSION, data);
+    let _ = decode::<OpenraftVote>(BASELINE_WRITE_VERSION, data);
+    let _ = decode::<OpenraftLogId>(BASELINE_WRITE_VERSION, data);
     if let Some(&first) = data.first() {
         let _ = decode::<OpenraftVote>(first, data);
         let _ = decode::<OpenraftLogId>(first, data);


### PR DESCRIPTION
## Summary

- Replaces `SCHEMA_VERSION` (single global, value `4`) with three concepts — `MIN_READABLE_VERSION` / `MAX_READABLE_VERSION` / `BASELINE_WRITE_VERSION` (all `4` today) — and a process-shared `ActiveWriteVersion(Arc<AtomicU8>)` cell.
- Adds `recover_active_write_version(snapshot_leading_byte, highest_log_record_byte) = max(BASELINE, ...)`, used at bootstrap to seed the cell from fsync-durable evidence; the same cell is threaded into `RocksdbLogStore` and `HighWaterStateMachine` (and surfaced on `StandaloneHost::active_write_version()`) so all writers stamp from one source of truth.
- Behavior-preserving: the cell never moves in production (no `.set()` outside tests), every framed record still leads with `4`, all pin-byte tests are unchanged. Breaking public-API change to `tsoracle-openraft-toolkit` (the old constant is removed; the new constants + cell type are added).

The active write version is deliberately NOT persisted under a meta-CF key — the state machine has no path to the log store's meta CF, and a separate non-synced counter would reintroduce the barrier-seq durability hazard. Durability of any future activation lives in the raft log (committed entries are fsynced and re-applied deterministically on restart) plus the snapshot's leading frame byte; the `highest_log_record_version` reverse scan is the belt-and-suspenders floor.

## Test plan

- [x] `cargo build --workspace --all-features` is clean
- [x] `cargo test --workspace` passes (every pre-existing pin-byte / round-trip test still passes byte-identically; new tests cover cell defaults, cell sharing across clones, `recover_active_write_version` corners, and the `highest_log_record_version` scan)
- [x] `cargo clippy --workspace --all-features -- -D warnings` is clean
- [x] `grep -rn "SCHEMA_VERSION" crates/tsoracle-openraft-toolkit crates/tsoracle-driver-openraft crates/tsoracle-standalone fuzz` returns no matches (only the paxos toolkit's own `SCHEMA_VERSION` remains, which is intentionally out of scope)
- [x] `grep -rn "active_write_version" --include='*.rs' crates/ | grep '\.set('` finds matches only in `mod tests` blocks (proves no production code moves the cell)
- [x] The fuzz crate builds: `cargo build --manifest-path fuzz/Cargo.toml`