### PR TITLE
fix(standalone): require mTLS for non-loopback admin gRPC bind

### DIFF
--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -64,11 +64,27 @@ pub enum AdminCmd {
 }
 
 #[cfg(feature = "openraft")]
+#[derive(Parser, Debug, Clone)]
+pub struct AdminClientTlsArgs {
+    /// PEM client certificate to present to the admin gRPC server (admin mTLS).
+    #[arg(long)]
+    pub client_tls_cert: Option<std::path::PathBuf>,
+    /// PEM private key for `--client-tls-cert`.
+    #[arg(long)]
+    pub client_tls_key: Option<std::path::PathBuf>,
+    /// PEM CA to verify the admin server's certificate.
+    #[arg(long)]
+    pub client_tls_ca: Option<std::path::PathBuf>,
+}
+
+#[cfg(feature = "openraft")]
 #[derive(Parser, Debug)]
 pub struct AdminEndpointArgs {
-    /// Any node's admin endpoint, e.g. `http://127.0.0.1:50561`.
+    /// Any node's admin endpoint, e.g. `https://127.0.0.1:50561`.
     #[arg(long)]
     pub endpoint: String,
+    #[command(flatten)]
+    pub tls: AdminClientTlsArgs,
 }
 
 #[cfg(feature = "openraft")]
@@ -78,6 +94,8 @@ pub struct AdminIdArgs {
     pub endpoint: String,
     #[arg(long)]
     pub id: u64,
+    #[command(flatten)]
+    pub tls: AdminClientTlsArgs,
 }
 
 #[cfg(feature = "openraft")]
@@ -93,6 +111,8 @@ pub struct AddLearnerArgs {
     pub service_endpoint: String,
     #[arg(long)]
     pub admin_endpoint: String,
+    #[command(flatten)]
+    pub tls: AdminClientTlsArgs,
 }
 
 #[derive(Subcommand, Debug)]
@@ -165,9 +185,18 @@ pub struct OpenraftArgs {
     pub election_min_ms: u64,
     #[arg(long, default_value = "2000")]
     pub election_max_ms: u64,
-    /// Bind address for the membership-admin gRPC server. Omit to serve no admin surface.
+    /// Bind address for the membership-admin gRPC server. UNAUTHENTICATED plaintext on loopback; non-loopback bind requires --admin-tls-{cert,key,ca}. Omit to serve no admin surface.
     #[arg(long)]
     pub admin_listen: Option<SocketAddr>,
+    /// PEM server certificate for the admin gRPC server (enables admin mTLS; needs all three).
+    #[arg(long)]
+    pub admin_tls_cert: Option<std::path::PathBuf>,
+    /// PEM private key for `--admin-tls-cert`.
+    #[arg(long)]
+    pub admin_tls_key: Option<std::path::PathBuf>,
+    /// PEM CA (operator-dedicated, NOT the peer CA) to verify connecting admin clients.
+    #[arg(long)]
+    pub admin_tls_ca: Option<std::path::PathBuf>,
     /// PEM node certificate for the peer transport (enables peer mTLS; needs all three).
     #[arg(long)]
     pub peer_tls_cert: Option<std::path::PathBuf>,

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -136,6 +136,11 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         args.peer_tls_ca,
                     )?,
                     admin_listen: args.admin_listen,
+                    admin_tls: admin_tls_config(
+                        args.admin_tls_cert,
+                        args.admin_tls_key,
+                        args.admin_tls_ca,
+                    )?,
                 });
                 run_serve(args.common, cfg).await
             }
@@ -241,6 +246,72 @@ fn peer_tls_config(
     }
 }
 
+/// Assemble the admin `AdminTlsConfig` from the all-or-nothing flag trio.
+#[cfg(feature = "openraft")]
+fn admin_tls_config(
+    cert: Option<std::path::PathBuf>,
+    key: Option<std::path::PathBuf>,
+    ca: Option<std::path::PathBuf>,
+) -> anyhow::Result<Option<tsoracle_standalone::AdminTlsConfig>> {
+    match (cert, key, ca) {
+        (None, None, None) => Ok(None),
+        (Some(cert), Some(key), Some(ca)) => {
+            Ok(Some(tsoracle_standalone::AdminTlsConfig { cert, key, ca }))
+        }
+        _ => anyhow::bail!(
+            "--admin-tls-cert, --admin-tls-key, and --admin-tls-ca must all be set together"
+        ),
+    }
+}
+
+/// Build a `ClientTlsConfig` for `tsoracle admin` from the all-or-nothing flag trio.
+#[cfg(feature = "openraft")]
+fn admin_client_tls(
+    args: &cli::AdminClientTlsArgs,
+) -> anyhow::Result<Option<tonic::transport::ClientTlsConfig>> {
+    match (
+        args.client_tls_cert.as_ref(),
+        args.client_tls_key.as_ref(),
+        args.client_tls_ca.as_ref(),
+    ) {
+        (None, None, None) => Ok(None),
+        (Some(cert), Some(key), Some(ca)) => {
+            let cert_pem =
+                std::fs::read(cert).with_context(|| format!("read {}", cert.display()))?;
+            let key_pem = std::fs::read(key).with_context(|| format!("read {}", key.display()))?;
+            let ca_pem = std::fs::read(ca).with_context(|| format!("read {}", ca.display()))?;
+            Ok(Some(
+                tonic::transport::ClientTlsConfig::new()
+                    .ca_certificate(tonic::transport::Certificate::from_pem(&ca_pem))
+                    .identity(tonic::transport::Identity::from_pem(&cert_pem, &key_pem)),
+            ))
+        }
+        _ => anyhow::bail!(
+            "--client-tls-cert, --client-tls-key, and --client-tls-ca must all be set together"
+        ),
+    }
+}
+
+/// Dial an admin endpoint, optionally with mTLS material.
+#[cfg(feature = "openraft")]
+async fn admin_connect(
+    endpoint: &str,
+    tls: Option<&tonic::transport::ClientTlsConfig>,
+) -> anyhow::Result<tonic::transport::Channel> {
+    let builder = tonic::transport::Channel::from_shared(endpoint.to_string())
+        .with_context(|| format!("invalid endpoint {endpoint}"))?;
+    let builder = match tls {
+        Some(t) => builder
+            .tls_config(t.clone())
+            .with_context(|| "apply admin client TLS")?,
+        None => builder,
+    };
+    builder
+        .connect()
+        .await
+        .with_context(|| format!("connect {endpoint}"))
+}
+
 async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_new(&common.log).unwrap_or_else(|_| EnvFilter::new("info")))
@@ -329,8 +400,15 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
         PromoteRequest, RemoveNodeRequest,
     };
 
-    // Re-run `op` against the leader if the first call says NOT_LEADER.
-    async fn with_redirect<MakeCall>(endpoint: String, op: MakeCall) -> Result<ChangeResponse>
+    // Re-run `op` against the leader if the first call says NOT_LEADER. The
+    // leader-hint's scheme is reconstructed from the originally dialed
+    // endpoint so a `https://` operator session doesn't get downgraded to
+    // plaintext on redirect (and vice versa).
+    async fn with_redirect<MakeCall>(
+        endpoint: String,
+        tls: Option<&tonic::transport::ClientTlsConfig>,
+        op: MakeCall,
+    ) -> Result<ChangeResponse>
     where
         MakeCall: Fn(
             MembershipAdminClient<tonic::transport::Channel>,
@@ -338,17 +416,22 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
             Box<dyn std::future::Future<Output = Result<ChangeResponse, tonic::Status>> + Send>,
         >,
     {
-        let client = MembershipAdminClient::connect(endpoint.clone())
+        let channel = admin_connect(&endpoint, tls).await?;
+        let resp = op(MembershipAdminClient::new(channel))
             .await
-            .with_context(|| format!("connect {endpoint}"))?;
-        let resp = op(client).await.context("admin rpc")?;
+            .context("admin rpc")?;
         if resp.error == AdminErrorKind::NotLeader as i32 && !resp.leader_admin_endpoint.is_empty()
         {
-            let leader = format!("http://{}", resp.leader_admin_endpoint);
-            let client = MembershipAdminClient::connect(leader.clone())
+            let scheme = if endpoint.starts_with("https://") {
+                "https"
+            } else {
+                "http"
+            };
+            let leader = format!("{scheme}://{}", resp.leader_admin_endpoint);
+            let channel = admin_connect(&leader, tls).await?;
+            return op(MembershipAdminClient::new(channel))
                 .await
-                .with_context(|| format!("connect leader {leader}"))?;
-            return op(client).await.context("admin rpc (leader)");
+                .context("admin rpc (leader)");
         }
         Ok(resp)
     }
@@ -367,9 +450,9 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
 
     match cmd {
         AdminCmd::Members(args) => {
-            let mut client = MembershipAdminClient::connect(args.endpoint.clone())
-                .await
-                .with_context(|| format!("connect {}", args.endpoint))?;
+            let tls = admin_client_tls(&args.tls)?;
+            let channel = admin_connect(&args.endpoint, tls.as_ref()).await?;
+            let mut client = MembershipAdminClient::new(channel);
             let view = client
                 .list_members(ListMembersRequest {})
                 .await
@@ -392,40 +475,60 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
             }
             Ok(())
         }
-        AdminCmd::AddLearner(args) => report(
-            with_redirect(args.endpoint.clone(), move |mut client| {
-                let request = AddLearnerRequest {
-                    id: args.id,
-                    raft_addr: args.raft_addr.clone(),
-                    service_endpoint: args.service_endpoint.clone(),
-                    admin_endpoint: args.admin_endpoint.clone(),
-                };
-                Box::pin(async move { client.add_learner(request).await.map(|r| r.into_inner()) })
-            })
-            .await?,
-        ),
-        AdminCmd::Promote(args) => report(
-            with_redirect(args.endpoint.clone(), move |mut client| {
-                Box::pin(async move {
-                    client
-                        .promote(PromoteRequest { id: args.id })
-                        .await
-                        .map(|r| r.into_inner())
+        AdminCmd::AddLearner(args) => {
+            let tls = admin_client_tls(&args.tls)?;
+            let endpoint = args.endpoint.clone();
+            let id = args.id;
+            let raft_addr = args.raft_addr.clone();
+            let service_endpoint = args.service_endpoint.clone();
+            let admin_endpoint = args.admin_endpoint.clone();
+            report(
+                with_redirect(endpoint, tls.as_ref(), move |mut client| {
+                    let request = AddLearnerRequest {
+                        id,
+                        raft_addr: raft_addr.clone(),
+                        service_endpoint: service_endpoint.clone(),
+                        admin_endpoint: admin_endpoint.clone(),
+                    };
+                    Box::pin(
+                        async move { client.add_learner(request).await.map(|r| r.into_inner()) },
+                    )
                 })
-            })
-            .await?,
-        ),
-        AdminCmd::Remove(args) => report(
-            with_redirect(args.endpoint.clone(), move |mut client| {
-                Box::pin(async move {
-                    client
-                        .remove_node(RemoveNodeRequest { id: args.id })
-                        .await
-                        .map(|r| r.into_inner())
+                .await?,
+            )
+        }
+        AdminCmd::Promote(args) => {
+            let tls = admin_client_tls(&args.tls)?;
+            let endpoint = args.endpoint.clone();
+            let id = args.id;
+            report(
+                with_redirect(endpoint, tls.as_ref(), move |mut client| {
+                    Box::pin(async move {
+                        client
+                            .promote(PromoteRequest { id })
+                            .await
+                            .map(|r| r.into_inner())
+                    })
                 })
-            })
-            .await?,
-        ),
+                .await?,
+            )
+        }
+        AdminCmd::Remove(args) => {
+            let tls = admin_client_tls(&args.tls)?;
+            let endpoint = args.endpoint.clone();
+            let id = args.id;
+            report(
+                with_redirect(endpoint, tls.as_ref(), move |mut client| {
+                    Box::pin(async move {
+                        client
+                            .remove_node(RemoveNodeRequest { id })
+                            .await
+                            .map(|r| r.into_inner())
+                    })
+                })
+                .await?,
+            )
+        }
     }
 }
 
@@ -451,4 +554,83 @@ mod parse_members_tests {
             "got: {err}"
         );
     }
+}
+
+#[cfg(all(test, feature = "openraft"))]
+mod admin_tls_config_tests {
+    use super::admin_tls_config;
+    use std::path::PathBuf;
+
+    #[test]
+    fn none_returns_none() {
+        let result = admin_tls_config(None, None, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn full_trio_returns_some() {
+        let cfg = admin_tls_config(
+            Some(PathBuf::from("/x/c")),
+            Some(PathBuf::from("/x/k")),
+            Some(PathBuf::from("/x/a")),
+        )
+        .unwrap()
+        .expect("Some");
+        assert_eq!(cfg.cert, PathBuf::from("/x/c"));
+        assert_eq!(cfg.key, PathBuf::from("/x/k"));
+        assert_eq!(cfg.ca, PathBuf::from("/x/a"));
+    }
+
+    #[test]
+    fn partial_trio_errors() {
+        for (c, k, a) in [
+            (Some(PathBuf::from("c")), None, None),
+            (None, Some(PathBuf::from("k")), None),
+            (None, None, Some(PathBuf::from("a"))),
+            (Some(PathBuf::from("c")), Some(PathBuf::from("k")), None),
+            (Some(PathBuf::from("c")), None, Some(PathBuf::from("a"))),
+            (None, Some(PathBuf::from("k")), Some(PathBuf::from("a"))),
+        ] {
+            let err = admin_tls_config(c, k, a).unwrap_err();
+            assert!(
+                err.to_string().contains("must all be set together"),
+                "got: {err}"
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "openraft"))]
+mod admin_client_tls_tests {
+    use super::admin_client_tls;
+    use crate::cli::AdminClientTlsArgs;
+    use std::path::PathBuf;
+
+    fn args(cert: Option<&str>, key: Option<&str>, ca: Option<&str>) -> AdminClientTlsArgs {
+        AdminClientTlsArgs {
+            client_tls_cert: cert.map(PathBuf::from),
+            client_tls_key: key.map(PathBuf::from),
+            client_tls_ca: ca.map(PathBuf::from),
+        }
+    }
+
+    #[test]
+    fn none_returns_none() {
+        let result = admin_client_tls(&args(None, None, None)).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn partial_trio_errors() {
+        let err = admin_client_tls(&args(Some("c"), None, None)).unwrap_err();
+        assert!(
+            err.to_string().contains("must all be set together"),
+            "got: {err}"
+        );
+    }
+
+    // No "full trio returns Some" test here — that would require real PEM files
+    // on disk because admin_client_tls reads + parses them. The integration test
+    // in openraft_membership.rs already proves a real cert produces a working
+    // channel.
 }

--- a/crates/tsoracle-standalone/src/admin/service.rs
+++ b/crates/tsoracle-standalone/src/admin/service.rs
@@ -181,21 +181,36 @@ impl GrpcAdmin for AdminServiceImpl {
 
 /// Bind `listen` and spawn the admin gRPC server under a cancel token. Mirrors
 /// the peer-server pattern in `drivers/openraft/mod.rs` (bind before spawn so a
-/// bind failure surfaces to the caller).
+/// bind failure surfaces to the caller). When `admin_tls` is `Some`, the server
+/// requires a client certificate signed by the configured admin CA (mTLS).
+/// Returns the actual bound `SocketAddr` (resolves :0 to the OS-picked port)
+/// for caller-side observability — stored on `Standalone::admin_listen_addr`.
 pub(crate) async fn serve_admin(
     admin: Arc<dyn MembershipAdmin>,
     listen: std::net::SocketAddr,
-) -> Result<(oneshot::Sender<()>, JoinHandle<()>), std::io::Error> {
+    admin_tls: Option<crate::admin_tls::AdminTlsMaterial>,
+) -> Result<(oneshot::Sender<()>, JoinHandle<()>, std::net::SocketAddr), std::io::Error> {
     let listener = tokio::net::TcpListener::bind(listen).await?;
+    let bound = listener.local_addr()?;
     let service = MembershipAdminServer::new(AdminServiceImpl::new(admin))
         .max_decoding_message_size(MAX_ADMIN_MESSAGE_BYTES)
         .max_encoding_message_size(MAX_ADMIN_MESSAGE_BYTES);
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+    let mut builder = tonic::transport::Server::builder();
+    if let Some(material) = admin_tls {
+        // tls_config() on a pre-validated ServerTlsConfig cannot fail in
+        // practice (admin_tls.rs already dry-ran the build), but tonic's
+        // signature returns Result so we surface any residual error as an
+        // io::Error rather than panic.
+        builder = builder.tls_config(material.server).map_err(|err| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, err.to_string())
+        })?;
+    }
     let join = tokio::spawn(async move {
         let shutdown = async {
             let _ = cancel_rx.await;
         };
-        if let Err(err) = tonic::transport::Server::builder()
+        if let Err(err) = builder
             .add_service(service)
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
             .await
@@ -203,5 +218,5 @@ pub(crate) async fn serve_admin(
             tracing::error!(error = ?err, "admin server died");
         }
     });
-    Ok((cancel_tx, join))
+    Ok((cancel_tx, join, bound))
 }

--- a/crates/tsoracle-standalone/src/admin_tls.rs
+++ b/crates/tsoracle-standalone/src/admin_tls.rs
@@ -1,0 +1,131 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Builds and eagerly validates the TLS config for the membership-admin
+//! gRPC server. Mirrors `peer_tls.rs` but produces only the server side;
+//! the `tsoracle admin` CLI assembles its own `ClientTlsConfig` in the bin.
+
+use tonic::transport::{Certificate, Identity, ServerTlsConfig};
+
+use crate::config::AdminTlsConfig;
+use crate::error::StandaloneError;
+
+/// Validated TLS material for one node's admin gRPC server.
+pub(crate) struct AdminTlsMaterial {
+    pub server: ServerTlsConfig,
+}
+
+fn read(path: &std::path::Path) -> Result<Vec<u8>, StandaloneError> {
+    std::fs::read(path).map_err(|source| StandaloneError::Tls {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })
+}
+
+/// Read the PEM trio and build the admin mTLS server config, eagerly
+/// validating it so a bad cert/key/CA fails at build() rather than on
+/// first client connect. `tonic`'s `Identity/Certificate::from_pem` are
+/// lazy (just wrap bytes); the cryptographic parse happens when the
+/// acceptor is materialized, so we force that here via a Server dry-run.
+pub(crate) fn build_admin_tls(cfg: &AdminTlsConfig) -> Result<AdminTlsMaterial, StandaloneError> {
+    let cert = read(&cfg.cert)?;
+    let key = read(&cfg.key)?;
+    let ca = read(&cfg.ca)?;
+
+    let identity = Identity::from_pem(&cert, &key);
+    let ca_cert = Certificate::from_pem(&ca);
+
+    let server = ServerTlsConfig::new()
+        .identity(identity)
+        .client_ca_root(ca_cert);
+
+    // Force the lazy parse before bind/spawn.
+    tonic::transport::Server::builder()
+        .tls_config(server.clone())
+        .map_err(|source| StandaloneError::Tls {
+            path: cfg.cert.clone(),
+            source: Box::new(source),
+        })?;
+
+    Ok(AdminTlsMaterial { server })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AdminTlsConfig;
+
+    fn write_admin_certs(dir: &std::path::Path) -> AdminTlsConfig {
+        use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+        let ca_key = KeyPair::generate().unwrap();
+        let mut ca_params = CertificateParams::new(vec!["tso-admin-ca".to_string()]).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let node_key = KeyPair::generate().unwrap();
+        let node_params = CertificateParams::new(vec!["127.0.0.1".to_string()]).unwrap();
+        let node_cert = node_params.signed_by(&node_key, &ca_cert, &ca_key).unwrap();
+
+        let cert = dir.join("admin.crt");
+        let key = dir.join("admin.key");
+        let ca = dir.join("admin-ca.crt");
+        std::fs::write(&cert, node_cert.pem()).unwrap();
+        std::fs::write(&key, node_key.serialize_pem()).unwrap();
+        std::fs::write(&ca, ca_cert.pem()).unwrap();
+        AdminTlsConfig { cert, key, ca }
+    }
+
+    #[tokio::test]
+    async fn valid_trio_builds_admin_server_tls() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_admin_certs(dir.path());
+        let mat = build_admin_tls(&cfg).expect("valid trio must build");
+        let _ = mat.server;
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_a_tls_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = write_admin_certs(dir.path());
+        cfg.cert = dir.path().join("does-not-exist.crt");
+        let err = match build_admin_tls(&cfg) {
+            Ok(_) => panic!("expected a Tls error"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, StandaloneError::Tls { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn invalid_pem_is_a_tls_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = write_admin_certs(dir.path());
+        let garbage = dir.path().join("garbage.crt");
+        std::fs::write(&garbage, b"not a pem").unwrap();
+        cfg.cert = garbage;
+        let err = match build_admin_tls(&cfg) {
+            Ok(_) => panic!("expected a Tls error"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, StandaloneError::Tls { .. }), "got {err:?}");
+    }
+}

--- a/crates/tsoracle-standalone/src/config.rs
+++ b/crates/tsoracle-standalone/src/config.rs
@@ -71,6 +71,26 @@ pub struct PeerTlsConfig {
     pub ca: PathBuf,
 }
 
+/// mTLS material for the membership-admin gRPC server (PEM file paths,
+/// read at build()). Presence on an `OpenraftConfig` turns the admin port
+/// into mutual TLS: `cert`/`key` is this node's admin-server identity; `ca`
+/// verifies connecting admin clients (operators dialing via `tsoracle admin`).
+///
+/// Security contract: the admin CA MUST be issued from a CA chain independent
+/// of the peer CA. Anyone holding a cert signed by the configured admin CA can
+/// change cluster membership (AddLearner / Promote / RemoveNode). `build`
+/// enforces the trivial form of this — it rejects sharing the same CA file
+/// (by path or by byte content) — but it CANNOT detect two distinct CA files
+/// where one is in the trust chain of the other, or both chained under a
+/// shared root. Issuing the two CAs from independent roots is the operator's
+/// responsibility.
+#[derive(Debug, Clone)]
+pub struct AdminTlsConfig {
+    pub cert: PathBuf,
+    pub key: PathBuf,
+    pub ca: PathBuf,
+}
+
 #[derive(Debug, Clone)]
 pub struct OpenraftConfig {
     pub id: u64,
@@ -85,6 +105,10 @@ pub struct OpenraftConfig {
     /// Bind address for the membership-admin gRPC server. `None` serves no
     /// admin surface.
     pub admin_listen: Option<std::net::SocketAddr>,
+    /// mTLS material for the admin gRPC server. `None` means plaintext on
+    /// loopback only; routable `admin_listen` without TLS is rejected at
+    /// build() (see `StandaloneError::AdminInsecureRoutable`).
+    pub admin_tls: Option<AdminTlsConfig>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/tsoracle-standalone/src/drivers/file.rs
+++ b/crates/tsoracle-standalone/src/drivers/file.rs
@@ -58,6 +58,7 @@ pub(crate) fn build_file(cfg: FileConfig) -> Result<Standalone, StandaloneError>
             },
         )),
         admin_transport: crate::TransportHandle::noop(),
+        admin_listen_addr: None,
     })
 }
 

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -89,6 +89,55 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         _ => {}
     }
 
+    // Cross-trio guard: reject the trivial operator error of pointing
+    // --peer-tls-ca and --admin-tls-ca at the same CA file. tonic's
+    // client_ca_root accepts ANY cert signed by the configured CA, so a
+    // shared CA means a compromised peer key can escalate to membership
+    // control via the admin port (and vice versa). We check canonicalized
+    // paths AND file bytes; we cannot detect "two distinct CAs where one
+    // chains to the other" — that remains an operator deployment concern
+    // documented in the AdminTlsConfig doc comment.
+    if let (Some(peer), Some(admin)) = (cfg.peer_tls.as_ref(), cfg.admin_tls.as_ref()) {
+        let same_path = std::fs::canonicalize(&peer.ca)
+            .ok()
+            .zip(std::fs::canonicalize(&admin.ca).ok())
+            .map(|(a, b)| a == b)
+            .unwrap_or(false);
+        let same_bytes = !same_path
+            && std::fs::read(&peer.ca)
+                .ok()
+                .zip(std::fs::read(&admin.ca).ok())
+                .map(|(a, b)| a == b)
+                .unwrap_or(false);
+        if same_path || same_bytes {
+            return Err(StandaloneError::Config(format!(
+                "--peer-tls-ca ({}) and --admin-tls-ca ({}) resolve to the same CA; \
+                 admin authentication must use a CA distinct from the peer CA so a \
+                 compromised peer cert cannot change cluster membership",
+                peer.ca.display(),
+                admin.ca.display(),
+            )));
+        }
+    }
+    // Build (and eagerly dry-run validate) admin TLS material first, so a
+    // bad PEM surfaces as Tls — the operator's explicit intent — and takes
+    // precedence over the secure-by-default routable guard below.
+    let admin_tls_material: Option<crate::admin_tls::AdminTlsMaterial> = match &cfg.admin_tls {
+        Some(t) => Some(crate::admin_tls::build_admin_tls(t)?),
+        None => None,
+    };
+    // Secure-by-default: routable bind requires admin TLS. Loopback
+    // (127.0.0.0/8, ::1) is allowed plaintext for local-dev and same-pod
+    // sidecar callers; everything else must present TLS. Run BEFORE opening
+    // storage / binding any socket so a misconfigured deployment fails fast
+    // without leaving a half-initialized data dir.
+    if let Some(listen) = cfg.admin_listen
+        && admin_tls_material.is_none()
+        && !listen.ip().is_loopback()
+    {
+        return Err(StandaloneError::AdminInsecureRoutable { addr: listen });
+    }
+
     std::fs::create_dir_all(&cfg.raft_dir).map_err(|source| StandaloneError::Storage {
         path: cfg.raft_dir.clone(),
         source: Box::new(source),
@@ -212,17 +261,18 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         crate::admin::openraft::OpenraftMembershipAdmin::new(raft_for_admin),
     );
 
-    let admin_transport = match cfg.admin_listen {
+    let (admin_transport, admin_listen_addr) = match cfg.admin_listen {
         Some(listen) => {
-            let (cancel, join) = crate::admin::service::serve_admin(admin.clone(), listen)
-                .await
-                .map_err(|source| StandaloneError::AdminBind {
-                    addr: listen,
-                    source,
-                })?;
-            TransportHandle::new(cancel, join)
+            let (cancel, join, bound) =
+                crate::admin::service::serve_admin(admin.clone(), listen, admin_tls_material)
+                    .await
+                    .map_err(|source| StandaloneError::AdminBind {
+                        addr: listen,
+                        source,
+                    })?;
+            (TransportHandle::new(cancel, join), Some(bound))
         }
-        None => TransportHandle::noop(),
+        None => (TransportHandle::noop(), None),
     };
 
     Ok(Standalone {
@@ -233,5 +283,6 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         })),
         admin,
         admin_transport,
+        admin_listen_addr,
     })
 }

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -188,6 +188,7 @@ pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, Standalo
         drain: None,
         admin: std::sync::Arc::new(crate::admin::UnsupportedAdmin::new(admin_view)),
         admin_transport: crate::TransportHandle::noop(),
+        admin_listen_addr: None,
     })
 }
 

--- a/crates/tsoracle-standalone/src/error.rs
+++ b/crates/tsoracle-standalone/src/error.rs
@@ -45,6 +45,11 @@ pub enum StandaloneError {
         #[source]
         source: std::io::Error,
     },
+    #[error(
+        "admin listener on {addr} requires --admin-tls-{{cert,key,ca}} \
+         (only loopback addresses may bind without admin TLS)"
+    )]
+    AdminInsecureRoutable { addr: SocketAddr },
     #[error("driver bootstrap failed: {0}")]
     Bootstrap(Box<dyn std::error::Error + Send + Sync>),
     #[error("invalid configuration: {0}")]

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -35,8 +35,8 @@ use tsoracle_consensus::ConsensusDriver;
 
 mod config;
 pub use config::{
-    DriverConfig, FileConfig, MemberAddr, OpenraftConfig, PaxosConfig, PeerTlsConfig, RaftTuning,
-    parse_peer_map,
+    AdminTlsConfig, DriverConfig, FileConfig, MemberAddr, OpenraftConfig, PaxosConfig,
+    PeerTlsConfig, RaftTuning, parse_peer_map,
 };
 
 mod drivers;
@@ -66,6 +66,9 @@ pub use transport::TransportHandle;
 #[cfg(any(feature = "openraft", feature = "paxos"))]
 pub(crate) mod peer_tls;
 
+#[cfg(feature = "openraft")]
+pub(crate) mod admin_tls;
+
 /// A constructed, running standalone node: the consensus driver plus the
 /// background peer-transport task (if any). The caller (the bin) owns the
 /// client-facing `tsoracle_server::Server`; this type owns only the driver
@@ -82,6 +85,10 @@ pub struct Standalone {
     /// Peer transport for the membership-admin gRPC server (openraft only;
     /// `noop` for file/paxos in this sub-project).
     admin_transport: TransportHandle,
+    /// Address the admin gRPC server actually bound to, after `:0` resolution.
+    /// `None` when no admin listener was requested or for drivers that do not
+    /// serve an admin surface (file, paxos).
+    admin_listen_addr: Option<std::net::SocketAddr>,
 }
 
 impl Standalone {
@@ -98,6 +105,13 @@ impl Standalone {
     pub async fn shutdown(mut self) {
         self.admin_transport.shutdown().await;
         self.transport.shutdown().await;
+    }
+
+    /// Address the admin gRPC server actually bound to (resolves `:0` to the
+    /// OS-picked port). `None` when no admin listener was requested or for
+    /// drivers without an admin surface.
+    pub fn admin_listen_addr(&self) -> Option<std::net::SocketAddr> {
+        self.admin_listen_addr
     }
 }
 

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -115,6 +115,7 @@ mod openraft_driver {
             },
             peer_tls: None,
             admin_listen: None,
+            admin_tls: None,
         }
     }
 
@@ -170,6 +171,7 @@ mod openraft_driver {
             tuning: RaftTuning::default(),
             peer_tls: None,
             admin_listen: None,
+            admin_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -197,6 +199,7 @@ mod openraft_driver {
             tuning: RaftTuning::default(),
             peer_tls: None,
             admin_listen: None,
+            admin_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -224,6 +227,7 @@ mod openraft_driver {
             tuning: RaftTuning::default(),
             peer_tls: None,
             admin_listen: None,
+            admin_tls: None,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,

--- a/crates/tsoracle-standalone/tests/openraft_membership.rs
+++ b/crates/tsoracle-standalone/tests/openraft_membership.rs
@@ -83,6 +83,7 @@ async fn add_learner_promote_then_remove() {
         tuning: fast_tuning(),
         peer_tls: None,
         admin_listen: None,
+        admin_tls: None,
     }))
     .await
     .expect("build node 1");
@@ -108,6 +109,7 @@ async fn add_learner_promote_then_remove() {
         tuning: fast_tuning(),
         peer_tls: None,
         admin_listen: None,
+        admin_tls: None,
     }))
     .await
     .expect("build node 2");
@@ -192,6 +194,7 @@ async fn admin_grpc_list_and_add_learner() {
         tuning: fast_tuning(),
         peer_tls: None,
         admin_listen: Some(admin_addr),
+        admin_tls: None,
     }))
     .await
     .expect("build node 1");
@@ -217,6 +220,7 @@ async fn admin_grpc_list_and_add_learner() {
         tuning: fast_tuning(),
         peer_tls: None,
         admin_listen: None,
+        admin_tls: None,
     }))
     .await
     .expect("build node 2");
@@ -287,6 +291,7 @@ async fn coexisting_learner_survives_a_promote() {
         tuning: fast_tuning(),
         peer_tls: None,
         admin_listen: None,
+        admin_tls: None,
     }))
     .await
     .expect("build node 1");
@@ -313,6 +318,7 @@ async fn coexisting_learner_survives_a_promote() {
             tuning: fast_tuning(),
             peer_tls: None,
             admin_listen: None,
+            admin_tls: None,
         }))
     };
     let node2 = build_follower(2, raft2, dir2.path().join("raft"))
@@ -375,4 +381,304 @@ async fn coexisting_learner_survives_a_promote() {
     node3.shutdown().await;
     node2.shutdown().await;
     node1.shutdown().await;
+}
+
+#[tokio::test]
+async fn admin_insecure_routable_bind_rejected_at_build() {
+    // The guard runs at the top of build_openraft — before open_rocksdb,
+    // Raft::new, peer bind/spawn, and initialize() — so neither the admin
+    // port nor the raft port is touched and the raft_dir stays empty.
+    let routable: std::net::SocketAddr = "0.0.0.0:0".parse().unwrap();
+
+    let raft_dir = tempdir().unwrap();
+    let raft_dir_path = raft_dir.path().to_path_buf();
+    let cfg = OpenraftConfig {
+        id: 1,
+        raft_addr: "127.0.0.1:0".parse().unwrap(),
+        raft_dir: raft_dir_path.clone(),
+        bootstrap: true,
+        initial_membership: Some(BTreeMap::from([(
+            1u64,
+            MemberAddr {
+                raft_addr: "127.0.0.1:9".into(),
+                service_endpoint: "127.0.0.1:8".into(),
+                admin_endpoint: "127.0.0.1:7".into(),
+            },
+        )])),
+        tuning: RaftTuning::default(),
+        peer_tls: None,
+        admin_listen: Some(routable),
+        admin_tls: None,
+    };
+
+    let err = match build(DriverConfig::Openraft(cfg)).await {
+        Ok(_) => panic!("expected AdminInsecureRoutable"),
+        Err(e) => e,
+    };
+    assert!(
+        matches!(
+            err,
+            tsoracle_standalone::StandaloneError::AdminInsecureRoutable { .. }
+        ),
+        "got {err:?}"
+    );
+    // Guard fires before create_dir_all/open_rocksdb; raft_dir is the
+    // tempdir itself (pre-created), so assert it stays empty.
+    let entries = std::fs::read_dir(&raft_dir_path)
+        .expect("raft_dir is the tempdir, still present")
+        .count();
+    assert_eq!(
+        entries, 0,
+        "guard must run before open_rocksdb; raft_dir should be untouched"
+    );
+}
+
+#[tokio::test]
+async fn shared_ca_for_peer_and_admin_rejected_at_build() {
+    use tsoracle_standalone::{AdminTlsConfig, PeerTlsConfig};
+
+    let ca_dir = tempdir().unwrap();
+    let ca_path = ca_dir.path().join("shared-ca.pem");
+    // Realistic-shaped placeholder; the cross-trio check is bytes/path-based,
+    // it does not parse the PEM. The build fails before any TLS parse
+    // because the Config error is returned first.
+    std::fs::write(
+        &ca_path,
+        b"-----BEGIN CERTIFICATE-----\nshared\n-----END CERTIFICATE-----\n",
+    )
+    .unwrap();
+    let cert_path = ca_dir.path().join("node.crt");
+    let key_path = ca_dir.path().join("node.key");
+    std::fs::write(&cert_path, b"placeholder-cert").unwrap();
+    std::fs::write(&key_path, b"placeholder-key").unwrap();
+
+    let raft_dir = tempdir().unwrap();
+    let cfg = OpenraftConfig {
+        id: 1,
+        raft_addr: "127.0.0.1:0".parse().unwrap(),
+        raft_dir: raft_dir.path().to_path_buf(),
+        bootstrap: true,
+        initial_membership: Some(BTreeMap::from([(
+            1u64,
+            MemberAddr {
+                raft_addr: "127.0.0.1:9".into(),
+                service_endpoint: "127.0.0.1:8".into(),
+                admin_endpoint: "127.0.0.1:7".into(),
+            },
+        )])),
+        tuning: RaftTuning::default(),
+        peer_tls: Some(PeerTlsConfig {
+            cert: cert_path.clone(),
+            key: key_path.clone(),
+            ca: ca_path.clone(),
+        }),
+        admin_listen: Some("127.0.0.1:0".parse().unwrap()),
+        admin_tls: Some(AdminTlsConfig {
+            cert: cert_path,
+            key: key_path,
+            ca: ca_path,
+        }),
+    };
+
+    let err = match build(DriverConfig::Openraft(cfg)).await {
+        Ok(_) => panic!("expected Config rejection for shared CA"),
+        Err(e) => e,
+    };
+    let msg = match err {
+        tsoracle_standalone::StandaloneError::Config(m) => m,
+        other => panic!("expected Config, got {other:?}"),
+    };
+    assert!(
+        msg.contains("same CA") || msg.contains("distinct from the peer CA"),
+        "got {msg:?}"
+    );
+}
+
+/// Generate a self-signed CA + server leaf (SAN 127.0.0.1) + client leaf,
+/// and return (`AdminTlsConfig` for the server, `ClientTlsConfig` ready to
+/// dial it). Mirrors `peer_tls.rs`'s `write_node_certs` pattern.
+fn write_admin_certs(
+    dir: &std::path::Path,
+) -> (
+    tsoracle_standalone::AdminTlsConfig,
+    tonic::transport::ClientTlsConfig,
+) {
+    use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+    use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+
+    let ca_key = KeyPair::generate().unwrap();
+    let mut ca_params = CertificateParams::new(vec!["tso-admin-ca".into()]).unwrap();
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+    let server_key = KeyPair::generate().unwrap();
+    let server_params = CertificateParams::new(vec!["127.0.0.1".into()]).unwrap();
+    let server_cert = server_params
+        .signed_by(&server_key, &ca_cert, &ca_key)
+        .unwrap();
+
+    let client_key = KeyPair::generate().unwrap();
+    let client_params = CertificateParams::new(vec!["tso-admin-cli".into()]).unwrap();
+    let client_cert = client_params
+        .signed_by(&client_key, &ca_cert, &ca_key)
+        .unwrap();
+
+    let s_cert = dir.join("admin.crt");
+    let s_key = dir.join("admin.key");
+    let ca = dir.join("admin-ca.crt");
+    std::fs::write(&s_cert, server_cert.pem()).unwrap();
+    std::fs::write(&s_key, server_key.serialize_pem()).unwrap();
+    std::fs::write(&ca, ca_cert.pem()).unwrap();
+
+    let admin_tls = tsoracle_standalone::AdminTlsConfig {
+        cert: s_cert,
+        key: s_key,
+        ca: ca.clone(),
+    };
+    let ca_pem = std::fs::read(&ca).unwrap();
+    let client_tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(&ca_pem))
+        .identity(Identity::from_pem(
+            client_cert.pem(),
+            client_key.serialize_pem(),
+        ))
+        .domain_name("127.0.0.1");
+    (admin_tls, client_tls)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn admin_mtls_listener_serves_with_matching_client_cert() {
+    use tsoracle_standalone::admin_proto::ListMembersRequest;
+    use tsoracle_standalone::admin_proto::membership_admin_client::MembershipAdminClient;
+
+    let raft_dir = tempdir().unwrap();
+    let cert_dir = tempdir().unwrap();
+    let (admin_tls, client_tls) = write_admin_certs(cert_dir.path());
+
+    let cfg = OpenraftConfig {
+        id: 1,
+        raft_addr: "127.0.0.1:0".parse().unwrap(),
+        raft_dir: raft_dir.path().to_path_buf(),
+        bootstrap: true,
+        initial_membership: Some(BTreeMap::from([(
+            1u64,
+            MemberAddr {
+                raft_addr: "127.0.0.1:9".into(),
+                service_endpoint: "127.0.0.1:8".into(),
+                admin_endpoint: "127.0.0.1:7".into(),
+            },
+        )])),
+        tuning: fast_tuning(),
+        peer_tls: None,
+        admin_listen: Some("127.0.0.1:0".parse().unwrap()),
+        admin_tls: Some(admin_tls),
+    };
+
+    let node = build(DriverConfig::Openraft(cfg))
+        .await
+        .expect("build with admin mTLS");
+
+    // build() returns once raft is constructed and the listener is bound,
+    // but election runs asynchronously — list_members().has_leader right
+    // after build is a flake against fast_tuning's 150-300ms election
+    // window. Mirror the wait pattern at line 90 above.
+    let mut events = node.driver.leadership_events();
+    tokio::time::timeout(Duration::from_secs(15), async {
+        while let Some(state) = events.next().await {
+            if matches!(state, LeaderState::Leader { .. }) {
+                return;
+            }
+        }
+    })
+    .await
+    .expect("single-node cluster elected");
+    drop(events);
+
+    let admin_addr = node.admin_listen_addr().expect("admin port bound");
+    let endpoint = format!("https://{admin_addr}");
+
+    let channel = tonic::transport::Channel::from_shared(endpoint)
+        .unwrap()
+        .tls_config(client_tls)
+        .unwrap()
+        .connect()
+        .await
+        .expect("client mTLS connect succeeds");
+    let mut client = MembershipAdminClient::new(channel);
+    let view = client
+        .list_members(ListMembersRequest {})
+        .await
+        .expect("list_members ok")
+        .into_inner();
+    assert!(view.has_leader);
+    assert_eq!(view.members.len(), 1);
+
+    node.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn admin_mtls_listener_rejects_no_client_cert() {
+    use tsoracle_standalone::admin_proto::ListMembersRequest;
+    use tsoracle_standalone::admin_proto::membership_admin_client::MembershipAdminClient;
+
+    let raft_dir = tempdir().unwrap();
+    let cert_dir = tempdir().unwrap();
+    let (admin_tls, _client_tls) = write_admin_certs(cert_dir.path());
+
+    // Server CA only — the test asserts the *client cert requirement*
+    // rejects even when the channel CA matches and the TLS handshake
+    // otherwise validates the server.
+    let ca_pem = std::fs::read(&admin_tls.ca).unwrap();
+    let no_cert_tls = tonic::transport::ClientTlsConfig::new()
+        .ca_certificate(tonic::transport::Certificate::from_pem(&ca_pem))
+        .domain_name("127.0.0.1");
+
+    let cfg = OpenraftConfig {
+        id: 1,
+        raft_addr: "127.0.0.1:0".parse().unwrap(),
+        raft_dir: raft_dir.path().to_path_buf(),
+        bootstrap: true,
+        initial_membership: Some(BTreeMap::from([(
+            1u64,
+            MemberAddr {
+                raft_addr: "127.0.0.1:9".into(),
+                service_endpoint: "127.0.0.1:8".into(),
+                admin_endpoint: "127.0.0.1:7".into(),
+            },
+        )])),
+        tuning: fast_tuning(),
+        peer_tls: None,
+        admin_listen: Some("127.0.0.1:0".parse().unwrap()),
+        admin_tls: Some(admin_tls),
+    };
+
+    let node = build(DriverConfig::Openraft(cfg)).await.unwrap();
+    let admin_addr = node.admin_listen_addr().expect("admin port bound");
+    let endpoint = format!("https://{admin_addr}");
+
+    let channel_result = tonic::transport::Channel::from_shared(endpoint)
+        .unwrap()
+        .tls_config(no_cert_tls)
+        .unwrap()
+        .connect()
+        .await;
+
+    // tonic+rustls may either fail at connect() (handshake closed) or
+    // succeed and then fail on the first RPC when the server rejects a
+    // missing client cert. Accept either — tonic 0.14 has no public
+    // `From<io::Error>` on `transport::Error`, so don't unify the error
+    // types; just assert no successful list_members ever returns.
+    let rpc_succeeded = match channel_result {
+        Err(_) => false,
+        Ok(channel) => {
+            let mut client = MembershipAdminClient::new(channel);
+            client.list_members(ListMembersRequest {}).await.is_ok()
+        }
+    };
+    assert!(
+        !rpc_succeeded,
+        "expected handshake or RPC failure with no client cert"
+    );
+
+    node.shutdown().await;
 }

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -109,6 +109,7 @@ async fn main() -> Result<()> {
         tuning: RaftTuning::default(),
         peer_tls,
         admin_listen: None,
+        admin_tls: None,
     });
     let mut node = build(cfg).await?;
     let drain = node.take_drain();


### PR DESCRIPTION
## Summary

- The membership-admin gRPC surface introduced in #453 (`--admin-listen`) was unauthenticated. Any client that could reach the port could `AddLearner` / `Promote` / `RemoveNode` and take over openraft membership. This change closes that surface.
- New `--admin-tls-{cert,key,ca}` on `serve openraft` (server side) and `--client-tls-{cert,key,ca}` on `tsoracle admin` (operator dial). Non-loopback `--admin-listen` without admin TLS is now rejected at build, before any side effects (no `raft_dir` created, no RocksDB opened, no peer port bound, no `initialize()`). Loopback plaintext is still allowed for local dev.
- The admin CA is deliberately kept separate from the peer CA. A trivial reuse — pointing `--peer-tls-ca` and `--admin-tls-ca` at the same file (by path or by byte content) — is rejected at config time, since `tonic`'s `client_ca_root` would otherwise let a peer cert escalate to membership control. Issuing the two CAs from independent chains remains an operator responsibility (documented on `AdminTlsConfig`).

## Test plan

- [x] `cargo test --workspace --all-features` — 128 binaries, 0 failures.
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo build --workspace --all-features` — clean.
- [x] Per-driver feature isolation: `cargo build -p tsoracle-standalone --no-default-features --features {file|openraft|paxos}` — all three clean.
- [x] New regression tests:
  - `admin_insecure_routable_bind_rejected_at_build` — asserts the `AdminInsecureRoutable` variant **and** that `raft_dir` stays empty (proving the guard fires before `open_rocksdb`).
  - `shared_ca_for_peer_and_admin_rejected_at_build` — covers both the same-path and same-bytes cross-trio check.
  - `admin_mtls_listener_serves_with_matching_client_cert` — waits for `LeaderState::Leader` before the first `list_members` (avoids the election-window flake).
  - `admin_mtls_listener_rejects_no_client_cert` — accepts either handshake failure or first-RPC failure (tonic 0.14 has no public `From<io::Error>` on `transport::Error`).
  - `admin_tls.rs`: `valid_trio_builds_admin_server_tls`, `missing_file_is_a_tls_error`, `invalid_pem_is_a_tls_error`.
  - bin: `admin_tls_config` (3 cases) + `admin_client_tls` (none/partial).
- [x] Run `serve openraft --admin-listen 0.0.0.0:NNN` without `--admin-tls-*` against a real binary and confirm the build fails with `AdminInsecureRoutable` before the data dir is created.
- [x] Dial `tsoracle admin members` over `https://` against a node serving admin mTLS with matching client cert.