### PR TITLE
feat(driver-openraft): add format-activation gate and Capabilities RPC

### DIFF
--- a/crates/tsoracle-driver-openraft/src/capabilities.rs
+++ b/crates/tsoracle-driver-openraft/src/capabilities.rs
@@ -1,0 +1,303 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Format-migration capability reporting and the leader-side all-members
+//! activation gate's pure logic.
+//!
+//! A [`NodeCapabilities`] is the answer to "what schema versions can this node
+//! read, and what version is it actively writing?" Every member reports its own
+//! via the `Capabilities` peer RPC (see `tsoracle-standalone`); the leader
+//! gathers all members' reports and runs [`all_members_can_read`] before any
+//! format bump is proposed (the proposal itself is a later phase). The struct
+//! crosses the wire as a postcard body inside the existing `RaftMessage`
+//! envelope, so it lives here in the driver crate where both the peer transport
+//! and the leader-side gate can reach it.
+
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+type NodeId = u64;
+
+/// What schema versions a single node can read, and the version it is actively
+/// writing right now.
+///
+/// `min_readable_version` / `max_readable_version` are compile-time constants of
+/// the running binary (the oldest and newest formats it has a parser for);
+/// `active_write_version` is the durable, runtime value the node currently
+/// stamps on new records and wire bodies. The activation gate compares every
+/// member's `max_readable_version` against a proposed target so no committed
+/// record can reach a member that cannot decode it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeCapabilities {
+    pub min_readable_version: u8,
+    pub max_readable_version: u8,
+    pub active_write_version: u8,
+}
+
+impl NodeCapabilities {
+    /// Build the local node's capabilities: the readable range is fixed by this
+    /// binary's compile-time constants; the active write version is the durable
+    /// runtime value supplied by the caller (read through the state machine's
+    /// `active_write_version()` accessor).
+    pub fn local(active_write_version: u8) -> Self {
+        Self {
+            min_readable_version: tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            max_readable_version: tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            active_write_version,
+        }
+    }
+}
+
+/// The all-members activation gate: return the set of member node ids iff
+/// **every** gathered member can read `target` (its `max_readable_version >=
+/// target`), otherwise `None`.
+///
+/// The gate is all-members, not quorum, and the caller must have gathered every
+/// current member (voters AND learners) before calling this — a lagging or
+/// learner peer on an old-only binary would otherwise reject every record at
+/// the new version once it committed. The returned set is exactly the gathered
+/// members; a later phase embeds it in the bump entry so apply can re-validate
+/// the membership at the entry's own log position against this snapshot.
+pub fn all_members_can_read(
+    target: u8,
+    capabilities: &[(NodeId, NodeCapabilities)],
+) -> Option<BTreeSet<NodeId>> {
+    if capabilities
+        .iter()
+        .all(|(_, member)| member.max_readable_version >= target)
+    {
+        Some(capabilities.iter().map(|(node_id, _)| *node_id).collect())
+    } else {
+        None
+    }
+}
+
+/// Why an operator-initiated format activation could not proceed past the gate.
+///
+/// Returned by `StandaloneHost::initiate_format_activation`. None of these are
+/// retryable in place by the caller without remediation: `NotLeader` means
+/// re-issue against the leader; `MembersBelowTarget` means upgrade or remove
+/// the named members and re-issue; `MemberUnreachable` means the cluster could
+/// not confirm a member's capability and the gate fails closed rather than
+/// guess.
+#[derive(Debug, thiserror::Error)]
+pub enum FormatActivationError {
+    /// This node is not the raft leader, so it cannot drive an activation.
+    #[error("cannot initiate format activation: this node is not the leader")]
+    NotLeader,
+    /// At least one current member cannot read `target`. `incapable` lists the
+    /// offending `(node_id, max_readable_version)` pairs for the operator.
+    #[error("format activation to target {target} blocked: members below target: {incapable:?}")]
+    MembersBelowTarget {
+        target: u8,
+        incapable: Vec<(NodeId, u8)>,
+    },
+    /// A member could not be queried for its capabilities; the gate fails closed.
+    #[error("format activation gate failed: member {node_id} unreachable: {detail}")]
+    MemberUnreachable { node_id: NodeId, detail: String },
+}
+
+/// Abstracts querying one peer member for its [`NodeCapabilities`]. Implemented
+/// in the standalone transport crate as a thin adapter over the `Capabilities`
+/// peer RPC; defined here so [`StandaloneHost::gather_member_capabilities`]
+/// (in `standalone.rs`) can be generic over it (the driver crate does not
+/// depend on the transport crate) and so the gate is unit-testable with a fake
+/// source.
+///
+/// [`StandaloneHost::gather_member_capabilities`]: crate::standalone::StandaloneHost::gather_member_capabilities
+#[async_trait]
+pub trait CapabilitySource: Send + Sync {
+    /// The `Node` (membership endpoint) type this source dials.
+    type Node: Send + Sync;
+
+    /// Query `member`'s capabilities. `detail` on failure is a human-readable
+    /// reason folded into [`FormatActivationError::MemberUnreachable`].
+    async fn query(&self, node_id: NodeId, member: &Self::Node)
+    -> Result<NodeCapabilities, String>;
+}
+
+/// Gather every member's capabilities, answering the `local_node` from
+/// `local_capabilities` directly (no self-RPC) and every other member via
+/// `source`. Fails closed ([`FormatActivationError::MemberUnreachable`]) the
+/// moment any remote query fails — the all-members gate cannot pass on a
+/// member it could not confirm. `membership` is the full current voter+learner
+/// set.
+pub async fn gather_with<S: CapabilitySource>(
+    local_node: NodeId,
+    local_capabilities: NodeCapabilities,
+    membership: &[(NodeId, S::Node)],
+    source: &S,
+) -> Result<Vec<(NodeId, NodeCapabilities)>, FormatActivationError> {
+    let mut gathered = Vec::with_capacity(membership.len());
+    for (node_id, member) in membership {
+        let capabilities = if *node_id == local_node {
+            local_capabilities
+        } else {
+            source.query(*node_id, member).await.map_err(|detail| {
+                FormatActivationError::MemberUnreachable {
+                    node_id: *node_id,
+                    detail,
+                }
+            })?
+        };
+        gathered.push((*node_id, capabilities));
+    }
+    Ok(gathered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+
+    fn caps(active: u8, max: u8) -> NodeCapabilities {
+        NodeCapabilities {
+            min_readable_version: tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            max_readable_version: max,
+            active_write_version: active,
+        }
+    }
+
+    #[test]
+    fn local_capabilities_reports_compile_time_read_range() {
+        let capabilities = NodeCapabilities::local(7);
+        assert_eq!(
+            capabilities.min_readable_version,
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION
+        );
+        assert_eq!(
+            capabilities.max_readable_version,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION
+        );
+        assert_eq!(capabilities.active_write_version, 7);
+    }
+
+    #[test]
+    fn node_capabilities_postcard_round_trips() {
+        let original = NodeCapabilities {
+            min_readable_version: 3,
+            max_readable_version: 5,
+            active_write_version: 4,
+        };
+        let bytes = postcard::to_stdvec(&original).expect("encode");
+        let decoded: NodeCapabilities = postcard::from_bytes(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn gate_passes_when_all_members_can_read_target() {
+        let reports = vec![(1u64, caps(3, 4)), (2, caps(3, 5)), (3, caps(3, 4))];
+        let gated = all_members_can_read(4, &reports).expect("all members can read 4");
+        assert_eq!(gated, BTreeSet::from([1, 2, 3]));
+    }
+
+    #[test]
+    fn gate_passes_at_exact_equality() {
+        // max_readable_version == target is sufficient (>=, not >).
+        let reports = vec![(1u64, caps(3, 4)), (2, caps(3, 4))];
+        assert_eq!(
+            all_members_can_read(4, &reports),
+            Some(BTreeSet::from([1, 2]))
+        );
+    }
+
+    #[test]
+    fn gate_fails_when_one_member_is_below_target() {
+        // Node 2 can only read up to v3; target v4 must be refused.
+        let reports = vec![(1u64, caps(3, 4)), (2, caps(3, 3)), (3, caps(3, 4))];
+        assert_eq!(all_members_can_read(4, &reports), None);
+    }
+
+    #[test]
+    fn gate_on_empty_membership_is_vacuously_satisfied_with_empty_set() {
+        // No members → no member can fail the predicate → Some(empty). A real
+        // cluster always has at least the local node, but the predicate itself
+        // is total; the empty case is documented and tested so callers above
+        // it can rely on Some meaning "every gathered member passed".
+        assert_eq!(all_members_can_read(4, &[]), Some(BTreeSet::new()));
+    }
+
+    #[test]
+    fn format_activation_error_below_target_names_members_and_target() {
+        let err = FormatActivationError::MembersBelowTarget {
+            target: 4,
+            incapable: vec![(2, 3), (5, 3)],
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains("target 4"), "got: {rendered}");
+        assert!(
+            rendered.contains('2') && rendered.contains('5'),
+            "got: {rendered}"
+        );
+    }
+
+    struct FakeSource {
+        responses: HashMap<NodeId, Result<NodeCapabilities, String>>,
+    }
+
+    #[async_trait]
+    impl CapabilitySource for FakeSource {
+        type Node = ();
+
+        async fn query(&self, node_id: NodeId, _member: &()) -> Result<NodeCapabilities, String> {
+            self.responses
+                .get(&node_id)
+                .cloned()
+                .unwrap_or_else(|| Err(format!("no fake response for {node_id}")))
+        }
+    }
+
+    #[tokio::test]
+    async fn gather_with_collects_remote_and_local() {
+        // Local node 1 reports active=3,max=4 directly; remote node 2 answers
+        // via the source. Membership = {1: (), 2: ()}.
+        let source = FakeSource {
+            responses: HashMap::from([(2u64, Ok(caps(3, 5)))]),
+        };
+        let membership: Vec<(NodeId, ())> = vec![(1, ()), (2, ())];
+        let gathered = gather_with(1, caps(3, 4), &membership, &source)
+            .await
+            .expect("gather succeeds");
+        let by_id: HashMap<NodeId, NodeCapabilities> = gathered.into_iter().collect();
+        assert_eq!(by_id[&1].active_write_version, 3);
+        assert_eq!(by_id[&2].max_readable_version, 5);
+    }
+
+    #[tokio::test]
+    async fn gather_with_surfaces_unreachable_member() {
+        let source = FakeSource {
+            responses: HashMap::from([(2u64, Err("connection refused".to_string()))]),
+        };
+        let membership: Vec<(NodeId, ())> = vec![(1, ()), (2, ())];
+        let err = gather_with(1, caps(3, 4), &membership, &source)
+            .await
+            .expect_err("an unreachable member fails the gather closed");
+        assert!(matches!(
+            err,
+            FormatActivationError::MemberUnreachable { node_id: 2, .. }
+        ));
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -26,6 +26,7 @@
 // for the lib's own unit tests; integration tests are separate compilation units.
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
+pub mod capabilities;
 pub mod driver;
 pub mod host;
 pub mod log_codec;
@@ -35,6 +36,9 @@ pub mod standalone;
 pub mod state_machine;
 pub mod type_config;
 
+pub use capabilities::{
+    CapabilitySource, FormatActivationError, NodeCapabilities, all_members_can_read, gather_with,
+};
 pub use driver::OpenraftDriver;
 pub use host::OpenraftHighWaterHost;
 pub use log_codec::OpenraftLogCodec;

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -29,18 +29,25 @@
 //! [`OpenraftHighWaterHost`](crate::OpenraftHighWaterHost) directly against
 //! that existing cluster instead.
 
+use std::collections::BTreeSet;
+
 use async_trait::async_trait;
 use openraft::Raft;
 use openraft::RaftMetrics;
 use openraft::ReadPolicy;
+use openraft::ServerState;
+use openraft::async_runtime::watch::WatchReceiver;
 use openraft::error::{ClientWriteError, LinearizableReadError, RaftError};
 use openraft::type_config::alias::WatchReceiverOf;
 use tsoracle_consensus::ConsensusError;
 
+use crate::capabilities::{
+    CapabilitySource, FormatActivationError, NodeCapabilities, all_members_can_read, gather_with,
+};
 use crate::host::OpenraftHighWaterHost;
 use crate::log_entry::HighWaterCommand;
 use crate::state_machine::HighWaterStateMachine;
-use crate::type_config::TypeConfig;
+use crate::type_config::{OpenraftPeer, TypeConfig};
 use tsoracle_consensus::AdvancePayload;
 
 /// `OpenraftHighWaterHost` that owns its own raft cluster + state machine.
@@ -76,6 +83,102 @@ impl StandaloneHost {
     /// a successful activation apply (later phase) advances it.
     pub fn active_write_version(&self) -> u8 {
         self.state_machine.active_write_version()
+    }
+
+    /// The local node's format-migration capabilities: compile-time read range
+    /// plus the durable active write version.
+    pub fn local_capabilities(&self) -> NodeCapabilities {
+        NodeCapabilities::local(self.active_write_version())
+    }
+
+    /// Read the current voter+learner membership and the local node id /
+    /// leader state from `raft.metrics()`. Returns `(local_node_id, is_leader,
+    /// members)`, where `members` is every node in
+    /// `membership_config.nodes()` — voters and learners both, because the
+    /// all-members gate covers learners too.
+    fn membership_snapshot(&self) -> (u64, bool, Vec<(u64, OpenraftPeer)>) {
+        let metrics = self.raft.metrics();
+        let snapshot = metrics.borrow_watched();
+        let local_node_id = snapshot.id;
+        let is_leader = snapshot.state == ServerState::Leader;
+        let members = snapshot
+            .membership_config
+            .nodes()
+            .map(|(node_id, node)| (*node_id, node.clone()))
+            .collect();
+        (local_node_id, is_leader, members)
+    }
+
+    /// Query every current member (voters AND learners) for its capabilities,
+    /// answering the local node directly. `source` dials remote members. Fails
+    /// closed the moment any remote query fails — the all-members gate cannot
+    /// pass on a member it could not confirm.
+    pub async fn gather_member_capabilities<S>(
+        &self,
+        source: &S,
+    ) -> Result<Vec<(u64, NodeCapabilities)>, FormatActivationError>
+    where
+        S: CapabilitySource<Node = OpenraftPeer>,
+    {
+        let (local_node_id, _is_leader, members) = self.membership_snapshot();
+        gather_with(local_node_id, self.local_capabilities(), &members, source).await
+    }
+
+    /// Run the all-members activation gate for `target`. Requires local
+    /// leadership (only the leader may drive activation), gathers every
+    /// member's capabilities, and returns the gated member set iff all can
+    /// read `target`. On failure returns a [`FormatActivationError`] (not
+    /// leader / a member below target / a member unreachable). This is the
+    /// function boundary that a later phase's proposal step will consume: the
+    /// returned set is exactly the snapshot a `SetFormatVersion` log entry
+    /// would embed for apply to re-validate against.
+    pub async fn run_activation_gate<S>(
+        &self,
+        target: u8,
+        source: &S,
+    ) -> Result<BTreeSet<u64>, FormatActivationError>
+    where
+        S: CapabilitySource<Node = OpenraftPeer>,
+    {
+        let (_local_node_id, is_leader, _members) = self.membership_snapshot();
+        if !is_leader {
+            return Err(FormatActivationError::NotLeader);
+        }
+        let gathered = self.gather_member_capabilities(source).await?;
+        match all_members_can_read(target, &gathered) {
+            Some(gated_members) => Ok(gated_members),
+            None => {
+                let incapable = gathered
+                    .iter()
+                    .filter(|(_, capabilities)| capabilities.max_readable_version < target)
+                    .map(|(node_id, capabilities)| (*node_id, capabilities.max_readable_version))
+                    .collect();
+                Err(FormatActivationError::MembersBelowTarget { target, incapable })
+            }
+        }
+    }
+
+    /// Operator entry point to begin a format-version activation to `target`
+    /// (interim, library-only). Runs the all-members gate and returns
+    /// `Ok(())` when it passes. A later phase fills the body between the gate
+    /// and this return — it takes the `gated_members` set returned by
+    /// [`run_activation_gate`](Self::run_activation_gate) and proposes a
+    /// `SetFormatVersion { target, gated_members }` entry at the pre-bump
+    /// active write version via `self.raft.client_write(...)`, then keys the
+    /// write-version flip off the successful apply. The function boundary
+    /// `run_activation_gate(target) -> Ok(gated_members)` is the exact seam
+    /// that proposal step builds on; today the gate result is simply not yet
+    /// consumed.
+    pub async fn initiate_format_activation<S>(
+        &self,
+        target: u8,
+        source: &S,
+    ) -> Result<(), FormatActivationError>
+    where
+        S: CapabilitySource<Node = OpenraftPeer>,
+    {
+        let _gated_members = self.run_activation_gate(target, source).await?;
+        Ok(())
     }
 }
 

--- a/crates/tsoracle-driver-openraft/tests/activation_gate.rs
+++ b/crates/tsoracle-driver-openraft/tests/activation_gate.rs
@@ -1,0 +1,137 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Leader-side activation-gate tests.
+//!
+//! Stands up a single-voter openraft cluster via [`common::build_single_node`]
+//! and drives the gate on a [`StandaloneHost`] built from the cluster's raft +
+//! state machine. Single-node means the local-node short-circuit answers
+//! everything, so the supplied [`CapabilitySource`] is never called — we
+//! supply [`UnusedSource`] which panics on any remote query as a sanity check.
+
+mod common;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, LeaderState};
+use tsoracle_driver_openraft::{
+    CapabilitySource, FormatActivationError, NodeCapabilities, OpenraftPeer, StandaloneHost,
+};
+
+use common::build_single_node;
+
+/// A source that must never be called: a single-node gate answers entirely
+/// from the local short-circuit, so any remote query is a bug.
+struct UnusedSource;
+
+#[async_trait]
+impl CapabilitySource for UnusedSource {
+    type Node = OpenraftPeer;
+
+    async fn query(
+        &self,
+        node_id: u64,
+        _member: &OpenraftPeer,
+    ) -> Result<NodeCapabilities, String> {
+        panic!("single-node gate must not query remote node {node_id}");
+    }
+}
+
+/// Stand up a single-voter cluster, wait until it elects itself, and return a
+/// [`StandaloneHost`] handle plus a guard that holds the temp dirs alive for
+/// the duration of the test.
+async fn single_node_leader_host() -> (StandaloneHost, common::TestCluster) {
+    let cluster = build_single_node().await;
+    let driver = &cluster.drivers[0];
+
+    let mut events = driver.leadership_events();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let state = events.next().await.expect("event stream alive");
+            if matches!(state, LeaderState::Leader { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("single-node openraft did not elect itself within 5s");
+
+    let host = StandaloneHost::new(cluster.nodes[0].raft.clone(), cluster.nodes[0].sm.clone());
+    (host, cluster)
+}
+
+#[tokio::test(start_paused = true)]
+async fn gate_passes_when_target_within_local_max() {
+    let (host, _cluster) = single_node_leader_host().await;
+    // The local node's max_readable_version is MAX_READABLE_VERSION; a target
+    // at or below it must pass and return the gated set {1}.
+    let gated = host
+        .run_activation_gate(
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            &UnusedSource,
+        )
+        .await
+        .expect("gate passes for an in-range target");
+    assert_eq!(gated, std::collections::BTreeSet::from([1]));
+}
+
+#[tokio::test(start_paused = true)]
+async fn gate_fails_when_target_above_local_max() {
+    let (host, _cluster) = single_node_leader_host().await;
+    let target = tsoracle_openraft_toolkit::MAX_READABLE_VERSION + 1;
+    let err = host
+        .run_activation_gate(target, &UnusedSource)
+        .await
+        .expect_err("gate fails when the only member cannot read the target");
+    let FormatActivationError::MembersBelowTarget {
+        target: returned,
+        incapable,
+    } = err
+    else {
+        panic!("expected MembersBelowTarget");
+    };
+    assert_eq!(returned, target);
+    assert_eq!(incapable.len(), 1);
+    assert_eq!(incapable[0].0, 1);
+    assert_eq!(
+        incapable[0].1,
+        tsoracle_openraft_toolkit::MAX_READABLE_VERSION
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn initiate_format_activation_runs_gate_and_returns_ok_for_now() {
+    let (host, _cluster) = single_node_leader_host().await;
+    // The all-members gate against the only voter (local short-circuit)
+    // passes; the body between the gate and Ok(()) is a later phase's
+    // proposal step.
+    host.initiate_format_activation(
+        tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+        &UnusedSource,
+    )
+    .await
+    .expect("a passing gate returns Ok in this phase");
+}

--- a/crates/tsoracle-standalone/proto/raft_peer.proto
+++ b/crates/tsoracle-standalone/proto/raft_peer.proto
@@ -17,6 +17,15 @@ service RaftPeerService {
   rpc Vote (RaftMessage) returns (RaftMessage);
   rpc Snapshot (stream SnapshotChunk) returns (RaftMessage);
   rpc TransferLeader (RaftMessage) returns (RaftMessage);
+  // Format-migration capability query. The request `RaftMessage.payload` is
+  // empty (the query takes no arguments). The reply `RaftMessage.payload` is
+  // a postcard-encoded `NodeCapabilities { min_readable_version,
+  // max_readable_version, active_write_version }`. The response body is the
+  // bootstrap message that tells the caller which versions this node supports,
+  // so it is NOT itself version-framed (its scalar-u8 shape never changes);
+  // any `format_version` envelope field on the carrier `RaftMessage` is
+  // ignored here.
+  rpc Capabilities (RaftMessage) returns (RaftMessage);
 }
 
 message RaftMessage {

--- a/crates/tsoracle-standalone/src/drivers/openraft/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/network.rs
@@ -56,7 +56,7 @@ use openraft::type_config::alias::{SnapshotOf, VoteOf};
 use tokio::sync::Mutex;
 use tonic::transport::{Channel, ClientTlsConfig};
 
-use tsoracle_driver_openraft::{OpenraftPeer as Node, TypeConfig};
+use tsoracle_driver_openraft::{NodeCapabilities, OpenraftPeer as Node, TypeConfig};
 use tsoracle_openraft_toolkit::{
     BASELINE_WRITE_VERSION, MAX_READABLE_VERSION, MIN_READABLE_VERSION,
 };
@@ -255,6 +255,70 @@ pub struct PeerNetwork {
     active_write_version: WriteVersionSource,
 }
 
+/// Deadline for a single capability query. The gate is operator-initiated and
+/// not on the hot path, so a generous fixed bound is fine; it exists only to
+/// fail closed on a black-holed peer rather than hang the gate forever.
+const CAPABILITY_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Concrete [`CapabilitySource`](tsoracle_driver_openraft::CapabilitySource)
+/// that dials a member via the `Capabilities` peer RPC. Constructed in the
+/// transport crate (where `PeerNetwork` lives) and handed to
+/// `StandaloneHost::run_activation_gate`; the driver crate stays free of a
+/// dependency on this crate.
+pub struct PeerCapabilitySource {
+    pool: Pool,
+    tls: Option<ClientTlsConfig>,
+}
+
+impl PeerCapabilitySource {
+    // The only in-workspace caller today is the round-trip test; a later
+    // phase wires this into the production `initiate_format_activation`
+    // path. `pub` is the intended surface — this `allow` documents that and
+    // unblocks the workspace build's `-D warnings` lint.
+    #[allow(dead_code)]
+    pub fn new(tls: Option<ClientTlsConfig>) -> Self {
+        Self {
+            pool: Arc::new(Mutex::new(HashMap::new())),
+            tls,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl tsoracle_driver_openraft::CapabilitySource for PeerCapabilitySource {
+    type Node = Node;
+
+    async fn query(&self, node_id: NodeId, member: &Node) -> Result<NodeCapabilities, String> {
+        // The `Capabilities` request payload is empty and the response body
+        // is not version-framed, so the outbound carrier's `format_version`
+        // is informational only. Stamping `BASELINE_WRITE_VERSION` is correct
+        // for any pre-activation node (and any post-activation node that has
+        // not yet handled the bump apply) — the gate is exactly the operator
+        // step that precedes a target bump.
+        let network = PeerNetwork {
+            target: node_id,
+            addr: member.addr.clone(),
+            pool: self.pool.clone(),
+            tls: self.tls.clone(),
+            active_write_version: Arc::new(|| tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION),
+        };
+        network
+            .capabilities(CAPABILITY_QUERY_TIMEOUT)
+            .await
+            .map_err(|err| format!("{err:?}"))
+    }
+}
+
+/// Build the postcard body of a `Capabilities` reply for the local node with
+/// the given active write version. Split out from the tonic handler so the
+/// decode→build→encode contract is unit-testable without a live `Raft`.
+fn capabilities_response(active_write_version: u8) -> Vec<u8> {
+    let capabilities = NodeCapabilities::local(active_write_version);
+    // `NodeCapabilities` is three `u8`s; postcard encoding is infallible for
+    // it, but we surface a definite `Vec` either way to keep the handler total.
+    postcard::to_stdvec(&capabilities).unwrap_or_default()
+}
+
 impl PeerNetwork {
     /// Return a cached (or freshly connected) tonic client to the target.
     async fn client(&self) -> Result<RaftPeerServiceClient<Channel>, RPCError<TypeConfig>> {
@@ -282,6 +346,37 @@ impl PeerNetwork {
         let client = RaftPeerServiceClient::new(channel);
         self.pool.lock().await.insert(key, client.clone());
         Ok(client)
+    }
+
+    /// Query the target peer for its format-migration capabilities. Not part
+    /// of `RaftNetworkV2` (openraft has no such RPC); used only by the
+    /// leader-side activation gate. The request payload is empty; the reply
+    /// is a postcard `NodeCapabilities`.
+    ///
+    /// `format_version` on the carrier `RaftMessage` is stamped from the
+    /// node's active write version (same as every other outbound message),
+    /// but the response body itself is NOT version-framed — its scalar-u8
+    /// shape never changes, it is the bootstrap message that tells the caller
+    /// what versions the peer supports.
+    pub async fn capabilities(
+        &self,
+        deadline: Duration,
+    ) -> Result<NodeCapabilities, RPCError<TypeConfig>> {
+        let mut client = self.client().await?;
+        let reply = unary_call(
+            &self.pool,
+            self.target,
+            &self.addr,
+            deadline,
+            client.capabilities(RaftMessage {
+                payload: Vec::new(),
+                format_version: wire::stamp((self.active_write_version)()),
+            }),
+        )
+        .await?;
+        let capabilities: NodeCapabilities = postcard::from_bytes(&reply.payload)
+            .map_err(|err| RPCError::Network(NetworkError::new(&err)))?;
+        Ok(capabilities)
     }
 }
 
@@ -555,6 +650,24 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
             format_version: wire::stamp((self.active_write_version)()),
         }))
     }
+
+    /// Answer with the local node's format-migration capabilities. The
+    /// request payload is ignored (the query takes no arguments); the
+    /// envelope's `format_version` is ignored too because the response body
+    /// itself is not version-framed (its scalar-u8 shape is the bootstrap
+    /// message that tells the caller which versions to use). The reply
+    /// carrier still stamps `format_version` for symmetry with the rest of
+    /// the peer transport.
+    async fn capabilities(
+        &self,
+        _request: tonic::Request<RaftMessage>,
+    ) -> Result<tonic::Response<RaftMessage>, tonic::Status> {
+        let payload = capabilities_response((self.active_write_version)());
+        Ok(tonic::Response::new(RaftMessage {
+            payload,
+            format_version: wire::stamp((self.active_write_version)()),
+        }))
+    }
 }
 
 /// A snapshot reassembled from a peer's client-streaming RPC.
@@ -744,6 +857,12 @@ mod tls_tests {
             Err(tonic::Status::unimplemented("stub"))
         }
         async fn transfer_leader(
+            &self,
+            _: tonic::Request<proto::RaftMessage>,
+        ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+            Err(tonic::Status::unimplemented("stub"))
+        }
+        async fn capabilities(
             &self,
             _: tonic::Request<proto::RaftMessage>,
         ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
@@ -1276,5 +1395,129 @@ mod tests {
             .await
             .expect("absent format_version assembles as baseline");
         assert_eq!(assembled.data, b"x");
+    }
+
+    // ---- Capabilities RPC ----
+
+    #[test]
+    fn capabilities_response_reports_local_node() {
+        // The server handler answers Capabilities by encoding `NodeCapabilities::local`
+        // of the supplied active write version. The decode→build→encode contract
+        // lives in `capabilities_response`, exercised here without a live tonic
+        // server.
+        let payload = capabilities_response(7);
+        let decoded: NodeCapabilities =
+            postcard::from_bytes(&payload).expect("decode NodeCapabilities");
+        assert_eq!(
+            decoded,
+            NodeCapabilities {
+                min_readable_version: tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+                max_readable_version: tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+                active_write_version: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn capabilities_payload_round_trips_client_side() {
+        // A client decoding the same payload over the RaftMessage envelope
+        // recovers the struct — the wire contract `PeerCapabilitySource` relies
+        // on. The envelope's `format_version` is unrelated to this body
+        // (NodeCapabilities is the bootstrap message and is not version-framed).
+        let server_payload = capabilities_response(4);
+        let message = RaftMessage {
+            payload: server_payload,
+            format_version: 0,
+        };
+        let decoded: NodeCapabilities =
+            postcard::from_bytes(&message.payload).expect("client decode");
+        assert_eq!(decoded.active_write_version, 4);
+    }
+
+    // Stand up a real RaftPeerService whose `capabilities` handler reports a
+    // fixed active write version, then dial it through the `PeerCapabilitySource`
+    // adapter and assert the round-trip recovers the reported capabilities. The
+    // server uses a `CapStub` rather than building a full `Raft`, so the test
+    // proves the adapter + RPC wire contract in isolation.
+    #[tokio::test]
+    async fn peer_capability_source_round_trips_against_live_server() {
+        use proto::raft_peer_service_server::{
+            RaftPeerService as ProtoService, RaftPeerServiceServer,
+        };
+        use tsoracle_driver_openraft::CapabilitySource;
+
+        struct CapStub {
+            active_write_version: u8,
+        }
+
+        #[tonic::async_trait]
+        impl ProtoService for CapStub {
+            async fn append_entries(
+                &self,
+                _: tonic::Request<proto::RaftMessage>,
+            ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+                Err(tonic::Status::unimplemented("cap stub"))
+            }
+            async fn vote(
+                &self,
+                _: tonic::Request<proto::RaftMessage>,
+            ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+                Err(tonic::Status::unimplemented("cap stub"))
+            }
+            async fn snapshot(
+                &self,
+                _: tonic::Request<tonic::Streaming<proto::SnapshotChunk>>,
+            ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+                Err(tonic::Status::unimplemented("cap stub"))
+            }
+            async fn transfer_leader(
+                &self,
+                _: tonic::Request<proto::RaftMessage>,
+            ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+                Err(tonic::Status::unimplemented("cap stub"))
+            }
+            async fn capabilities(
+                &self,
+                _: tonic::Request<proto::RaftMessage>,
+            ) -> Result<tonic::Response<proto::RaftMessage>, tonic::Status> {
+                Ok(tonic::Response::new(proto::RaftMessage {
+                    payload: capabilities_response(self.active_write_version),
+                    format_version: 0,
+                }))
+            }
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(RaftPeerServiceServer::new(CapStub {
+                    active_write_version: 5,
+                }))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let source = PeerCapabilitySource::new(None);
+        let node = Node {
+            addr: addr.to_string(),
+            service_endpoint: String::new(),
+            admin_endpoint: String::new(),
+        };
+        let capabilities = source
+            .query(2, &node)
+            .await
+            .expect("live capabilities query");
+        assert_eq!(capabilities.active_write_version, 5);
+        assert_eq!(
+            capabilities.min_readable_version,
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION
+        );
+        assert_eq!(
+            capabilities.max_readable_version,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `NodeCapabilities { min_readable_version, max_readable_version, active_write_version: u8 }` plus a pure all-members gate predicate `all_members_can_read(target, &reports) -> Option<BTreeSet<NodeId>>`, a `FormatActivationError` enum, a `CapabilitySource` async trait, and a `gather_with` helper — all in `tsoracle-driver-openraft::capabilities`.
- Adds `local_capabilities()` / `gather_member_capabilities()` / `run_activation_gate(target, source)` / `initiate_format_activation(target, source)` on `StandaloneHost`. The gate reads voter+learner membership from `raft.metrics()`, gathers via the `CapabilitySource`, and returns the gated `BTreeSet<u64>`. `initiate_format_activation` runs the gate and returns `Ok(())` — the function boundary `run_activation_gate -> gated_members` is the seam a future proposal step consumes.
- Adds an additive peer RPC `Capabilities (RaftMessage) returns (RaftMessage)` on the existing `RaftPeerService` (no new service, no new listener, no new port). The request payload is empty; the response payload is a postcard-encoded `NodeCapabilities`. The body itself is not version-framed (it is the bootstrap message that tells the caller which versions to use); the carrier `RaftMessage.format_version` is still stamped/read like every other RPC.
- Adds the concrete `PeerCapabilitySource` in `tsoracle-standalone` dialing the new RPC via `PeerNetwork::capabilities` with a 10-second deadline.

The query is fully self-contained on the existing peer transport — no admin service or CLI is added. The operator trigger is an interim library method (`StandaloneHost::initiate_format_activation`); a later phase will move it behind whatever admin surface is in place by then.

## Test plan

- [x] `cargo build --workspace --all-features` is clean
- [x] `cargo test --workspace --all-features` passes: 9 new `capabilities::tests` (postcard round-trip, `all_members_can_read` passes/fails/equal-edge/empty, `FormatActivationError` formatting, `gather_with` collect + unreachable), 3 new `network::tests` (`capabilities_response_reports_local_node`, `capabilities_payload_round_trips_client_side`, live round-trip `peer_capability_source_round_trips_against_live_server` via a lightweight `CapStub`), 3 new integration tests in `tests/activation_gate.rs` (single-node gate pass, gate fail with `MembersBelowTarget`, `initiate_format_activation` returns `Ok(())`)
- [x] `cargo clippy --workspace --all-features -- -D warnings` is clean
- [x] No new admin RPC, admin listener, or `tsoracle admin` subcommand is introduced (the new `Capabilities` RPC rides the existing peer transport — confirm with `rg -n 'AdminService|tsoracle admin' crates/`)
- [x] `rg -n 'SetFormatVersion|HighWaterCommand::SetFormatVersion' crates/` returns nothing — the apply arm and write-version flip are deferred to a later phase, intentionally