### PR TITLE
feat(driver-openraft): apply-keyed activation barrier with subset gate

### DIFF
--- a/crates/tsoracle-driver-openraft/src/capabilities.rs
+++ b/crates/tsoracle-driver-openraft/src/capabilities.rs
@@ -117,6 +117,18 @@ pub enum FormatActivationError {
     /// A member could not be queried for its capabilities; the gate fails closed.
     #[error("format activation gate failed: member {node_id} unreachable: {detail}")]
     MemberUnreachable { node_id: NodeId, detail: String },
+    /// The membership committed as of the bump's own log position was no
+    /// longer a subset of the set the gate observed — an un-gated member was
+    /// added or promoted between the live gate query and the entry's
+    /// commit/apply, so the bump applied as a no-op. Re-gate and re-issue.
+    #[error(
+        "format activation to target {target} applied as a no-op: membership changed since the gate"
+    )]
+    MembershipChangedSinceGate { target: u8 },
+    /// The proposal (`raft.client_write`) failed before / during commit —
+    /// e.g. lost leadership, the cluster lost quorum, or a fatal raft error.
+    #[error("format activation proposal failed: {0}")]
+    ProposalFailed(String),
 }
 
 /// Abstracts querying one peer member for its [`NodeCapabilities`]. Implemented

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -42,7 +42,7 @@ pub use capabilities::{
 pub use driver::OpenraftDriver;
 pub use host::OpenraftHighWaterHost;
 pub use log_codec::OpenraftLogCodec;
-pub use log_entry::HighWaterCommand;
+pub use log_entry::{HighWaterCommand, SetFormatVersionPayload};
 #[cfg(feature = "rocksdb-snapshot-store")]
 pub use snapshot_store::RocksdbSnapshotStore;
 pub use snapshot_store::{InMemorySnapshotStore, SnapshotStore};
@@ -53,6 +53,6 @@ pub use state_machine::{HighWaterStateMachine, HighWaterStateMachineSnapshot};
 pub use tsoracle_consensus::AdvancePayload;
 pub use tsoracle_core::TsoPeer;
 pub use type_config::{
-    HighWaterApplied, OpenraftEntry, OpenraftLogId, OpenraftPeer, OpenraftVote, ServiceEndpoint,
-    TypeConfig,
+    ApplyOutcome, HighWaterApplied, OpenraftEntry, OpenraftLogId, OpenraftPeer, OpenraftVote,
+    ServiceEndpoint, TypeConfig,
 };

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -33,10 +33,29 @@
 //! with the paxos driver so the "advance" command carries one name and one
 //! field across backends.
 
+use std::collections::BTreeSet;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use tsoracle_consensus::AdvancePayload;
+
+/// Payload of [`HighWaterCommand::SetFormatVersion`]: the committed activation
+/// barrier that flips the cluster's active write version.
+///
+/// `gated_members` is the exact member set (voters ∪ learners) the leader's
+/// activation gate observed as capable of reading `target` at proposal time.
+/// It travels inside the entry because the state-machine apply cannot perform
+/// a live capability query; apply re-validates that the membership committed
+/// as of this entry's own log position is a subset of `gated_members` before
+/// taking effect. `NodeId` is `u64` (the type config's `Node` id type), so the
+/// set is `BTreeSet<u64>` — a deterministic, ordered, postcard-stable layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SetFormatVersionPayload {
+    /// The active write version to flip to on a successful (non-no-op) apply.
+    pub target: u8,
+    /// Voters ∪ learners the leader gated as `target`-readable at proposal time.
+    pub gated_members: BTreeSet<u64>,
+}
 
 /// Commands the state machine knows how to apply.
 ///
@@ -46,6 +65,10 @@ use tsoracle_consensus::AdvancePayload;
 pub enum HighWaterCommand {
     /// Advance the high-water mark to at least `at_least`. Idempotent.
     Advance(AdvancePayload),
+    /// Activate a new active write version, gated on the carried member set.
+    /// Applies as a no-op if the membership at this entry's log position is
+    /// not a subset of `gated_members`.
+    SetFormatVersion(SetFormatVersionPayload),
 }
 
 impl fmt::Display for HighWaterCommand {
@@ -53,6 +76,17 @@ impl fmt::Display for HighWaterCommand {
         match self {
             HighWaterCommand::Advance(AdvancePayload { at_least }) => {
                 write!(f, "Advance {{ at_least: {at_least} }}")
+            }
+            HighWaterCommand::SetFormatVersion(SetFormatVersionPayload {
+                target,
+                gated_members,
+            }) => {
+                let rendered: Vec<String> = gated_members.iter().map(|id| id.to_string()).collect();
+                write!(
+                    f,
+                    "SetFormatVersion {{ target: {target}, gated_members: [{}] }}",
+                    rendered.join(", ")
+                )
             }
         }
     }
@@ -95,6 +129,43 @@ mod tests {
     #[test]
     fn postcard_round_trip_max() {
         let cmd = HighWaterCommand::Advance(AdvancePayload { at_least: u64::MAX });
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn display_renders_set_format_version() {
+        let cmd = HighWaterCommand::SetFormatVersion(SetFormatVersionPayload {
+            target: 4,
+            gated_members: BTreeSet::from([1u64, 2u64, 3u64]),
+        });
+        assert_eq!(
+            format!("{cmd}"),
+            "SetFormatVersion { target: 4, gated_members: [1, 2, 3] }"
+        );
+    }
+
+    #[test]
+    fn postcard_round_trip_set_format_version() {
+        let cmd = HighWaterCommand::SetFormatVersion(SetFormatVersionPayload {
+            target: 7,
+            gated_members: BTreeSet::from([10u64, 20u64]),
+        });
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn postcard_round_trip_set_format_version_empty_gate() {
+        // The gated set may legitimately be empty for a degenerate re-issue;
+        // it must still round-trip so the apply-time subset check sees
+        // exactly what the proposer recorded.
+        let cmd = HighWaterCommand::SetFormatVersion(SetFormatVersionPayload {
+            target: 4,
+            gated_members: BTreeSet::new(),
+        });
         let bytes = postcard::to_stdvec(&cmd).expect("serialize");
         let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, cmd);

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -45,9 +45,9 @@ use crate::capabilities::{
     CapabilitySource, FormatActivationError, NodeCapabilities, all_members_can_read, gather_with,
 };
 use crate::host::OpenraftHighWaterHost;
-use crate::log_entry::HighWaterCommand;
+use crate::log_entry::{HighWaterCommand, SetFormatVersionPayload};
 use crate::state_machine::HighWaterStateMachine;
-use crate::type_config::{OpenraftPeer, TypeConfig};
+use crate::type_config::{ApplyOutcome, OpenraftPeer, TypeConfig};
 use tsoracle_consensus::AdvancePayload;
 
 /// `OpenraftHighWaterHost` that owns its own raft cluster + state machine.
@@ -158,17 +158,48 @@ impl StandaloneHost {
         }
     }
 
+    /// Propose a `SetFormatVersion` bump and return the apply outcome
+    /// observed through the `client_write` response. The flip (if any) has
+    /// already happened inside the apply by the time this returns — the
+    /// shared cell reads `target` iff the outcome is
+    /// [`ApplyOutcome::FormatActivated`]. NO meta key is written; durability
+    /// is the committed log entry plus the snapshot byte.
+    async fn submit_set_format_version(
+        &self,
+        target: u8,
+        gated_members: BTreeSet<u64>,
+    ) -> Result<ApplyOutcome, FormatActivationError> {
+        match self
+            .raft
+            .client_write(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target,
+                    gated_members,
+                },
+            ))
+            .await
+        {
+            Ok(resp) => Ok(resp.data.outcome),
+            Err(err) => Err(FormatActivationError::ProposalFailed(err.to_string())),
+        }
+    }
+
     /// Operator entry point to begin a format-version activation to `target`
-    /// (interim, library-only). Runs the all-members gate and returns
-    /// `Ok(())` when it passes. A later phase fills the body between the gate
-    /// and this return — it takes the `gated_members` set returned by
-    /// [`run_activation_gate`](Self::run_activation_gate) and proposes a
-    /// `SetFormatVersion { target, gated_members }` entry at the pre-bump
-    /// active write version via `self.raft.client_write(...)`, then keys the
-    /// write-version flip off the successful apply. The function boundary
-    /// `run_activation_gate(target) -> Ok(gated_members)` is the exact seam
-    /// that proposal step builds on; today the gate result is simply not yet
-    /// consumed.
+    /// (interim, library-only).
+    ///
+    /// Runs the all-members gate (which live-queries every current
+    /// voter+learner via `source` for its capabilities) and, on a passing
+    /// gate, proposes a `SetFormatVersion { target, gated_members }` entry
+    /// via `raft.client_write`. The state-machine apply re-validates the
+    /// subset against the membership committed AS OF the entry's own log
+    /// position — apply-keyed, never raw-commit-keyed — and sets the shared
+    /// active-write-version cell only on a successful (non-no-op) apply.
+    ///
+    /// Returns `Ok(())` iff the apply reported
+    /// [`ApplyOutcome::FormatActivated`] (the cell now reads `target`). A
+    /// [`ApplyOutcome::FormatActivationNoop`] surfaces as
+    /// [`FormatActivationError::MembershipChangedSinceGate`] — the operator
+    /// re-gates and re-issues.
     pub async fn initiate_format_activation<S>(
         &self,
         target: u8,
@@ -177,8 +208,40 @@ impl StandaloneHost {
     where
         S: CapabilitySource<Node = OpenraftPeer>,
     {
-        let _gated_members = self.run_activation_gate(target, source).await?;
-        Ok(())
+        // Gate: live-query every current member; returns the exact gated
+        // member set on success, or a gate error.
+        let gated_members = self.run_activation_gate(target, source).await?;
+
+        // Propose the bump carrying the gated set. Apply re-validates the
+        // subset at the entry's own log position and sets the shared cell
+        // ONLY on a successful (non-no-op) apply. We learn which happened
+        // from the returned `ApplyOutcome` — the apply-keyed flip.
+        let outcome = self
+            .submit_set_format_version(target, gated_members)
+            .await?;
+        classify_activation_outcome(outcome, target)
+    }
+}
+
+/// Map a `SetFormatVersion` apply outcome to the activation result.
+///
+/// `FormatActivated { target }` is the apply-keyed flip succeeding (the
+/// shared cell now reads `target`). `FormatActivationNoop` means membership
+/// drifted out of the gated set by the bump's log position; surface as
+/// [`FormatActivationError::MembershipChangedSinceGate`]. `Advanced` is
+/// impossible for a `SetFormatVersion` entry but is mapped defensively to
+/// the no-op error rather than silently claiming success.
+fn classify_activation_outcome(
+    outcome: ApplyOutcome,
+    target: u8,
+) -> Result<(), FormatActivationError> {
+    match outcome {
+        ApplyOutcome::FormatActivated { target: applied } if applied == target => Ok(()),
+        ApplyOutcome::FormatActivated { .. }
+        | ApplyOutcome::FormatActivationNoop { .. }
+        | ApplyOutcome::Advanced => {
+            Err(FormatActivationError::MembershipChangedSinceGate { target })
+        }
     }
 }
 
@@ -333,5 +396,54 @@ mod tests {
         assert_eq!(state_machine.active_write_version(), 7);
         // Compile-time guard that the host accessor exists and returns u8:
         let _assert_signature: fn(&StandaloneHost) -> u8 = StandaloneHost::active_write_version;
+    }
+
+    #[test]
+    fn classify_activation_outcome_maps_success_to_ok() {
+        let result = classify_activation_outcome(ApplyOutcome::FormatActivated { target: 7 }, 7);
+        assert!(matches!(result, Ok(())));
+    }
+
+    #[test]
+    fn classify_activation_outcome_maps_noop_to_membership_changed() {
+        let result =
+            classify_activation_outcome(ApplyOutcome::FormatActivationNoop { target: 7 }, 7);
+        assert!(matches!(
+            result,
+            Err(FormatActivationError::MembershipChangedSinceGate { target: 7 })
+        ));
+    }
+
+    #[test]
+    fn classify_activation_outcome_maps_advanced_to_membership_changed() {
+        // `Advanced` cannot legally come back from a SetFormatVersion entry,
+        // but we map it defensively rather than silently claiming success.
+        let result = classify_activation_outcome(ApplyOutcome::Advanced, 7);
+        assert!(matches!(
+            result,
+            Err(FormatActivationError::MembershipChangedSinceGate { target: 7 })
+        ));
+    }
+
+    #[test]
+    fn classify_activation_outcome_rejects_target_mismatch() {
+        // A reply naming a different target than the proposer asked for is
+        // mapped to the same error — never silently claim success.
+        let result = classify_activation_outcome(ApplyOutcome::FormatActivated { target: 8 }, 7);
+        assert!(matches!(
+            result,
+            Err(FormatActivationError::MembershipChangedSinceGate { target: 7 })
+        ));
+    }
+
+    #[test]
+    fn membership_changed_since_gate_is_a_distinct_variant() {
+        // Pin that the variant is constructible and matchable; it is the
+        // operator-actionable surface for the apply-time no-op.
+        let err = FormatActivationError::MembershipChangedSinceGate { target: 4 };
+        assert!(matches!(
+            err,
+            FormatActivationError::MembershipChangedSinceGate { target: 4 }
+        ));
     }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -65,9 +65,9 @@ use tsoracle_openraft_toolkit::{
     codec_io_error,
 };
 
-use crate::log_entry::HighWaterCommand;
+use crate::log_entry::{HighWaterCommand, SetFormatVersionPayload};
 use crate::snapshot_store::{InMemorySnapshotStore, SnapshotStore};
-use crate::type_config::{HighWaterApplied, TypeConfig};
+use crate::type_config::{ApplyOutcome, HighWaterApplied, TypeConfig};
 
 type LogId = LogIdOf<TypeConfig>;
 type SnapMeta = SnapshotMetaOf<TypeConfig>;
@@ -455,15 +455,59 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                     core.last_applied = Some(log_id);
                     HighWaterApplied {
                         value: core.current_value,
+                        outcome: ApplyOutcome::Advanced,
                     }
                 }
-                EntryPayload::Normal(cmd) => {
-                    let HighWaterCommand::Advance(advance) = cmd;
+                EntryPayload::Normal(HighWaterCommand::Advance(advance)) => {
                     let mut core = self.core.lock();
                     core.current_value = advance.merge(core.current_value);
                     core.last_applied = Some(log_id);
                     HighWaterApplied {
                         value: core.current_value,
+                        outcome: ApplyOutcome::Advanced,
+                    }
+                }
+                EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                    SetFormatVersionPayload {
+                        target,
+                        gated_members,
+                    },
+                )) => {
+                    let target = *target;
+                    // Evaluate the subset against the membership committed as
+                    // of this entry's log position. Apply folds the log in
+                    // index order, so `core.last_membership` is exactly that
+                    // membership (a `Membership` entry at a lower index has
+                    // already updated it; a later one has not). Cover BOTH
+                    // voters and learners: openraft replicates/snapshots
+                    // learners, so an un-gated learner must force a no-op.
+                    let mut core = self.core.lock();
+                    let committed_members: std::collections::BTreeSet<u64> = core
+                        .last_membership
+                        .membership()
+                        .nodes()
+                        .map(|(node_id, _node)| *node_id)
+                        .collect();
+                    let outcome = if committed_members.is_subset(gated_members) {
+                        // Successful (non-no-op) apply: set the
+                        // process-shared active-write-version cell. NO meta
+                        // write — durability is the raft log (deterministic
+                        // replay re-runs this exact check) plus the snapshot
+                        // frame byte.
+                        self.active_write_version.set(target);
+                        ApplyOutcome::FormatActivated { target }
+                    } else {
+                        // Membership grew an un-gated member between the gate
+                        // and this entry's position. Leave the cell
+                        // untouched; the operator re-gates and re-issues. A
+                        // no-op writes nothing at `target`, so it cannot
+                        // resurrect on restart.
+                        ApplyOutcome::FormatActivationNoop { target }
+                    };
+                    core.last_applied = Some(log_id);
+                    HighWaterApplied {
+                        value: core.current_value,
+                        outcome,
                     }
                 }
                 EntryPayload::Membership(membership) => {
@@ -472,6 +516,7 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                     core.last_applied = Some(log_id);
                     HighWaterApplied {
                         value: core.current_value,
+                        outcome: ApplyOutcome::Advanced,
                     }
                 }
             };
@@ -681,6 +726,251 @@ mod tests {
         assert_eq!(sm.current_value().await, 42);
         let (last, _) = sm.applied_state().await.unwrap();
         assert_eq!(last.map(|l| l.index), Some(2));
+    }
+
+    // ---- SetFormatVersion apply tests ----
+    //
+    // The apply path keys the flip off a successful (non-no-op) apply: the
+    // subset check `committed_members ⊆ gated_members` runs against
+    // `core.last_membership` evaluated at the bump's own log position (apply
+    // folds the log in index order). On a hit the shared cell is set; on a
+    // miss the cell is untouched and a no-op outcome is returned. Direct
+    // cell observation is sufficient since `SetFormatVersionPayload`'s effect
+    // is exactly "did the cell move?"; we don't need to capture the
+    // ApplyOutcome through the responder channel for these checks.
+
+    /// A membership whose voter config is `voters`, as a `Membership` payload.
+    /// The concrete `Membership<NID, N>` type is inferred from the call site
+    /// (e.g. `EntryPayload::Membership(...)` infers it for `TypeConfig`).
+    fn voters_membership(
+        voters: &[u64],
+    ) -> openraft::Membership<u64, crate::type_config::OpenraftPeer> {
+        openraft::Membership::new_with_defaults(
+            vec![voters.iter().copied().collect::<BTreeSet<u64>>()],
+            voters.to_vec(),
+        )
+    }
+
+    #[tokio::test]
+    async fn set_format_version_subset_match_sets_cell() {
+        let mut sm = HighWaterStateMachine::new();
+        // Establish membership {1, 2} at index 1.
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Membership(voters_membership(&[1, 2])),
+        )
+        .await;
+        // Bump gated on a superset of the committed membership → subset holds.
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target: 7,
+                    gated_members: BTreeSet::from([1u64, 2u64, 3u64]),
+                },
+            )),
+        )
+        .await;
+        assert_eq!(
+            sm.active_write_version(),
+            7,
+            "cell set on successful subset apply"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_format_version_membership_not_subset_is_noop() {
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.active_write_version();
+        // Membership {1, 2, 9} at index 1; the gate only covered {1, 2}.
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Membership(voters_membership(&[1, 2, 9])),
+        )
+        .await;
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target: 7,
+                    gated_members: BTreeSet::from([1u64, 2u64]),
+                },
+            )),
+        )
+        .await;
+        assert_eq!(
+            sm.active_write_version(),
+            before,
+            "no-op must leave the shared cell untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_format_version_covers_learners_not_only_voters() {
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.active_write_version();
+        // Voter {1}, learner {2}. `new_with_defaults(voter_groups, all_ids)`
+        // treats node ids in `all_ids` but absent from `voter_groups` as
+        // learners. A voter-only gate `{1}` must NOT satisfy the subset —
+        // the learner is a current member and openraft replicates to it,
+        // so an un-gated learner forces a no-op.
+        let membership =
+            openraft::Membership::new_with_defaults(vec![BTreeSet::from([1u64])], [1u64, 2u64]);
+        apply_one(&mut sm, 1, EntryPayload::Membership(membership)).await;
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target: 7,
+                    gated_members: BTreeSet::from([1u64]),
+                },
+            )),
+        )
+        .await;
+        assert_eq!(
+            sm.active_write_version(),
+            before,
+            "un-gated learner must force a no-op"
+        );
+    }
+
+    // ---- Replay / recovery confirmation tests ----
+    //
+    // These model openraft's deterministic recovery: a fresh state machine
+    // (fresh BASELINE-seeded cell) re-applies the committed log in index
+    // order, so the SetFormatVersion subset check re-runs per entry. A
+    // no-op replays as a no-op (no record was ever written at the higher
+    // version); a success re-establishes the cell.
+
+    #[derive(Clone)]
+    enum ReplayEntry {
+        Membership(Vec<u64>),
+        Bump { target: u8, gated: Vec<u64> },
+    }
+
+    async fn replay(sm: &mut HighWaterStateMachine, log: &[(u64, ReplayEntry)]) {
+        for (index, kind) in log {
+            let payload = match kind {
+                ReplayEntry::Membership(voters) => {
+                    EntryPayload::Membership(voters_membership(voters))
+                }
+                ReplayEntry::Bump { target, gated } => EntryPayload::Normal(
+                    HighWaterCommand::SetFormatVersion(SetFormatVersionPayload {
+                        target: *target,
+                        gated_members: gated.iter().copied().collect(),
+                    }),
+                ),
+            };
+            apply_one(sm, *index, payload).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_activation_survives_replay() {
+        let log = vec![
+            (1u64, ReplayEntry::Membership(vec![1, 2])),
+            (
+                2u64,
+                ReplayEntry::Bump {
+                    target: 7,
+                    gated: vec![1, 2, 3],
+                },
+            ),
+        ];
+        // Live apply sets the cell.
+        let mut live = HighWaterStateMachine::new();
+        replay(&mut live, &log).await;
+        assert_eq!(live.active_write_version(), 7);
+
+        // "Restart": a fresh SM with a fresh BASELINE-seeded cell, replaying
+        // the same committed log, re-establishes target via the re-run
+        // subset check. NO meta key consulted.
+        let mut recovered = HighWaterStateMachine::new();
+        assert_ne!(
+            recovered.active_write_version(),
+            7,
+            "fresh cell starts at baseline"
+        );
+        replay(&mut recovered, &log).await;
+        assert_eq!(
+            recovered.active_write_version(),
+            7,
+            "replay re-applies the flip"
+        );
+    }
+
+    #[tokio::test]
+    async fn noop_bump_never_advances_across_restart() {
+        let log = vec![
+            // Membership has an un-gated member 9; the gate only covered {1, 2}.
+            (1u64, ReplayEntry::Membership(vec![1, 2, 9])),
+            (
+                2u64,
+                ReplayEntry::Bump {
+                    target: 7,
+                    gated: vec![1, 2],
+                },
+            ),
+        ];
+        let mut live = HighWaterStateMachine::new();
+        let baseline = live.active_write_version();
+        replay(&mut live, &log).await;
+        assert_eq!(
+            live.active_write_version(),
+            baseline,
+            "no-op leaves the cell"
+        );
+
+        // Restart: replay the same log; the no-op replays as a no-op (the
+        // subset check fails identically), so the cell stays at baseline.
+        // The committed entry's mere presence never advances the version.
+        let mut recovered = HighWaterStateMachine::new();
+        replay(&mut recovered, &log).await;
+        assert_eq!(
+            recovered.active_write_version(),
+            baseline,
+            "a no-op'd bump cannot resurrect on restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_is_deterministic() {
+        let log = vec![
+            (1u64, ReplayEntry::Membership(vec![1, 2])),
+            (
+                2u64,
+                ReplayEntry::Bump {
+                    target: 7,
+                    gated: vec![1, 2, 3],
+                },
+            ),
+            // A later bump gated on a set that excludes a now-added member.
+            (3u64, ReplayEntry::Membership(vec![1, 2, 5])),
+            (
+                4u64,
+                ReplayEntry::Bump {
+                    target: 8,
+                    gated: vec![1, 2],
+                },
+            ),
+        ];
+        let mut first = HighWaterStateMachine::new();
+        replay(&mut first, &log).await;
+        let mut second = HighWaterStateMachine::new();
+        replay(&mut second, &log).await;
+        // Index-2 bump succeeded (membership {1,2} ⊆ {1,2,3}); index-4 bump
+        // no-ops (membership {1,2,5} ⊄ {1,2}), so the cell stays at 7.
+        assert_eq!(first.active_write_version(), 7);
+        assert_eq!(
+            first.active_write_version(),
+            second.active_write_version(),
+            "two replays of the same committed log yield the same cell"
+        );
     }
 
     // ---- Snapshot tests ----

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -76,15 +76,44 @@ impl ServiceEndpoint for OpenraftPeer {
     }
 }
 
+/// What an applied entry did, beyond moving the high-water value.
+///
+/// Returned on every [`HighWaterApplied`] so the proposer's `client_write`
+/// response proves the apply's semantic outcome — specifically whether a
+/// [`crate::log_entry::SetFormatVersionPayload`] bump took effect or applied
+/// as a membership-subset no-op. A bare `Ok` from `client_write` proves the
+/// entry committed and applied, but not that the subset check passed; the
+/// leader's activation flip is keyed off observing
+/// [`ApplyOutcome::FormatActivated`] here — apply-keyed, never commit-keyed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApplyOutcome {
+    /// A `Blank`, `Advance`, or `Membership` entry (the active write version
+    /// is untouched).
+    Advanced,
+    /// A `SetFormatVersion` bump applied successfully: the membership at the
+    /// entry's log position was a subset of the gated set, so the shared
+    /// active-write-version cell was set to `target`. NO meta key was written.
+    FormatActivated { target: u8 },
+    /// A `SetFormatVersion` bump applied as a no-op: the membership at the
+    /// entry's log position was NOT a subset of the gated set, so the shared
+    /// cell was left untouched and `target` did not take effect. The operator
+    /// re-gates and re-issues.
+    FormatActivationNoop { target: u8 },
+}
+
 /// Per-entry apply result.
 ///
 /// Returned by the state machine for each replicated entry. The driver reads
 /// `value` from the `client_write` response to confirm the committed value
-/// observed by the apply pipeline.
+/// observed by the apply pipeline; `outcome` proves which apply path ran
+/// (specifically, whether a [`crate::log_entry::HighWaterCommand::SetFormatVersion`]
+/// bump took effect or applied as a no-op).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HighWaterApplied {
     /// The high-water value after this entry's apply.
     pub value: u64,
+    /// The semantic outcome of this entry's apply (see [`ApplyOutcome`]).
+    pub outcome: ApplyOutcome,
 }
 
 declare_raft_types_ext! {
@@ -187,7 +216,10 @@ mod tests {
 
     #[test]
     fn high_water_applied_round_trips() {
-        let applied = HighWaterApplied { value: 12_345 };
+        let applied = HighWaterApplied {
+            value: 12_345,
+            outcome: ApplyOutcome::Advanced,
+        };
         let bytes = postcard::to_stdvec(&applied).expect("serialize");
         let back: HighWaterApplied = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, applied);
@@ -196,11 +228,46 @@ mod tests {
     #[test]
     fn high_water_applied_round_trips_zero_and_max() {
         for v in [0u64, u64::MAX] {
-            let applied = HighWaterApplied { value: v };
+            let applied = HighWaterApplied {
+                value: v,
+                outcome: ApplyOutcome::Advanced,
+            };
             let bytes = postcard::to_stdvec(&applied).expect("serialize");
             let back: HighWaterApplied = postcard::from_bytes(&bytes).expect("deserialize");
             assert_eq!(back, applied);
         }
+    }
+
+    #[test]
+    fn apply_outcome_variants_round_trip() {
+        for outcome in [
+            ApplyOutcome::Advanced,
+            ApplyOutcome::FormatActivated { target: 4 },
+            ApplyOutcome::FormatActivationNoop { target: 4 },
+        ] {
+            let applied = HighWaterApplied {
+                value: 42,
+                outcome: outcome.clone(),
+            };
+            let bytes = postcard::to_stdvec(&applied).expect("serialize");
+            let back: HighWaterApplied = postcard::from_bytes(&bytes).expect("deserialize");
+            assert_eq!(back, applied);
+        }
+    }
+
+    #[test]
+    fn apply_outcome_distinguishes_success_from_noop() {
+        let success = ApplyOutcome::FormatActivated { target: 5 };
+        let noop = ApplyOutcome::FormatActivationNoop { target: 5 };
+        assert_ne!(success, noop);
+        assert!(matches!(
+            success,
+            ApplyOutcome::FormatActivated { target: 5 }
+        ));
+        assert!(matches!(
+            noop,
+            ApplyOutcome::FormatActivationNoop { target: 5 }
+        ));
     }
 
     #[test]

--- a/crates/tsoracle-driver-openraft/tests/activation_gate.rs
+++ b/crates/tsoracle-driver-openraft/tests/activation_gate.rs
@@ -123,15 +123,19 @@ async fn gate_fails_when_target_above_local_max() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn initiate_format_activation_runs_gate_and_returns_ok_for_now() {
+async fn initiate_format_activation_proposes_and_observes_flip() {
     let (host, _cluster) = single_node_leader_host().await;
+    let target = tsoracle_openraft_toolkit::MAX_READABLE_VERSION;
     // The all-members gate against the only voter (local short-circuit)
-    // passes; the body between the gate and Ok(()) is a later phase's
-    // proposal step.
-    host.initiate_format_activation(
-        tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
-        &UnusedSource,
-    )
-    .await
-    .expect("a passing gate returns Ok in this phase");
+    // passes; the propose step writes `SetFormatVersion` through the raft;
+    // apply re-validates the subset at the entry's log position and (since
+    // committed_members = {1} ⊆ gated_members = {1}) sets the shared cell.
+    // The classifier maps the returned `FormatActivated` outcome to `Ok(())`.
+    host.initiate_format_activation(target, &UnusedSource)
+        .await
+        .expect("a passing gate followed by a successful apply returns Ok");
+    // Verify the apply-keyed flip actually happened: the shared cell now
+    // reads `target` (this is the seam the leader observes through the
+    // `client_write` response).
+    assert_eq!(host.active_write_version(), target);
 }

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -259,6 +259,19 @@ impl RaftStateMachine<HostTypeConfig> for HostStateMachine {
                         tso: Some(core.high_water),
                     }
                 }
+                EntryPayload::Normal(HostCommand::Tso(HighWaterCommand::SetFormatVersion(_))) => {
+                    // The piggyback example does not own an active-write-version
+                    // cell of its own — the format activation barrier is a no-op
+                    // here. A real piggyback host that cares about the format
+                    // version would forward this entry to its embedded
+                    // `HighWaterStateMachine`'s apply.
+                    let mut core = self.core.lock();
+                    core.last_applied = Some(log_id);
+                    HostApplied {
+                        kv: None,
+                        tso: Some(core.high_water),
+                    }
+                }
                 EntryPayload::Membership(membership) => {
                     let mut core = self.core.lock();
                     core.last_membership = StoredMembership::new(Some(log_id), membership.clone());


### PR DESCRIPTION
## Summary

- Adds `HighWaterCommand::SetFormatVersion(SetFormatVersionPayload { target: u8, gated_members: BTreeSet<u64> })` — the committed activation barrier carrying the exact member set the leader's gate observed at proposal time.
- Adds `ApplyOutcome { Advanced, FormatActivated { target }, FormatActivationNoop { target } }` and a new `outcome: ApplyOutcome` field on `HighWaterApplied` so the leader can prove from the `client_write` response whether the apply was a non-no-op success.
- The state-machine apply arm reads `core.last_membership.membership().nodes()` (voters AND learners, evaluated at the bump's own log position since apply folds the log in index order), checks `committed_members ⊆ gated_members`, and **only on a subset hit** sets the process-shared `ActiveWriteVersion` cell to `target`. A no-op leaves the cell untouched and returns `FormatActivationNoop`.
- `StandaloneHost::initiate_format_activation(target, source)` (gate-only before this PR) now (1) runs the all-members gate, (2) proposes `SetFormatVersion { target, gated_members }` via `raft.client_write`, (3) classifies the returned outcome. Returns `Ok(())` iff the apply reported `FormatActivated { target }`; a `FormatActivationNoop` surfaces as `FormatActivationError::MembershipChangedSinceGate { target }`; a `client_write` failure surfaces as `FormatActivationError::ProposalFailed(...)`.

**No meta key is written or read anywhere.** Durability rides the raft log (deterministic replay re-runs the subset check) plus the snapshot's leading frame byte. The state machine reaches storage only through its `SnapshotStore`, which is exactly why the meta-key design was retired in favour of the apply-keyed flip against the shared `ActiveWriteVersion` cell.

## Test plan

- [x] `cargo build --workspace --all-features` is clean
- [x] `cargo test --workspace --all-features` passes — 3 new `log_entry::tests`, 2 new `type_config::tests`, 6 new `state_machine::tests` (3 apply-arm: subset match / no-op / learner coverage + 3 replay: success-survives-replay / no-op-never-resurrects / replay-is-deterministic), 5 new `standalone::tests::classify_*`, and the updated integration `initiate_format_activation_proposes_and_observes_flip` (asserts the shared cell flipped after a passing single-node gate)
- [x] `cargo clippy --workspace --all-features -- -D warnings` is clean
- [x] `rg -n 'MetaLabel::ActiveWriteVersion|active_write_version_meta|put_active_write_version' crates/` returns zero matches — confirm no meta-CF key is introduced for the active write version
- [x] `rg -n 'set_format_version|SetFormatVersion' crates/tsoracle-driver-openraft/src/state_machine.rs` shows the subset check, the conditional `self.active_write_version.set(target)`, and the `ApplyOutcome::FormatActivated` return — the apply-keyed flip is centralised in one arm
- [x] No new RPC, listener, or CLI surface is added — the operator trigger remains the interim library method `StandaloneHost::initiate_format_activation`