### PR TITLE
feat(driver-openraft): joiner gate and migration-on-next-write tests

### DIFF
--- a/crates/tsoracle-driver-openraft/src/capabilities.rs
+++ b/crates/tsoracle-driver-openraft/src/capabilities.rs
@@ -244,6 +244,31 @@ mod tests {
     }
 
     #[test]
+    fn existing_incompatible_learner_blocks_activation_via_all_members_gate() {
+        // An existing incompatible learner blocks activation until
+        // remediated. There is NO separate "existing-learner block" code
+        // path: the all-members gate already covers learners (the leader
+        // gathers capabilities from voters AND learners read from
+        // `raft.metrics().borrow_watched().membership_config.nodes()`, then
+        // runs this predicate). The toolkit's `learner_meets_active_write_version`
+        // (the joiner gate) refuses NEW learners on admission; this
+        // predicate refuses an activation when an already-admitted member
+        // (voter or learner) cannot read the target. The two together
+        // cover spec §12's joiner-gate and existing-learner-block
+        // requirements without duplicate enforcement.
+        let target = 4u8;
+        let capable_voter = caps(3, 4);
+        let incompatible_learner = caps(3, 3); // max_readable_version < target
+        let reports = vec![(1u64, capable_voter), (2u64, incompatible_learner)];
+        assert_eq!(
+            all_members_can_read(target, &reports),
+            None,
+            "an incompatible already-admitted member (here a learner) must \
+             fail the all-members gate, blocking activation until remediated"
+        );
+    }
+
+    #[test]
     fn gate_on_empty_membership_is_vacuously_satisfied_with_empty_set() {
         // No members → no member can fail the predicate → Some(empty). A real
         // cluster always has at least the local node, but the predicate itself

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -973,6 +973,201 @@ mod tests {
         );
     }
 
+    // ---- Snapshot active-write-version stamping (format migration) ----
+    //
+    // These tests pin the contract that the snapshot builder reads the
+    // node's CURRENT active write version (the shared cell) at build time,
+    // rather than a hard-coded constant. Today that is BASELINE_WRITE_VERSION
+    // since no activation has flipped the cell; the assertions are written
+    // against the accessor (`sm.active_write_version()`) so they remain
+    // correct after a real activation moves the cell forward and the next
+    // build emits at the new version.
+
+    #[tokio::test]
+    async fn build_snapshot_stamps_active_write_version() {
+        // The persisted envelope's leading version byte must equal what the
+        // accessor reports — not a literal. This proves the plumbing is
+        // active-version-driven and would catch a regression to a constant.
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        let mut sm = HighWaterStateMachine::with_store(store.clone()).expect("with_store");
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 321 })),
+        )
+        .await;
+
+        let active = sm.active_write_version();
+        sm.build_snapshot().await.expect("build_snapshot");
+
+        let envelope_bytes = store.load().expect("load").expect("snapshot present");
+        assert_eq!(
+            envelope_bytes[0], active,
+            "envelope leading version byte must equal the active write version"
+        );
+
+        // The inner payload blob is the on-disk record openraft replays from
+        // on snapshot install; it must be stamped at the active version too
+        // so a follower receiving it can decode against its own version
+        // window.
+        let persisted: PersistedSnapshot = tsoracle_codec::decode_framed(
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            &envelope_bytes,
+        )
+        .expect("decode envelope");
+        assert_eq!(
+            persisted.data[0], active,
+            "inner snapshot payload leading version byte must equal the active write version"
+        );
+    }
+
+    #[tokio::test]
+    async fn old_version_snapshot_is_read_and_reemitted_at_active_version() {
+        // Migration-on-next-write: a snapshot persisted at version V is
+        // readable across the multi-version codec and the next
+        // build_snapshot re-emits at the cluster's ACTIVE write version.
+        //
+        // HONESTY: MIN==MAX==BASELINE today, so there is no genuine lower
+        // production version. This exercises the seam end-to-end at the
+        // only version that exists; the genuine cross-version rewrite
+        // (install vN, flip to vN+1, assert rebuild is vN+1) is the
+        // structural extension a real vN+1 work would make by
+        // parameterizing the installed version.
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+
+        // Persist a snapshot via a first SM instance, then drop it.
+        {
+            let mut writer = HighWaterStateMachine::with_store(store.clone()).expect("writer SM");
+            apply_one(
+                &mut writer,
+                3,
+                EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 777 })),
+            )
+            .await;
+            writer
+                .build_snapshot()
+                .await
+                .expect("build initial snapshot");
+        }
+
+        // Reopen: the recovery path decodes across the readable range and
+        // restores state.
+        let mut sm = HighWaterStateMachine::with_store(store.clone()).expect("reopened SM");
+        assert_eq!(
+            sm.current_value().await,
+            777,
+            "recovered value across reopen"
+        );
+
+        // The next build re-emits at the active write version.
+        let active = sm.active_write_version();
+        apply_one(
+            &mut sm,
+            4,
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 888 })),
+        )
+        .await;
+        sm.build_snapshot().await.expect("rebuild snapshot");
+
+        let rebuilt = store.load().expect("load").expect("snapshot present");
+        assert_eq!(
+            rebuilt[0], active,
+            "rebuilt snapshot must be emitted at the active write version"
+        );
+        let payload: PersistedSnapshot = tsoracle_codec::decode_framed(
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            &rebuilt,
+        )
+        .expect("decode rebuilt envelope");
+        assert_eq!(payload.meta.last_log_id.map(|l| l.index), Some(4));
+    }
+
+    #[test]
+    fn snapshot_codec_accepts_full_readable_range() {
+        // The migration-seam invariant in isolation: the snapshot decoder
+        // must accept any version in [MIN_READABLE_VERSION,
+        // MAX_READABLE_VERSION] and reject anything outside it. This is
+        // what makes an OLD-version on-disk snapshot readable after the
+        // active version moves forward. Asserted against the codec range
+        // directly so it documents the contract even while MIN==MAX today.
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 5,
+            last_applied: Some(log_id(2)),
+            last_membership: StoredMem::default(),
+        };
+        for version in tsoracle_openraft_toolkit::MIN_READABLE_VERSION
+            ..=tsoracle_openraft_toolkit::MAX_READABLE_VERSION
+        {
+            let framed = tsoracle_codec::encode_framed(version, &payload).expect("encode in range");
+            let decoded: HighWaterStateMachineSnapshot = tsoracle_codec::decode_framed(
+                tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+                tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+                &framed,
+            )
+            .expect("decode in range");
+            assert_eq!(decoded, payload);
+        }
+
+        // One past the readable max must be rejected loudly.
+        let above = tsoracle_openraft_toolkit::MAX_READABLE_VERSION.saturating_add(1);
+        let mut framed_above = vec![above];
+        framed_above.extend_from_slice(&tsoracle_codec::encode_postcard(&payload).expect("body"));
+        assert!(
+            tsoracle_codec::decode_framed::<HighWaterStateMachineSnapshot>(
+                tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+                tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+                &framed_above,
+            )
+            .is_err(),
+            "a version above the readable max must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_write_version_survives_reopen_and_drives_writes() {
+        // The durable active write version is recovered on reopen and is
+        // the version stamped onto snapshot writes. On `main` the recovered
+        // value is BASELINE because no activation has flipped it; this
+        // test pins that (a) the accessor is stable across a reopen and
+        // (b) the snapshot write uses exactly that recovered value.
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        let recovered_active;
+        {
+            let mut sm = HighWaterStateMachine::with_store(store.clone()).expect("first SM");
+            apply_one(
+                &mut sm,
+                1,
+                EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 55 })),
+            )
+            .await;
+            sm.build_snapshot().await.expect("build_snapshot");
+            recovered_active = sm.active_write_version();
+        }
+
+        let mut reopened = HighWaterStateMachine::with_store(store.clone()).expect("reopened SM");
+        assert_eq!(
+            reopened.active_write_version(),
+            recovered_active,
+            "active write version must be stable across reopen"
+        );
+
+        apply_one(
+            &mut reopened,
+            2,
+            EntryPayload::Normal(HighWaterCommand::Advance(AdvancePayload { at_least: 66 })),
+        )
+        .await;
+        reopened.build_snapshot().await.expect("rebuild");
+        let bytes = store.load().expect("load").expect("snapshot present");
+        assert_eq!(
+            bytes[0],
+            reopened.active_write_version(),
+            "rebuilt snapshot stamped with the recovered active write version"
+        );
+    }
+
     // ---- Snapshot tests ----
 
     #[tokio::test]

--- a/crates/tsoracle-openraft-toolkit/src/lib.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lib.rs
@@ -45,8 +45,9 @@ pub use codec::{
 };
 pub use codec_provider::{DefaultLogStoreCodec, LogStoreCodec};
 pub use lifecycle::{
-    BootstrapError, BootstrapMode, LeadershipState, MembershipError, add_learner, bootstrap,
-    change_membership, join, leadership_events, leadership_events_from_metrics,
+    BootstrapError, BootstrapMode, GatedAdmissionError, JoinerGateError, LeadershipState,
+    MembershipError, add_learner, add_learner_gated, bootstrap, change_membership, join,
+    leadership_events, leadership_events_from_metrics, learner_meets_active_write_version,
 };
 
 #[cfg(feature = "rocksdb-log-store")]

--- a/crates/tsoracle-openraft-toolkit/src/lifecycle/membership.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lifecycle/membership.rs
@@ -131,3 +131,142 @@ where
         Err(e) => Err(MembershipError::Other(e.to_string())),
     }
 }
+
+/// Why a learner-admission capability pre-check refused a candidate.
+///
+/// LATENT: nothing in this crate currently calls [`add_learner_gated`]; the
+/// guard is a pure predicate ready for a future admit-path consumer (the
+/// dynamic-membership admin already calls `Raft::add_learner` directly and
+/// would need to be re-routed through [`add_learner_gated`] to take effect).
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum JoinerGateError {
+    /// The candidate cannot read the cluster's active write version, so it
+    /// must not be admitted as a learner: openraft replicates and
+    /// snapshot-installs a learner before promotion, and those bytes are at
+    /// the active write version. Admitting it would either strand the
+    /// candidate or block a later activation behind an incompatible member.
+    #[error(
+        "candidate cannot read the cluster active write version: \
+         candidate max_readable_version={candidate_max_readable_version}, \
+         active_write_version={active_write_version}"
+    )]
+    IncompatibleCandidate {
+        candidate_max_readable_version: u8,
+        active_write_version: u8,
+    },
+}
+
+/// Capability pre-check for learner admission.
+///
+/// Returns `Ok(())` when the candidate's `candidate_max_readable_version` is
+/// at or above the cluster's `active_write_version`; otherwise
+/// [`JoinerGateError::IncompatibleCandidate`]. Pure and driver-agnostic on
+/// purpose: the caller projects the candidate's capability struct (e.g. the
+/// driver's `NodeCapabilities.max_readable_version`) and the leader's active
+/// write version into the two `u8` arguments, so the toolkit does not
+/// depend on the driver's capability type.
+pub fn learner_meets_active_write_version(
+    candidate_max_readable_version: u8,
+    active_write_version: u8,
+) -> Result<(), JoinerGateError> {
+    if candidate_max_readable_version < active_write_version {
+        return Err(JoinerGateError::IncompatibleCandidate {
+            candidate_max_readable_version,
+            active_write_version,
+        });
+    }
+    Ok(())
+}
+
+/// Failure of [`add_learner_gated`]: either the joiner gate refused the
+/// candidate (no raft call made) or the underlying [`add_learner`] failed.
+#[derive(Debug, Error)]
+pub enum GatedAdmissionError {
+    /// The joiner-gate capability pre-check refused the candidate; no raft
+    /// membership change was attempted.
+    #[error(transparent)]
+    Gate(#[from] JoinerGateError),
+    /// The capability check passed but the raft `add_learner` call failed.
+    #[error(transparent)]
+    Membership(#[from] MembershipError),
+}
+
+/// Capability-gated learner admission.
+///
+/// Runs [`learner_meets_active_write_version`] against the candidate's
+/// `candidate_max_readable_version` and the cluster's `active_write_version`
+/// FIRST; only if it passes does it delegate to [`add_learner`]. An admit
+/// path that routes through this entry point refuses an incompatible
+/// candidate before any replication or snapshot transfer is initiated.
+///
+/// LATENT: the existing admin path on this branch calls
+/// `Raft::add_learner` directly, not the toolkit `add_learner`. This
+/// wrapper is the seam a future admit caller can switch to.
+pub async fn add_learner_gated<C, SM>(
+    raft: &Raft<C, SM>,
+    id: C::NodeId,
+    node: C::Node,
+    blocking: bool,
+    candidate_max_readable_version: u8,
+    active_write_version: u8,
+) -> Result<(), GatedAdmissionError>
+where
+    C: RaftTypeConfig,
+    SM: RaftStateMachine<C>,
+{
+    learner_meets_active_write_version(candidate_max_readable_version, active_write_version)?;
+    add_learner(raft, id, node, blocking).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod joiner_gate_tests {
+    use super::*;
+
+    #[test]
+    fn admits_when_candidate_can_read_active_version() {
+        // max_readable >= active => admitted.
+        assert!(learner_meets_active_write_version(3, 3).is_ok());
+        assert!(learner_meets_active_write_version(4, 3).is_ok());
+    }
+
+    #[test]
+    fn refuses_when_candidate_below_active_version() {
+        // Refuse a learner whose max_readable_version is below the cluster's
+        // active write version — replication / snapshot transfer would hand
+        // it bytes it cannot decode.
+        let err = learner_meets_active_write_version(3, 4)
+            .expect_err("a candidate that cannot read the active version must be refused");
+        let JoinerGateError::IncompatibleCandidate {
+            candidate_max_readable_version,
+            active_write_version,
+        } = err;
+        assert_eq!(candidate_max_readable_version, 3);
+        assert_eq!(active_write_version, 4);
+    }
+
+    #[test]
+    fn refusal_message_is_actionable() {
+        let err = learner_meets_active_write_version(2, 5).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains('2'), "names the candidate capability");
+        assert!(message.contains('5'), "names the active write version");
+    }
+
+    #[test]
+    fn gated_admission_error_unifies_gate_and_membership_failures() {
+        // `add_learner_gated` can fail either because the joiner gate
+        // refused the candidate (before touching raft) or because the
+        // underlying `add_learner` raft call failed. `GatedAdmissionError`
+        // must carry both via `#[from]`.
+        let gate: GatedAdmissionError = JoinerGateError::IncompatibleCandidate {
+            candidate_max_readable_version: 3,
+            active_write_version: 4,
+        }
+        .into();
+        assert!(matches!(gate, GatedAdmissionError::Gate(_)));
+
+        let membership: GatedAdmissionError = MembershipError::NotLeader { leader: None }.into();
+        assert!(matches!(membership, GatedAdmissionError::Membership(_)));
+    }
+}

--- a/crates/tsoracle-openraft-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lifecycle/mod.rs
@@ -29,4 +29,7 @@ pub mod membership;
 
 pub use bootstrap::{BootstrapError, BootstrapMode, bootstrap, join};
 pub use leader::{LeadershipState, leadership_events, leadership_events_from_metrics};
-pub use membership::{MembershipError, add_learner, change_membership};
+pub use membership::{
+    GatedAdmissionError, JoinerGateError, MembershipError, add_learner, add_learner_gated,
+    change_membership, learner_meets_active_write_version,
+};


### PR DESCRIPTION
## Summary

- **Migration-on-next-write pin tests** in `state_machine.rs`: 4 new tests asserting that `build_snapshot` stamps `sm.active_write_version()` rather than a constant (`build_snapshot_stamps_active_write_version`), that a recovered snapshot is decoded across `[MIN, MAX]` and the next build re-emits at the current active version (`old_version_snapshot_is_read_and_reemitted_at_active_version`), that the codec accepts the full readable range and rejects `MAX + 1` loudly (`snapshot_codec_accepts_full_readable_range`), and that the durable active version is stable across reopen and drives the next build (`active_write_version_survives_reopen_and_drives_writes`). The earlier phases already routed the snapshot encoder through the active version — these tests pin against regression to a literal.
- **Joiner gate** in `tsoracle-openraft-toolkit/src/lifecycle/membership.rs`: a pure capability pre-check `learner_meets_active_write_version(candidate_max_readable_version: u8, active_write_version: u8) -> Result<(), JoinerGateError>` plus a thin enforcement wrapper `add_learner_gated(...)` that runs the guard then delegates to `add_learner`. `JoinerGateError::IncompatibleCandidate { ... }` carries the offending values; `GatedAdmissionError::{Gate, Membership}` unifies the two failure families via `#[from]`. Driver-agnostic on purpose (`u8` arguments, not `NodeCapabilities`).
- **Existing-incompatible-learner block cross-reference** in `capabilities.rs`: a test (`existing_incompatible_learner_blocks_activation_via_all_members_gate`) pinning that the all-members gate already enforces this — voters AND learners are read from `raft.metrics().borrow_watched().membership_config.nodes()`, so the gate fails activation when any current member (voter or learner) cannot read the target. No duplicate enforcement is added here.

**Latency notice.** The joiner gate is implemented and unit-tested but unreachable from a live admit path on the current branch: the admin's \`add_learner\` calls \`Raft::add_learner\` directly, not the toolkit's \`add_learner\`. A future admit caller that routes through \`add_learner_gated\` turns the guard into a live refusal of incompatible candidates. This is documented on every new public item.

## Test plan

- [ ] \`cargo build --workspace --all-features\` is clean
- [ ] \`cargo test --workspace --all-features\` passes: 4 new \`state_machine::tests\` (migration-on-next-write pins), 4 new \`lifecycle::membership::joiner_gate_tests\`, 1 new \`capabilities::tests\` (cross-ref). The wrapper's live-raft delegation arm is unit-tested via its error-unification test; downstream integration tests will exercise it end-to-end when an admit path adopts the wrapper.
- [ ] \`cargo clippy --workspace --all-features -- -D warnings\` is clean
- [ ] \`rg -n 'add_learner_gated|learner_meets_active_write_version' crates/tsoracle-openraft-toolkit/src/lib.rs crates/tsoracle-openraft-toolkit/src/lifecycle/mod.rs\` confirms both items are re-exported at the same level as \`add_learner\`
- [ ] \`rg -n 'all_members_can_read' crates/tsoracle-driver-openraft/src/capabilities.rs\` confirms the existing-learner block test runs against the existing P4 predicate, not a new duplicate