### PR TITLE
ci(release-images): per-arch matrix; file + openraft; manual dispatch

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -4,53 +4,126 @@ on:
     tags: ['tsoracle-v*']     # the BINARY crate's release-plz tag ONLY (not per-crate library tags)
   pull_request:
     paths: ['deploy/**', 'crates/**', 'Cargo.*', '.github/workflows/release-images.yml']
+  workflow_dispatch:
+    inputs:
+      tag_suffix:
+        description: 'Throwaway suffix appended after 0.0.0- (default: test-<run_id>). Never publishes :latest.'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  build:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      v: ${{ steps.ver.outputs.v }}
+    steps:
+      - name: Resolve version
+        id: ver
+        env:
+          SUFFIX: ${{ inputs.tag_suffix }}
+          RUN_ID: ${{ github.run_id }}
+          PR_NUM: ${{ github.event.number }}
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "v=${GITHUB_REF_NAME#tsoracle-v}" >> "$GITHUB_OUTPUT"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            SUFFIX="${SUFFIX:-test-${RUN_ID}}"
+            echo "v=0.0.0-${SUFFIX}" >> "$GITHUB_OUTPUT"
+          else
+            echo "v=0.0.0-pr${PR_NUM}" >> "$GITHUB_OUTPUT"
+          fi
+
+  pr-smoke:
+    needs: version
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - name: Resolve version
-        id: ver
+      - name: Build file + openraft and smoke
         run: |
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then echo "v=${GITHUB_REF_NAME#tsoracle-v}" >> "$GITHUB_OUTPUT";
-          else echo "v=0.0.0-pr${{ github.event.number }}" >> "$GITHUB_OUTPUT"; fi
-      - name: Login to GHCR
-        if: github.ref_type == 'tag'
-        uses: docker/login-action@v3
+          docker build -f deploy/Dockerfile --build-arg FEATURES=file -t tsoracle-file:pr .
+          docker run --rm --entrypoint tsoracle tsoracle-file:pr --help | head -1
+          docker build -f deploy/Dockerfile --build-arg FEATURES=openraft -t tsoracle-openraft:pr .
+          docker run --rm --entrypoint tsoracle tsoracle-openraft:pr --help | head -1
+          curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
+          ./linux-amd64/helm lint deploy/charts/tsoracle
+          PATH="$PWD/linux-amd64:$PATH" sh deploy/charts/tsoracle/tests/render.sh
+
+  build-image:
+    needs: version
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [file, openraft]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: PR build + smoke (no push)
-        if: github.ref_type != 'tag'
+      - name: Build and push per-arch image
         run: |
-          docker build -f deploy/Dockerfile -t tsoracle:pr .
-          docker run --rm --entrypoint tsoracle tsoracle:pr --help | head -1
-          docker build -f deploy/Dockerfile --build-arg FEATURES=paxos -t tsoracle-paxos:pr .
-          curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
-          ./linux-amd64/helm lint deploy/charts/tsoracle
-          PATH="$PWD/linux-amd64:$PATH" sh deploy/charts/tsoracle/tests/render.sh
-      - name: Push images (multi-arch)
-        if: github.ref_type == 'tag'
+          V=${{ needs.version.outputs.v }}
+          docker buildx build \
+            --platform linux/${{ matrix.arch }} \
+            -f deploy/Dockerfile \
+            --build-arg FEATURES=${{ matrix.variant }} \
+            -t "ghcr.io/prisma-risk/tsoracle-${{ matrix.variant }}:${V}-${{ matrix.arch }}" \
+            --push .
+
+  manifest:
+    needs: [version, build-image]
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+    strategy:
+      matrix:
+        variant: [file, openraft]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest list
         run: |
-          V=${{ steps.ver.outputs.v }}
-          for variant in "tsoracle:" "tsoracle-file:file" "tsoracle-openraft:openraft" "tsoracle-paxos:paxos"; do
-            name="${variant%%:*}"; feats="${variant#*:}"
-            docker buildx build --platform linux/amd64,linux/arm64 -f deploy/Dockerfile \
-              ${feats:+--build-arg FEATURES=$feats} \
-              -t "ghcr.io/prisma-risk/${name}:${V}" -t "ghcr.io/prisma-risk/${name}:latest" --push .
-          done
+          V=${{ needs.version.outputs.v }}
+          IMG=ghcr.io/prisma-risk/tsoracle-${{ matrix.variant }}
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            docker buildx imagetools create \
+              -t "$IMG:$V" -t "$IMG:latest" \
+              "$IMG:$V-amd64" "$IMG:$V-arm64"
+          else
+            docker buildx imagetools create \
+              -t "$IMG:$V" \
+              "$IMG:$V-amd64" "$IMG:$V-arm64"
+          fi
+
+  chart:
+    needs: version
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
       - name: Push chart
-        if: github.ref_type == 'tag'
         run: |
-          V=${{ steps.ver.outputs.v }}
+          V=${{ needs.version.outputs.v }}
           curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
           ./linux-amd64/helm package deploy/charts/tsoracle --version "$V" --app-version "$V"
           echo "${{ secrets.GITHUB_TOKEN }}" | ./linux-amd64/helm registry login ghcr.io -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
## Summary

- Replace QEMU-emulated multi-arch buildx with a variant x arch matrix on native runners (ubuntu-latest, ubuntu-24.04-arm), fanning into a per-variant manifest list via `docker buildx imagetools create`.
- Narrow published images to `tsoracle-file` and `tsoracle-openraft`; drop the fat `tsoracle:` and `tsoracle-paxos:` variants from both push and PR smoke.
- Add `workflow_dispatch` with an optional `tag_suffix` input so the matrix + manifest path can be exercised without cutting a real release tag; dispatch publishes `0.0.0-<suffix>` only (never `:latest`, no chart push).

## Test plan

- [ ] Trigger via Actions -> release-images -> Run workflow on `ci/release-images-per-arch-matrix` with `tag_suffix` left blank; confirm the resolved version is `0.0.0-test-<run_id>`
- [ ] Confirm the four `build-image` matrix jobs land on native runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) with no QEMU step in the logs
- [ ] Confirm both `manifest` jobs publish `ghcr.io/prisma-risk/tsoracle-{file,openraft}:0.0.0-test-<run_id>` alongside the `:<V>-amd64` and `:<V>-arm64` siblings
- [ ] Verify `:latest` is NOT updated on the dispatch run, and the `chart` job is skipped
- [ ] On the next real `tsoracle-v*` tag, confirm the full publish path (per-arch + manifest with `:latest` + chart push) still works

`actionlint` clean. Pre-commit (`cargo fmt --check` + `cargo clippy`) passes.