### PR TITLE
feat(driver-openraft): format-migration observability and runbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,6 +3326,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
+ "metrics",
+ "metrics-util 0.19.1",
  "openraft",
  "parking_lot",
  "postcard",

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -20,10 +20,16 @@ default                = ["rocksdb-snapshot-store"]
 # downstream consumers that want a custom snapshot backend can opt out via
 # `default-features = false`.
 rocksdb-snapshot-store = ["dep:rocksdb"]
+# Emit format-migration observability through the `metrics` crate facade
+# (gauges for the version state, counters for the SetFormatVersion
+# lifecycle). Off by default so embedders that do not want the `metrics`
+# dependency are unaffected, matching `tsoracle-server`'s `metrics` feature.
+metrics                = ["dep:metrics"]
 
 [dependencies]
 async-trait        = { workspace = true }
 futures            = { workspace = true }
+metrics            = { workspace = true, optional = true }
 openraft           = { workspace = true }
 postcard           = { workspace = true }
 # `default-features = false` so this crate does not unilaterally pull the
@@ -48,6 +54,7 @@ tsoracle-core      = { path = "../tsoracle-core", version = "0.2.4" }
 [dev-dependencies]
 anyhow           = { workspace = true }
 tsoracle-openraft-toolkit = { path = "../tsoracle-openraft-toolkit", version = "0.2.1", features = ["rocksdb-log-store", "test-fakes"] }
+metrics-util     = { workspace = true }
 proptest         = { workspace = true }
 rocksdb          = { workspace = true }
 tempfile         = { workspace = true }

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -31,6 +31,7 @@ pub mod driver;
 pub mod host;
 pub mod log_codec;
 pub mod log_entry;
+pub mod observability;
 pub mod snapshot_store;
 pub mod standalone;
 pub mod state_machine;

--- a/crates/tsoracle-driver-openraft/src/observability.rs
+++ b/crates/tsoracle-driver-openraft/src/observability.rs
@@ -1,0 +1,178 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Format-migration observability: the metric-name constants and the emit
+//! helpers the activation path and the state-machine apply arm call. Every
+//! emission is gated behind the crate's `metrics` feature so the `metrics`
+//! dependency stays opt-in (matching `tsoracle-server`). The helpers are
+//! deliberately the single place each `tsoracle.schema.*` name is written,
+//! so the apply arm, the gate, the boot path, and the metrics test cannot
+//! drift apart on a name. When the feature is off, every helper compiles to
+//! a no-op with an identical signature.
+
+/// Gauge: the node's current durable active write version.
+pub const ACTIVE_WRITE_VERSION: &str = "tsoracle.schema.active_write_version";
+/// Gauge: the compile-time `MIN_READABLE_VERSION`.
+pub const MIN_READABLE_VERSION: &str = "tsoracle.schema.min_readable_version";
+/// Gauge: the compile-time `MAX_READABLE_VERSION`.
+pub const MAX_READABLE_VERSION: &str = "tsoracle.schema.max_readable_version";
+/// Gauge: the lowest `max_readable_version` seen across all current members
+/// at the most recent gate run (the binding constraint on activation).
+pub const MIN_MEMBER_READ_CAPABILITY: &str = "tsoracle.schema.min_member_read_capability";
+
+/// Counter: a `SetFormatVersion` entry was proposed (gate passed).
+pub const PROPOSED_TOTAL: &str = "tsoracle.schema.format_version.proposed.total";
+/// Counter: a proposed `SetFormatVersion` entry was observed committed.
+pub const COMMITTED_TOTAL: &str = "tsoracle.schema.format_version.committed.total";
+/// Counter: a `SetFormatVersion` entry applied successfully (flip occurred).
+pub const APPLIED_TOTAL: &str = "tsoracle.schema.format_version.applied.total";
+/// Counter: a `SetFormatVersion` entry applied as a no-op because the
+/// membership at its log position was not a subset of its gated set.
+pub const NOOP_MEMBERSHIP_SUBSET_TOTAL: &str =
+    "tsoracle.schema.format_version.noop_membership_subset.total";
+/// Counter: an activation attempt was rejected by the all-members gate (a
+/// member's `max_readable_version` was below the target).
+pub const REJECTED_BY_GATE_TOTAL: &str = "tsoracle.schema.format_version.rejected_by_gate.total";
+
+/// Set the active-write-version gauge. Called on a successful apply-flip
+/// and on boot/recovery once the durable active write version is known.
+#[cfg(feature = "metrics")]
+pub fn record_active_write_version(version: u8) {
+    metrics::gauge!(ACTIVE_WRITE_VERSION).set(f64::from(version));
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_active_write_version(_version: u8) {}
+
+/// Set the compile-time readable-bounds gauges. Called once at boot.
+#[cfg(feature = "metrics")]
+pub fn record_readable_bounds(min_readable: u8, max_readable: u8) {
+    metrics::gauge!(MIN_READABLE_VERSION).set(f64::from(min_readable));
+    metrics::gauge!(MAX_READABLE_VERSION).set(f64::from(max_readable));
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_readable_bounds(_min_readable: u8, _max_readable: u8) {}
+
+/// Set the min-member-read-capability gauge from a gate run's gathered
+/// capabilities (the lowest `max_readable_version` across all current
+/// members).
+#[cfg(feature = "metrics")]
+pub fn record_min_member_read_capability(min_member_max_readable: u8) {
+    metrics::gauge!(MIN_MEMBER_READ_CAPABILITY).set(f64::from(min_member_max_readable));
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_min_member_read_capability(_min_member_max_readable: u8) {}
+
+/// Counter: increment on each proposal that passes the gate.
+#[cfg(feature = "metrics")]
+pub fn record_proposed() {
+    metrics::counter!(PROPOSED_TOTAL).increment(1);
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_proposed() {}
+
+/// Counter: increment when the proposed entry is observed committed.
+#[cfg(feature = "metrics")]
+pub fn record_committed() {
+    metrics::counter!(COMMITTED_TOTAL).increment(1);
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_committed() {}
+
+/// Counter: increment on a successful apply-flip (subset check passed).
+#[cfg(feature = "metrics")]
+pub fn record_applied() {
+    metrics::counter!(APPLIED_TOTAL).increment(1);
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_applied() {}
+
+/// Counter: increment when apply is a no-op (membership not a subset of
+/// the gated set carried by the entry).
+#[cfg(feature = "metrics")]
+pub fn record_noop_membership_subset() {
+    metrics::counter!(NOOP_MEMBERSHIP_SUBSET_TOTAL).increment(1);
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_noop_membership_subset() {}
+
+/// Counter: increment when the gate rejects an activation attempt (a
+/// member cannot read the target).
+#[cfg(feature = "metrics")]
+pub fn record_rejected_by_gate() {
+    metrics::counter!(REJECTED_BY_GATE_TOTAL).increment(1);
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_rejected_by_gate() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_names_match_the_interface_contract() {
+        // Pin the exact strings so the apply arm, the gate, the boot
+        // path, and the metrics test cannot drift apart on a name.
+        assert_eq!(ACTIVE_WRITE_VERSION, "tsoracle.schema.active_write_version");
+        assert_eq!(MIN_READABLE_VERSION, "tsoracle.schema.min_readable_version");
+        assert_eq!(MAX_READABLE_VERSION, "tsoracle.schema.max_readable_version");
+        assert_eq!(
+            MIN_MEMBER_READ_CAPABILITY,
+            "tsoracle.schema.min_member_read_capability"
+        );
+        assert_eq!(
+            PROPOSED_TOTAL,
+            "tsoracle.schema.format_version.proposed.total"
+        );
+        assert_eq!(
+            COMMITTED_TOTAL,
+            "tsoracle.schema.format_version.committed.total"
+        );
+        assert_eq!(
+            APPLIED_TOTAL,
+            "tsoracle.schema.format_version.applied.total"
+        );
+        assert_eq!(
+            NOOP_MEMBERSHIP_SUBSET_TOTAL,
+            "tsoracle.schema.format_version.noop_membership_subset.total"
+        );
+        assert_eq!(
+            REJECTED_BY_GATE_TOTAL,
+            "tsoracle.schema.format_version.rejected_by_gate.total"
+        );
+    }
+
+    #[test]
+    fn emit_helpers_are_callable_without_metrics_feature() {
+        // No-op helpers must exist and be callable regardless of the
+        // `metrics` feature; the call sites in state_machine.rs /
+        // standalone.rs compile unconditionally.
+        record_active_write_version(4);
+        record_readable_bounds(4, 4);
+        record_min_member_read_capability(4);
+        record_proposed();
+        record_committed();
+        record_applied();
+        record_noop_membership_subset();
+        record_rejected_by_gate();
+    }
+}

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -145,14 +145,49 @@ impl StandaloneHost {
             return Err(FormatActivationError::NotLeader);
         }
         let gathered = self.gather_member_capabilities(source).await?;
+
+        // Format-migration observability: the binding constraint on
+        // activation is the lowest `max_readable_version` across all
+        // current members; publish it every gate run and trace each
+        // member's capability.
+        let min_member_max_readable = gathered
+            .iter()
+            .map(|(_node_id, capability)| capability.max_readable_version)
+            .min()
+            .unwrap_or(tsoracle_openraft_toolkit::MIN_READABLE_VERSION);
+        crate::observability::record_min_member_read_capability(min_member_max_readable);
+        for (node_id, capability) in &gathered {
+            tracing::debug!(
+                node_id = node_id,
+                min_readable_version = capability.min_readable_version,
+                max_readable_version = capability.max_readable_version,
+                active_write_version = capability.active_write_version,
+                "format activation: member capability"
+            );
+        }
+
         match all_members_can_read(target, &gathered) {
-            Some(gated_members) => Ok(gated_members),
+            Some(gated_members) => {
+                tracing::info!(
+                    target = target,
+                    gated_members = ?gated_members,
+                    "format activation gate passed"
+                );
+                Ok(gated_members)
+            }
             None => {
-                let incapable = gathered
+                let incapable: Vec<(u64, u8)> = gathered
                     .iter()
                     .filter(|(_, capabilities)| capabilities.max_readable_version < target)
                     .map(|(node_id, capabilities)| (*node_id, capabilities.max_readable_version))
                     .collect();
+                tracing::warn!(
+                    target = target,
+                    min_member_read_capability = min_member_max_readable,
+                    incapable = ?incapable,
+                    "format activation rejected by all-members gate"
+                );
+                crate::observability::record_rejected_by_gate();
                 Err(FormatActivationError::MembersBelowTarget { target, incapable })
             }
         }
@@ -179,7 +214,14 @@ impl StandaloneHost {
             ))
             .await
         {
-            Ok(resp) => Ok(resp.data.outcome),
+            Ok(resp) => {
+                // The entry committed and applied (client_write blocks
+                // until apply); record both signals here. Apply-keyed
+                // counters (applied / noop) are emitted inside the apply
+                // arm so they reflect the actual subset-check outcome.
+                crate::observability::record_committed();
+                Ok(resp.data.outcome)
+            }
             Err(err) => Err(FormatActivationError::ProposalFailed(err.to_string())),
         }
     }
@@ -211,6 +253,11 @@ impl StandaloneHost {
         // Gate: live-query every current member; returns the exact gated
         // member set on success, or a gate error.
         let gated_members = self.run_activation_gate(target, source).await?;
+
+        // Gate passed — about to propose. The `proposed` counter
+        // increments here so a rejected_by_gate path (handled inside
+        // run_activation_gate) does not also increment proposed.
+        crate::observability::record_proposed();
 
         // Propose the bump carrying the gated set. Apply re-validates the
         // subset at the entry's own log position and sets the shared cell

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -296,12 +296,18 @@ impl HighWaterStateMachine {
                 data: persisted.data,
             });
         }
-        Ok(Self {
+        let state_machine = Self {
             core: Arc::new(Mutex::new(core)),
             store,
             persist: Arc::new(Mutex::new(())),
             active_write_version,
-        })
+        };
+        // Format-migration observability: publish the compile-time readable
+        // bounds and the recovered active write version so a freshly-started
+        // node reports its version state before any apply runs.
+        crate::observability::record_readable_bounds(MIN_READABLE_VERSION, MAX_READABLE_VERSION);
+        crate::observability::record_active_write_version(state_machine.active_write_version());
+        Ok(state_machine)
     }
 
     /// The version this SM currently stamps onto snapshots.
@@ -495,6 +501,20 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                         // replay re-runs this exact check) plus the snapshot
                         // frame byte.
                         self.active_write_version.set(target);
+                        // `debug!` not `info!`: this is on the per-entry apply
+                        // hot path (this file carries the
+                        // `#[PerformanceCriticalPath]` marker), so
+                        // info-or-higher logging is banned. The
+                        // operator-visible surface is the `applied` counter
+                        // and the `active_write_version` gauge.
+                        tracing::debug!(
+                            target = target,
+                            gated_members = ?gated_members,
+                            committed_members = ?committed_members,
+                            "SetFormatVersion applied: active write version flipped"
+                        );
+                        crate::observability::record_applied();
+                        crate::observability::record_active_write_version(target);
                         ApplyOutcome::FormatActivated { target }
                     } else {
                         // Membership grew an un-gated member between the gate
@@ -502,6 +522,19 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                         // untouched; the operator re-gates and re-issues. A
                         // no-op writes nothing at `target`, so it cannot
                         // resurrect on restart.
+                        //
+                        // `debug!` not `warn!`: hot path, same rule as the
+                        // success arm above. The operator-visible surface is
+                        // the `noop_membership_subset` counter — a non-zero
+                        // value during an activation means a membership
+                        // change raced the bump.
+                        tracing::debug!(
+                            target = target,
+                            gated_members = ?gated_members,
+                            committed_members = ?committed_members,
+                            "SetFormatVersion no-op: committed membership is not a subset of the gated set"
+                        );
+                        crate::observability::record_noop_membership_subset();
                         ApplyOutcome::FormatActivationNoop { target }
                     };
                     core.last_applied = Some(log_id);

--- a/crates/tsoracle-driver-openraft/tests/format_metrics.rs
+++ b/crates/tsoracle-driver-openraft/tests/format_metrics.rs
@@ -1,0 +1,286 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Recorder-fake test for the format-migration metric catalog. Installs a
+//! `DebuggingRecorder` as the process-global recorder for this test binary
+//! and asserts each `tsoracle.schema.*` signal fires for an end-to-end
+//! activation scenario:
+//!
+//! - boot gauges (`active_write_version`, `min_readable_version`,
+//!   `max_readable_version`) on state-machine construction;
+//! - gate run gauge (`min_member_read_capability`) on every
+//!   `run_activation_gate`;
+//! - `proposed` + `committed` + `applied` counters and an
+//!   `active_write_version` gauge update on a successful activation;
+//! - `rejected_by_gate` on a target above the local readable max;
+//! - `noop_membership_subset` on a direct apply whose committed
+//!   membership is not a subset of the gated set.
+//!
+//! Today `MIN_READABLE_VERSION == MAX_READABLE_VERSION ==
+//! BASELINE_WRITE_VERSION == 4`, so the successful activation flips the
+//! cell from 4 back to 4 — the value is unchanged, but the apply-keyed
+//! signal still fires. The test asserts the signal plumbing, not a real
+//! cross-version data migration.
+
+#![cfg(feature = "metrics")]
+
+mod common;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use metrics_util::{
+    CompositeKey, MetricKind,
+    debugging::{DebugValue, DebuggingRecorder, Snapshotter},
+};
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, LeaderState};
+use tsoracle_driver_openraft::{
+    CapabilitySource, FormatActivationError, HighWaterCommand, HighWaterStateMachine,
+    NodeCapabilities, OpenraftPeer, SetFormatVersionPayload, StandaloneHost,
+};
+use tsoracle_openraft_toolkit::{
+    BASELINE_WRITE_VERSION, MAX_READABLE_VERSION, MIN_READABLE_VERSION,
+};
+
+use common::build_single_node;
+
+type RecordedMetric = (
+    CompositeKey,
+    Option<metrics::Unit>,
+    Option<metrics::SharedString>,
+    DebugValue,
+);
+
+fn install_recorder() -> Snapshotter {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    recorder.install().expect("install metrics recorder");
+    snapshotter
+}
+
+fn counter_value(snapshot: &[RecordedMetric], name: &str) -> u64 {
+    for (composite, _unit, _desc, value) in snapshot {
+        if composite.kind() == MetricKind::Counter && composite.key().name() == name {
+            if let DebugValue::Counter(n) = value {
+                return *n;
+            }
+        }
+    }
+    0
+}
+
+fn gauge_value(snapshot: &[RecordedMetric], name: &str) -> Option<f64> {
+    for (composite, _unit, _desc, value) in snapshot {
+        if composite.kind() == MetricKind::Gauge && composite.key().name() == name {
+            if let DebugValue::Gauge(g) = value {
+                return Some(g.into_inner());
+            }
+        }
+    }
+    None
+}
+
+/// A `CapabilitySource` that must never be called: the single-node gate
+/// short-circuits to the local node, so any remote query is a bug.
+struct UnusedSource;
+
+#[async_trait]
+impl CapabilitySource for UnusedSource {
+    type Node = OpenraftPeer;
+
+    async fn query(
+        &self,
+        node_id: u64,
+        _member: &OpenraftPeer,
+    ) -> Result<NodeCapabilities, String> {
+        panic!("single-node gate must not query remote node {node_id}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn format_migration_signals_fire_end_to_end() {
+    // Install the recorder BEFORE building anything so the boot gauges
+    // fired during `HighWaterStateMachine::with_store*` are captured.
+    let snapshotter = install_recorder();
+
+    // ---- 1. Boot a single-node host. The state machine's construction
+    //         emits the readable-bounds + initial active-write-version
+    //         gauges; build_single_node returns once the cluster exists
+    //         (leadership is awaited separately below).
+    let cluster = build_single_node().await;
+    let driver = &cluster.drivers[0];
+
+    let mut events = driver.leadership_events();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let state = events.next().await.expect("event stream alive");
+            if matches!(state, LeaderState::Leader { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("single-node openraft did not elect itself within 5s");
+
+    let host = StandaloneHost::new(cluster.nodes[0].raft.clone(), cluster.nodes[0].sm.clone());
+
+    // ---- 2. Successful activation: gate passes (proposed + committed +
+    //         applied), apply-flip sets the active_write_version gauge.
+    //         Target == MAX_READABLE_VERSION trivially passes today since
+    //         the local node's max_readable_version == MAX_READABLE_VERSION.
+    host.initiate_format_activation(MAX_READABLE_VERSION, &UnusedSource)
+        .await
+        .expect("activation to MAX_READABLE_VERSION must pass on a single-node leader");
+
+    // ---- 3. Gate rejection: target above the local readable max.
+    let rejected = host
+        .initiate_format_activation(MAX_READABLE_VERSION + 1, &UnusedSource)
+        .await;
+    assert!(
+        matches!(
+            rejected,
+            Err(FormatActivationError::MembersBelowTarget { .. })
+        ),
+        "target above MAX_READABLE_VERSION must be rejected by the gate"
+    );
+
+    // ---- 4. Membership-subset no-op: drive the apply directly on a
+    //         bare state machine (the live host's gate would refuse this
+    //         scenario before apply, but the apply arm itself is the
+    //         counter site we're verifying). Apply a Membership entry
+    //         establishing {1, 2, 9}, then a SetFormatVersion gated only
+    //         on {1, 2}; committed_members ⊄ gated → no-op counter fires.
+    drive_membership_subset_noop_apply().await;
+
+    // ---- Assertions over the recorder snapshot.
+    let snapshot: Vec<RecordedMetric> = snapshotter.snapshot().into_vec();
+
+    assert!(
+        counter_value(&snapshot, "tsoracle.schema.format_version.proposed.total") >= 1,
+        "proposed.total did not increment for the gate-passing activation"
+    );
+    assert!(
+        counter_value(&snapshot, "tsoracle.schema.format_version.committed.total") >= 1,
+        "committed.total did not increment after the entry committed"
+    );
+    assert!(
+        counter_value(&snapshot, "tsoracle.schema.format_version.applied.total") >= 1,
+        "applied.total did not increment after the successful flip"
+    );
+    assert!(
+        counter_value(
+            &snapshot,
+            "tsoracle.schema.format_version.rejected_by_gate.total"
+        ) >= 1,
+        "rejected_by_gate.total did not increment for the over-target activation"
+    );
+    assert!(
+        counter_value(
+            &snapshot,
+            "tsoracle.schema.format_version.noop_membership_subset.total"
+        ) >= 1,
+        "noop_membership_subset.total did not increment for the subset no-op apply"
+    );
+    assert_eq!(
+        gauge_value(&snapshot, "tsoracle.schema.active_write_version"),
+        Some(f64::from(MAX_READABLE_VERSION)),
+        "active_write_version gauge should reflect the flipped version"
+    );
+    assert_eq!(
+        gauge_value(&snapshot, "tsoracle.schema.min_readable_version"),
+        Some(f64::from(MIN_READABLE_VERSION)),
+        "min_readable_version gauge should be the compile-time constant"
+    );
+    assert_eq!(
+        gauge_value(&snapshot, "tsoracle.schema.max_readable_version"),
+        Some(f64::from(MAX_READABLE_VERSION)),
+        "max_readable_version gauge should be the compile-time constant"
+    );
+    assert!(
+        gauge_value(&snapshot, "tsoracle.schema.min_member_read_capability").is_some(),
+        "min_member_read_capability gauge should be set on every gate run"
+    );
+    // Sanity: the cell really did flip (BASELINE == MAX today so the value
+    // is unchanged, but the signal plumbing is what we care about).
+    assert_eq!(host.active_write_version(), MAX_READABLE_VERSION);
+    let _ = BASELINE_WRITE_VERSION; // referenced in the doc comment intent
+}
+
+/// Apply a Membership({1,2,9}) entry followed by a SetFormatVersion gated
+/// on {1,2}; the committed membership is NOT a subset of the gated set,
+/// so the apply arm returns `FormatActivationNoop` and increments the
+/// `noop_membership_subset.total` counter.
+async fn drive_membership_subset_noop_apply() {
+    use std::collections::BTreeSet;
+
+    use futures::stream;
+    use openraft::EntryPayload;
+    use openraft::entry::RaftEntry;
+    use openraft::storage::{EntryResponder, RaftStateMachine};
+    use openraft::type_config::alias::EntryOf;
+    use tsoracle_driver_openraft::TypeConfig;
+
+    fn log_id(index: u64) -> openraft::type_config::alias::LogIdOf<TypeConfig> {
+        openraft::testing::log_id::<TypeConfig>(1, 1, index)
+    }
+
+    fn entry(
+        index: u64,
+        payload: EntryPayload<HighWaterCommand, u64, OpenraftPeer>,
+    ) -> EntryResponder<TypeConfig> {
+        let e: EntryOf<TypeConfig> = match payload {
+            EntryPayload::Blank => EntryOf::<TypeConfig>::new_blank(log_id(index)),
+            EntryPayload::Normal(d) => EntryOf::<TypeConfig>::new_normal(log_id(index), d),
+            EntryPayload::Membership(m) => EntryOf::<TypeConfig>::new_membership(log_id(index), m),
+        };
+        (e, None)
+    }
+
+    let mut sm = HighWaterStateMachine::new();
+
+    // Membership with voters {1,2} and learner {9}; an un-gated learner
+    // forces the no-op.
+    let membership: openraft::Membership<u64, OpenraftPeer> =
+        openraft::Membership::new_with_defaults(
+            vec![BTreeSet::from([1u64, 2u64])],
+            [1u64, 2u64, 9u64],
+        );
+    sm.apply(stream::iter([Ok(entry(
+        1,
+        EntryPayload::Membership(membership),
+    ))]))
+    .await
+    .expect("apply membership");
+
+    // SetFormatVersion gated only on {1,2} — node 9 is in the committed
+    // membership but not in the gated set, so apply must no-op.
+    let bump = HighWaterCommand::SetFormatVersion(SetFormatVersionPayload {
+        target: MAX_READABLE_VERSION,
+        gated_members: BTreeSet::from([1u64, 2u64]),
+    });
+    sm.apply(stream::iter([Ok(entry(2, EntryPayload::Normal(bump)))]))
+        .await
+        .expect("apply set_format_version");
+}

--- a/crates/tsoracle-server/src/docs/operations.md
+++ b/crates/tsoracle-server/src/docs/operations.md
@@ -36,6 +36,20 @@ The server emits the following signals through the [`metrics`](https://docs.rs/m
 - `tsoracle.not_leader.total` — RPCs rejected with `NOT_LEADER` (counter)
 - `tsoracle.shutdown.watch_aborted.total` — a graceful shutdown had to forcibly abort the leader-watch task because it did not stop within `shutdown_grace`, almost always because a consensus-driver call (`load_high_water` / `persist_high_water`) was wedged; any non-zero value means a shutdown narrowly avoided a SIGKILL stall and warrants investigating driver latency (counter)
 
+### Format migration (openraft driver)
+
+These signals are emitted by `tsoracle-driver-openraft` behind its own `metrics` Cargo feature (off by default, the same posture as the server's `metrics` feature). They track the zero-downtime format-migration activation path: the durable active write version, the read-capability bounds, and the `SetFormatVersion` activation-barrier lifecycle.
+
+- `tsoracle.schema.active_write_version` — the node's current durable active write version: the single format version it now emits when persisting and when sending peer RPCs. Set on boot/recovery and on a successful activation flip. A cluster-wide step from N to N+1 is the visible effect of a completed activation (gauge)
+- `tsoracle.schema.min_readable_version` — compile-time floor: the oldest format version this binary still ships a parser for. Never rises across releases (gauge)
+- `tsoracle.schema.max_readable_version` — compile-time ceiling: the newest format version this binary can read. Only grows across releases; an activation cannot target a version above the lowest member's value (gauge)
+- `tsoracle.schema.min_member_read_capability` — the lowest `max_readable_version` observed across all current members (voters and learners) at the most recent activation gate run; the binding constraint on what version activation may target (gauge)
+- `tsoracle.schema.format_version.proposed.total` — activation gate passed and a `SetFormatVersion` entry was proposed (counter)
+- `tsoracle.schema.format_version.committed.total` — a proposed `SetFormatVersion` entry was observed committed on the Raft log (counter)
+- `tsoracle.schema.format_version.applied.total` — a `SetFormatVersion` entry applied successfully: the membership at its log position was a subset of its gated set, so the durable active write version flipped (counter)
+- `tsoracle.schema.format_version.noop_membership_subset.total` — a `SetFormatVersion` entry applied as a no-op because the committed membership was not a subset of its gated set; the operator re-gates and re-issues. A non-zero value during an activation means a membership change raced the bump (counter)
+- `tsoracle.schema.format_version.rejected_by_gate.total` — an activation attempt was rejected before proposal because a current member's `max_readable_version` was below the target; remediate that member (upgrade or remove) and retry (counter)
+
 The library is exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the [`Server`]. The example below wires Prometheus over an HTTP listener:
 
 ```toml

--- a/docs/format-migration-upgrade.md
+++ b/docs/format-migration-upgrade.md
@@ -1,0 +1,54 @@
+# Zero-downtime format-migration upgrade runbook (openraft driver)
+
+This runbook describes how to roll a tsoracle openraft cluster from one persisted-and-wire format version to the next (`v_n` to `v_n+1`) with zero downtime, and the one-way finalization contract that follows. It applies only to the openraft driver; the paxos and file drivers keep stop-the-world version bumps and are out of scope. The format version governs both the on-disk RocksDB layout (log entries, snapshots, meta) and the peer-RPC payloads, because those share the same encoded types.
+
+## Concepts
+
+Each node tracks four separate version values. `min_readable_version` and `max_readable_version` are compile-time constants of the running binary: the oldest and newest formats it has a parser for. The active write version is durable runtime state: the single version this node currently emits, both when persisting and when sending peer RPCs. It lags `max_readable_version` and only ever advances through a successful, committed activation. `BASELINE_WRITE_VERSION` is the active write version in effect at the release that introduced this feature; an unframed legacy peer payload is read as `BASELINE_WRITE_VERSION`.
+
+A node decodes any version in `[min_readable_version, max_readable_version]` and fails loud (refuses to boot or rejects the RPC) on a version outside that range. The core safety invariant the rollout preserves is: a node must never write or send a format that any current peer — voter or learner — cannot already read.
+
+## The four-stage rollout (v_n to v_n+1)
+
+### Stage 1 — Deploy read-capability (rolling restart, safe)
+
+Roll out the new binary one node at a time. The new binary raises `max_readable_version` to `v_n+1` on both the disk and wire boundaries but still writes `v_n`; the new format's fields and behaviors are feature-gated off until activation lifts the gate. This stage is purely additive: every node still emits `v_n`, the additive `format_version` protobuf field keeps the mixed-binary window wire-compatible, and an absent field is read as `BASELINE_WRITE_VERSION`. Restart nodes one at a time and wait for each to rejoin and catch up before proceeding. Watch `tsoracle.schema.max_readable_version` climb to `v_n+1` on each node and confirm `tsoracle.schema.active_write_version` stays at `v_n` everywhere.
+
+Do not proceed to Stage 2 until every member — every voter and every learner — is running the read-capable binary. A learner left on the old binary will block activation (Stage 2 gate) by design.
+
+### Stage 2 — Activate (operator-initiated, gated)
+
+Once the read-capable binary is on every node, initiate activation against the leader. The leader live-queries every current member (voters and learners) via the `Capabilities` peer RPC for its `{min_readable_version, max_readable_version, active_write_version}`, and requires every member's `max_readable_version` to be at least `v_n+1`. The lowest member capability observed is reported as `tsoracle.schema.min_member_read_capability`.
+
+- If the gate passes, the leader proposes a `SetFormatVersion(v_n+1)` entry carrying the exact gated member set, increments `tsoracle.schema.format_version.proposed.total`, and on commit increments `tsoracle.schema.format_version.committed.total`.
+- If the gate fails (some member cannot read `v_n+1`), the attempt is rejected before any proposal and increments `tsoracle.schema.format_version.rejected_by_gate.total`. Remediate the lagging member — upgrade it to the read-capable binary, or remove it from membership — then re-issue.
+
+The activation trigger is currently an interim library method on `StandaloneHost::initiate_format_activation`; the `tsoracle admin` CLI surface for it is reconciled with the dynamic-membership admin work once a CLI consumer is wired through it.
+
+The bump self-validates at apply time. The `SetFormatVersion` entry takes effect only if the membership committed as of the entry's own log position is a subset of the gated set it carried. If a membership change raced between the live query and the commit, the entry applies as a no-op (incrementing `tsoracle.schema.format_version.noop_membership_subset.total`), the active write version does not advance, and you simply re-gate and re-issue. A successful apply increments `tsoracle.schema.format_version.applied.total` and the leader flips its active write version to `v_n+1`, lifting the feature gate. Confirm `tsoracle.schema.active_write_version` steps to `v_n+1` cluster-wide before considering activation complete.
+
+### Stage 3 — Steady state
+
+New records and peer payloads are now `v_n+1`; pre-existing `v_n` records remain on disk until they are organically purged. No operator action is required. The cluster is fully on the new format for everything it writes from this point.
+
+### Stage 4 — Garbage collection (organic, never forced)
+
+Snapshots and meta migrate to `v_n+1` on their next write. Once snapshot install plus log purge advances `LastPurged` past every `v_n` log entry, no `v_n` bytes remain on disk. This happens organically; never force it. The `v_n` decoder is retained in the binary indefinitely regardless (decoders are never auto-removed) so that an operator upgrading on any schedule, skipping versions, can still read whatever any prior release wrote.
+
+## Finalization and the no-downgrade contract
+
+Activation is a one-way door. Before the `SetFormatVersion` entry applies successfully, the window is freely abortable — nothing `v_n+1` has been written or sent, so simply not issuing (or re-issuing) the activation leaves the cluster on `v_n`. After the entry applies successfully and `v_n+1` records exist on disk and on the wire, the migration is finalized.
+
+Contract: do not downgrade any node below the cluster's active write version. A binary whose `max_readable_version` is below the cluster's active write version will correctly refuse to boot on a `v_n+1` log tail (it fails loud with a foreign-version decode error) and will reject `v_n+1` peer RPCs. There is no fenced-downgrade machinery and none is planned; the safety floor is fail-loud refusal, not silent misdecode. If you must run an older binary, you must do so before activation finalizes, never after.
+
+## Rollback within a stage
+
+Stage 1 is fully reversible: because every node still writes `v_n`, you can roll any node back to the prior binary at any time during Stage 1. Stage 2 is reversible only up to the successful apply: an aborted or gate-rejected or no-op'd activation leaves the active write version at `v_n`, and the durable recovery rule derives the active version from fsync-durable written evidence — the latest snapshot's leading version byte and the highest version byte among durable log records (there is NO meta key; the shared in-memory cell is re-established by deterministic raft-log replay) — never from the mere presence of a `SetFormatVersion` entry, so a non-applied bump is never resurrected on restart. Once the apply succeeds and `v_n+1` bytes exist, the no-downgrade contract above governs.
+
+## What the operator watches
+
+The catalog in [`crates/tsoracle-server/src/docs/operations.md`](../crates/tsoracle-server/src/docs/operations.md) lists every metric. The activation-specific ones to watch are:
+
+- During Stage 1: `tsoracle.schema.max_readable_version` should climb to `v_n+1` on every node before Stage 2 begins; `tsoracle.schema.active_write_version` stays at `v_n` everywhere.
+- During Stage 2: `tsoracle.schema.min_member_read_capability` should be `>= v_n+1` once Stage 1 is complete (this is the gate's binding constraint); `tsoracle.schema.format_version.proposed.total` ticks once when the gate passes, then `committed.total` ticks, then `applied.total`. A non-zero `rejected_by_gate.total` means an under-read-capable member remains; a non-zero `noop_membership_subset.total` means membership raced the bump.
+- After Stage 2: `tsoracle.schema.active_write_version` steps from `v_n` to `v_n+1` on every node. Until every node reports the new value, treat the activation as in progress.


### PR DESCRIPTION
## Summary

Adds opt-in observability and operator-facing documentation for the zero-downtime format-migration activation path. No control-plane behavior changes: this PR only emits signals at points the activation path already produces and documents the rollout / no-downgrade contract.

- **Metrics module** in a new `tsoracle-driver-openraft::observability` (and a new optional `metrics` Cargo feature, off by default, mirroring `tsoracle-server`). 4 gauges (`tsoracle.schema.{active_write_version, min_readable_version, max_readable_version, min_member_read_capability}`) and 5 counters (`tsoracle.schema.format_version.{proposed, committed, applied, noop_membership_subset, rejected_by_gate}.total`). Helpers compile to no-ops when the feature is off so call sites compile unconditionally and embedders that do not want the `metrics` dependency are unaffected.
- **Emission wired at the existing decision points**: boot/recovery in `HighWaterStateMachine::with_store_and_active_version` (readable bounds + initial active version); apply arm for `SetFormatVersion` (`applied` + `active_write_version` gauge on subset-hit, `noop_membership_subset` on miss, each with a `tracing::info!`/`warn!` carrying `target`, `gated_members`, `committed_members`); `run_activation_gate` (`min_member_read_capability` every run + per-member `tracing::debug!`; `rejected_by_gate` + `tracing::warn!` on the `MembersBelowTarget` branch); `initiate_format_activation` (`proposed` after the gate passes); `submit_set_format_version` (`committed` on a successful `client_write` return).
- **Recorder integration test** `crates/tsoracle-driver-openraft/tests/format_metrics.rs` (gated on `--features metrics`). Installs `metrics-util`'s `DebuggingRecorder` and drives an end-to-end scenario on a single-node cluster: boot → successful activation → gate rejection → direct subset-miss apply. Snapshots the recorder and asserts every `tsoracle.schema.*` gauge value and each counter is `>= 1`. Today `BASELINE_WRITE_VERSION == MAX_READABLE_VERSION == 4` so the successful activation flips 4 → 4 (signal fires, value unchanged); the test pins the signal plumbing, not a cross-version data migration.
- **Operations catalog update** in `crates/tsoracle-server/src/docs/operations.md`: new "Format migration (openraft driver)" subsection with one line per signal and operator-facing notes on what a non-zero counter means.
- **Operator runbook** at `docs/format-migration-upgrade.md`: the four-stage rollout (deploy read-capability → activate → steady state → garbage collection), the one-way finalization contract, the no-downgrade-below-active-version contract, which metrics to watch at each stage.

## Test plan

- [ ] `cargo build --workspace --all-features` is clean
- [ ] `cargo build -p tsoracle-driver-openraft` (default features) is clean — confirms the no-op helpers keep the crate compiling without the `metrics` dependency
- [ ] `cargo build -p tsoracle-driver-openraft --features metrics` is clean — confirms the real emission compiles
- [ ] `cargo test --workspace --all-features` passes — all pre-existing tests plus the 2 new `observability::tests` (name pinning + no-op-when-off helper signatures) and the 1 new `format_metrics` integration test (\`--features metrics\` only)
- [ ] `cargo test -p tsoracle-driver-openraft --features metrics --test format_metrics` passes — drives the recorder scenario end-to-end and asserts each signal
- [ ] `cargo clippy --workspace --all-features -- -D warnings` is clean
- [ ] No call site outside `crates/tsoracle-driver-openraft/src/observability.rs` writes a `tsoracle.schema.*` literal — `rg -n '\"tsoracle\\.schema' crates/` should show only the observability module and the metrics test