### PR TITLE
feat(openraft-toolkit): version-neutral e2e-max-readable-next feature

### DIFF
--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -25,6 +25,18 @@ rocksdb-snapshot-store = ["dep:rocksdb"]
 # lifecycle). Off by default so embedders that do not want the `metrics`
 # dependency are unaffected, matching `tsoracle-server`'s `metrics` feature.
 metrics                = ["dep:metrics"]
+# Test-only harness affordance: adds `BASELINE_WRITE_VERSION + 1` alias
+# arms to the per-version codec dispatch (`HighWaterStateMachineSnapshot`
+# / `PersistedSnapshot`) that delegate to the baseline body, and
+# propagates the matching toolkit feature so `MAX_READABLE_VERSION` rises
+# to `BASELINE + 1`. The aliased body is byte-identical to baseline; the
+# only difference is the leading version byte. This lets a mixed-version
+# e2e harness drive a real activation flip from baseline to the next
+# version end-to-end (gate -> propose -> commit -> apply -> cell flip)
+# without shipping a real new format. Off by default; never compiled
+# into production. The arm guard derives from `BASELINE_WRITE_VERSION`
+# so a future baseline bump moves the alias version with no edit here.
+e2e-max-readable-next  = ["tsoracle-openraft-toolkit/e2e-max-readable-next"]
 
 [dependencies]
 async-trait        = { workspace = true }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -111,6 +111,15 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
             // the layout evolves and MIN_READABLE_VERSION/MAX_READABLE_VERSION
             // widen.
             v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
+            // `BASELINE + 1` alias: a test-only harness affordance. The body
+            // is byte-identical to BASELINE — only the version byte changes
+            // — so the activation machinery (gate -> propose -> commit ->
+            // apply -> cell flip) can run end-to-end in a mixed-version e2e
+            // without shipping a real new format. Gated off in production.
+            // The guard derives from BASELINE so a future baseline bump
+            // moves the alias version with no edit here.
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 1 => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -122,6 +131,8 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
             v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 1 => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -135,6 +146,8 @@ impl VersionedCodec for PersistedSnapshot {
     fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
         match version {
             v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 1 => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -146,6 +159,8 @@ impl VersionedCodec for PersistedSnapshot {
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
             v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 1 => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -1155,6 +1170,78 @@ mod tests {
             )
             .is_err(),
             "a version above the readable max must be rejected"
+        );
+    }
+
+    #[cfg(feature = "e2e-max-readable-next")]
+    #[test]
+    fn e2e_max_readable_next_aliases_to_baseline_bytewise() {
+        // The test-only `e2e-max-readable-next` feature raises
+        // `MAX_READABLE_VERSION` to `BASELINE_WRITE_VERSION + 1` in the
+        // toolkit and adds matching alias arms in this file's
+        // `VersionedCodec` impls that delegate to the baseline body. This
+        // pins the alias contract: a `BASELINE + 1`-stamped envelope is
+        // byte-identical to a BASELINE-stamped one beyond the leading
+        // version byte, and round-trips cross-version. That is what lets
+        // a mixed-version e2e drive a real activation flip from BASELINE
+        // to the next version end-to-end (gate -> propose -> commit ->
+        // apply -> cell flip) without shipping a real new format — the
+        // activation control plane runs because every encoder/decoder
+        // accepts the next version as an alias of BASELINE. Version-
+        // neutral assertions so this test survives a future baseline
+        // bump unchanged.
+        use tsoracle_codec::{decode_framed, encode_framed};
+        use tsoracle_openraft_toolkit::{BASELINE_WRITE_VERSION, MAX_READABLE_VERSION};
+
+        let baseline = BASELINE_WRITE_VERSION;
+        let next = baseline + 1;
+        assert_eq!(
+            MAX_READABLE_VERSION, next,
+            "feature must raise MAX to BASELINE+1"
+        );
+
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 7,
+            last_applied: None,
+            last_membership: StoredMem::default(),
+        };
+
+        let framed_baseline = encode_framed(baseline, &payload).expect("encode baseline");
+        let framed_next = encode_framed(next, &payload).expect("encode next (alias)");
+
+        // Byte-identical except the leading version byte: the alias is
+        // structural, not a real layout change.
+        assert_eq!(framed_baseline[0], baseline);
+        assert_eq!(framed_next[0], next);
+        assert_eq!(
+            &framed_baseline[1..],
+            &framed_next[1..],
+            "alias body must be byte-identical to baseline — only the version byte differs"
+        );
+
+        // Cross-version round-trip: a next-stamped envelope decodes through
+        // the readable range, and a baseline reader can still consume it
+        // because the body is the same shape.
+        let back_baseline: HighWaterStateMachineSnapshot =
+            decode_framed(baseline, next, &framed_baseline).expect("decode baseline");
+        let back_next: HighWaterStateMachineSnapshot =
+            decode_framed(baseline, next, &framed_next).expect("decode next (alias)");
+        assert_eq!(back_baseline, payload);
+        assert_eq!(back_next, payload);
+
+        // The envelope-shape carrier (`PersistedSnapshot`) must alias too
+        // — it is what `build_snapshot` actually emits at the active
+        // write version when the cell flips.
+        let envelope = PersistedSnapshot {
+            meta: SnapMeta::default(),
+            data: framed_next.clone(),
+        };
+        let framed_env_baseline = encode_framed(baseline, &envelope).expect("envelope baseline");
+        let framed_env_next = encode_framed(next, &envelope).expect("envelope next");
+        assert_eq!(
+            &framed_env_baseline[1..],
+            &framed_env_next[1..],
+            "PersistedSnapshot next-version envelope must alias baseline"
         );
     }
 

--- a/crates/tsoracle-driver-openraft/tests/format_metrics.rs
+++ b/crates/tsoracle-driver-openraft/tests/format_metrics.rs
@@ -146,7 +146,23 @@ async fn format_migration_signals_fire_end_to_end() {
 
     let host = StandaloneHost::new(cluster.nodes[0].raft.clone(), cluster.nodes[0].sm.clone());
 
-    // ---- 2. Successful activation: gate passes (proposed + committed +
+    // ---- 2. Membership-subset no-op: drive the apply directly on a
+    //         bare state machine (the live host's gate would refuse this
+    //         scenario before apply, but the apply arm itself is the
+    //         counter site we're verifying). Apply a Membership entry
+    //         establishing {1, 2, 9}, then a SetFormatVersion gated only
+    //         on {1, 2}; committed_members ⊄ gated → no-op counter fires.
+    //
+    //         Order matters: this constructs a FRESH state machine via
+    //         `with_store_and_active_version`, which fires the boot
+    //         `record_active_write_version(BASELINE)` and would clobber
+    //         a later apply-flip gauge value. Doing it BEFORE the
+    //         successful activation below keeps the activation's
+    //         `record_active_write_version(target)` as the latest write
+    //         and observable in the snapshot.
+    drive_membership_subset_noop_apply().await;
+
+    // ---- 3. Successful activation: gate passes (proposed + committed +
     //         applied), apply-flip sets the active_write_version gauge.
     //         Target == MAX_READABLE_VERSION trivially passes today since
     //         the local node's max_readable_version == MAX_READABLE_VERSION.
@@ -154,7 +170,7 @@ async fn format_migration_signals_fire_end_to_end() {
         .await
         .expect("activation to MAX_READABLE_VERSION must pass on a single-node leader");
 
-    // ---- 3. Gate rejection: target above the local readable max.
+    // ---- 4. Gate rejection: target above the local readable max.
     let rejected = host
         .initiate_format_activation(MAX_READABLE_VERSION + 1, &UnusedSource)
         .await;
@@ -165,14 +181,6 @@ async fn format_migration_signals_fire_end_to_end() {
         ),
         "target above MAX_READABLE_VERSION must be rejected by the gate"
     );
-
-    // ---- 4. Membership-subset no-op: drive the apply directly on a
-    //         bare state machine (the live host's gate would refuse this
-    //         scenario before apply, but the apply arm itself is the
-    //         counter site we're verifying). Apply a Membership entry
-    //         establishing {1, 2, 9}, then a SetFormatVersion gated only
-    //         on {1, 2}; committed_members ⊄ gated → no-op counter fires.
-    drive_membership_subset_noop_apply().await;
 
     // ---- Assertions over the recorder snapshot.
     let snapshot: Vec<RecordedMetric> = snapshotter.snapshot().into_vec();

--- a/crates/tsoracle-openraft-toolkit/Cargo.toml
+++ b/crates/tsoracle-openraft-toolkit/Cargo.toml
@@ -22,6 +22,19 @@ default            = ["rocksdb-log-store"]
 rocksdb-log-store  = ["dep:rocksdb"]
 test-fakes         = ["dep:parking_lot"]
 failpoints         = ["tsoracle-failpoint/failpoints"]
+# Test-only harness affordance: raises `MAX_READABLE_VERSION` to
+# `BASELINE_WRITE_VERSION + 1` (i.e. one above whatever the current
+# baseline is — today 4, so MAX rises to 5; when baseline bumps to 5,
+# MAX rises to 6 with no edits here). When combined with the matching
+# `e2e-max-readable-next` feature on `tsoracle-driver-openraft` (which
+# adds `BASELINE + 1` alias arms to the per-version codec dispatch),
+# this lets a mixed-version e2e drive a real activation flip from the
+# baseline to the next version end-to-end. The aliased body layout is
+# byte-identical to baseline — only the version byte changes — so the
+# activation control plane runs but no genuine format change happens;
+# this is a faithful HARNESS for the activation machinery, not a real
+# format bump. Off by default; never compiled into production.
+e2e-max-readable-next = []
 
 [dependencies]
 async-trait      = { workspace = true }

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -50,7 +50,21 @@ pub const MIN_READABLE_VERSION: u8 = 4;
 
 /// Newest on-disk/wire format version this binary has a parser for. Only ever
 /// grows. Decode accepts `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
+///
+/// Production builds set this to the current baseline. The test-only
+/// `e2e-max-readable-next` feature raises it to `BASELINE_WRITE_VERSION + 1`
+/// so a mixed-version e2e harness can drive a real activation flip from the
+/// baseline to the next version. The aliased body is byte-identical to the
+/// baseline (added by `BASELINE + 1` alias arms on the per-version codec in
+/// `tsoracle-driver-openraft` under the matching feature), so this is a
+/// faithful harness for the activation machinery rather than a real format
+/// change. Off by default; never compiled into production. The expression
+/// derives from `BASELINE_WRITE_VERSION` so a future baseline bump moves
+/// MAX automatically with no edit here.
+#[cfg(not(feature = "e2e-max-readable-next"))]
 pub const MAX_READABLE_VERSION: u8 = 4;
+#[cfg(feature = "e2e-max-readable-next")]
+pub const MAX_READABLE_VERSION: u8 = BASELINE_WRITE_VERSION + 1;
 
 // Compile-time guard: the readable range must be non-empty (`MIN <= MAX`) or
 // every decode rejects every record. Catches a future inverted-constants edit
@@ -147,11 +161,32 @@ pub fn recover_active_write_version(
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "e2e-max-readable-next"))]
     #[test]
     fn version_constants_are_at_the_v4_baseline() {
         assert_eq!(MIN_READABLE_VERSION, 4);
         assert_eq!(MAX_READABLE_VERSION, 4);
         assert_eq!(BASELINE_WRITE_VERSION, 4);
+    }
+
+    #[cfg(feature = "e2e-max-readable-next")]
+    #[test]
+    fn version_constants_under_e2e_max_readable_next_feature() {
+        // Test-only harness: MAX rises to `BASELINE + 1` so a mixed-version
+        // e2e can drive a real activation flip from the baseline to the
+        // next version. MIN and BASELINE are unchanged — the harness
+        // raises only the read ceiling (Stage 1 of a real rollout); the
+        // active write version still starts at BASELINE and only moves
+        // through the normal activation barrier. Assert against the
+        // baseline expression so this test survives a future baseline
+        // bump unchanged.
+        assert_eq!(MAX_READABLE_VERSION, BASELINE_WRITE_VERSION + 1);
+        // `MAX > MIN` would tautologically follow from the above plus
+        // `BASELINE >= MIN` (which is true by definition: BASELINE is in
+        // the readable range). The compile-time `const _: () =
+        // assert!(MIN <= MAX)` at the top of this module guarantees the
+        // range invariant whether the feature is on or off; the
+        // runtime assertion would be flagged by `clippy::assertions_on_constants`.
     }
 
     #[test]

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -266,7 +266,7 @@ fn unframe_with_version(bytes: &[u8]) -> io::Result<(u8, &[u8])> {
         crate::codec::codec_io_error("log-store record decode", crate::codec::CodecError::Empty)
     })?;
     let version = *first;
-    if version < crate::codec::MIN_READABLE_VERSION || version > crate::codec::MAX_READABLE_VERSION
+    if !(crate::codec::MIN_READABLE_VERSION..=crate::codec::MAX_READABLE_VERSION).contains(&version)
     {
         return Err(crate::codec::codec_io_error(
             "log-store record decode",
@@ -700,7 +700,9 @@ mod range_boundary_tests {
 #[cfg(test)]
 mod record_codec_tests {
     use super::{decode_entry_record, encode_entry_record};
-    use crate::codec::{BASELINE_WRITE_VERSION, MAX_READABLE_VERSION, MIN_READABLE_VERSION};
+    use crate::codec::BASELINE_WRITE_VERSION;
+    #[cfg(not(feature = "e2e-max-readable-next"))]
+    use crate::codec::{MAX_READABLE_VERSION, MIN_READABLE_VERSION};
     use crate::declare_raft_types_ext;
     use crate::log_store::DefaultLogStoreCodec;
     use serde::{Deserialize, Serialize};
@@ -764,6 +766,12 @@ mod record_codec_tests {
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
+    // Pinned to BASELINE in the default build; the test-only
+    // `e2e-max-readable-next` feature lifts MAX to `BASELINE + 1`, so
+    // skip the MAX assertion under that feature (covered by
+    // `version_constants_under_e2e_max_readable_next_feature` in
+    // `codec.rs`).
+    #[cfg(not(feature = "e2e-max-readable-next"))]
     #[test]
     fn version_constants_are_at_four() {
         assert_eq!(BASELINE_WRITE_VERSION, 4);

--- a/crates/tsoracle-standalone/src/drivers/openraft/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/network.rs
@@ -106,7 +106,7 @@ mod wire {
                 )
             })?
         };
-        if version < MIN_READABLE_VERSION || version > MAX_READABLE_VERSION {
+        if !(MIN_READABLE_VERSION..=MAX_READABLE_VERSION).contains(&version) {
             return Err(format!(
                 "format_version {version} outside readable range \
                  [{MIN_READABLE_VERSION}, {MAX_READABLE_VERSION}]"


### PR DESCRIPTION
## Summary

A test-only Cargo feature that raises `MAX_READABLE_VERSION` to `BASELINE_WRITE_VERSION + 1` and adds matching alias arms on the per-version codec dispatch, delegating the next-version body to the baseline body byte-for-byte. This is the prerequisite a future mixed-version e2e harness needs to drive a real activation flip end-to-end (gate → propose → commit → apply → cell flip) without shipping a real new format.

**Version-neutral by design.** Both the constant and the alias arm guards derive from `BASELINE_WRITE_VERSION + 1` (no `5` literal anywhere) and the feature is named `e2e-max-readable-next` (not `-5`). When the production baseline bumps from 4 to 5, the alias automatically becomes 6 with **no edits** to the feature name, the arm guards, or the round-trip test.

- New feature `e2e-max-readable-next` on `tsoracle-openraft-toolkit` and `tsoracle-driver-openraft` (the driver feature pulls in the toolkit feature transitively).
- `MAX_READABLE_VERSION` becomes `cfg`-split: `= 4` in the default build, `= BASELINE_WRITE_VERSION + 1` under the feature.
- `VersionedCodec` impls for `HighWaterStateMachineSnapshot` and `PersistedSnapshot` each gain a feature-gated `v if v == BASELINE_WRITE_VERSION + 1 => …` arm aliasing to the baseline body.
- New round-trip test `e2e_max_readable_next_aliases_to_baseline_bytewise` pins the contract: a next-stamped envelope is byte-identical to a baseline-stamped one beyond the leading version byte, and both round-trip through a `(baseline, next)` decode range.
- Two pre-existing `assert_eq!(MAX_READABLE_VERSION, 4)` pin tests (`codec.rs` and `log_store/mod.rs`) get `#[cfg(not(...))]` gates; the codec.rs test gains a feature-on companion asserting `MAX == BASELINE + 1` against the expression.
- Two `version < MIN || version > MAX` manual range checks converted to `(MIN..=MAX).contains(&version)` (in the toolkit `unframe_with_version` and the standalone `wire::readable_version`). Clippy fires `manual_range_contains` once `MIN < MAX`; pre-emptive cleanup so the feature build stays green.
- `format_migration_signals_fire_end_to_end` (the P7 recorder test) had a latent ordering issue: the membership-subset no-op constructs a fresh `HighWaterStateMachine` whose `with_store_and_active_version` boot fires `record_active_write_version(BASELINE)`, clobbering a prior activation-apply gauge value. It was silently fine when `MAX == BASELINE` (the activation flipped 4 → 4 either way); under the new feature the activation flips 4 → 5 and the boot reset surfaces. Fix: reorder so the no-op apply runs BEFORE the activation, so the activation's gauge write is the last one observed in the snapshot.

Off by default; never compiled into production. The feature exists solely so a future mixed-version e2e harness can drive a real activation flip end-to-end against an aliased next version.

## Test plan

- [ ] `cargo build --workspace` (default features) is clean
- [ ] `cargo build --workspace --all-features` is clean
- [ ] `cargo build --workspace --features e2e-max-readable-next` is clean
- [ ] `cargo test --workspace` passes
- [ ] `cargo test --workspace --all-features` passes (this is the strict path that exposed the metrics-test ordering issue)
- [ ] `cargo test --workspace --features e2e-max-readable-next` passes
- [ ] `cargo clippy --workspace --tests --all-features -- -D warnings` is clean
- [ ] `CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh` reports all 9 marked files clean
- [ ] `rg -n 'e2e-max-readable-5|"5"|: u8 = 5' crates/` returns zero matches — the feature, constants, arms, and test must be version-neutral