### PR TITLE
chore(fuzz): resync fuzz/Cargo.lock with workspace

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1143,12 +1143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pastey"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
-
-[[package]]
 name = "peel-off"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,7 +2006,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsoracle-codec"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "postcard",
  "serde",
@@ -2021,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-consensus"
-version = "0.1.6"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "futures",
@@ -2032,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-core"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "serde",
  "thiserror",
@@ -2040,14 +2034,13 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-file"
-version = "0.1.6"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "crc32c",
  "fs2",
  "futures",
  "libc",
- "parking_lot",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2058,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-openraft"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -2068,8 +2061,8 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tracing",
+ "tsoracle-codec",
  "tsoracle-consensus",
  "tsoracle-core",
  "tsoracle-openraft-toolkit",
@@ -2077,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-paxos"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -2097,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-failpoint"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "tsoracle-fuzz"
@@ -2116,16 +2109,14 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-openraft-toolkit"
-version = "0.1.7"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "futures",
  "openraft",
- "postcard",
  "serde",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tracing",
  "tsoracle-codec",
  "tsoracle-failpoint",
@@ -2133,13 +2124,12 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-paxos-toolkit"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "futures",
  "omnipaxos",
  "parking_lot",
- "pastey",
  "serde",
  "thiserror",
  "tokio",
@@ -2153,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-proto"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "prost",
  "tonic",
@@ -2163,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-yieldpoint"
-version = "0.1.5"
+version = "0.1.6"
 
 [[package]]
 name = "unicase"


### PR DESCRIPTION
## Summary

- Lockfile-only update to bring `fuzz/Cargo.lock` (separate cargo-fuzz workspace) back in sync with the parent workspace.
- Crate version bumps from release-plz (#448) across `tsoracle-codec`, `-consensus`, `-core`, `-driver-file`, `-driver-openraft`, `-driver-paxos`, `-openraft-toolkit`, `-paxos-toolkit`, `-proto`, `-yieldpoint`, `-failpoint`.
- Dep-graph adjustments from recent merges: `tsoracle-driver-openraft` now depends on `tsoracle-codec` (LogStoreCodec seam, #454/#459/#460/#461); `tsoracle-openraft-toolkit` drops `postcard` and `tokio-stream`; `tsoracle-driver-file` drops `parking_lot`; `tsoracle-paxos-toolkit` drops `pastey` (which leaves the graph entirely).

No source or fuzz-target changes.

## Test plan

- [x] `cargo metadata --locked --offline` passes inside `fuzz/`.
- [x] Pre-commit (`cargo fmt --check`, `cargo clippy`) passes for the workspace.
- [ ] CI green on the PR.