### PR TITLE
test(e2e): add mixed-version-soak driver mode and Job manifest

### DIFF
--- a/e2e/kube/driver/job-mixed-version-soak.yaml
+++ b/e2e/kube/driver/job-mixed-version-soak.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-mixed-version-soak
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=mixed-version-soak
+            # All replica endpoints (not the Service VIP) so the client has a
+            # known-live peer to fail over to when the pod it is bound to is
+            # torn down during the rolling restart — matching how a real
+            # tsoracle client is configured (leader-hint failover assumes the
+            # client knows every replica).
+            - --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051
+            # Longer than the plain soak: must cover the rolling restart of
+            # every replica (one at a time, with readiness wait between) AND
+            # the operator-initiated activation that follows. 180s leaves
+            # ample headroom on top of a typical ~90s rolling restart of a
+            # 3-replica StatefulSet plus the activation round-trip; tune
+            # alongside the workflow if its sequencing grows.
+            - --duration-secs=180

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -31,12 +31,20 @@ use tsoracle_client::{ClientBuilder, RetryPolicy};
 
 use crate::tracker::Tracker;
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
 enum Mode {
     /// Probe each endpoint in turn; every one must serve or redirect to success.
     ColdStart,
     /// Hammer one client for a fixed duration; emit a sentinel on first success.
     Soak,
+    /// Soak variant for the mixed-version rollout: sustain load with the same
+    /// zero-monotonicity-violation invariant and 0.5% error tolerance while the
+    /// orchestrator rolls a subset of replicas to the next image and drives
+    /// activation. Prints a distinct sentinel (`mixed-version-soak: first GetTs
+    /// ok`) so the orchestrator only perturbs the cluster after load is provably
+    /// live. The driver itself is a pure observer of monotonicity — it does not
+    /// perform the rollout or the activation; the orchestrator does.
+    MixedVersionSoak,
 }
 
 #[derive(Parser, Debug)]
@@ -83,6 +91,9 @@ async fn main() -> Result<()> {
     let passed = match cli.mode {
         Mode::ColdStart => run_cold_start(&cli.endpoints, cli.count).await?,
         Mode::Soak => run_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?,
+        Mode::MixedVersionSoak => {
+            run_mixed_version_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
+        }
     };
     if !passed {
         std::process::exit(1);
@@ -119,11 +130,31 @@ async fn run_cold_start(endpoints: &[String], count: u32) -> Result<bool> {
 /// on the first success so the workflow knows load is live before it restarts
 /// the StatefulSet.
 async fn run_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
+    sustain_load(endpoints, duration, "soak").await
+}
+
+/// Sustain GetTs load while the orchestrator performs a mixed-version rolling
+/// restart and drives activation. Identical invariants to [`run_soak`] — zero
+/// monotonicity violations, final error rate below [`MAX_SOAK_ERROR_RATE`] —
+/// because timestamp monotonicity is exactly the property a format activation
+/// must not break. The distinct sentinel (`mixed-version-soak: first GetTs ok`)
+/// lets the orchestrator sequence the partial upgrade + activation only after
+/// load is provably live, mirroring how the existing soak lane sequences a
+/// rolling restart.
+async fn run_mixed_version_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
+    sustain_load(endpoints, duration, "mixed-version-soak").await
+}
+
+/// Shared body of [`run_soak`] and [`run_mixed_version_soak`]. The `label` is
+/// the per-mode prefix used in the first-success sentinel, the per-error log
+/// line, and the final-verdict tracker report — so the orchestrator can grep
+/// for the right mode unambiguously.
+async fn sustain_load(endpoints: &[String], duration: Duration, label: &str) -> Result<bool> {
     let client = ClientBuilder::endpoints(endpoints.to_vec())
         .retry_policy(generous_policy())
         .build()
         .await
-        .context("build soak client")?;
+        .with_context(|| format!("build {label} client"))?;
     let mut tracker: Tracker<_> = Tracker::new();
     let mut announced = false;
     // The deadline is checked before each call, so the loop can overrun by up
@@ -134,16 +165,63 @@ async fn run_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
         match client.get_ts().await {
             Ok(ts) => {
                 if !announced {
-                    println!("soak: first GetTs ok");
+                    println!("{label}: first GetTs ok");
                     announced = true;
                 }
                 tracker.record_ok(ts);
             }
             Err(error) => {
-                eprintln!("soak: get_ts error: {error}");
+                eprintln!("{label}: get_ts error: {error}");
                 tracker.record_err();
             }
         }
     }
-    Ok(tracker.report_within_error_tolerance("soak", MAX_SOAK_ERROR_RATE))
+    Ok(tracker.report_within_error_tolerance(label, MAX_SOAK_ERROR_RATE))
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn cold_start_mode_parses() {
+        let cli = Cli::parse_from([
+            "kube-e2e-driver",
+            "--mode=cold-start",
+            "--endpoints=a:5051,b:5051,c:5051",
+            "--count=3",
+        ]);
+        assert_eq!(cli.mode, Mode::ColdStart);
+        assert_eq!(cli.endpoints.len(), 3);
+        assert_eq!(cli.count, 3);
+    }
+
+    #[test]
+    fn soak_mode_parses() {
+        let cli = Cli::parse_from([
+            "kube-e2e-driver",
+            "--mode=soak",
+            "--endpoints=a:5051,b:5051,c:5051",
+            "--duration-secs=30",
+        ]);
+        assert_eq!(cli.mode, Mode::Soak);
+        assert_eq!(cli.duration_secs, 30);
+    }
+
+    #[test]
+    fn mixed_version_soak_mode_parses() {
+        // The new mode shares the CLI surface of `soak` (a list of endpoints
+        // + a duration); the orchestrator only needs to switch the value of
+        // `--mode` and route to a job manifest using the matching sentinel.
+        let cli = Cli::parse_from([
+            "kube-e2e-driver",
+            "--mode=mixed-version-soak",
+            "--endpoints=a:5051,b:5051,c:5051",
+            "--duration-secs=180",
+        ]);
+        assert_eq!(cli.mode, Mode::MixedVersionSoak);
+        assert_eq!(cli.endpoints.len(), 3);
+        assert_eq!(cli.duration_secs, 180);
+    }
 }


### PR DESCRIPTION
## Depends on

**#468** must merge first — this PR contains the #468 commit (`version-neutral e2e-max-readable-next feature`) plus the new mixed-version-soak driver commit. A rebase after #468 lands will leave only the new commit on this branch.

## Summary

Adds a new `Mode::MixedVersionSoak` variant on the existing `kube-e2e-driver` plus a Job manifest using it. The driver sustains GetTs load while the orchestrator (a future GitHub Actions workflow path) performs a partial rolling restart to a new image and drives an activation against live traffic. It asserts the same invariants as the existing `Soak` mode — **zero monotonicity violations** and final error rate below `MAX_SOAK_ERROR_RATE` (0.5%) — because timestamp monotonicity is exactly the property a format activation must not break.

The driver is a pure observer of monotonicity; it does NOT perform the rollout or the activation. The distinct first-success sentinel (`mixed-version-soak: first GetTs ok`) lets the orchestrator sequence the partial upgrade + activation only after load is provably live, mirroring how the existing soak lane sequences a rolling restart.

- **Mode + runner** (`e2e/kube/driver/src/main.rs`): new `Mode::MixedVersionSoak`, new `run_mixed_version_soak`. Both runners share a `sustain_load(endpoints, duration, label)` helper — `label` is the per-mode prefix used in the first-success sentinel, the per-error log line, and the final-verdict tracker report, so the orchestrator can grep for the right mode unambiguously. Behaviour-preserving for the pre-existing `soak` path (same sentinel `soak: first GetTs ok`, same error log shape).
- **CLI parse tests**: 3 small unit tests pin that `cold-start`, `soak`, and `mixed-version-soak` all parse with the expected `--mode=` value and that endpoint/count/duration flow through. `Mode` gains `PartialEq, Eq` so the tests can match cleanly.
- **Job manifest** (`e2e/kube/driver/job-mixed-version-soak.yaml`): modeled on `job-soak.yaml` — same labels, backoff/restart policy, per-replica endpoint list. Differs in `--mode=mixed-version-soak` and `--duration-secs=180` (vs 120 for soak) to leave headroom for a rolling restart of every replica plus the operator-initiated activation that follows.

## Test plan

- [ ] `cargo build --workspace --all-features` is clean
- [ ] `cargo test --workspace` passes — 3 new `cli_tests` (cold_start_mode_parses, soak_mode_parses, mixed_version_soak_mode_parses) alongside all pre-existing tests
- [ ] `cargo test -p kube-e2e-driver` passes — 9 existing `tracker::tests` + 3 new `cli_tests`
- [ ] `cargo clippy --workspace --all-features -- -D warnings` is clean
- [ ] `bash -n e2e/kube/run-assertions.sh` (script untouched) and a YAML parse on `e2e/kube/driver/job-mixed-version-soak.yaml` succeed
- [ ] `rg -n '"soak"|"cold-start"|"mixed-version-soak"' e2e/kube/driver/src/main.rs` shows each label used as both the CLI value and the runner's sentinel/log prefix — no drift between the two