### PR TITLE
chore(ci): guard fuzz/Cargo.lock from drift (CI check + Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,14 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(ci)"
+
+  - package-ecosystem: cargo
+    directory: /fuzz
+    schedule:
+      interval: weekly
+    groups:
+      fuzz:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(fuzz)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,23 @@ jobs:
       - name: guard
         run: python3 scripts/check-ts-header.py
 
+  fuzz-lockfile:
+    name: fuzz lockfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - name: check fuzz/Cargo.lock is in sync
+        working-directory: fuzz
+        run: |
+          if ! cargo metadata --locked --format-version=1 > /dev/null 2>cargo-metadata.err; then
+            cat cargo-metadata.err
+            echo "::error::fuzz/Cargo.lock is stale. Run 'cargo update -w' (or 'cargo generate-lockfile') in fuzz/ and commit the result."
+            exit 1
+          fi
+
   coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Follow-up to #469. Two complementary additions so the `fuzz/` workspace's lockfile stops drifting silently between cargo invocations there.

- **CI guard.** New `fuzz-lockfile` job in `.github/workflows/ci.yml` runs `cargo metadata --locked --format-version=1` inside `fuzz/` on every push and PR. The fuzz workspace is sealed off with its own `[workspace]` table (so `#![no_main]` harnesses don't break `cargo build --workspace` from the parent), which means workspace-wide version bumps and dep-graph changes don't propagate to `fuzz/Cargo.lock` until someone runs cargo inside `fuzz/`. The guard catches drift at the PR that introduced it instead of weeks later. Metadata-only — no compilation, so the clang/rocksdb dep chain stays out of the build. Failure surfaces a `::error::` message with the remediation command.

- **Dependabot.** New `cargo` updates entry for `directory: /fuzz` in `.github/dependabot.yml`, weekly, grouped under `fuzz`, `chore(fuzz)` commit prefix. Handles drift originating from upstream registry bumps (`libfuzzer-sys`, `postcard`, `prost`, `tonic`, etc.) that the CI guard alone wouldn't surface (the guard catches lockfile-vs-manifest inconsistency, not stale-but-consistent versions).

Together these make #469 the last manual `fuzz/Cargo.lock` resync.

## Test plan

- [x] `cargo metadata --locked --format-version=1` exits 0 inside `fuzz/` on `main` (current state).
- [x] Both YAML files parse (Ruby `YAML.load_file`).
- [x] Pre-commit (`cargo fmt --check`, `cargo clippy`) green.
- [x] CI green on this PR.
- [ ] First Dependabot run lands a `chore(fuzz):` PR (visible after merge, on the next weekly schedule).