### PR TITLE
ci(release-plz): sync fuzz/Cargo.lock onto release PR branch

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -86,7 +86,41 @@ jobs:
           packages: protobuf-compiler clang libclang-dev
           version: 1
       - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db  # v0.5
+        id: release-plz
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # `fuzz/` is its own cargo workspace (cargo-fuzz convention) and
+      # path-depends on workspace crates. When release-plz bumps a workspace
+      # crate's `[package].version`, fuzz/Cargo.lock keeps the pre-bump pin
+      # and the CI `fuzz lockfile` guard (ci.yml) fails on the release PR.
+      # Resync the lock on top of the release branch so the PR ships green.
+      - name: sync fuzz/Cargo.lock onto release PR
+        env:
+          RELEASE_PRS: ${{ steps.release-plz.outputs.prs }}
+          GIT_AUTHOR_NAME: release-plz[bot]
+          GIT_AUTHOR_EMAIL: release-plz[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: release-plz[bot]
+          GIT_COMMITTER_EMAIL: release-plz[bot]@users.noreply.github.com
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_PRS:-}" ] || [ "${RELEASE_PRS}" = "[]" ]; then
+            echo "release-plz did not open/update a PR; nothing to sync."
+            exit 0
+          fi
+          branch="$(jq -r '.[0].head_branch // empty' <<<"$RELEASE_PRS")"
+          if [ -z "$branch" ]; then
+            echo "release-plz outputs did not include a head_branch; nothing to sync."
+            exit 0
+          fi
+          git fetch origin "$branch"
+          git checkout "$branch"
+          (cd fuzz && cargo update --workspace)
+          if git diff --quiet -- fuzz/Cargo.lock; then
+            echo "fuzz/Cargo.lock already in sync."
+            exit 0
+          fi
+          git commit -m 'chore(fuzz): resync fuzz/Cargo.lock with workspace bumps' -- fuzz/Cargo.lock
+          git push origin "$branch"


### PR DESCRIPTION
## Summary

`fuzz/` is its own cargo workspace (cargo-fuzz convention) and path-depends on workspace crates, so release-plz's workspace `cargo update` never touches `fuzz/Cargo.lock`. When a release PR bumps a crate `fuzz/` depends on, the `fuzz lockfile` guard added in #471 fails — and there's no self-healing path: every release PR goes red until someone manually resyncs the lock (as #469 did).

This wedges a `sync fuzz/Cargo.lock onto release PR` step into the `release-pr` job, right after the release-plz action runs. It reads the action's `prs` output, fetches the release branch, runs `cargo update --workspace` inside `fuzz/`, and — only if `fuzz/Cargo.lock` actually changed — commits as `release-plz[bot]` and pushes onto the same branch.

The full sequence:

1. Bail early if release-plz did not open/update a PR this run.
2. Fetch + checkout the release branch in the runner.
3. `cd fuzz && cargo update --workspace`.
4. If the lockfile diff is empty, log "already in sync" and exit zero (idempotent).
5. Otherwise, commit + push.

The action output is consumed via `env: RELEASE_PRS:` and quoted in the shell — no template interpolation into `run:`, per [GitHub Actions injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Motivation

The current release PR #456 hit exactly this failure when it bumped 5 workspace crates (tsoracle-codec, -driver-openraft, -driver-paxos, -openraft-toolkit, -paxos-toolkit) without `fuzz/Cargo.lock` keeping pace. The fuzz lockfile guard correctly caught it, but the only fix was a manual resync push (411fe37 on the #456 branch). This PR makes that automatic for the next release PR and every one after it.

## Test plan

- [ ] Merge to main.
- [ ] Wait for the next release-plz workflow run (either from this merge or the next conventional `feat:`/`fix:`/`perf:` commit).
- [ ] Inspect the workflow run: confirm the `sync fuzz/Cargo.lock onto release PR` step ran. On a release PR that does not change `fuzz/`'s dep versions, it should log "fuzz/Cargo.lock already in sync." and exit zero. On one that does, it should produce a `chore(fuzz): resync ...` commit on the release branch authored by `release-plz[bot]`.
- [ ] Confirm the `fuzz lockfile` check on the subsequent release PR is green from the first CI run, without manual intervention.
- [ ] Verify the step is a no-op (logs the early-return message) on workflow runs where release-plz produces no PR.