### PR TITLE
fix(ci): validate tag_suffix and pass version via env to block shell injection

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -33,6 +33,10 @@ jobs:
             echo "v=${GITHUB_REF_NAME#tsoracle-v}" >> "$GITHUB_OUTPUT"
           elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             SUFFIX="${SUFFIX:-test-${RUN_ID}}"
+            if ! printf '%s' "$SUFFIX" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
+              echo "Invalid tag_suffix: must match ^[A-Za-z0-9_.-]+\$" >&2
+              exit 1
+            fi
             echo "v=0.0.0-${SUFFIX}" >> "$GITHUB_OUTPUT"
           else
             echo "v=0.0.0-pr${PR_NUM}" >> "$GITHUB_OUTPUT"
@@ -78,8 +82,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push per-arch image
+        env:
+          V: ${{ needs.version.outputs.v }}
         run: |
-          V=${{ needs.version.outputs.v }}
           docker buildx build \
             --platform linux/${{ matrix.arch }} \
             -f deploy/Dockerfile \
@@ -102,8 +107,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create multi-arch manifest list
+        env:
+          V: ${{ needs.version.outputs.v }}
         run: |
-          V=${{ needs.version.outputs.v }}
           IMG=ghcr.io/prisma-risk/tsoracle-${{ matrix.variant }}
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             docker buildx imagetools create \
@@ -122,8 +128,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Push chart
+        env:
+          V: ${{ needs.version.outputs.v }}
         run: |
-          V=${{ needs.version.outputs.v }}
           curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
           ./linux-amd64/helm package deploy/charts/tsoracle --version "$V" --app-version "$V"
           echo "${{ secrets.GITHUB_TOKEN }}" | ./linux-amd64/helm registry login ghcr.io -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
## Summary

- Resolves a high-severity command-injection sink in `.github/workflows/release-images.yml` introduced by the `workflow_dispatch` path added in #466 (commit a321970).
- The manual `tag_suffix` input flowed unvalidated into the `version` job output (`v=0.0.0-${SUFFIX}`) and was then interpolated directly into shell assignments (`V=${{ needs.version.outputs.v }}`) in the `build-image` and `manifest` jobs **after** `docker/login-action` authenticated to GHCR. Because GitHub expression substitution happens before the shell parses the `run:` script, a suffix like `x; cmd #` or `x$(cmd)` became executable shell syntax in jobs with `packages: write` — arbitrary command execution with the registry credentials needed to tamper with published `tsoracle` container images.
- Two-layer fix: (1) strict allowlist `^[A-Za-z0-9_.-]+$` on `tag_suffix` in the `version` job — the workflow fails loudly at the source, before any GHCR login; (2) `env: V: ${{ needs.version.outputs.v }}` indirection in `build-image`, `manifest`, and `chart`, so the value lands in an environment variable the shell reads as data, not source code.
- The `chart` job is included for defense-in-depth: it is gated on tag-push and not reachable from `workflow_dispatch`, but the same sink shape was fed by `${GITHUB_REF_NAME#tsoracle-v}`, and git tag names are permissive enough to contain shell metacharacters — closing it here costs nothing.

## Threat model and severity

- **Likelihood:** medium — exploitation requires GitHub Actions `workflow_dispatch` permission on the repo (typically write/maintainer), not anonymous internet access.
- **Impact:** high — supply-chain compromise of published `ghcr.io/prisma-risk/tsoracle-*` container images. The attack is a privilege escalation against the release pipeline: a contributor who could otherwise only land code via reviewed PR could dispatch this workflow and execute arbitrary code with `packages: write`, bypassing branch protection and code review.
- **Why two layers:** the allowlist is the primary defense (fails at the source). The `env:` indirection is defense in depth — if a future contributor adds another suffix-producing branch in the `version` step and forgets to validate, the downstream sinks still treat the value as data.

## Test plan

- [x] Local YAML parse check (`ruby -ryaml -e YAML.safe_load(...)`) passes.
- [x] Workspace pre-commit hook (`cargo fmt --check`, `cargo clippy`) passes on the commit.
- [x] Local shell PoC against the patched `version` step:
  - `SUFFIX='x; touch /tmp/marker #'` → rejected, exit 1, no marker file created.
  - `SUFFIX='x$(touch /tmp/marker)'` → rejected, exit 1, no marker file created.
  - `SUFFIX=''` (default fallback) → produces `v=0.0.0-test-<run_id>`.
  - `SUFFIX='nightly.2026-05-25_a1b2c3'` → accepted.
  - `SUFFIX='has space'`, `SUFFIX='|'` → rejected.
- [ ] CI on this PR runs the `pr-smoke` lane (touches `.github/workflows/release-images.yml`, so the path filter matches) — verify it stays green.
- [ ] After merge, a manual `workflow_dispatch` run with a benign suffix to confirm the legitimate path still publishes per-arch images and a manifest tag.