### PR TITLE
fix(openraft-toolkit): clamp recovered write version to readable range

### DIFF
--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -133,12 +133,25 @@ impl Default for ActiveWriteVersion {
 /// fsync-durable lower bounds.
 ///
 /// Returns `max(BASELINE_WRITE_VERSION, snapshot_leading_byte?,
-/// highest_log_record_byte?)`. Both inputs are `Option` because a fresh store
-/// has neither a persisted snapshot nor any log record. Taking the max of
+/// highest_log_record_byte?)` when every present input is within the readable
+/// range `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`, and
+/// [`CodecError::VersionUnsupported`] when any present input exceeds
+/// `MAX_READABLE_VERSION`. Both inputs are `Option` because a fresh store has
+/// neither a persisted snapshot nor any log record. Taking the max of
 /// durably-*written* evidence is monotone and safe: a rejected or no-op
 /// activation never caused any record to be written at the higher version, so it
 /// cannot be resurrected here, and a node never recovers a version below what it
 /// actually emitted.
+///
+/// The upper-bound check matters when this binary is older than the on-disk
+/// data — for example a rolling-restart that downgrades a node to a release
+/// whose [`MAX_READABLE_VERSION`] is lower than a leading byte already stamped
+/// in the log or snapshot by a newer release. Without the check the cell would
+/// be seeded to a value the decode side cannot handle, and the writers would
+/// stamp every new record at that unreadable version (a persistent availability
+/// failure). Failing the recovery fast surfaces the version mismatch at the
+/// boundary between durable bytes and the in-memory cell, instead of silently
+/// poisoning later reads.
 ///
 /// This deliberately does NOT read any meta-CF counter and does NOT inspect the
 /// mere presence of a committed `SetFormatVersion` log entry. Durability of an
@@ -151,10 +164,22 @@ impl Default for ActiveWriteVersion {
 pub fn recover_active_write_version(
     snapshot_leading_byte: Option<u8>,
     highest_log_record_byte: Option<u8>,
-) -> u8 {
-    BASELINE_WRITE_VERSION
+) -> Result<u8, CodecError> {
+    for byte in [snapshot_leading_byte, highest_log_record_byte]
+        .into_iter()
+        .flatten()
+    {
+        if byte > MAX_READABLE_VERSION {
+            return Err(CodecError::VersionUnsupported {
+                min: MIN_READABLE_VERSION,
+                max: MAX_READABLE_VERSION,
+                actual: byte,
+            });
+        }
+    }
+    Ok(BASELINE_WRITE_VERSION
         .max(snapshot_leading_byte.unwrap_or(BASELINE_WRITE_VERSION))
-        .max(highest_log_record_byte.unwrap_or(BASELINE_WRITE_VERSION))
+        .max(highest_log_record_byte.unwrap_or(BASELINE_WRITE_VERSION)))
 }
 
 #[cfg(test)]
@@ -213,24 +238,85 @@ mod tests {
     #[test]
     fn recover_returns_baseline_with_no_durable_evidence() {
         assert_eq!(
-            recover_active_write_version(None, None),
+            recover_active_write_version(None, None).unwrap(),
             BASELINE_WRITE_VERSION
         );
     }
 
     #[test]
     fn recover_takes_the_max_of_present_lower_bounds() {
-        assert_eq!(recover_active_write_version(Some(5), None), 5);
-        assert_eq!(recover_active_write_version(None, Some(6)), 6);
-        assert_eq!(recover_active_write_version(Some(5), Some(6)), 6);
-        assert_eq!(recover_active_write_version(Some(7), Some(5)), 7);
+        // The "max" only differs from BASELINE when MAX_READABLE_VERSION >
+        // BASELINE_WRITE_VERSION — the e2e-max-readable-next harness. Under the
+        // production cfg the range is a single point so every assertion here
+        // collapses to BASELINE, but the test still exercises every input shape.
+        assert_eq!(
+            recover_active_write_version(Some(MAX_READABLE_VERSION), None).unwrap(),
+            MAX_READABLE_VERSION
+        );
+        assert_eq!(
+            recover_active_write_version(None, Some(MAX_READABLE_VERSION)).unwrap(),
+            MAX_READABLE_VERSION
+        );
+        assert_eq!(
+            recover_active_write_version(Some(BASELINE_WRITE_VERSION), Some(MAX_READABLE_VERSION))
+                .unwrap(),
+            MAX_READABLE_VERSION
+        );
+        assert_eq!(
+            recover_active_write_version(Some(MAX_READABLE_VERSION), Some(BASELINE_WRITE_VERSION))
+                .unwrap(),
+            MAX_READABLE_VERSION
+        );
     }
 
     #[test]
     fn recover_never_drops_below_baseline() {
         assert_eq!(
-            recover_active_write_version(Some(1), Some(2)),
+            recover_active_write_version(Some(1), Some(2)).unwrap(),
             BASELINE_WRITE_VERSION
+        );
+    }
+
+    #[test]
+    fn recover_rejects_snapshot_byte_above_max_readable() {
+        let above = MAX_READABLE_VERSION + 1;
+        let err = recover_active_write_version(Some(above), None).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CodecError::VersionUnsupported {
+                    min: MIN_READABLE_VERSION,
+                    max: MAX_READABLE_VERSION,
+                    actual,
+                } if actual == above,
+            ),
+            "expected VersionUnsupported for snapshot byte above MAX_READABLE_VERSION, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn recover_rejects_log_byte_above_max_readable() {
+        let above = MAX_READABLE_VERSION + 1;
+        let err = recover_active_write_version(None, Some(above)).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CodecError::VersionUnsupported {
+                    min: MIN_READABLE_VERSION,
+                    max: MAX_READABLE_VERSION,
+                    actual,
+                } if actual == above,
+            ),
+            "expected VersionUnsupported for log byte above MAX_READABLE_VERSION, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn recover_accepts_byte_at_max_readable() {
+        assert_eq!(
+            recover_active_write_version(Some(MAX_READABLE_VERSION), Some(MAX_READABLE_VERSION))
+                .unwrap(),
+            MAX_READABLE_VERSION,
         );
     }
 }

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -175,10 +175,10 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
     let highest_log_record_byte = log_store
         .highest_log_record_version()
         .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?;
-    let active_write_version = ActiveWriteVersion::new(recover_active_write_version(
-        snapshot_leading_byte,
-        highest_log_record_byte,
-    ));
+    let active_write_version = ActiveWriteVersion::new(
+        recover_active_write_version(snapshot_leading_byte, highest_log_record_byte)
+            .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?,
+    );
 
     // Thread the SAME cell into both writers: the log store stamps appended
     // records, the state machine stamps snapshots, both reading this one cell.


### PR DESCRIPTION
## Summary

- `recover_active_write_version` trusted the raw leading byte from the snapshot store and the log CF and only floored at `BASELINE_WRITE_VERSION`, so any durable byte above `MAX_READABLE_VERSION` (e.g. a record written by a newer release before a binary downgrade, or local corruption that flipped a leading byte upward) silently seeded the `ActiveWriteVersion` cell to an unreadable value — and the writers then stamped every new record at that unreadable version. The next read or snapshot build then failed, leaving the node persistently unavailable.
- Signature is now `Result<u8, CodecError>`; any present input byte above `MAX_READABLE_VERSION` short-circuits with `CodecError::VersionUnsupported { min, max, actual }` before the floor-at-baseline `.max()` chain runs. The single production caller in `tsoracle-standalone` maps the new error into `StandaloneError::Bootstrap`, identical shape to the surrounding `snapshot_store.load` / `highest_log_record_version` boxings, so a bad on-disk byte fails the node start at the same boundary instead of poisoning later writes. Floor semantics for bytes at or below `MAX_READABLE_VERSION` (including bytes below baseline) are preserved.
- The realistic exploitation path is operational, not adversarial: a rolling-restart that downgrades a node to a binary whose `MAX_READABLE_VERSION` is lower than what the cluster has already written. This becomes load-bearing as soon as `BASELINE_WRITE_VERSION` advances past 4 in later phases of the openraft format migration.

## Test plan

- [x] `cargo test -p tsoracle-openraft-toolkit --lib codec::` — 10/10 pass, including three new tests: rejects-above-max for snapshot byte, rejects-above-max for log byte, accepts-at-max boundary
- [x] `cargo build --workspace --all-features` clean (verifies the `e2e-max-readable-next` variant where `MAX_READABLE_VERSION = BASELINE + 1 = 5` still compiles and accepts a `Some(5)` byte as legitimate)
- [x] `cargo test --workspace --all-features --no-fail-fast` — 130 test binaries pass, 0 failures
- [x] `cargo clippy -p tsoracle-openraft-toolkit -p tsoracle-standalone --all-features --all-targets -- -D warnings` clean