### PR TITLE
fix(driver-openraft): enforce lower-bound on format activation target

### DIFF
--- a/crates/tsoracle-driver-openraft/src/capabilities.rs
+++ b/crates/tsoracle-driver-openraft/src/capabilities.rs
@@ -101,12 +101,23 @@ pub fn all_members_can_read(
 /// re-issue against the leader; `MembersBelowTarget` means upgrade or remove
 /// the named members and re-issue; `MemberUnreachable` means the cluster could
 /// not confirm a member's capability and the gate fails closed rather than
-/// guess.
+/// guess; `TargetOutOfRange` means re-issue with a target the local binary
+/// can actually read or upgrade the binary.
 #[derive(Debug, thiserror::Error)]
 pub enum FormatActivationError {
     /// This node is not the raft leader, so it cannot drive an activation.
     #[error("cannot initiate format activation: this node is not the leader")]
     NotLeader,
+    /// `target` is outside the local binary's readable range
+    /// `[min, max]`. The gate short-circuits here before any peer RPC: an
+    /// out-of-range target is the same answer regardless of peer reports,
+    /// and the operator gets a fast, unambiguous rejection. The same
+    /// surface is used by the apply arm's defense-in-depth — see
+    /// `ApplyOutcome::FormatActivationTargetOutOfRange`.
+    #[error(
+        "format activation to target {target} blocked: target outside local readable range [{min}, {max}]"
+    )]
+    TargetOutOfRange { target: u8, min: u8, max: u8 },
     /// At least one current member cannot read `target`. `incapable` lists the
     /// offending `(node_id, max_readable_version)` pairs for the operator.
     #[error("format activation to target {target} blocked: members below target: {incapable:?}")]
@@ -129,6 +140,25 @@ pub enum FormatActivationError {
     /// e.g. lost leadership, the cluster lost quorum, or a fatal raft error.
     #[error("format activation proposal failed: {0}")]
     ProposalFailed(String),
+}
+
+/// Reject `target` if it is outside the local binary's readable range
+/// `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
+///
+/// This is the lower-bound (and symmetric upper-bound) companion to the
+/// per-member [`all_members_can_read`] check. The per-member predicate
+/// guards against any member that cannot read the target; this local check
+/// guards against an unsupported target up front so the activation never
+/// even reaches a peer RPC or the apply arm. A target below MIN would flip
+/// the active write version to a value the encode/decode codec arms reject,
+/// wedging all subsequent log appends and snapshot builds.
+pub fn target_in_local_readable_range(target: u8) -> Result<(), FormatActivationError> {
+    let min = tsoracle_openraft_toolkit::MIN_READABLE_VERSION;
+    let max = tsoracle_openraft_toolkit::MAX_READABLE_VERSION;
+    if !(min..=max).contains(&target) {
+        return Err(FormatActivationError::TargetOutOfRange { target, min, max });
+    }
+    Ok(())
 }
 
 /// Abstracts querying one peer member for its [`NodeCapabilities`]. Implemented
@@ -289,6 +319,97 @@ mod tests {
             rendered.contains('2') && rendered.contains('5'),
             "got: {rendered}"
         );
+    }
+
+    // ---- Local-binary readable-range gate (lower-bound check) ----
+    //
+    // The all-members gate at `all_members_can_read` checks every member's
+    // `max_readable_version >= target` — the upper-bound side. The
+    // lower-bound side is symmetric: `target` must also be at least
+    // `MIN_READABLE_VERSION` of the local binary, otherwise the activation
+    // would flip the cell to a version no member can encode/decode (an
+    // operator-facing footgun and durable-damage hazard). The gate also
+    // short-circuits at the local binary's range before any peer RPC: an
+    // out-of-range target is the same answer regardless of what peers
+    // report, and the operator gets a fast, clear rejection instead of an
+    // unreachable-peer noise tail.
+
+    #[test]
+    fn target_in_local_readable_range_accepts_min() {
+        assert!(
+            target_in_local_readable_range(tsoracle_openraft_toolkit::MIN_READABLE_VERSION).is_ok()
+        );
+    }
+
+    #[test]
+    fn target_in_local_readable_range_accepts_max() {
+        assert!(
+            target_in_local_readable_range(tsoracle_openraft_toolkit::MAX_READABLE_VERSION).is_ok()
+        );
+    }
+
+    #[test]
+    fn target_in_local_readable_range_rejects_zero() {
+        // Target 0 is the worst case: 0 is also the legacy-unframed wire
+        // sentinel, so a 0-stamped record collides with the legacy
+        // interpretation while also failing recovery decode.
+        let err = target_in_local_readable_range(0).expect_err("0 is below MIN");
+        match err {
+            FormatActivationError::TargetOutOfRange { target, min, max } => {
+                assert_eq!(target, 0);
+                assert_eq!(min, tsoracle_openraft_toolkit::MIN_READABLE_VERSION);
+                assert_eq!(max, tsoracle_openraft_toolkit::MAX_READABLE_VERSION);
+            }
+            other => panic!("expected TargetOutOfRange, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn target_in_local_readable_range_rejects_below_min() {
+        // The exact below-min boundary. MIN is at least 1 in any sensible
+        // build (the codec's compile-time assert forbids an empty range),
+        // so MIN - 1 is always a representable u8 and always out of range.
+        let just_below = tsoracle_openraft_toolkit::MIN_READABLE_VERSION - 1;
+        let err = target_in_local_readable_range(just_below).expect_err("MIN-1 is out of range");
+        assert!(matches!(
+            err,
+            FormatActivationError::TargetOutOfRange { target, .. } if target == just_below
+        ));
+    }
+
+    #[test]
+    fn target_in_local_readable_range_rejects_above_max() {
+        // MAX + 1: this case is normally caught by the per-member
+        // `max_readable_version >= target` predicate at the gate, but the
+        // local-binary short-circuit must also reject it so a one-member
+        // cluster (or a misconfigured operator command) fails fast at the
+        // leader before any RPC.
+        let just_above = tsoracle_openraft_toolkit::MAX_READABLE_VERSION.saturating_add(1);
+        if just_above == tsoracle_openraft_toolkit::MAX_READABLE_VERSION {
+            // MAX is u8::MAX (impossible in practice but defended against);
+            // skip rather than spuriously fail.
+            return;
+        }
+        let err = target_in_local_readable_range(just_above).expect_err("MAX+1 is out of range");
+        assert!(matches!(
+            err,
+            FormatActivationError::TargetOutOfRange { target, .. } if target == just_above
+        ));
+    }
+
+    #[test]
+    fn target_out_of_range_error_names_target_and_local_range() {
+        // The operator-facing message must name the offending target AND
+        // the binary's own range, so the remediation is unambiguous: either
+        // re-issue with an in-range target, or upgrade the binary.
+        let err = FormatActivationError::TargetOutOfRange {
+            target: 1,
+            min: 4,
+            max: 4,
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains('1'), "target missing: {rendered}");
+        assert!(rendered.contains('4'), "range missing: {rendered}");
     }
 
     struct FakeSource {

--- a/crates/tsoracle-driver-openraft/src/observability.rs
+++ b/crates/tsoracle-driver-openraft/src/observability.rs
@@ -53,6 +53,15 @@ pub const NOOP_MEMBERSHIP_SUBSET_TOTAL: &str =
 /// Counter: an activation attempt was rejected by the all-members gate (a
 /// member's `max_readable_version` was below the target).
 pub const REJECTED_BY_GATE_TOTAL: &str = "tsoracle.schema.format_version.rejected_by_gate.total";
+/// Counter: a `SetFormatVersion` entry applied as a no-op because `target`
+/// was outside the local binary's
+/// `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]` range. The gate at
+/// proposal time normally prevents this from being committed; a non-zero
+/// value here means an older binary committed an out-of-range bump or a
+/// peer violated protocol, and the apply arm's defense-in-depth contained
+/// it. Distinct from `noop_membership_subset`.
+pub const NOOP_TARGET_OUT_OF_RANGE_TOTAL: &str =
+    "tsoracle.schema.format_version.noop_target_out_of_range.total";
 
 /// Set the active-write-version gauge. Called on a successful apply-flip
 /// and on boot/recovery once the durable active write version is known.
@@ -124,6 +133,15 @@ pub fn record_rejected_by_gate() {
 #[cfg(not(feature = "metrics"))]
 pub fn record_rejected_by_gate() {}
 
+/// Counter: increment when apply is a no-op because `target` is outside
+/// the local binary's readable range (apply-arm defense-in-depth).
+#[cfg(feature = "metrics")]
+pub fn record_noop_target_out_of_range() {
+    metrics::counter!(NOOP_TARGET_OUT_OF_RANGE_TOTAL).increment(1);
+}
+#[cfg(not(feature = "metrics"))]
+pub fn record_noop_target_out_of_range() {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,6 +177,10 @@ mod tests {
             REJECTED_BY_GATE_TOTAL,
             "tsoracle.schema.format_version.rejected_by_gate.total"
         );
+        assert_eq!(
+            NOOP_TARGET_OUT_OF_RANGE_TOTAL,
+            "tsoracle.schema.format_version.noop_target_out_of_range.total"
+        );
     }
 
     #[test]
@@ -174,5 +196,6 @@ mod tests {
         record_applied();
         record_noop_membership_subset();
         record_rejected_by_gate();
+        record_noop_target_out_of_range();
     }
 }

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -43,6 +43,7 @@ use tsoracle_consensus::ConsensusError;
 
 use crate::capabilities::{
     CapabilitySource, FormatActivationError, NodeCapabilities, all_members_can_read, gather_with,
+    target_in_local_readable_range,
 };
 use crate::host::OpenraftHighWaterHost;
 use crate::log_entry::{HighWaterCommand, SetFormatVersionPayload};
@@ -143,6 +144,21 @@ impl StandaloneHost {
         let (_local_node_id, is_leader, _members) = self.membership_snapshot();
         if !is_leader {
             return Err(FormatActivationError::NotLeader);
+        }
+        // Local-binary range short-circuit BEFORE any peer RPC: an
+        // out-of-range target cannot be made valid by what peers report,
+        // and the apply arm would no-op it anyway. Fail fast with a
+        // clear, operator-actionable error and account the rejection
+        // under the same `rejected_by_gate` counter as the per-member
+        // path — both are "the gate refused this activation".
+        if let Err(err) = target_in_local_readable_range(target) {
+            tracing::warn!(
+                target = target,
+                ?err,
+                "format activation rejected: target outside local readable range"
+            );
+            crate::observability::record_rejected_by_gate();
+            return Err(err);
         }
         let gathered = self.gather_member_capabilities(source).await?;
 
@@ -278,12 +294,25 @@ impl StandaloneHost {
 /// [`FormatActivationError::MembershipChangedSinceGate`]. `Advanced` is
 /// impossible for a `SetFormatVersion` entry but is mapped defensively to
 /// the no-op error rather than silently claiming success.
+/// `FormatActivationTargetOutOfRange` is the apply arm's defense-in-depth
+/// firing — possible only if a buggy or protocol-violating proposal reached
+/// commit despite the gate's `target_in_local_readable_range` short-circuit;
+/// surface it as [`FormatActivationError::TargetOutOfRange`] using the local
+/// binary's range so the operator's remediation matches the gate-rejection
+/// surface.
 fn classify_activation_outcome(
     outcome: ApplyOutcome,
     target: u8,
 ) -> Result<(), FormatActivationError> {
     match outcome {
         ApplyOutcome::FormatActivated { target: applied } if applied == target => Ok(()),
+        ApplyOutcome::FormatActivationTargetOutOfRange { target: applied } => {
+            Err(FormatActivationError::TargetOutOfRange {
+                target: applied,
+                min: tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+                max: tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            })
+        }
         ApplyOutcome::FormatActivated { .. }
         | ApplyOutcome::FormatActivationNoop { .. }
         | ApplyOutcome::Advanced => {
@@ -492,5 +521,23 @@ mod tests {
             err,
             FormatActivationError::MembershipChangedSinceGate { target: 4 }
         ));
+    }
+
+    #[test]
+    fn classify_activation_outcome_maps_target_out_of_range_to_local_range_error() {
+        // Apply-arm defense-in-depth surfaces a distinct outcome variant;
+        // the proposer-side classifier must re-emit it as the
+        // operator-facing `TargetOutOfRange` (carrying the local binary's
+        // range), matching the surface the gate's short-circuit returns.
+        let outcome = ApplyOutcome::FormatActivationTargetOutOfRange { target: 1 };
+        let result = classify_activation_outcome(outcome, 1);
+        match result {
+            Err(FormatActivationError::TargetOutOfRange { target, min, max }) => {
+                assert_eq!(target, 1);
+                assert_eq!(min, tsoracle_openraft_toolkit::MIN_READABLE_VERSION);
+                assert_eq!(max, tsoracle_openraft_toolkit::MAX_READABLE_VERSION);
+            }
+            other => panic!("expected TargetOutOfRange, got: {other:?}"),
+        }
     }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -508,7 +508,19 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                     // down the leader) — emit a NO-OP outcome and a
                     // distinct counter so the operator sees it.
                     if !(MIN_READABLE_VERSION..=MAX_READABLE_VERSION).contains(&target) {
-                        tracing::error!(
+                        // `debug!` not `error!`: hot path, same rule as the
+                        // subset arms below. The operator-visible surface
+                        // is the `noop_target_out_of_range` counter — a
+                        // non-zero value means an older binary committed
+                        // an out-of-range bump (or a peer violated
+                        // protocol) and the apply arm's defense-in-depth
+                        // contained it. The gate's `warn!` at
+                        // `run_activation_gate` is the loud, operator-
+                        // facing surface for the in-process path; this
+                        // branch only fires on replay of an already-
+                        // committed entry, where loud logging on every
+                        // restart would just spam.
+                        tracing::debug!(
                             target = target,
                             min = MIN_READABLE_VERSION,
                             max = MAX_READABLE_VERSION,

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -495,67 +495,95 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                     },
                 )) => {
                     let target = *target;
-                    // Evaluate the subset against the membership committed as
-                    // of this entry's log position. Apply folds the log in
-                    // index order, so `core.last_membership` is exactly that
-                    // membership (a `Membership` entry at a lower index has
-                    // already updated it; a later one has not). Cover BOTH
-                    // voters and learners: openraft replicates/snapshots
-                    // learners, so an un-gated learner must force a no-op.
-                    let mut core = self.core.lock();
-                    let committed_members: std::collections::BTreeSet<u64> = core
-                        .last_membership
-                        .membership()
-                        .nodes()
-                        .map(|(node_id, _node)| *node_id)
-                        .collect();
-                    let outcome = if committed_members.is_subset(gated_members) {
-                        // Successful (non-no-op) apply: set the
-                        // process-shared active-write-version cell. NO meta
-                        // write — durability is the raft log (deterministic
-                        // replay re-runs this exact check) plus the snapshot
-                        // frame byte.
-                        self.active_write_version.set(target);
-                        // `debug!` not `info!`: this is on the per-entry apply
-                        // hot path (this file carries the
-                        // `#[PerformanceCriticalPath]` marker), so
-                        // info-or-higher logging is banned. The
-                        // operator-visible surface is the `applied` counter
-                        // and the `active_write_version` gauge.
-                        tracing::debug!(
+                    // Defense-in-depth ahead of the subset check: refuse to
+                    // flip the cell to a target outside the LOCAL binary's
+                    // readable range. The gate at proposal time
+                    // (`target_in_local_readable_range` in `capabilities`)
+                    // is the primary safety mechanism, but the apply arm
+                    // re-checks here so an older (buggy) binary's committed
+                    // out-of-range entry cannot poison a fixed binary's
+                    // active write version on replay. Reaching this branch
+                    // means a protocol invariant was already broken; the
+                    // apply pipeline still must not panic (that would tear
+                    // down the leader) — emit a NO-OP outcome and a
+                    // distinct counter so the operator sees it.
+                    if !(MIN_READABLE_VERSION..=MAX_READABLE_VERSION).contains(&target) {
+                        tracing::error!(
                             target = target,
-                            gated_members = ?gated_members,
-                            committed_members = ?committed_members,
-                            "SetFormatVersion applied: active write version flipped"
+                            min = MIN_READABLE_VERSION,
+                            max = MAX_READABLE_VERSION,
+                            "SetFormatVersion apply rejected: target outside local readable range"
                         );
-                        crate::observability::record_applied();
-                        crate::observability::record_active_write_version(target);
-                        ApplyOutcome::FormatActivated { target }
+                        crate::observability::record_noop_target_out_of_range();
+                        let mut core = self.core.lock();
+                        core.last_applied = Some(log_id);
+                        HighWaterApplied {
+                            value: core.current_value,
+                            outcome: ApplyOutcome::FormatActivationTargetOutOfRange { target },
+                        }
                     } else {
-                        // Membership grew an un-gated member between the gate
-                        // and this entry's position. Leave the cell
-                        // untouched; the operator re-gates and re-issues. A
-                        // no-op writes nothing at `target`, so it cannot
-                        // resurrect on restart.
-                        //
-                        // `debug!` not `warn!`: hot path, same rule as the
-                        // success arm above. The operator-visible surface is
-                        // the `noop_membership_subset` counter — a non-zero
-                        // value during an activation means a membership
-                        // change raced the bump.
-                        tracing::debug!(
-                            target = target,
-                            gated_members = ?gated_members,
-                            committed_members = ?committed_members,
-                            "SetFormatVersion no-op: committed membership is not a subset of the gated set"
-                        );
-                        crate::observability::record_noop_membership_subset();
-                        ApplyOutcome::FormatActivationNoop { target }
-                    };
-                    core.last_applied = Some(log_id);
-                    HighWaterApplied {
-                        value: core.current_value,
-                        outcome,
+                        // Evaluate the subset against the membership committed as
+                        // of this entry's log position. Apply folds the log in
+                        // index order, so `core.last_membership` is exactly that
+                        // membership (a `Membership` entry at a lower index has
+                        // already updated it; a later one has not). Cover BOTH
+                        // voters and learners: openraft replicates/snapshots
+                        // learners, so an un-gated learner must force a no-op.
+                        let mut core = self.core.lock();
+                        let committed_members: std::collections::BTreeSet<u64> = core
+                            .last_membership
+                            .membership()
+                            .nodes()
+                            .map(|(node_id, _node)| *node_id)
+                            .collect();
+                        let outcome = if committed_members.is_subset(gated_members) {
+                            // Successful (non-no-op) apply: set the
+                            // process-shared active-write-version cell. NO meta
+                            // write — durability is the raft log (deterministic
+                            // replay re-runs this exact check) plus the snapshot
+                            // frame byte.
+                            self.active_write_version.set(target);
+                            // `debug!` not `info!`: this is on the per-entry apply
+                            // hot path (this file carries the
+                            // `#[PerformanceCriticalPath]` marker), so
+                            // info-or-higher logging is banned. The
+                            // operator-visible surface is the `applied` counter
+                            // and the `active_write_version` gauge.
+                            tracing::debug!(
+                                target = target,
+                                gated_members = ?gated_members,
+                                committed_members = ?committed_members,
+                                "SetFormatVersion applied: active write version flipped"
+                            );
+                            crate::observability::record_applied();
+                            crate::observability::record_active_write_version(target);
+                            ApplyOutcome::FormatActivated { target }
+                        } else {
+                            // Membership grew an un-gated member between the gate
+                            // and this entry's position. Leave the cell
+                            // untouched; the operator re-gates and re-issues. A
+                            // no-op writes nothing at `target`, so it cannot
+                            // resurrect on restart.
+                            //
+                            // `debug!` not `warn!`: hot path, same rule as the
+                            // success arm above. The operator-visible surface is
+                            // the `noop_membership_subset` counter — a non-zero
+                            // value during an activation means a membership
+                            // change raced the bump.
+                            tracing::debug!(
+                                target = target,
+                                gated_members = ?gated_members,
+                                committed_members = ?committed_members,
+                                "SetFormatVersion no-op: committed membership is not a subset of the gated set"
+                            );
+                            crate::observability::record_noop_membership_subset();
+                            ApplyOutcome::FormatActivationNoop { target }
+                        };
+                        core.last_applied = Some(log_id);
+                        HighWaterApplied {
+                            value: core.current_value,
+                            outcome,
+                        }
                     }
                 }
                 EntryPayload::Membership(membership) => {
@@ -799,9 +827,19 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn set_format_version_subset_match_sets_cell() {
+        // The flip is only observable when the local binary's readable
+        // range contains a target distinct from BASELINE. The
+        // `e2e-max-readable-next` test harness raises MAX to
+        // BASELINE + 1; in default builds MIN == MAX == BASELINE, so any
+        // distinct target is out of range and the apply-arm
+        // defense-in-depth (correctly) no-ops it. The behavior pinned by
+        // this test — "subset OK + in-range target ⇒ cell flips" — is
+        // unchanged; only the in-range target is feature-dependent.
         let mut sm = HighWaterStateMachine::new();
+        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 1;
         // Establish membership {1, 2} at index 1.
         apply_one(
             &mut sm,
@@ -815,7 +853,7 @@ mod tests {
             2,
             EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
                 SetFormatVersionPayload {
-                    target: 7,
+                    target,
                     gated_members: BTreeSet::from([1u64, 2u64, 3u64]),
                 },
             )),
@@ -823,8 +861,167 @@ mod tests {
         .await;
         assert_eq!(
             sm.active_write_version(),
-            7,
+            target,
             "cell set on successful subset apply"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_format_version_subset_match_out_of_range_target_is_apply_noop() {
+        // Mirror of the (feature-gated) "subset match" test but for the
+        // default build: a subset-OK bump whose target is OUT of the
+        // local readable range must be no-op'd by the apply-arm
+        // defense-in-depth, regardless of subset success. Pins the
+        // ordering invariant — the range check runs BEFORE the subset
+        // check, so an OOR target never sneaks through on a gate
+        // committed by an older buggy binary.
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.active_write_version();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Membership(voters_membership(&[1, 2])),
+        )
+        .await;
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target: 7, // out of range under default features.
+                    gated_members: BTreeSet::from([1u64, 2u64, 3u64]),
+                },
+            )),
+        )
+        .await;
+        assert_eq!(
+            sm.active_write_version(),
+            before,
+            "subset-OK + OOR target ⇒ apply-arm defense-in-depth no-op"
+        );
+    }
+
+    // ---- Apply-arm defense-in-depth: out-of-range target is a no-op ----
+    //
+    // The all-members gate at proposal time is the primary safety
+    // mechanism, but the apply arm independently refuses to flip the
+    // shared cell to a target outside the LOCAL binary's
+    // [MIN_READABLE_VERSION, MAX_READABLE_VERSION]. This guards against
+    // two paths the gate cannot:
+    //
+    //   1. Replay of a log committed by an older (buggy) binary that
+    //      let an out-of-range target through. A fixed binary replaying
+    //      that log must NOT propagate the corruption into its in-memory
+    //      cell, since the codec arms reject encode/decode at that
+    //      version and the cluster wedges.
+    //   2. A protocol-violating peer somehow committing such an entry
+    //      (e.g. a forged proposal). The fail-safe at apply contains
+    //      blast radius to "the flip didn't take effect" instead of
+    //      "all subsequent log appends fail".
+    //
+    // The behavior is a NO-OP (cell untouched + `FormatActivationTargetOutOfRange`
+    // outcome), never a panic. The apply pipeline is on the critical
+    // path; refusing to apply would tear the leader down rather than
+    // contain the bad entry.
+
+    #[tokio::test]
+    async fn set_format_version_target_above_max_is_apply_noop() {
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.active_write_version();
+        // Membership matches the gated set (subset OK) so the only thing
+        // that can hold the flip back is the range check.
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Membership(voters_membership(&[1, 2])),
+        )
+        .await;
+        let above_max = tsoracle_openraft_toolkit::MAX_READABLE_VERSION.saturating_add(1);
+        if above_max == tsoracle_openraft_toolkit::MAX_READABLE_VERSION {
+            return; // MAX == u8::MAX (impossible in practice).
+        }
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target: above_max,
+                    gated_members: BTreeSet::from([1u64, 2u64]),
+                },
+            )),
+        )
+        .await;
+        assert_eq!(
+            sm.active_write_version(),
+            before,
+            "apply must refuse to flip to a target above MAX_READABLE_VERSION"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_format_version_target_below_min_is_apply_noop() {
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.active_write_version();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Membership(voters_membership(&[1, 2])),
+        )
+        .await;
+        // MIN_READABLE_VERSION is at least 1 in any sensible build (the
+        // codec's compile-time `MIN <= MAX` plus the framing layer's
+        // version byte both effectively forbid MIN == 0), so MIN - 1 is
+        // always representable and out of range. This is the bug class
+        // the finding hit: a target below MIN that the (pre-fix) gate
+        // accepted because it only checked the upper bound.
+        let below_min = tsoracle_openraft_toolkit::MIN_READABLE_VERSION - 1;
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target: below_min,
+                    gated_members: BTreeSet::from([1u64, 2u64]),
+                },
+            )),
+        )
+        .await;
+        assert_eq!(
+            sm.active_write_version(),
+            before,
+            "apply must refuse to flip to a target below MIN_READABLE_VERSION"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_format_version_target_zero_is_apply_noop() {
+        // Target 0 is the worst case: 0 is also the legacy-unframed wire
+        // sentinel, so a 0-stamped record collides with that
+        // interpretation. The apply arm must refuse the flip rather than
+        // let it through (the codec would later reject every encode).
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.active_write_version();
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Membership(voters_membership(&[1, 2])),
+        )
+        .await;
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::SetFormatVersion(
+                SetFormatVersionPayload {
+                    target: 0,
+                    gated_members: BTreeSet::from([1u64, 2u64]),
+                },
+            )),
+        )
+        .await;
+        assert_eq!(
+            sm.active_write_version(),
+            before,
+            "apply must refuse to flip to a 0 target"
         );
     }
 
@@ -918,14 +1115,16 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn successful_activation_survives_replay() {
+        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 1;
         let log = vec![
             (1u64, ReplayEntry::Membership(vec![1, 2])),
             (
                 2u64,
                 ReplayEntry::Bump {
-                    target: 7,
+                    target,
                     gated: vec![1, 2, 3],
                 },
             ),
@@ -933,7 +1132,7 @@ mod tests {
         // Live apply sets the cell.
         let mut live = HighWaterStateMachine::new();
         replay(&mut live, &log).await;
-        assert_eq!(live.active_write_version(), 7);
+        assert_eq!(live.active_write_version(), target);
 
         // "Restart": a fresh SM with a fresh BASELINE-seeded cell, replaying
         // the same committed log, re-establishes target via the re-run
@@ -941,14 +1140,50 @@ mod tests {
         let mut recovered = HighWaterStateMachine::new();
         assert_ne!(
             recovered.active_write_version(),
-            7,
+            target,
             "fresh cell starts at baseline"
         );
         replay(&mut recovered, &log).await;
         assert_eq!(
             recovered.active_write_version(),
-            7,
+            target,
             "replay re-applies the flip"
+        );
+    }
+
+    #[tokio::test]
+    async fn out_of_range_bump_replays_as_noop_across_restart() {
+        // Replay-determinism contract for an out-of-range bump committed
+        // by an older (buggy) binary: every replay reaches the same
+        // state (cell stays at baseline) because the apply arm's range
+        // check uses ONLY the local binary's constants + the entry
+        // data, never timing or per-replay side state. The fix CANNOT
+        // resurrect the bad flip on restart.
+        let log = vec![
+            (1u64, ReplayEntry::Membership(vec![1, 2])),
+            (
+                2u64,
+                ReplayEntry::Bump {
+                    target: 7, // out of range under default features.
+                    gated: vec![1, 2, 3],
+                },
+            ),
+        ];
+        let mut live = HighWaterStateMachine::new();
+        let baseline = live.active_write_version();
+        replay(&mut live, &log).await;
+        assert_eq!(
+            live.active_write_version(),
+            baseline,
+            "live apply no-ops on OOR target"
+        );
+
+        let mut recovered = HighWaterStateMachine::new();
+        replay(&mut recovered, &log).await;
+        assert_eq!(
+            recovered.active_write_version(),
+            baseline,
+            "replay is deterministic: OOR bump stays a no-op across restart"
         );
     }
 
@@ -986,8 +1221,52 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn replay_is_deterministic() {
+        let in_range = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 1;
+        let log = vec![
+            (1u64, ReplayEntry::Membership(vec![1, 2])),
+            (
+                2u64,
+                ReplayEntry::Bump {
+                    target: in_range,
+                    gated: vec![1, 2, 3],
+                },
+            ),
+            // A later bump gated on a set that excludes a now-added member.
+            (3u64, ReplayEntry::Membership(vec![1, 2, 5])),
+            (
+                4u64,
+                ReplayEntry::Bump {
+                    target: in_range,
+                    gated: vec![1, 2],
+                },
+            ),
+        ];
+        let mut first = HighWaterStateMachine::new();
+        replay(&mut first, &log).await;
+        let mut second = HighWaterStateMachine::new();
+        replay(&mut second, &log).await;
+        // Index-2 bump succeeded (membership {1,2} ⊆ {1,2,3}); index-4
+        // bump no-ops (membership {1,2,5} ⊄ {1,2}), so the cell stays at
+        // `in_range`.
+        assert_eq!(first.active_write_version(), in_range);
+        assert_eq!(
+            first.active_write_version(),
+            second.active_write_version(),
+            "two replays of the same committed log yield the same cell"
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_is_deterministic_default_features() {
+        // Default-features replay-determinism check: any mix of
+        // out-of-range bumps and membership entries produces the same
+        // cell state across two independent replays, because the apply
+        // arm folds the log deterministically (range check + subset
+        // check are both pure functions of entry data + local binary
+        // constants).
         let log = vec![
             (1u64, ReplayEntry::Membership(vec![1, 2])),
             (
@@ -997,7 +1276,6 @@ mod tests {
                     gated: vec![1, 2, 3],
                 },
             ),
-            // A later bump gated on a set that excludes a now-added member.
             (3u64, ReplayEntry::Membership(vec![1, 2, 5])),
             (
                 4u64,
@@ -1008,12 +1286,11 @@ mod tests {
             ),
         ];
         let mut first = HighWaterStateMachine::new();
+        let baseline = first.active_write_version();
         replay(&mut first, &log).await;
         let mut second = HighWaterStateMachine::new();
         replay(&mut second, &log).await;
-        // Index-2 bump succeeded (membership {1,2} ⊆ {1,2,3}); index-4 bump
-        // no-ops (membership {1,2,5} ⊄ {1,2}), so the cell stays at 7.
-        assert_eq!(first.active_write_version(), 7);
+        assert_eq!(first.active_write_version(), baseline);
         assert_eq!(
             first.active_write_version(),
             second.active_write_version(),

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -99,6 +99,17 @@ pub enum ApplyOutcome {
     /// cell was left untouched and `target` did not take effect. The operator
     /// re-gates and re-issues.
     FormatActivationNoop { target: u8 },
+    /// A `SetFormatVersion` bump applied as a no-op for the apply arm's
+    /// defense-in-depth range check: `target` was outside the LOCAL
+    /// binary's `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]` so the
+    /// shared cell was left untouched. Distinct from
+    /// [`FormatActivationNoop`] because the failure class is "this entry
+    /// should never have been proposed" (a gate bug or a log committed
+    /// by an older binary), not "the membership drifted" — different
+    /// remediation, different counter, different operator surface. The
+    /// gate at proposal time normally prevents this from being committed
+    /// (see `target_in_local_readable_range`).
+    FormatActivationTargetOutOfRange { target: u8 },
 }
 
 /// Per-entry apply result.
@@ -244,6 +255,7 @@ mod tests {
             ApplyOutcome::Advanced,
             ApplyOutcome::FormatActivated { target: 4 },
             ApplyOutcome::FormatActivationNoop { target: 4 },
+            ApplyOutcome::FormatActivationTargetOutOfRange { target: 1 },
         ] {
             let applied = HighWaterApplied {
                 value: 42,

--- a/crates/tsoracle-driver-openraft/tests/activation_gate.rs
+++ b/crates/tsoracle-driver-openraft/tests/activation_gate.rs
@@ -100,25 +100,53 @@ async fn gate_passes_when_target_within_local_max() {
 
 #[tokio::test(start_paused = true)]
 async fn gate_fails_when_target_above_local_max() {
+    // The local-binary range short-circuit fires BEFORE any per-member
+    // check: a target above the local binary's MAX_READABLE_VERSION
+    // can't be read regardless of what peers report, so the gate emits
+    // `TargetOutOfRange` (not `MembersBelowTarget`) without ever
+    // invoking `CapabilitySource::query`. `UnusedSource`'s panic in its
+    // query method enforces that no peer RPC was attempted.
     let (host, _cluster) = single_node_leader_host().await;
     let target = tsoracle_openraft_toolkit::MAX_READABLE_VERSION + 1;
     let err = host
         .run_activation_gate(target, &UnusedSource)
         .await
-        .expect_err("gate fails when the only member cannot read the target");
-    let FormatActivationError::MembersBelowTarget {
+        .expect_err("gate fails when target is above the local readable max");
+    let FormatActivationError::TargetOutOfRange {
         target: returned,
-        incapable,
+        min,
+        max,
     } = err
     else {
-        panic!("expected MembersBelowTarget");
+        panic!("expected TargetOutOfRange, got: {err:?}");
     };
     assert_eq!(returned, target);
-    assert_eq!(incapable.len(), 1);
-    assert_eq!(incapable[0].0, 1);
-    assert_eq!(
-        incapable[0].1,
-        tsoracle_openraft_toolkit::MAX_READABLE_VERSION
+    assert_eq!(min, tsoracle_openraft_toolkit::MIN_READABLE_VERSION);
+    assert_eq!(max, tsoracle_openraft_toolkit::MAX_READABLE_VERSION);
+}
+
+#[tokio::test(start_paused = true)]
+async fn gate_fails_when_target_below_local_min() {
+    // The lower-bound branch of the local-binary range short-circuit:
+    // a target below MIN_READABLE_VERSION is unsupported regardless of
+    // peer capabilities and must be refused at the leader before any
+    // RPC. This is the path the security finding exercised — a
+    // pre-fix gate accepted `target=1` because it only checked the
+    // upper bound.
+    let (host, _cluster) = single_node_leader_host().await;
+    // MIN is at least 1 in any sensible build (compile-time `MIN <=
+    // MAX`); MIN - 1 is therefore always representable.
+    let target = tsoracle_openraft_toolkit::MIN_READABLE_VERSION - 1;
+    let err = host
+        .run_activation_gate(target, &UnusedSource)
+        .await
+        .expect_err("gate fails when target is below the local readable min");
+    assert!(
+        matches!(
+            err,
+            FormatActivationError::TargetOutOfRange { target: returned, .. } if returned == target
+        ),
+        "expected TargetOutOfRange for target below MIN"
     );
 }
 

--- a/crates/tsoracle-driver-openraft/tests/format_metrics.rs
+++ b/crates/tsoracle-driver-openraft/tests/format_metrics.rs
@@ -171,15 +171,20 @@ async fn format_migration_signals_fire_end_to_end() {
         .expect("activation to MAX_READABLE_VERSION must pass on a single-node leader");
 
     // ---- 4. Gate rejection: target above the local readable max.
+    //         The local-binary range short-circuit fires BEFORE any
+    //         per-member RPC, surfacing `TargetOutOfRange` rather than
+    //         `MembersBelowTarget`. Both increment the same
+    //         `rejected_by_gate` counter, which is what this end-to-end
+    //         metrics test cares about.
     let rejected = host
         .initiate_format_activation(MAX_READABLE_VERSION + 1, &UnusedSource)
         .await;
     assert!(
         matches!(
             rejected,
-            Err(FormatActivationError::MembersBelowTarget { .. })
+            Err(FormatActivationError::TargetOutOfRange { .. })
         ),
-        "target above MAX_READABLE_VERSION must be rejected by the gate"
+        "target above MAX_READABLE_VERSION must be rejected by the gate, got: {rejected:?}"
     );
 
     // ---- Assertions over the recorder snapshot.


### PR DESCRIPTION
## Summary

The all-members activation gate previously checked only `max_readable_version >= target`, with no `target >= MIN_READABLE_VERSION` (or `target <= MAX_READABLE_VERSION`) check. With `MIN == MAX == 4` today, an operator call to `initiate_format_activation(0..=3)` passed the gate, committed a `SetFormatVersion` raft entry, and flipped `ActiveWriteVersion` to a value the encode/decode codec arms reject — wedging subsequent log appends and snapshot builds.

- New `target_in_local_readable_range` helper + `FormatActivationError::TargetOutOfRange { target, min, max }` variant. `run_activation_gate` short-circuits before any peer RPC so an out-of-range target is rejected fast and unambiguously, regardless of peer capabilities; the existing `rejected_by_gate` counter records it.
- Defense-in-depth at apply: the `SetFormatVersion` arm independently refuses to flip the cell to a target outside the local binary's range, emits `ApplyOutcome::FormatActivationTargetOutOfRange`, and a distinct `noop_target_out_of_range` counter. Guards a fixed binary replaying a log committed by an older buggy binary, and a protocol-violating peer. Uses only entry data plus the binary's compile-time constants, so replay is deterministic for any single binary.
- `classify_activation_outcome` maps the new outcome back to `FormatActivationError::TargetOutOfRange`, so the operator-facing surface is uniform whether the gate or the apply arm fires.

Surface area is contained to `tsoracle-driver-openraft`; no public-API removals.

## Validation

- `cargo test --workspace` and `cargo test --workspace --all-features`: all green. The driver crate gains 11 new tests (gate helper, apply-arm no-op for target=0 / target<MIN / target>MAX, OOR replay determinism, classifier mapping, integration tests for above-max + below-min, error message shape).
- The existing `set_format_version_subset_match_sets_cell`, `successful_activation_survives_replay`, and `replay_is_deterministic` tests split into in-range flip assertions (now feature-gated behind `e2e-max-readable-next` using `BASELINE+1`) and OOR no-op assertions (always-on, same inputs).
- `tests/activation_gate.rs` and `tests/format_metrics.rs` integration tests updated to expect `TargetOutOfRange` for the above-max path (it now fires the local-binary short-circuit before any per-member RPC).
- `cargo clippy --workspace --all-targets [--all-features] -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `scripts/check-ts-header.py`: 261 files OK.

## Background

External security review (Codex finding `3ad6a3ccf1e081918c91be94865a8bf8`, low severity / low attack path) — the operator/library `initiate_format_activation` path on `StandaloneHost` is the only reachable entry today (no CLI/admin RPC surface for format activation), so the rating is hardening + operator-footgun mitigation rather than externally-reachable CVE.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `scripts/check-ts-header.py`