### PR TITLE
fix(standalone/tests): hold listener until bind to close port-lease TOCTOU

### DIFF
--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -35,17 +35,7 @@
 //! from the coverage report in the Makefile.
 
 #[cfg(any(feature = "openraft", feature = "paxos"))]
-async fn lease_port() -> std::net::SocketAddr {
-    // Bind an ephemeral port to learn a free address, then release it so the
-    // driver's peer listener can claim it. Same TOCTOU-tolerant trick the smoke
-    // tests use.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind ephemeral port");
-    let addr = listener.local_addr().expect("read local addr");
-    drop(listener);
-    addr
-}
+mod common;
 
 #[cfg(feature = "file")]
 mod file_driver {
@@ -84,7 +74,7 @@ mod openraft_driver {
         DriverConfig, MemberAddr, OpenraftConfig, RaftTuning, StandaloneError, build,
     };
 
-    use crate::lease_port;
+    use crate::common::lease_port;
 
     fn single_node_cfg(
         raft_addr: std::net::SocketAddr,
@@ -127,9 +117,10 @@ mod openraft_driver {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn build_openraft_single_node_boots_and_drains() {
         let dir = tempdir().unwrap();
-        let raft_addr = lease_port().await;
+        let (raft_addr, raft_lease) = lease_port().await;
         let cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
 
+        drop(raft_lease);
         let mut node = build(DriverConfig::Openraft(cfg))
             .await
             .expect("build openraft driver");
@@ -259,13 +250,14 @@ mod openraft_driver {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn admin_bind_conflict_is_a_bind_error() {
         let dir = tempdir().unwrap();
-        let raft_addr = lease_port().await;
+        let (raft_addr, raft_lease) = lease_port().await;
         // Hold the admin address so the admin server's bind collides with it.
         let squatter = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let taken = squatter.local_addr().unwrap();
 
         let mut cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
         cfg.admin_listen = Some(taken);
+        drop(raft_lease);
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
             Err(StandaloneError::AdminBind { .. })
@@ -281,7 +273,7 @@ mod paxos_driver {
     use tempfile::tempdir;
     use tsoracle_standalone::{DriverConfig, PaxosConfig, build};
 
-    use crate::lease_port;
+    use crate::common::lease_port;
 
     /// A paxos node boots through `build()`: storage opens, the peer listener
     /// binds, and the lifecycle host starts. OmniPaxos refuses a single-node
@@ -294,10 +286,10 @@ mod paxos_driver {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn build_paxos_boots_and_shuts_down() {
         let dir = tempdir().unwrap();
-        let peer_listen = lease_port().await;
+        let (peer_listen, peer_lease) = lease_port().await;
         // A second voter that we deliberately never start, just to satisfy
         // OmniPaxos's >1-node requirement.
-        let absent_peer = lease_port().await;
+        let (absent_peer, absent_lease) = lease_port().await;
         let mut peers = BTreeMap::new();
         peers.insert(1, peer_listen.to_string());
         peers.insert(2, absent_peer.to_string());
@@ -317,6 +309,8 @@ mod paxos_driver {
             peer_tls: None,
         };
 
+        drop(peer_lease);
+        drop(absent_lease);
         let mut node = build(DriverConfig::Paxos(cfg))
             .await
             .expect("build paxos driver");
@@ -355,7 +349,7 @@ mod paxos_driver {
         let dir = tempdir().unwrap();
         let squatter = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let taken = squatter.local_addr().unwrap();
-        let unused = lease_port().await;
+        let (unused, unused_lease) = lease_port().await;
 
         let mut peers = BTreeMap::new();
         peers.insert(1, taken.to_string());
@@ -369,6 +363,7 @@ mod paxos_driver {
             tick_interval: Duration::from_millis(20),
             peer_tls: None,
         };
+        drop(unused_lease);
         assert!(matches!(
             build(DriverConfig::Paxos(cfg)).await,
             Err(tsoracle_standalone::StandaloneError::PeerBind { .. })

--- a/crates/tsoracle-standalone/tests/common/mod.rs
+++ b/crates/tsoracle-standalone/tests/common/mod.rs
@@ -1,0 +1,65 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Shared test scaffolding for `tsoracle-standalone` integration tests.
+//!
+//! Each `tests/*.rs` declares `mod common;` and imports via `use common::*;`.
+//! Rust compiles this module per integration-test binary (a known minor
+//! duplication; negligible at our scale).
+
+#![allow(dead_code)] // each test binary uses a subset; allow the rest
+
+use std::net::SocketAddr;
+
+use tokio::net::TcpListener;
+
+/// Holds an open ephemeral-port listener so the kernel will not re-assign
+/// that port to any other `bind(:0)` in the system. Drop just before the
+/// consumer's own bind to keep the residual TOCTOU window microscopic.
+pub struct PortLease {
+    _listener: Option<TcpListener>,
+}
+
+/// Bind an ephemeral port and return its address paired with a `PortLease`
+/// holding the listener open. Drop the `PortLease` at the exact moment the
+/// consumer is about to bind the address.
+///
+/// The earlier helper just dropped the listener and returned the address —
+/// a classic TOCTOU race. Under parallel `#[tokio::test]` execution (each
+/// integration-test binary spreads tests across worker threads), the kernel
+/// would re-issue a freshly-freed ephemeral port to another test's
+/// `bind(:0)` before the original test's consumer got around to binding,
+/// causing `EADDRINUSE` panics. Holding the listener until the consumer is
+/// ready makes the port unassignable for the entire lease window.
+pub async fn lease_port() -> (SocketAddr, PortLease) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("read local addr");
+    (
+        addr,
+        PortLease {
+            _listener: Some(listener),
+        },
+    )
+}

--- a/crates/tsoracle-standalone/tests/openraft_membership.rs
+++ b/crates/tsoracle-standalone/tests/openraft_membership.rs
@@ -23,6 +23,8 @@
 
 #![cfg(feature = "openraft")]
 
+mod common;
+
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -33,21 +35,13 @@ use tsoracle_standalone::{
     DriverConfig, MemberAddr, MemberRole, NewMember, OpenraftConfig, RaftTuning, build,
 };
 
+use common::lease_port;
+
 #[test]
 fn admin_proto_types_exist() {
     // Compiles only if the generated module is present and named as expected.
     let _ = tsoracle_standalone::admin_proto::ChangeResponse::default();
     let _ = tsoracle_standalone::admin_proto::MemberRole::Voter;
-}
-
-/// Bind an ephemeral port, read its address, then release it so the node can
-/// rebind it on boot. TOCTOU-tolerant in practice (same trick the build and
-/// smoke tests use): the window is tiny and the test owns the loopback range.
-async fn lease_port() -> std::net::SocketAddr {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
 }
 
 fn fast_tuning() -> RaftTuning {
@@ -62,8 +56,8 @@ fn fast_tuning() -> RaftTuning {
 async fn add_learner_promote_then_remove() {
     let dir1 = tempdir().unwrap();
     let dir2 = tempdir().unwrap();
-    let raft1 = lease_port().await;
-    let raft2 = lease_port().await;
+    let (raft1, lease1) = lease_port().await;
+    let (raft2, lease2) = lease_port().await;
 
     let mut members = BTreeMap::new();
     members.insert(
@@ -74,6 +68,7 @@ async fn add_learner_promote_then_remove() {
             admin_endpoint: "127.0.0.1:11".into(),
         },
     );
+    drop(lease1);
     let node1 = build(DriverConfig::Openraft(OpenraftConfig {
         id: 1,
         raft_addr: raft1,
@@ -100,6 +95,7 @@ async fn add_learner_promote_then_remove() {
     .expect("node 1 elected");
     drop(events);
 
+    drop(lease2);
     let node2 = build(DriverConfig::Openraft(OpenraftConfig {
         id: 2,
         raft_addr: raft2,
@@ -172,9 +168,9 @@ async fn admin_grpc_list_and_add_learner() {
 
     let dir1 = tempdir().unwrap();
     let dir2 = tempdir().unwrap();
-    let raft1 = lease_port().await;
-    let raft2 = lease_port().await;
-    let admin_addr = lease_port().await;
+    let (raft1, lease1) = lease_port().await;
+    let (raft2, lease2) = lease_port().await;
+    let (admin_addr, admin_lease) = lease_port().await;
 
     let mut members = BTreeMap::new();
     members.insert(
@@ -185,6 +181,8 @@ async fn admin_grpc_list_and_add_learner() {
             admin_endpoint: admin_addr.to_string(),
         },
     );
+    drop(lease1);
+    drop(admin_lease);
     let node1 = build(DriverConfig::Openraft(OpenraftConfig {
         id: 1,
         raft_addr: raft1,
@@ -211,6 +209,7 @@ async fn admin_grpc_list_and_add_learner() {
     .expect("elected");
     drop(events);
 
+    drop(lease2);
     let node2 = build(DriverConfig::Openraft(OpenraftConfig {
         id: 2,
         raft_addr: raft2,
@@ -269,9 +268,9 @@ async fn coexisting_learner_survives_a_promote() {
     let dir1 = tempdir().unwrap();
     let dir2 = tempdir().unwrap();
     let dir3 = tempdir().unwrap();
-    let raft1 = lease_port().await;
-    let raft2 = lease_port().await;
-    let raft3 = lease_port().await;
+    let (raft1, lease1) = lease_port().await;
+    let (raft2, lease2) = lease_port().await;
+    let (raft3, lease3) = lease_port().await;
 
     let mut members = BTreeMap::new();
     members.insert(
@@ -282,6 +281,7 @@ async fn coexisting_learner_survives_a_promote() {
             admin_endpoint: "127.0.0.1:11".into(),
         },
     );
+    drop(lease1);
     let node1 = build(DriverConfig::Openraft(OpenraftConfig {
         id: 1,
         raft_addr: raft1,
@@ -321,9 +321,11 @@ async fn coexisting_learner_survives_a_promote() {
             admin_tls: None,
         }))
     };
+    drop(lease2);
     let node2 = build_follower(2, raft2, dir2.path().join("raft"))
         .await
         .expect("build node 2");
+    drop(lease3);
     let node3 = build_follower(3, raft3, dir3.path().join("raft"))
         .await
         .expect("build node 3");


### PR DESCRIPTION
## Summary

- `lease_port` in `tsoracle-standalone` integration tests bound `127.0.0.1:0`, read the addr, dropped the listener, and returned the addr — the classic TOCTOU race. Once the listener is dropped, the kernel can re-issue that ephemeral port to any concurrent `bind(:0)` (parallel `#[tokio::test]` threads do this constantly), so two tests "own" the same port and the second to actually bind hits `EADDRINUSE`.
- Switch to a `PortLease` that holds the listener open and is dropped at the consumer's bind site. While the listener is alive the kernel won't re-issue the port; the residual race window shrinks from the multi-second gap between leasing and `build()` down to microseconds.
- Consolidate the previously duplicated `lease_port` into `tests/common/mod.rs`, matching the convention used by every sister-crate integration-test directory (`tsoracle-driver-openraft`, `tsoracle-driver-paxos`, `tsoracle-openraft-toolkit`, `tsoracle-paxos-toolkit`).

## Context

Surfaced as a coverage-job flake on https://github.com/prisma-risk/tsoracle/actions/runs/26439830368 (`admin_grpc_list_and_add_learner`), where the gap between three back-to-back leases and the second node's `build()` is multi-second. `admin_grpc_list_and_add_learner` panicked at:

```
build node 2: PeerBind { addr: 127.0.0.1:42841, source: Os { code: 98, kind: AddrInUse } }
```

The mechanism is the canonical one: `bind(:0)` reserves the port only while the socket is open. `inet_csk_find_open_port` walks the ephemeral range forward from the last allocation, so a port freed milliseconds ago is fair game for the next `:0` bind. The previous helper's "TOCTOU-tolerant in practice — the window is tiny" comment was wrong: the window between `lease_port` and the consumer's bind spans multiple seconds (lease all ports up front, wait for election, then build follower).

`SO_REUSEADDR` doesn't help (different sockets, different processes), and a process-wide `Mutex` wouldn't help across binaries. The kernel guarantee about open listeners is the only primitive that actually works here, so we lean on it: keep the listener until the consumer is ready.

## Changes

- New `crates/tsoracle-standalone/tests/common/mod.rs` with `PortLease` + `lease_port() -> (SocketAddr, PortLease)`.
- `openraft_membership.rs` and `build_in_process.rs` drop their local `lease_port` copies, declare `mod common;`, and `drop(lease)` immediately before each `build()`. All seven existing lease/build sites updated.

## Test plan

- [x] `cargo check -p tsoracle-standalone --tests --all-features`
- [x] `cargo test --workspace --all-features --tests` — all green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check`
- [x] Ran the affected integration tests 5× in a loop locally — `8 passed; 0 failed` each iteration
- [x] CI coverage lane (the actual flake surface) on this branch