### PR TITLE
docs(proto): expand and correct service/RPC/field comments

### DIFF
--- a/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
+++ b/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
@@ -1,7 +1,23 @@
 syntax = "proto3";
 package tsoracle.v1;
 
+// Public timestamp-oracle service.
+//
+// Clients call `GetTs` to allocate one or more consecutive timestamps. The
+// service guarantees that successive successful grants are strictly
+// monotonically increasing (within and across calls) for the lifetime of a
+// leader epoch, and that no two grants from any epoch ever overlap.
 service TsoService {
+  // Allocate `count` consecutive timestamps.
+  //
+  // On success the response covers logicals
+  // [logical_start, logical_start + count - 1] at the returned `physical_ms`,
+  // stamped with the leader's `epoch_hi`/`epoch_lo`.
+  //
+  // Only the current leader serves this RPC. A non-leader returns
+  // `FAILED_PRECONDITION` with a `tsoracle-leader-hint-bin` binary metadata
+  // trailer carrying a postcard-encoded `LeaderHint` (see below); clients
+  // re-route to the hinted leader and retry.
   rpc GetTs(GetTsRequest) returns (GetTsResponse);
 }
 
@@ -16,19 +32,27 @@ message GetTsResponse {
   // 18-bit logical counter; the response covers logicals
   // [logical_start, logical_start + count - 1] at this physical_ms.
   uint32 logical_start = 2;
-  // Number of consecutive timestamps allocated.
+  // Number of consecutive timestamps allocated. Equals the request's `count`
+  // on success (the server never returns a partial grant).
   uint32 count = 3;
   // Leader epoch that issued this grant, as a 128-bit value split into two
   // 64-bit halves (epoch_hi is the more significant half). Lexicographic
-  // (epoch_hi, epoch_lo) order equals numeric order.
+  // (epoch_hi, epoch_lo) order equals numeric order. Strictly monotone per
+  // node across leader terms; clients use it to detect a leader handoff
+  // (a smaller epoch after a larger one indicates a stale server).
   uint64 epoch_hi = 4;
   uint64 epoch_lo = 5;
 }
 
 // Carried in the `tsoracle-leader-hint-bin` binary metadata trailer when the
 // server returns FAILED_PRECONDITION from GetTs because it is not currently
-// the leader.
+// the leader. The body is postcard-encoded; the client filters this trailer
+// out before exposing the gRPC `Status` to user code.
 message LeaderHint {
+  // Scheme-less `host:port` of the leader's TsoService endpoint as known to
+  // this node. Absent when the node has no leader information yet (cold start,
+  // or right after a leadership change). The client treats the hint as
+  // advisory: a stale hint costs an extra round trip, not correctness.
   optional string leader_endpoint = 1;
   // Leader epoch as a single nested message, so its presence implies both
   // halves: the hint either carries a complete epoch or none. Bundling the

--- a/crates/tsoracle-standalone/proto/admin.proto
+++ b/crates/tsoracle-standalone/proto/admin.proto
@@ -2,35 +2,86 @@ syntax = "proto3";
 
 package tsoracle.admin.v1;
 
+// Runtime cluster-membership administration.
+//
+// Implemented only by the openraft driver; the paxos and file drivers return
+// `UNSUPPORTED` for every mutating RPC (ListMembers still works on all
+// drivers and reports a fixed view for paxos/file).
+//
+// `AddLearner`, `Promote` and `RemoveNode` are leader-only. A non-leader
+// returns `ok=false`, `error=NOT_LEADER`, and — when known —
+// `leader_admin_endpoint` set to the leader's admin port; the `tsoracle
+// admin` CLI uses this to one-step re-route the request.
+//
+// All mutating RPCs are idempotent (re-issuing a successful change is a
+// no-op) and are serialized on the server by an internal lock so two
+// reconfigurations cannot race.
 service MembershipAdmin {
+  // Return the membership as this node currently sees it. Answerable by any
+  // node; returns at least its own entry even before the cluster has a
+  // leader.
   rpc ListMembers(ListMembersRequest) returns (MembershipView);
+  // Add a new node as a non-voting learner. Idempotent on `id`: a node
+  // already in the membership is a no-op, even if `raft_addr` /
+  // `service_endpoint` / `admin_endpoint` differ. Blocks until the learner
+  // is registered. Errors: NOT_LEADER, UNSUPPORTED, DRIVER.
   rpc AddLearner(AddLearnerRequest) returns (ChangeResponse);
+  // Promote an existing learner to voter. Idempotent on `id` (already-voter
+  // is a no-op). Errors: NOT_LEADER, NOT_MEMBER, UNSUPPORTED, DRIVER
+  // (including the underlying "learner not caught up" case).
   rpc Promote(PromoteRequest) returns (ChangeResponse);
+  // Remove a member by id (voter or learner). Idempotent on `id` (unknown
+  // ids return ok). The server refuses to remove the last remaining voter
+  // (`WOULD_LOSE_QUORUM`); other quorum-loss shapes are the operator's
+  // responsibility. Removing the current leader is allowed: openraft
+  // commits the removal while still leader, then steps down. Errors:
+  // NOT_LEADER, WOULD_LOSE_QUORUM, UNSUPPORTED, DRIVER.
   rpc RemoveNode(RemoveNodeRequest) returns (ChangeResponse);
 }
 
+// A node's role in the current membership.
 enum MemberRole {
+  // proto3 default. Treated as "unknown role"; the server never emits this.
   MEMBER_ROLE_UNSPECIFIED = 0;
+  // Counted in quorum and may vote in leader elections.
   MEMBER_ROLE_VOTER = 1;
+  // Replicates the log but is not counted in quorum and cannot vote.
   MEMBER_ROLE_LEARNER = 2;
 }
 
+// One member as the queried node understands it. The three addresses are
+// the three planes that participate in the cluster (see also
+// `tsoracle-driver-openraft::OpenraftPeer`):
 message MemberEntry {
+  // Cluster-unique node id. Stable across address changes.
   uint64 id = 1;
+  // Voter or Learner under the current committed membership.
   MemberRole role = 2;
+  // `host:port` of the node's openraft peer transport (consensus traffic).
   string raft_addr = 3;
+  // Scheme-less `host:port` of the node's public `TsoService` endpoint.
+  // What a client uses to issue `GetTs`; also what leader hints carry.
   string service_endpoint = 4;
+  // `host:port` of the node's admin gRPC endpoint. What `NOT_LEADER`
+  // responses redirect to.
   string admin_endpoint = 5;
 }
 
 message ListMembersRequest {}
 
+// Snapshot of the membership at the responding node. `has_leader` + `leader`
+// jointly encode `Option<u64>` (proto3 has no optional uint64): `leader` is
+// meaningful iff `has_leader` is true; consumers must NOT interpret
+// `leader == 0` as "no leader".
 message MembershipView {
   repeated MemberEntry members = 1;
   bool has_leader = 2;
   uint64 leader = 3;
 }
 
+// All three address fields are required by the openraft driver. They are
+// stored in the membership log and surfaced verbatim in subsequent
+// `ListMembers` responses; the server does not parse or canonicalize them.
 message AddLearnerRequest {
   uint64 id = 1;
   string raft_addr = 2;
@@ -41,22 +92,51 @@ message AddLearnerRequest {
 message PromoteRequest { uint64 id = 1; }
 message RemoveNodeRequest { uint64 id = 1; }
 
+// Typed error kinds for `ChangeResponse`. Adding a new variant is backwards
+// compatible: clients that don't recognize a value fall back to the
+// human-readable `message` field. `ok=true` is the authoritative success
+// flag — the wire never carries `error=UNSPECIFIED` with `ok=false`.
 enum AdminErrorKind {
-  ADMIN_ERROR_KIND_UNSPECIFIED = 0; // proto3 default / unset; `ok` is the authoritative success flag
+  // proto3 default / unset. `ok` is the authoritative success flag.
+  ADMIN_ERROR_KIND_UNSPECIFIED = 0;
+  // Mutating RPC reached a follower. `leader_admin_endpoint` carries the
+  // leader's admin port when this node knows it.
   ADMIN_ERROR_KIND_NOT_LEADER = 1;
+  // This driver does not implement runtime membership changes (paxos, file).
   ADMIN_ERROR_KIND_UNSUPPORTED = 2;
+  // `Promote` against an id that is not in the current membership.
   ADMIN_ERROR_KIND_NOT_MEMBER = 3;
+  // Reserved: a learner promotion was rejected because the learner had not
+  // yet caught up. The current openraft impl folds this case into `DRIVER`
+  // with the upstream error text; reserved here so future drivers (or a
+  // future explicit catch-up check) can surface it as a typed kind.
   ADMIN_ERROR_KIND_NOT_CAUGHT_UP = 4;
+  // `RemoveNode` against the last remaining voter. Other quorum-loss
+  // shapes are the operator's responsibility.
   ADMIN_ERROR_KIND_WOULD_LOSE_QUORUM = 5;
+  // Reserved: the membership change did not commit within an internal
+  // deadline. Not currently produced (the openraft impl folds timeouts
+  // into `DRIVER`); reserved for future explicit-deadline plumbing.
   ADMIN_ERROR_KIND_TIMEOUT = 6;
+  // Catch-all for an upstream driver error not captured by the typed
+  // variants above. `message` carries the driver's error string.
   ADMIN_ERROR_KIND_DRIVER = 7;
 }
 
+// Result of a mutating membership RPC. On success: `ok=true`, `error=
+// UNSPECIFIED`, the two string fields empty. On failure: `ok=false`,
+// `error` set to a typed kind, optionally a redirect endpoint and/or a
+// human-readable message.
 message ChangeResponse {
+  // Authoritative success flag. Always check this before reading `error`.
   bool ok = 1;
+  // Typed error kind; meaningful only when `ok=false`.
   AdminErrorKind error = 2;
-  // Set when error == NOT_LEADER and a leader admin endpoint is known.
+  // Set when `error == NOT_LEADER` and a leader admin endpoint is known.
+  // Empty string means "no hint available" (cold start, or no leader yet).
   string leader_admin_endpoint = 3;
-  // Human-readable detail (e.g. the driver error string).
+  // Human-readable detail (e.g. the driver error string for `DRIVER`).
+  // Empty on success. Suitable for surfacing to operators; clients should
+  // dispatch on `error`, not on this string.
   string message = 4;
 }

--- a/crates/tsoracle-standalone/proto/paxos_peer.proto
+++ b/crates/tsoracle-standalone/proto/paxos_peer.proto
@@ -5,15 +5,29 @@ package tsoracle.paxos.peer.v1;
 // Peer-transport service for OmniPaxos.
 //
 // OmniPaxos has a single inbound dispatch point (`handle_incoming`), so one
-// fire-and-forget unary RPC is enough. The payload is a postcard-encoded
-// `omnipaxos::messages::Message<HighWaterCommand>` from the
+// unary RPC is enough for all consensus traffic. The payload is a
+// postcard-encoded `omnipaxos::messages::Message<HighWaterCommand>` from the
 // `tsoracle-driver-paxos` crate.
 service PaxosPeerService {
+  // Deliver one message to the receiver's `OmniPaxos::handle_incoming`. The
+  // response is an empty `Ack`; the client awaits it for delivery
+  // confirmation but does not read any body. Idempotency / replay safety
+  // are handled by OmniPaxos itself — the transport layer has nothing to
+  // dedupe. The server drops its cached client channel on RPC failure so
+  // the next attempt reconnects rather than re-using a half-broken pool
+  // entry.
   rpc Send(PaxosMessage) returns (Ack);
 }
 
 message PaxosMessage {
+  // Postcard-encoded `omnipaxos::messages::Message<HighWaterCommand>`. The
+  // receiver decodes and routes via `OmniPaxos::handle_incoming`; a decode
+  // failure surfaces as `invalid_argument` and closes only this RPC (the
+  // shared OmniPaxos handle is unaffected).
   bytes payload = 1;
 }
 
+// Empty acknowledgement. Returned for every successful `Send`; absence of
+// the response (transport error) is the only failure signal the client
+// reacts to.
 message Ack {}

--- a/crates/tsoracle-standalone/proto/raft_peer.proto
+++ b/crates/tsoracle-standalone/proto/raft_peer.proto
@@ -4,8 +4,11 @@ package tsoracle.raft.peer.v1;
 
 // Peer-transport service for openraft.
 //
-// AppendEntries / Vote payloads are postcard-encoded openraft messages; we treat
-// them as opaque bytes because openraft's wire types are not protobuf-shaped.
+// AppendEntries / Vote / TransferLeader payloads are postcard-encoded openraft
+// messages; we treat them as opaque bytes because openraft's wire types are
+// not protobuf-shaped. The carrier `RaftMessage.format_version` field describes
+// the encoding version of `payload`; see that field's doc for how a 0 value
+// is interpreted by the receiver.
 //
 // Snapshot is a *client-streaming* RPC. The client sends exactly one
 // `SnapshotChunk { header }` followed by zero or more `SnapshotChunk { data }`
@@ -13,9 +16,20 @@ package tsoracle.raft.peer.v1;
 // `Raft::install_full_snapshot`. The reply is a single postcard-encoded
 // `SnapshotResponse` carried in `RaftMessage.payload`.
 service RaftPeerService {
+  // openraft `AppendEntriesRequest` → `AppendEntriesResponse`, both postcard.
+  // Carries log entries and heartbeats from leader to followers.
   rpc AppendEntries (RaftMessage) returns (RaftMessage);
+  // openraft `VoteRequest` → `VoteResponse`, both postcard. Used for leader
+  // election and pre-vote.
   rpc Vote (RaftMessage) returns (RaftMessage);
+  // Install a full snapshot on the receiver. Client-streaming: exactly one
+  // header chunk, then zero or more data chunks. See the `SnapshotChunk` and
+  // `SnapshotHeader` framing rules below.
   rpc Snapshot (stream SnapshotChunk) returns (RaftMessage);
+  // openraft `TransferLeaderRequest` → empty postcard reply. The caller is
+  // the outgoing leader asking a designated follower to start a new election;
+  // openraft self-wraps the call in `C::timeout`, so the transport need not
+  // impose its own deadline beyond `RPCOption::hard_ttl`.
   rpc TransferLeader (RaftMessage) returns (RaftMessage);
   // Format-migration capability query. The request `RaftMessage.payload` is
   // empty (the query takes no arguments). The reply `RaftMessage.payload` is
@@ -28,23 +42,36 @@ service RaftPeerService {
   rpc Capabilities (RaftMessage) returns (RaftMessage);
 }
 
+// Generic envelope shared by every unary openraft peer RPC. Both the request
+// and reply travel as `RaftMessage`; the meaning of `payload` is determined
+// by the RPC method.
 message RaftMessage {
+  // Postcard-encoded openraft message body. May be empty for RPCs whose
+  // request takes no arguments (currently `Capabilities`).
   bytes payload = 1;
   // Format version of the postcard-encoded `payload`. proto3 default 0 means
   // "absent" (a pre-feature sender) and is interpreted by the receiver as the
   // BASELINE write version. A versioned sender stamps its active write version.
+  // Stored in `u32` so the wire field stays room for future bumps; the value
+  // must fit in `u8` and lie within the receiver's readable range, otherwise
+  // the RPC fails with a typed transport error.
   uint32 format_version = 2;
 }
 
 // One chunk of a snapshot install RPC.
 //
-// Framing rules (enforced by the server):
+// Framing rules (enforced by the server; violations close the stream with
+// `invalid_argument`):
 //   - The FIRST chunk on the stream MUST be `header`.
 //   - Every subsequent chunk MUST be `data`.
-//   - End-of-stream signals the snapshot is complete.
+//   - End-of-stream signals the snapshot is complete; the server then calls
+//     `Raft::install_full_snapshot` and replies with a single `RaftMessage`
+//     carrying the postcard-encoded `SnapshotResponse`.
 message SnapshotChunk {
   oneof kind {
     SnapshotHeader header = 1;
+    // Raw snapshot bytes, in send order. The server concatenates these
+    // without per-chunk framing; chunking is purely a transport concern.
     bytes data = 2;
   }
 }


### PR DESCRIPTION
## Summary

- Bring the four `.proto` files up to contract-level documentation: every service, RPC, message and field now has a comment when one carries non-obvious information.
- Correct two existing comments that didn't match the implementation:
  - `paxos_peer.proto` previously called `Send` "fire-and-forget unary" — it's unary and the client awaits an empty `Ack`. Updated.
  - `admin.proto`'s `AdminErrorKind` previously implied `NOT_CAUGHT_UP` / `TIMEOUT` were live error kinds. The current openraft impl in `admin/openraft.rs::map_write_error` folds those upstream errors into `DRIVER`; both variants are now marked **reserved** with their conditions documented.
- Fact-checked everything against the code before writing: bit widths (`tsoracle-core/src/timestamp.rs`), trailer key (`tsoracle-proto/src/lib.rs::LEADER_HINT_TRAILER_KEY`), `Capabilities` payload shape (`drivers/openraft/network.rs`), `format_version` envelope semantics (`drivers/openraft/network.rs::wire`), idempotency rules (`admin/openraft.rs`).

### Per-file highlights

| File | What changed |
|---|---|
| `tso.proto` | `TsoService` monotonicity preamble; `GetTs` leader-only contract + `FAILED_PRECONDITION` / `tsoracle-leader-hint-bin` trailer protocol; epoch monotonicity rationale on `epoch_hi`/`epoch_lo`. |
| `admin.proto` | Full pass on a previously-undocumented surface. Service preamble (openraft-only, leader-only mutators, idempotency, server-side lock). Per-RPC contracts with verified error sets. Per-field comments for the three address planes (`raft_addr` / `service_endpoint` / `admin_endpoint`). `has_leader` + `leader` documented as the `Option<u64>` encoding. Every `AdminErrorKind` variant expanded; `NOT_CAUGHT_UP` and `TIMEOUT` reserved. |
| `raft_peer.proto` | Per-RPC doc for `AppendEntries` / `Vote` / `Snapshot` / `TransferLeader`. `RaftMessage` envelope comment, `format_version` u32-storage rationale, framing-error code on `SnapshotChunk`, data-chunk concatenation rule. |
| `paxos_peer.proto` | Replace inaccurate "fire-and-forget" with the real behavior; document `Send`'s OmniPaxos-owned idempotency and the server-side cached-channel eviction on RPC failure; per-message comments. |

No behavior changes. Comment-only diff in the `.proto` files; `prost`/`tonic` codegen picks up the new comments as Rust doc comments on the generated types.

## Test plan

- [x] `cargo check --workspace --all-features` — clean.
- [x] `cargo fmt --check` and `cargo clippy` — green (pre-commit hook).
- [x] CI green on the PR.