### PR TITLE
feat: GetCurrentMaxSafe RPC

### DIFF
--- a/crates/tsoracle-client/src/attempt.rs
+++ b/crates/tsoracle-client/src/attempt.rs
@@ -285,6 +285,16 @@ mod tests {
                     "unreachable: server should be timed out",
                 ))
             }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
+            }
         }
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -417,6 +427,16 @@ mod tests {
             {
                 Err(tonic::Status::internal("boom"))
             }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
+            }
         }
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -481,6 +501,16 @@ mod tests {
             {
                 tokio::time::sleep(Duration::from_secs(30)).await;
                 Err(tonic::Status::internal("unreachable: should be timed out"))
+            }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
             }
         }
 
@@ -554,6 +584,16 @@ mod tests {
                     epoch_hi: 0,
                     epoch_lo: 0,
                 }))
+            }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
             }
         }
 

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -48,7 +48,7 @@ pub use transport::BoxError;
 
 use std::sync::Arc;
 use std::time::Duration;
-use tsoracle_core::{LOGICAL_MAX, Timestamp};
+use tsoracle_core::{Epoch, LOGICAL_MAX, Timestamp};
 
 /// The server's per-call cap on requested timestamps, fixed by the 18-bit
 /// logical width. Callers asking for more than this can't be served by any
@@ -204,6 +204,41 @@ impl Client {
         }
         self.driver.request(count).await
     }
+
+    /// Read the leader's current safe-point in physical-millisecond units.
+    ///
+    /// Targets the cached leader if known, otherwise the first configured
+    /// endpoint. Followers return `MaxSafe::max_safe_physical_ms == 0` rather
+    /// than erroring, matching the proto contract; pollers needing freshness
+    /// should target the leader endpoint.
+    pub async fn get_current_max_safe(&self) -> Result<MaxSafe, ClientError> {
+        let endpoint = self
+            .pool
+            .cached_leader()
+            .or_else(|| self.pool.iter_round_robin().into_iter().next())
+            .ok_or(ClientError::NoReachableEndpoints)?;
+        let (mut svc, _cell) = self.pool.client_with_cell(&endpoint).await?;
+        let resp = svc
+            .get_current_max_safe(tsoracle_proto::v1::GetCurrentMaxSafeRequest {})
+            .await
+            .map_err(ClientError::Rpc)?;
+        let inner = resp.into_inner();
+        Ok(MaxSafe {
+            max_safe_physical_ms: inner.max_safe_physical_ms,
+            epoch: Epoch::from_wire(inner.epoch_hi, inner.epoch_lo),
+        })
+    }
+}
+
+/// The leader's view of the durable safe-point, returned by
+/// [`Client::get_current_max_safe`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct MaxSafe {
+    /// Safe-point in physical-millisecond units; `0` is the cold-start sentinel
+    /// (also the value any follower returns).
+    pub max_safe_physical_ms: u64,
+    /// Leader epoch that issued this view.
+    pub epoch: Epoch,
 }
 
 #[cfg(test)]

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -623,6 +623,16 @@ mod tests {
                 // → AttemptOutcome::NoLeaderYet in the retry loop.
                 Err(tonic::Status::failed_precondition("not leader"))
             }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
+            }
         }
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -710,6 +720,16 @@ mod tests {
                     leader_endpoint: Some("b:1".into()),
                     leader_epoch: Some(tsoracle_proto::v1::EpochWire { hi: 0, lo: 5 }),
                 }))
+            }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
             }
         }
 
@@ -824,6 +844,16 @@ mod tests {
                     }))
                 }
             }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
+            }
         }
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -919,6 +949,16 @@ mod tests {
                     }))
                 }
             }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
+            }
         }
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -1002,6 +1042,16 @@ mod tests {
                     leader_endpoint: Some(format!("redirect-{}:1", n + 1)),
                     leader_epoch: None,
                 }))
+            }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
             }
         }
 
@@ -1138,6 +1188,16 @@ mod tests {
                     }))
                 }
             }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
+            }
         }
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -1226,6 +1286,16 @@ mod tests {
                         epoch_lo: 0,
                     }))
                 }
+            }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
             }
         }
 
@@ -1337,6 +1407,16 @@ mod tests {
                 );
                 Err(status)
             }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
+            }
         }
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -1406,6 +1486,16 @@ mod tests {
             ) -> Result<tonic::Response<tsoracle_proto::v1::GetTsResponse>, tonic::Status>
             {
                 Err(tonic::Status::failed_precondition("no leader yet"))
+            }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
             }
         }
 
@@ -1513,6 +1603,16 @@ mod tests {
                     epoch_hi: 0,
                     epoch_lo: 0,
                 }))
+            }
+
+            async fn get_current_max_safe(
+                &self,
+                _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+            ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(
+                    tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+                ))
             }
         }
 

--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -262,6 +262,19 @@ impl Allocator {
         }
     }
 
+    /// Current committed high-water in physical-millisecond units, or `None`
+    /// when not the leader. The high-water is the upper bound the allocator
+    /// will not exceed without a fresh `try_commit_window_extension`.
+    pub fn committed_high_water(&self) -> Option<u64> {
+        match self.state {
+            State::Leader {
+                committed_high_water,
+                ..
+            } => Some(committed_high_water),
+            State::NotLeader => None,
+        }
+    }
+
     /// Shared count guard for `try_grant` and `would_grant`, kept here so the
     /// two entry points cannot drift. The server's extension single-flight
     /// relies on `would_grant(now_ms, count) == true` implying the retry
@@ -560,6 +573,28 @@ mod tests {
         allocator.on_leadership_lost();
         assert!(!allocator.is_leader());
         assert_eq!(allocator.epoch(), None);
+    }
+
+    #[test]
+    fn committed_high_water_tracks_leader_state_and_extensions() {
+        let mut allocator = Allocator::new();
+        assert_eq!(allocator.committed_high_water(), None);
+
+        allocator
+            .try_on_leadership_gained(1_000, 5_000, Epoch(1))
+            .unwrap();
+        assert_eq!(allocator.committed_high_water(), Some(5_000));
+
+        let target = allocator
+            .try_prepare_window_extension(2_000, 3_000)
+            .unwrap();
+        allocator
+            .try_commit_window_extension(target, Epoch(1))
+            .unwrap();
+        assert_eq!(allocator.committed_high_water(), Some(target));
+
+        allocator.on_leadership_lost();
+        assert_eq!(allocator.committed_high_water(), None);
     }
 
     #[test]

--- a/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
+++ b/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
@@ -19,11 +19,35 @@ service TsoService {
   // trailer carrying a postcard-encoded `LeaderHint` (see below); clients
   // re-route to the hinted leader and retry.
   rpc GetTs(GetTsRequest) returns (GetTsResponse);
+
+  // Read the current safe-point. Safe-point is the highest physical-millisecond
+  // at which any timestamp issued at or before that physical_ms is durably
+  // backed by the leader's persisted window. External coordinators poll this
+  // RPC to fence reads/writes that depend on a durable timestamp watermark.
+  //
+  // - Leaders return the authoritative current value.
+  // - Followers return 0; target the leader for an authoritative value.
+  // - A response of zero also means the leader has not yet admitted a window
+  //   (cold start before the first persist).
+  rpc GetCurrentMaxSafe(GetCurrentMaxSafeRequest) returns (GetCurrentMaxSafeResponse);
 }
 
 message GetTsRequest {
   // Number of consecutive timestamps to allocate. Must be >= 1.
   uint32 count = 1;
+}
+
+message GetCurrentMaxSafeRequest {}
+
+message GetCurrentMaxSafeResponse {
+  // Safe-point in physical-millisecond units (not the 64-bit packed form).
+  // Equal to `persisted_high_water - window_ahead_ms - 1` on the leader when
+  // a window has been admitted; zero otherwise (cold start or non-leader).
+  uint64 max_safe_physical_ms = 1;
+  // Leader epoch attached so long-lived pollers can fence stale-leader values,
+  // split into two 64-bit halves matching `GetTsResponse.epoch_hi`/`epoch_lo`.
+  uint64 epoch_hi = 2;
+  uint64 epoch_lo = 3;
 }
 
 message GetTsResponse {

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -62,6 +62,10 @@ name = "e2e"
 required-features = ["test-support"]
 
 [[test]]
+name = "get_current_max_safe"
+required-features = ["test-support"]
+
+[[test]]
 name = "leader_watch"
 required-features = ["test-fakes"]
 

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -174,7 +174,7 @@ impl ServerBuilder {
             window_ahead: self.window_ahead,
             failover_advance: self.failover_advance,
             shutdown_grace: self.shutdown_grace,
-            core: Arc::new(ServingCore::new()),
+            core: Arc::new(ServingCore::new(self.window_ahead)),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: self.tls_config,
         })
@@ -1025,7 +1025,7 @@ mod tests {
         // test runtime no other task can run between the synchronous `drop` and
         // the synchronous `serving_state` read, so observing `NotServing` proves
         // `Drop` closed the gate synchronously rather than the watch task.
-        let core = Arc::new(ServingCore::new());
+        let core = Arc::new(ServingCore::new(Duration::from_secs(3)));
         core.publish_serving();
 
         let handle: tokio::task::JoinHandle<Result<(), ServerError>> =
@@ -1056,7 +1056,7 @@ mod tests {
         // would stay open unless `serve_inner` closes it itself. Seed `Serving`,
         // run the user-shutdown arm with a zero grace (immediate abort), and
         // assert the gate is closed on return.
-        let core = Arc::new(ServingCore::new());
+        let core = Arc::new(ServingCore::new(Duration::from_secs(3)));
         core.publish_serving();
 
         let watch_handle: tokio::task::JoinHandle<Result<(), ServerError>> =

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -29,7 +29,8 @@ use tonic::{Request, Response, Status};
 use tsoracle_core::IgnoreReason;
 use tsoracle_core::{CommitOutcome, CoreError, Epoch};
 use tsoracle_proto::v1::{
-    EpochWire, GetTsRequest, GetTsResponse, LeaderHint, tso_service_server::TsoService,
+    EpochWire, GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetTsRequest, GetTsResponse,
+    LeaderHint, tso_service_server::TsoService,
 };
 
 use crate::leader_hint::not_leader_status;
@@ -196,6 +197,13 @@ impl TsoService for TsoServiceImpl {
                 Err(other) => return Err(core_status(other)),
             }
         }
+    }
+
+    async fn get_current_max_safe(
+        &self,
+        _request: Request<GetCurrentMaxSafeRequest>,
+    ) -> Result<Response<GetCurrentMaxSafeResponse>, Status> {
+        Ok(Response::new(GetCurrentMaxSafeResponse::default()))
     }
 }
 

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -203,7 +203,18 @@ impl TsoService for TsoServiceImpl {
         &self,
         _request: Request<GetCurrentMaxSafeRequest>,
     ) -> Result<Response<GetCurrentMaxSafeResponse>, Status> {
-        Ok(Response::new(GetCurrentMaxSafeResponse::default()))
+        let max_safe_physical_ms = self.server.core.current_max_safe_physical_ms();
+        let (epoch_hi, epoch_lo) = self
+            .server
+            .core
+            .current_epoch()
+            .unwrap_or(Epoch::ZERO)
+            .to_wire();
+        Ok(Response::new(GetCurrentMaxSafeResponse {
+            max_safe_physical_ms,
+            epoch_hi,
+            epoch_lo,
+        }))
     }
 }
 

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -45,6 +45,8 @@
 //!    [`ServingCore::drain_barrier_write`] and never takes `extension_lock`, so
 //!    it cannot close a lock cycle with an extender.
 
+use std::time::Duration;
+
 use parking_lot::Mutex;
 use tokio::sync::{
     Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
@@ -69,10 +71,14 @@ pub(crate) struct ServingCore {
     /// reloading the high-water, draining all in-flight extensions started under
     /// the prior epoch before it proceeds.
     extension_gate: RwLock<()>,
+    /// Mirrors `Server::window_ahead`; held here so the safe-point accessor
+    /// (`current_max_safe_physical_ms`) does not need a back-reference to
+    /// `Server`.
+    window_ahead: Duration,
 }
 
 impl ServingCore {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(window_ahead: Duration) -> Self {
         let (state_tx, _) = watch::channel(ServingState::NotServing {
             leader_endpoint: None,
             leader_epoch: None,
@@ -82,7 +88,28 @@ impl ServingCore {
             state_tx,
             extension_lock: AsyncMutex::new(()),
             extension_gate: RwLock::new(()),
+            window_ahead,
         }
+    }
+
+    /// Current safe-point in physical-millisecond units, matching the
+    /// `GetCurrentMaxSafeResponse.max_safe_physical_ms` contract: the highest
+    /// physical_ms such that any timestamp issued at or before this physical_ms
+    /// is durably backed by the persisted window. Returns `0` when this node
+    /// is not the leader, or before the leader admits its first window.
+    pub(crate) fn current_max_safe_physical_ms(&self) -> u64 {
+        let Some(persisted) = self.allocator.lock().committed_high_water() else {
+            return 0;
+        };
+        let window_ms = self.window_ahead.as_millis() as u64;
+        persisted.saturating_sub(window_ms + 1)
+    }
+
+    /// Current leader epoch, or `None` when not the leader. Mirrors
+    /// `Allocator::epoch` for the service layer (which holds `Arc<ServingCore>`
+    /// and has no direct allocator handle).
+    pub(crate) fn current_epoch(&self) -> Option<Epoch> {
+        self.allocator.lock().epoch()
     }
 
     pub(crate) fn subscribe(&self) -> watch::Receiver<ServingState> {
@@ -248,7 +275,7 @@ mod tests {
         // lands even when no receiver is subscribed (`receiver_count == 0`). Were
         // a publish site to use `send`, this would be silently dropped and a
         // leaderless-then-leader core could stay NotServing forever.
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         assert_eq!(core.state_tx.receiver_count(), 0);
 
         core.step_down(Some("http://new-leader:9000".into()), Some(Epoch(7)));
@@ -271,7 +298,7 @@ mod tests {
         // the read barrier on the current task; if step_down tried to take the
         // write lock it would deadlock here (single-threaded runtime, lock held
         // by us). Reaching the assertion proves it never touches the gate.
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         let slot = core.extension_slot().await;
         let _barrier = slot.drain_barrier().await;
 
@@ -289,7 +316,7 @@ mod tests {
         // extension readers to drain. `try_write` is a deterministic probe of
         // that exclusion (no timing): it fails while a read barrier is held and
         // succeeds once it is released.
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         let slot = core.extension_slot().await;
         let barrier = slot.drain_barrier().await;
 
@@ -311,7 +338,7 @@ mod tests {
         // A fresh core is NotLeader (no epoch). prepare_extension must surface
         // that as `NotLeader` so the caller emits a redirect, and would_grant is
         // false.
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         let slot = core.extension_slot().await;
         assert!(matches!(
             slot.prepare_extension(1, 1_000),
@@ -326,7 +353,7 @@ mod tests {
         // `ServingState`; it must agree with `serving_state`'s variant across
         // every transition. Fresh core is NotServing -> false; publish_serving
         // -> true; step_down -> false again.
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         assert!(!core.is_serving(), "fresh core is NotServing");
         assert!(matches!(
             core.serving_state(),
@@ -346,7 +373,7 @@ mod tests {
 
     #[test]
     fn try_grant_without_leadership_is_not_leader() {
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         assert!(matches!(core.try_grant(1, 1), Err(CoreError::NotLeader)));
     }
 
@@ -355,7 +382,7 @@ mod tests {
         // try_on_leadership_gained(floor, ceiling, epoch) seeds a serveable
         // window; a grant at the floor returns timestamps stamped with the
         // seeded epoch.
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
             .expect("seed must succeed (ceiling >= floor)");
         let grant = core.try_grant(1_000, 1).expect("grant must succeed");
@@ -369,7 +396,7 @@ mod tests {
         // the call site. Seed a serveable window first so the clear is
         // observable, then assert both effects: NotServing with no leader hint,
         // and a now-cleared allocator (try_grant -> NotLeader).
-        let core = ServingCore::new();
+        let core = ServingCore::new(Duration::from_secs(3));
         core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
             .expect("seed must succeed (ceiling >= floor)");
         assert!(core.try_grant(1_000, 1).is_ok(), "seeded core must grant");

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -303,6 +303,15 @@ impl TsoService for FixedHintService {
             leader_epoch: None,
         }))
     }
+
+    async fn get_current_max_safe(
+        &self,
+        _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+    ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status> {
+        Ok(tonic::Response::new(
+            tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+        ))
+    }
 }
 
 /// Bind a TLS gRPC peer on `127.0.0.1:0` that always replies `NOT_LEADER` with a

--- a/crates/tsoracle-server/tests/get_current_max_safe.rs
+++ b/crates/tsoracle-server/tests/get_current_max_safe.rs
@@ -1,0 +1,133 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::{sync::Arc, time::Duration};
+use tsoracle_core::Epoch;
+use tsoracle_proto::v1::{
+    GetCurrentMaxSafeRequest, GetTsRequest, tso_service_client::TsoServiceClient,
+};
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+use tsoracle_server::test_support::{boot_server, wait_for_grpc_handshake, wait_until_serving};
+
+const WINDOW_AHEAD: Duration = Duration::from_millis(500);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_current_max_safe_returns_zero_on_follower() {
+    let driver = Arc::new(InMemoryDriver::new());
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .window_ahead(WINDOW_AHEAD)
+        .failover_advance(Duration::from_millis(200))
+        .build()
+        .unwrap();
+
+    let booted = boot_server(server).await;
+
+    driver.become_follower(Some("10.9.8.7:50551".into()));
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
+
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_current_max_safe(GetCurrentMaxSafeRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.max_safe_physical_ms, 0,
+        "follower must report safe-point 0",
+    );
+    assert_eq!(
+        (resp.epoch_hi, resp.epoch_lo),
+        (0, 0),
+        "follower must report epoch zero",
+    );
+
+    booted.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_current_max_safe_advances_and_is_bounded() {
+    let driver = Arc::new(InMemoryDriver::new());
+
+    let server = Server::builder()
+        .consensus_driver(driver.clone())
+        .window_ahead(WINDOW_AHEAD)
+        .failover_advance(Duration::from_millis(200))
+        .build()
+        .unwrap();
+
+    let mut booted = boot_server(server).await;
+
+    driver.become_leader(Epoch(1));
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
+
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
+        .await
+        .unwrap();
+
+    // Issue a few timestamps so the allocator advances its committed high-water
+    // through window extensions; otherwise the safe-point only reflects the
+    // initial fence-seeded ceiling.
+    for _ in 0..4 {
+        client.get_ts(GetTsRequest { count: 64 }).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let safe_a = client
+        .get_current_max_safe(GetCurrentMaxSafeRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let safe_b = client
+        .get_current_max_safe(GetCurrentMaxSafeRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(
+        safe_a.max_safe_physical_ms > 0,
+        "safe-point did not advance after issued timestamps",
+    );
+    assert!(
+        safe_b.max_safe_physical_ms >= safe_a.max_safe_physical_ms,
+        "safe-point regressed: {} -> {}",
+        safe_a.max_safe_physical_ms,
+        safe_b.max_safe_physical_ms,
+    );
+    // Epoch(1).to_wire() == (hi: 0, lo: 1) — same encoding GetTs uses.
+    assert_eq!((safe_a.epoch_hi, safe_a.epoch_lo), (0, 1));
+
+    booted.shutdown().await.unwrap();
+}

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -164,6 +164,15 @@ impl TsoService for MalformedHintService {
             .insert_bin(key, BinaryMetadataValue::from_bytes(garbage));
         Err(status)
     }
+
+    async fn get_current_max_safe(
+        &self,
+        _request: tonic::Request<tsoracle_proto::v1::GetCurrentMaxSafeRequest>,
+    ) -> Result<tonic::Response<tsoracle_proto::v1::GetCurrentMaxSafeResponse>, tonic::Status> {
+        Ok(tonic::Response::new(
+            tsoracle_proto::v1::GetCurrentMaxSafeResponse::default(),
+        ))
+    }
 }
 
 /// Bind a malformed-hint fake server on a random port. Returns its socket


### PR DESCRIPTION
## Summary
- Adds `GetCurrentMaxSafe` to `TsoService` for external coordinators that fence reads on a durable safe-point.
- Server reads `persisted_high_water - window_ahead - 1` from `ServingCore` on the leader; followers return `0` and callers needing freshness target the leader.
- Adds matching client method returning the physical-millisecond safe-point plus the leader epoch.

## Test plan
- [x] Integration test asserts monotonic advance and non-zero progress after issued timestamps, plus a follower returns zero
- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`