### PR TITLE
chore(ci): harden pages-build-check workflow permissions

### DIFF
--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/pages-build-check.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
## Summary

- Add workflow-root `permissions: contents: read` to `.github/workflows/pages-build-check.yml` so the default `GITHUB_TOKEN` follows least privilege.
- Resolves CodeQL alert [security/code-scanning #1](https://github.com/prisma-risk/tsoracle/security/code-scanning/1) (`actions/missing-workflow-permissions`, medium).
- Mirrors the existing convention in `ci.yml`, `kube-e2e.yml`, `pages.yml`, `release-images.yml`, and `release-plz.yml` (workflow-root default-deny + per-job overrides where elevated perms are needed). Same pattern as PR #207 ("harden pages workflow permissions").

The workflow only runs on `pull_request` (and `workflow_dispatch`), checks out the repo, runs `cargo run` for the og-image generator, installs Zola, and runs `zola build` / `zola check --skip-external-links`. There are no `gh`/API calls, no PR comments, no pushes, and no releases — `contents: read` covers everything.

## Test plan

- [x] `actionlint .github/workflows/pages-build-check.yml` clean locally
- [x] Pre-commit `cargo fmt --check` + `cargo clippy` passed
- [ ] CI on this PR runs the affected workflow end-to-end (it touches `.github/workflows/pages-build-check.yml`, which is in its own `paths` filter, so it will self-trigger)
- [ ] After merge, CodeQL re-scan on `main` marks alert #1 as fixed