### PR TITLE
ci: add umbrella `tsoracle` image variant with all drivers

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -49,12 +49,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
-      - name: Build file + openraft and smoke
+      - name: Build file + openraft + umbrella and smoke
         run: |
           docker build -f deploy/Dockerfile --build-arg FEATURES=file -t tsoracle-file:pr .
           docker run --rm --entrypoint tsoracle tsoracle-file:pr --help | head -1
           docker build -f deploy/Dockerfile --build-arg FEATURES=openraft -t tsoracle-openraft:pr .
           docker run --rm --entrypoint tsoracle tsoracle-openraft:pr --help | head -1
+          docker build -f deploy/Dockerfile -t tsoracle:pr .
+          docker run --rm --entrypoint tsoracle tsoracle:pr --help | head -1
           curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
           ./linux-amd64/helm lint deploy/charts/tsoracle
           PATH="$PWD/linux-amd64:$PATH" sh deploy/charts/tsoracle/tests/render.sh
@@ -65,9 +67,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [file, openraft]
+        # `variant` selects which driver subset is compiled into the binary; the
+        # paired `image` / `features` columns (via include:) decouple the matrix
+        # label from the image name and the cargo features so the `umbrella`
+        # row can build the fat image as plain `tsoracle` with default features
+        # (empty FEATURES => Dockerfile builds without --no-default-features).
+        variant: [file, openraft, umbrella]
         arch: [amd64, arm64]
         include:
+          - variant: file
+            image: tsoracle-file
+            features: file
+          - variant: openraft
+            image: tsoracle-openraft
+            features: openraft
+          - variant: umbrella
+            image: tsoracle
+            features: ''
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
@@ -88,8 +104,8 @@ jobs:
           docker buildx build \
             --platform linux/${{ matrix.arch }} \
             -f deploy/Dockerfile \
-            --build-arg FEATURES=${{ matrix.variant }} \
-            -t "ghcr.io/prisma-risk/tsoracle-${{ matrix.variant }}:${V}-${{ matrix.arch }}" \
+            --build-arg FEATURES=${{ matrix.features }} \
+            -t "ghcr.io/prisma-risk/${{ matrix.image }}:${V}-${{ matrix.arch }}" \
             --push .
 
   manifest:
@@ -97,7 +113,14 @@ jobs:
     if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        variant: [file, openraft]
+        variant: [file, openraft, umbrella]
+        include:
+          - variant: file
+            image: tsoracle-file
+          - variant: openraft
+            image: tsoracle-openraft
+          - variant: umbrella
+            image: tsoracle
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-buildx-action@v4
@@ -110,7 +133,7 @@ jobs:
         env:
           V: ${{ needs.version.outputs.v }}
         run: |
-          IMG=ghcr.io/prisma-risk/tsoracle-${{ matrix.variant }}
+          IMG=ghcr.io/prisma-risk/${{ matrix.image }}
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             docker buildx imagetools create \
               -t "$IMG:$V" -t "$IMG:latest" \


### PR DESCRIPTION
## Summary

- Add a third matrix variant `umbrella` to `release-images` that builds and publishes the fat image as plain `ghcr.io/prisma-risk/tsoracle:<ver>` (plus `:latest` on tag pushes), bundling all three drivers (file, openraft, paxos) in one image. The lean per-driver images (`tsoracle-file`, `tsoracle-openraft`) are unchanged.
- The Dockerfile's `ARG FEATURES=""` path was already designed for this — cargo's default features on `tsoracle-bin` are `["file", "openraft", "paxos"]`, so an empty build-arg falls through to a fat build. This PR just wires that into CI.
- Refactor the matrix to carry explicit `image` / `features` columns via `include:` (previously the variant string was used as both the image suffix and the cargo features list — those need to decouple for the umbrella row, where image=`tsoracle` and features=`""`).
- Mirror the same `variant → image` mapping in the `manifest` job so the multi-arch manifest list is created for `tsoracle:V` alongside the existing per-driver images.
- Add a third `docker build` to `pr-smoke` so PRs touching the build envelope catch fat-build regressions, not just lean-build ones.

## Test plan

- [ ] `pr-smoke` builds all three variants (`tsoracle-file:pr`, `tsoracle-openraft:pr`, `tsoracle:pr`) and each `--help` invocation prints its first line.
- [ ] On a `workflow_dispatch` run, the `build-image` matrix expands to 3 variants × 2 arches = 6 per-arch image pushes, and `manifest` creates 3 multi-arch manifest lists (without `:latest`).
- [ ] On a `tsoracle-v*` tag push, the manifest job additionally tags `:latest` for all three images including `tsoracle:latest`.
- [ ] The lean images keep their existing names — no downstream consumer of `tsoracle-file` / `tsoracle-openraft` breaks.