### PR TITLE
test(e2e): wire mixed-version-soak Job + add tsoracle admin activate-format

### DIFF
--- a/.github/workflows/kube-e2e-mixed-version.yml
+++ b/.github/workflows/kube-e2e-mixed-version.yml
@@ -1,0 +1,74 @@
+name: kube-e2e-mixed-version
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  kube-e2e-mixed-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+      - name: build baseline image (openraft only, no e2e feature)
+        run: |
+          docker build -f deploy/Dockerfile \
+            --build-arg FEATURES=openraft \
+            -t tsoracle:e2e-baseline .
+      - name: build next image (openraft + e2e-max-readable-next)
+        run: |
+          docker build -f deploy/Dockerfile \
+            --build-arg FEATURES=openraft,e2e-max-readable-next \
+            -t tsoracle:e2e-next .
+      - name: build driver image
+        run: docker build -f e2e/kube/driver/Dockerfile -t tsoracle-e2e-driver:latest .
+      - name: create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
+        with:
+          cluster_name: tsoracle-e2e
+          config: e2e/kube/kind-config.yaml
+      - name: load images into kind
+        run: |
+          kind load docker-image tsoracle:e2e-baseline   --name tsoracle-e2e
+          kind load docker-image tsoracle:e2e-next       --name tsoracle-e2e
+          kind load docker-image tsoracle-e2e-driver:latest --name tsoracle-e2e
+      - name: install helm
+        run: |
+          curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
+      - name: deploy chart (baseline tag)
+        run: |
+          ./linux-amd64/helm install tsoracle deploy/charts/tsoracle \
+            --set image.repository=tsoracle,image.tag=e2e-baseline \
+            --set driver=openraft,replicas=3 \
+            --set ports.client=5051,ports.peer=5100 \
+            --set tls.allowInsecurePeer=true \
+            --wait --timeout 5m
+      - name: wait for cluster formation (TCP readiness)
+        run: kubectl rollout status statefulset/tsoracle --timeout=300s
+      - name: run mixed-version assertions
+        run: ./e2e/kube/run-mixed-version-assertions.sh
+      - name: dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -o wide || true
+          kubectl describe statefulset/tsoracle || true
+          kubectl get sts/tsoracle -o jsonpath='{.spec.updateStrategy}' || true
+          kubectl logs job/tsoracle-e2e-mixed-version-soak || true
+          kubectl logs -l app.kubernetes.io/name=tsoracle --tail=200 || true
+          kubectl get events --sort-by=.lastTimestamp || true

--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -48,6 +48,7 @@ jobs:
             --set image.repository=tsoracle,image.tag=e2e \
             --set driver=openraft,replicas=3 \
             --set ports.client=5051,ports.peer=5100 \
+            --set tls.allowInsecurePeer=true \
             --wait --timeout 5m
       - name: wait for cluster formation (TCP readiness)
         run: kubectl rollout status statefulset/tsoracle --timeout=300s

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -20,6 +20,12 @@ openraft   = ["tsoracle-standalone/openraft"]
 paxos      = ["tsoracle-standalone/paxos"]
 reflection = ["tsoracle-server/reflection"]
 bt         = ["tsoracle-core/bt", "tsoracle-server/bt"]
+# Pass through `e2e-max-readable-next` to the standalone crate so the
+# production image (`deploy/Dockerfile` passing `--build-arg FEATURES=...`)
+# can opt in for the mixed-version kube-e2e lane. NEVER set in production
+# builds — see `tsoracle-openraft-toolkit` Cargo.toml for the safety
+# contract.
+e2e-max-readable-next = ["tsoracle-standalone/e2e-max-readable-next"]
 
 [dependencies]
 anyhow                = "1"

--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -125,8 +125,11 @@ pub struct AddLearnerArgs {
 #[cfg(feature = "openraft")]
 #[derive(Parser, Debug)]
 pub struct ActivateFormatArgs {
-    /// Admin endpoint of any cluster member (the CLI does NOT follow
-    /// leader-redirect for activation — see `dispatch_admin`).
+    /// Admin endpoint of any cluster member. `NOT_LEADER` responses for
+    /// activation carry an empty `leader_admin_endpoint` (the underlying
+    /// `FormatActivationError::NotLeader` is a unit variant), so the
+    /// existing `with_redirect` short-circuits and the CLI exits 3 rather
+    /// than auto-redirecting. Re-issue against a known leader.
     #[arg(long)]
     pub endpoint: String,
     /// Target format version. Must be within the local binary's readable

--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -61,6 +61,13 @@ pub enum AdminCmd {
     Promote(AdminIdArgs),
     /// Remove a node.
     Remove(AdminIdArgs),
+    /// Initiate a format-version activation. Runs the all-members capability
+    /// gate then proposes the bump via raft. Exit codes:
+    /// 0=success, 2=gate-rejected (MEMBERS_BELOW_TARGET),
+    /// 3=NOT_LEADER (this node is a follower),
+    /// 4=local-range-rejected (TARGET_OUT_OF_RANGE — receiving node's
+    /// MAX_READABLE_VERSION < target), 1=other failure.
+    ActivateFormat(ActivateFormatArgs),
 }
 
 #[cfg(feature = "openraft")]
@@ -111,6 +118,21 @@ pub struct AddLearnerArgs {
     pub service_endpoint: String,
     #[arg(long)]
     pub admin_endpoint: String,
+    #[command(flatten)]
+    pub tls: AdminClientTlsArgs,
+}
+
+#[cfg(feature = "openraft")]
+#[derive(Parser, Debug)]
+pub struct ActivateFormatArgs {
+    /// Admin endpoint of any cluster member (the CLI does NOT follow
+    /// leader-redirect for activation — see `dispatch_admin`).
+    #[arg(long)]
+    pub endpoint: String,
+    /// Target format version. Must be within the local binary's readable
+    /// range and supported by every cluster member.
+    #[arg(long)]
+    pub target: u8,
     #[command(flatten)]
     pub tls: AdminClientTlsArgs,
 }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -409,9 +409,6 @@ fn classify_activation(resp: &ChangeResponse) -> ActivationOutcome {
     if resp.ok {
         return ActivationOutcome::Success;
     }
-    let kind_string = AdminErrorKind::try_from(resp.error)
-        .map(|k| format!("{k:?}"))
-        .unwrap_or_else(|_| resp.error.to_string());
     match AdminErrorKind::try_from(resp.error) {
         Ok(AdminErrorKind::MembersBelowTarget) => {
             ActivationOutcome::GateRejected(resp.message.clone())
@@ -420,8 +417,15 @@ fn classify_activation(resp: &ChangeResponse) -> ActivationOutcome {
         Ok(AdminErrorKind::TargetOutOfRange) => {
             ActivationOutcome::TargetOutOfRange(resp.message.clone())
         }
-        _ => ActivationOutcome::Other {
-            kind: kind_string,
+        // Decoded enum kinds other than the three script-meaningful ones
+        // (e.g. MembershipChanged, Unsupported, Driver) — surface the enum
+        // debug name. Undecodable integers fall through to the next arm.
+        Ok(k) => ActivationOutcome::Other {
+            kind: format!("{k:?}"),
+            message: resp.message.clone(),
+        },
+        Err(_) => ActivationOutcome::Other {
+            kind: resp.error.to_string(),
             message: resp.message.clone(),
         },
     }
@@ -781,7 +785,8 @@ mod activation_exit_code_tests {
         // future refactor that quietly conflates them is caught.
         assert!(matches!(
             classify_activation(&r),
-            ActivationOutcome::Other { .. }
+            ActivationOutcome::Other { kind, message }
+                if kind == "MembershipChanged" && message == "drift"
         ));
     }
 }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -36,6 +36,9 @@ use tracing_subscriber::EnvFilter;
 use tsoracle_server::Server;
 use tsoracle_standalone::{DriverConfig, Standalone};
 
+#[cfg(feature = "openraft")]
+use tsoracle_standalone::admin_proto::{AdminErrorKind, ChangeResponse};
+
 /// Drivers compiled into this build, for the friendly "not included" message.
 #[cfg(any(
     not(feature = "file"),
@@ -392,12 +395,45 @@ fn parse_members(input: &str) -> Result<BTreeMap<u64, tsoracle_standalone::Membe
 }
 
 #[cfg(feature = "openraft")]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+enum ActivationOutcome {
+    Success,
+    GateRejected(String),
+    NotLeader,
+    TargetOutOfRange(String),
+    Other { kind: String, message: String },
+}
+
+#[cfg(feature = "openraft")]
+fn classify_activation(resp: &ChangeResponse) -> ActivationOutcome {
+    if resp.ok {
+        return ActivationOutcome::Success;
+    }
+    let kind_string = AdminErrorKind::try_from(resp.error)
+        .map(|k| format!("{k:?}"))
+        .unwrap_or_else(|_| resp.error.to_string());
+    match AdminErrorKind::try_from(resp.error) {
+        Ok(AdminErrorKind::MembersBelowTarget) => {
+            ActivationOutcome::GateRejected(resp.message.clone())
+        }
+        Ok(AdminErrorKind::NotLeader) => ActivationOutcome::NotLeader,
+        Ok(AdminErrorKind::TargetOutOfRange) => {
+            ActivationOutcome::TargetOutOfRange(resp.message.clone())
+        }
+        _ => ActivationOutcome::Other {
+            kind: kind_string,
+            message: resp.message.clone(),
+        },
+    }
+}
+
+#[cfg(feature = "openraft")]
 async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
     use cli::AdminCmd;
     use tsoracle_standalone::admin_proto::membership_admin_client::MembershipAdminClient;
     use tsoracle_standalone::admin_proto::{
-        ActivateFormatRequest, AddLearnerRequest, AdminErrorKind, ChangeResponse,
-        ListMembersRequest, MemberRole, PromoteRequest, RemoveNodeRequest,
+        ActivateFormatRequest, AddLearnerRequest, ListMembersRequest, MemberRole, PromoteRequest,
+        RemoveNodeRequest,
     };
 
     // Re-run `op` against the leader if the first call says NOT_LEADER. The
@@ -451,31 +487,29 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
     /// Activation-specific reporter: success / gate-rejection / NOT_LEADER /
     /// local-range-rejection each get their own exit code per the issue #484
     /// contract. Anything else exits 1 via the bubbled `anyhow::Error`.
+    /// The pure classification lives in `classify_activation` so it can be
+    /// unit-tested without forking the process.
     fn report_activation(resp: ChangeResponse) -> Result<()> {
-        if resp.ok {
-            println!("ok");
-            return Ok(());
-        }
-        let kind = AdminErrorKind::try_from(resp.error)
-            .map(|k| format!("{k:?}"))
-            .unwrap_or_else(|_| resp.error.to_string());
-        match AdminErrorKind::try_from(resp.error) {
-            Ok(AdminErrorKind::MembersBelowTarget) => {
-                eprintln!("activate-format: gate rejected: {}", resp.message);
+        match classify_activation(&resp) {
+            ActivationOutcome::Success => {
+                println!("ok");
+                Ok(())
+            }
+            ActivationOutcome::GateRejected(message) => {
+                eprintln!("activate-format: gate rejected: {message}");
                 std::process::exit(2);
             }
-            Ok(AdminErrorKind::NotLeader) => {
+            ActivationOutcome::NotLeader => {
                 eprintln!("activate-format: not the leader");
                 std::process::exit(3);
             }
-            Ok(AdminErrorKind::TargetOutOfRange) => {
-                eprintln!(
-                    "activate-format: target outside local readable range: {}",
-                    resp.message
-                );
+            ActivationOutcome::TargetOutOfRange(message) => {
+                eprintln!("activate-format: target outside local readable range: {message}");
                 std::process::exit(4);
             }
-            _ => anyhow::bail!("activate-format error ({kind}): {}", resp.message),
+            ActivationOutcome::Other { kind, message } => {
+                anyhow::bail!("activate-format error ({kind}): {message}")
+            }
         }
     }
 
@@ -682,4 +716,72 @@ mod admin_client_tls_tests {
     // on disk because admin_client_tls reads + parses them. The integration test
     // in openraft_membership.rs already proves a real cert produces a working
     // channel.
+}
+
+#[cfg(all(test, feature = "openraft"))]
+mod activation_exit_code_tests {
+    use super::{ActivationOutcome, classify_activation};
+    use tsoracle_standalone::admin_proto::{AdminErrorKind, ChangeResponse};
+
+    fn resp(ok: bool, error: AdminErrorKind, message: &str) -> ChangeResponse {
+        ChangeResponse {
+            ok,
+            error: error as i32,
+            leader_admin_endpoint: String::new(),
+            message: message.into(),
+        }
+    }
+
+    #[test]
+    fn ok_classifies_as_success() {
+        let r = resp(true, AdminErrorKind::Unspecified, "");
+        assert_eq!(classify_activation(&r), ActivationOutcome::Success);
+    }
+
+    #[test]
+    fn members_below_target_classifies_as_gate_rejected() {
+        let r = resp(false, AdminErrorKind::MembersBelowTarget, "blocked");
+        assert!(matches!(
+            classify_activation(&r),
+            ActivationOutcome::GateRejected(s) if s == "blocked"
+        ));
+    }
+
+    #[test]
+    fn not_leader_classifies_as_not_leader() {
+        let r = resp(false, AdminErrorKind::NotLeader, "");
+        assert_eq!(classify_activation(&r), ActivationOutcome::NotLeader);
+    }
+
+    #[test]
+    fn target_out_of_range_classifies_as_target_out_of_range() {
+        let r = resp(false, AdminErrorKind::TargetOutOfRange, "range");
+        assert!(matches!(
+            classify_activation(&r),
+            ActivationOutcome::TargetOutOfRange(s) if s == "range"
+        ));
+    }
+
+    #[test]
+    fn driver_error_classifies_as_other() {
+        let r = resp(false, AdminErrorKind::Driver, "boom");
+        assert!(matches!(
+            classify_activation(&r),
+            ActivationOutcome::Other { kind, message } if kind == "Driver" && message == "boom"
+        ));
+    }
+
+    #[test]
+    fn membership_changed_classifies_as_other() {
+        let r = resp(false, AdminErrorKind::MembershipChanged, "drift");
+        // MembershipChanged is a real activation outcome the operator can
+        // remediate by re-issuing, but it's NOT a script-meaningful safety
+        // rejection (Other → exit 1) — distinct from MembersBelowTarget
+        // (exit 2) and TargetOutOfRange (exit 4). Explicit test so a
+        // future refactor that quietly conflates them is caught.
+        assert!(matches!(
+            classify_activation(&r),
+            ActivationOutcome::Other { .. }
+        ));
+    }
 }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -396,8 +396,8 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
     use cli::AdminCmd;
     use tsoracle_standalone::admin_proto::membership_admin_client::MembershipAdminClient;
     use tsoracle_standalone::admin_proto::{
-        AddLearnerRequest, AdminErrorKind, ChangeResponse, ListMembersRequest, MemberRole,
-        PromoteRequest, RemoveNodeRequest,
+        ActivateFormatRequest, AddLearnerRequest, AdminErrorKind, ChangeResponse,
+        ListMembersRequest, MemberRole, PromoteRequest, RemoveNodeRequest,
     };
 
     // Re-run `op` against the leader if the first call says NOT_LEADER. The
@@ -445,6 +445,37 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
                 .map(|kind| format!("{kind:?}"))
                 .unwrap_or_else(|_| resp.error.to_string());
             anyhow::bail!("admin error ({kind}): {}", resp.message)
+        }
+    }
+
+    /// Activation-specific reporter: success / gate-rejection / NOT_LEADER /
+    /// local-range-rejection each get their own exit code per the issue #484
+    /// contract. Anything else exits 1 via the bubbled `anyhow::Error`.
+    fn report_activation(resp: ChangeResponse) -> Result<()> {
+        if resp.ok {
+            println!("ok");
+            return Ok(());
+        }
+        let kind = AdminErrorKind::try_from(resp.error)
+            .map(|k| format!("{k:?}"))
+            .unwrap_or_else(|_| resp.error.to_string());
+        match AdminErrorKind::try_from(resp.error) {
+            Ok(AdminErrorKind::MembersBelowTarget) => {
+                eprintln!("activate-format: gate rejected: {}", resp.message);
+                std::process::exit(2);
+            }
+            Ok(AdminErrorKind::NotLeader) => {
+                eprintln!("activate-format: not the leader");
+                std::process::exit(3);
+            }
+            Ok(AdminErrorKind::TargetOutOfRange) => {
+                eprintln!(
+                    "activate-format: target outside local readable range: {}",
+                    resp.message
+                );
+                std::process::exit(4);
+            }
+            _ => anyhow::bail!("activate-format error ({kind}): {}", resp.message),
         }
     }
 
@@ -522,6 +553,24 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
                     Box::pin(async move {
                         client
                             .remove_node(RemoveNodeRequest { id })
+                            .await
+                            .map(|r| r.into_inner())
+                    })
+                })
+                .await?,
+            )
+        }
+        AdminCmd::ActivateFormat(args) => {
+            let tls = admin_client_tls(&args.tls)?;
+            let endpoint = args.endpoint.clone();
+            let target = args.target;
+            report_activation(
+                with_redirect(endpoint, tls.as_ref(), move |mut client| {
+                    Box::pin(async move {
+                        client
+                            .activate_format(ActivateFormatRequest {
+                                target: target as u32,
+                            })
                             .await
                             .map(|r| r.into_inner())
                     })

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -78,3 +78,13 @@ tonic-prost-build = { workspace = true }
 rcgen    = { workspace = true }
 tempfile = { workspace = true }
 tokio    = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+# Without `required-features`, `cargo test -p tsoracle-standalone` (developer
+# default, no `--features test-support`) silently compiles this test file to
+# zero test items — the `#![cfg(all(feature = "openraft", feature = "test-support"))]`
+# at the top of the file gates everything out. With this entry, cargo prints a
+# visible "skipped due to required-features" notice instead.
+[[test]]
+name = "activation_admin_rpc"
+path = "tests/activation_admin_rpc.rs"
+required-features = ["openraft", "test-support"]

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -24,6 +24,10 @@ paxos    = [
     "dep:prost", "dep:postcard", "dep:parking_lot", "dep:tokio-stream",
     "tonic/tls-aws-lc",
 ]
+# Gates `admin::test_support`, a tiny public seam exposing the otherwise
+# `pub(crate)` `AdminServiceImpl` constructor so an integration test can
+# drive the gRPC handler with a fake `MembershipAdmin`. Off in production.
+test-support = []
 
 [dependencies]
 tsoracle-core      = { path = "../tsoracle-core", version = "0.2.5" }

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -24,6 +24,10 @@ paxos    = [
     "dep:prost", "dep:postcard", "dep:parking_lot", "dep:tokio-stream",
     "tonic/tls-aws-lc",
 ]
+# Pass through `e2e-max-readable-next` to the openraft driver crate (which
+# propagates it to the toolkit). Only meaningful when `openraft` is also on;
+# cargo's feature unification handles the dependency direction automatically.
+e2e-max-readable-next = ["tsoracle-driver-openraft/e2e-max-readable-next"]
 # Gates `admin::test_support`, a tiny public seam exposing the otherwise
 # `pub(crate)` `AdminServiceImpl` constructor so an integration test can
 # drive the gRPC handler with a fake `MembershipAdmin`. Off in production.

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -25,9 +25,13 @@ paxos    = [
     "tonic/tls-aws-lc",
 ]
 # Pass through `e2e-max-readable-next` to the openraft driver crate (which
-# propagates it to the toolkit). Only meaningful when `openraft` is also on;
-# cargo's feature unification handles the dependency direction automatically.
-e2e-max-readable-next = ["tsoracle-driver-openraft/e2e-max-readable-next"]
+# propagates it to the toolkit). The `?` makes this a no-op unless
+# `openraft` (or another feature) has already pulled in the optional
+# `tsoracle-driver-openraft` dep — without `?`, bare `crate/feature`
+# syntax on an optional dep would forcibly activate it, silently
+# enabling half of the openraft stack under `--features e2e-max-readable-next`
+# alone.
+e2e-max-readable-next = ["tsoracle-driver-openraft?/e2e-max-readable-next"]
 # Gates `admin::test_support`, a tiny public seam exposing the otherwise
 # `pub(crate)` `AdminServiceImpl` constructor so an integration test can
 # drive the gRPC handler with a fake `MembershipAdmin`. Off in production.

--- a/crates/tsoracle-standalone/proto/admin.proto
+++ b/crates/tsoracle-standalone/proto/admin.proto
@@ -37,6 +37,16 @@ service MembershipAdmin {
   // commits the removal while still leader, then steps down. Errors:
   // NOT_LEADER, WOULD_LOSE_QUORUM, UNSUPPORTED, DRIVER.
   rpc RemoveNode(RemoveNodeRequest) returns (ChangeResponse);
+  // Initiate a format-version activation to `target`. Runs the all-members
+  // capability gate, proposes the bump via raft, and reports the apply-keyed
+  // outcome. Errors: NOT_LEADER, MEMBERS_BELOW_TARGET (gate rejection),
+  // TARGET_OUT_OF_RANGE (target outside local binary's readable range),
+  // MEMBERSHIP_CHANGED (apply-keyed no-op: gated set drifted by apply time),
+  // UNSUPPORTED (paxos/file), DRIVER. The `NOT_LEADER` response carries an
+  // empty `leader_admin_endpoint` (the underlying gate's `NotLeader` is a
+  // unit variant); the operator (or shell orchestrator) re-issues against a
+  // known leader rather than auto-redirecting.
+  rpc ActivateFormat(ActivateFormatRequest) returns (ChangeResponse);
 }
 
 // A node's role in the current membership.
@@ -92,6 +102,12 @@ message AddLearnerRequest {
 message PromoteRequest { uint64 id = 1; }
 message RemoveNodeRequest { uint64 id = 1; }
 
+message ActivateFormatRequest {
+  // Target format version. proto3 has no uint8, so encoded as uint32; the
+  // handler validates the value fits u8 before forwarding.
+  uint32 target = 1;
+}
+
 // Typed error kinds for `ChangeResponse`. Adding a new variant is backwards
 // compatible: clients that don't recognize a value fall back to the
 // human-readable `message` field. `ok=true` is the authoritative success
@@ -121,6 +137,13 @@ enum AdminErrorKind {
   // Catch-all for an upstream driver error not captured by the typed
   // variants above. `message` carries the driver's error string.
   ADMIN_ERROR_KIND_DRIVER = 7;
+  // Gate rejection: at least one member's max_readable_version < target.
+  ADMIN_ERROR_KIND_MEMBERS_BELOW_TARGET = 8;
+  // Apply-arm defense-in-depth: target outside local readable range.
+  ADMIN_ERROR_KIND_TARGET_OUT_OF_RANGE  = 9;
+  // Apply-keyed no-op: membership drifted out of the gated set by the
+  // entry's own log position. Operator re-gates and re-issues.
+  ADMIN_ERROR_KIND_MEMBERSHIP_CHANGED   = 10;
 }
 
 // Result of a mutating membership RPC. On success: `ok=true`, `error=

--- a/crates/tsoracle-standalone/src/admin/mod.rs
+++ b/crates/tsoracle-standalone/src/admin/mod.rs
@@ -92,6 +92,19 @@ pub enum AdminError {
     /// Wrapped driver error.
     #[error("driver error: {0}")]
     Driver(String),
+    /// Format-activation gate rejection: at least one member can't read the
+    /// target. `incapable` lists `(node_id, max_readable_version)`.
+    #[error("format activation to target {target} blocked: members below target: {incapable:?}")]
+    MembersBelowTarget {
+        target: u8,
+        incapable: Vec<(u64, u8)>,
+    },
+    /// Format-activation target outside local binary's readable range.
+    #[error("format activation: target {target} outside readable range [{min}, {max}]")]
+    TargetOutOfRange { target: u8, min: u8, max: u8 },
+    /// Format-activation apply-keyed no-op: membership changed since gate.
+    #[error("format activation to target {target} no-op: membership changed since gate")]
+    MembershipChangedSinceGate { target: u8 },
 }
 
 /// Runtime membership administration. One impl per driver.
@@ -101,6 +114,12 @@ pub trait MembershipAdmin: Send + Sync {
     async fn add_learner(&self, member: NewMember) -> Result<(), AdminError>;
     async fn promote(&self, id: u64) -> Result<(), AdminError>;
     async fn remove(&self, id: u64) -> Result<(), AdminError>;
+    /// Initiate an all-members format-version activation to `target`. The
+    /// implementation runs the all-members capability gate, proposes the
+    /// bump via raft, and reports the apply-keyed outcome. Returns
+    /// `Unsupported` on drivers without zero-downtime format migration
+    /// (file, paxos).
+    async fn activate_format(&self, target: u8) -> Result<(), AdminError>;
 }
 
 /// Admin handle for drivers without runtime membership (file, and — in this
@@ -128,6 +147,9 @@ impl MembershipAdmin for UnsupportedAdmin {
         Err(AdminError::Unsupported)
     }
     async fn remove(&self, _id: u64) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+    async fn activate_format(&self, _target: u8) -> Result<(), AdminError> {
         Err(AdminError::Unsupported)
     }
 }
@@ -165,6 +187,15 @@ mod tests {
         ));
         assert!(matches!(
             admin.remove(2).await,
+            Err(AdminError::Unsupported)
+        ));
+    }
+
+    #[tokio::test]
+    async fn unsupported_admin_rejects_activate_format() {
+        let admin = UnsupportedAdmin::new(empty_view());
+        assert!(matches!(
+            admin.activate_format(5).await,
             Err(AdminError::Unsupported)
         ));
     }

--- a/crates/tsoracle-standalone/src/admin/mod.rs
+++ b/crates/tsoracle-standalone/src/admin/mod.rs
@@ -30,6 +30,27 @@ pub(crate) mod openraft;
 #[cfg(feature = "openraft")]
 pub(crate) mod service;
 
+/// Test-only entry points into otherwise-`pub(crate)` admin internals.
+///
+/// Gated on both `cfg(test)`/`feature = "test-support"` AND
+/// `feature = "openraft"` because the only seam currently exposed is the
+/// openraft-shaped `AdminServiceImpl` constructor. Production builds (which
+/// enable `openraft` but not `test-support`) never compile this module.
+#[cfg(all(any(test, feature = "test-support"), feature = "openraft"))]
+pub mod test_support {
+    use std::sync::Arc;
+
+    use super::MembershipAdmin;
+    use crate::admin::service::AdminServiceImpl;
+    use crate::admin_proto::membership_admin_server::MembershipAdmin as GrpcAdmin;
+
+    /// Build the gRPC handler around an arbitrary `MembershipAdmin` so a
+    /// test can call the generated trait methods directly (no socket).
+    pub fn admin_service(admin: Arc<dyn MembershipAdmin>) -> impl GrpcAdmin {
+        AdminServiceImpl::new(admin)
+    }
+}
+
 use async_trait::async_trait;
 
 /// A node's role in the current membership.

--- a/crates/tsoracle-standalone/src/admin/openraft.rs
+++ b/crates/tsoracle-standalone/src/admin/openraft.rs
@@ -58,6 +58,35 @@ fn map_write_error(err: RaftError<TypeConfig, ClientWriteError<TypeConfig>>) -> 
     }
 }
 
+/// Map a `FormatActivationError` into an `AdminError` using the dedicated
+/// kinds added above. `NotLeader` is a unit variant in
+/// `FormatActivationError` (see capabilities.rs:107-110), so the resulting
+/// `AdminError::NotLeader.leader_admin_endpoint` is always None — the
+/// CLI's redirect path is intentionally bypassed for activation.
+fn map_activation_error(err: tsoracle_driver_openraft::FormatActivationError) -> AdminError {
+    use tsoracle_driver_openraft::FormatActivationError as FAE;
+    match err {
+        FAE::NotLeader => AdminError::NotLeader {
+            leader_admin_endpoint: None,
+        },
+        FAE::TargetOutOfRange { target, min, max } => {
+            AdminError::TargetOutOfRange { target, min, max }
+        }
+        FAE::MembersBelowTarget { target, incapable } => {
+            AdminError::MembersBelowTarget { target, incapable }
+        }
+        FAE::MemberUnreachable { node_id, detail } => AdminError::Driver(format!(
+            "format activation gate: member {node_id} unreachable: {detail}",
+        )),
+        FAE::MembershipChangedSinceGate { target } => {
+            AdminError::MembershipChangedSinceGate { target }
+        }
+        FAE::ProposalFailed(detail) => {
+            AdminError::Driver(format!("format activation proposal failed: {detail}",))
+        }
+    }
+}
+
 /// The voter set after adding `id`.
 fn voters_with(current: &BTreeSet<u64>, id: u64) -> BTreeSet<u64> {
     let mut next = current.clone();
@@ -82,17 +111,36 @@ fn voter_ids(view: &MembershipView) -> BTreeSet<u64> {
         .collect()
 }
 
-/// openraft-backed membership admin. Holds a clone of the `Raft` handle and a
-/// mutex that serializes mutating ops so two reconfigurations cannot race.
+/// openraft-backed membership admin. Holds a clone of the `Raft` handle
+/// for membership ops, plus an `Arc<StandaloneHost>` + concrete
+/// `Arc<PeerCapabilitySource>` for `activate_format`. We store
+/// `PeerCapabilitySource` CONCRETELY (not as `Arc<dyn CapabilitySource>`)
+/// because `StandaloneHost::initiate_format_activation<S>` has `S: CapabilitySource`
+/// with the default `Sized` bound — a `&dyn` would not satisfy it.
+/// Production has exactly one impl (the peer-RPC dialer), so the
+/// concretization costs nothing.
+///
+/// The mutex serializes mutating membership ops so two reconfigurations
+/// cannot race. Activation does not take this mutex —
+/// `StandaloneHost::initiate_format_activation` is itself apply-keyed
+/// and re-validates membership at the entry's log position.
 pub(crate) struct OpenraftMembershipAdmin {
     raft: Raft<TypeConfig, HighWaterStateMachine>,
+    host: std::sync::Arc<tsoracle_driver_openraft::StandaloneHost>,
+    source: std::sync::Arc<crate::drivers::openraft::network::PeerCapabilitySource>,
     op_lock: Mutex<()>,
 }
 
 impl OpenraftMembershipAdmin {
-    pub(crate) fn new(raft: Raft<TypeConfig, HighWaterStateMachine>) -> Self {
+    pub(crate) fn new(
+        raft: Raft<TypeConfig, HighWaterStateMachine>,
+        host: std::sync::Arc<tsoracle_driver_openraft::StandaloneHost>,
+        source: std::sync::Arc<crate::drivers::openraft::network::PeerCapabilitySource>,
+    ) -> Self {
         Self {
             raft,
+            host,
+            source,
             op_lock: Mutex::new(()),
         }
     }
@@ -194,6 +242,15 @@ impl MembershipAdmin for OpenraftMembershipAdmin {
             .await
             .map(|_| ())
             .map_err(map_write_error)
+    }
+
+    async fn activate_format(&self, target: u8) -> Result<(), AdminError> {
+        // Activation has its own internal serialization (apply-keyed flip,
+        // membership re-validation at entry log position) — no op_lock here.
+        self.host
+            .initiate_format_activation(target, &*self.source)
+            .await
+            .map_err(map_activation_error)
     }
 }
 

--- a/crates/tsoracle-standalone/src/admin/openraft.rs
+++ b/crates/tsoracle-standalone/src/admin/openraft.rs
@@ -62,7 +62,8 @@ fn map_write_error(err: RaftError<TypeConfig, ClientWriteError<TypeConfig>>) -> 
 /// kinds added above. `NotLeader` is a unit variant in
 /// `FormatActivationError` (see capabilities.rs:107-110), so the resulting
 /// `AdminError::NotLeader.leader_admin_endpoint` is always None — the
-/// CLI's redirect path is intentionally bypassed for activation.
+/// CLI cannot auto-redirect to the leader for activation; the operator
+/// (or shell orchestrator) must re-issue against a known leader.
 fn map_activation_error(err: tsoracle_driver_openraft::FormatActivationError) -> AdminError {
     use tsoracle_driver_openraft::FormatActivationError as FAE;
     match err {
@@ -312,5 +313,85 @@ mod tests {
                 ChangeMembershipError::LearnerNotFound(LearnerNotFound { node_id: 7 }),
             ));
         assert!(matches!(map_write_error(err), AdminError::NotMember(7)));
+    }
+
+    #[test]
+    fn activation_not_leader_maps_to_not_leader_none_endpoint() {
+        use tsoracle_driver_openraft::FormatActivationError as FAE;
+        match map_activation_error(FAE::NotLeader) {
+            AdminError::NotLeader {
+                leader_admin_endpoint,
+            } => {
+                assert_eq!(leader_admin_endpoint, None);
+            }
+            other => panic!("expected NotLeader, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn activation_target_out_of_range_maps_correctly() {
+        use tsoracle_driver_openraft::FormatActivationError as FAE;
+        match map_activation_error(FAE::TargetOutOfRange {
+            target: 99,
+            min: 4,
+            max: 5,
+        }) {
+            AdminError::TargetOutOfRange { target, min, max } => {
+                assert_eq!((target, min, max), (99, 4, 5));
+            }
+            other => panic!("expected TargetOutOfRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn activation_members_below_target_maps_preserves_incapable() {
+        use tsoracle_driver_openraft::FormatActivationError as FAE;
+        match map_activation_error(FAE::MembersBelowTarget {
+            target: 5,
+            incapable: vec![(1, 4), (3, 4)],
+        }) {
+            AdminError::MembersBelowTarget { target, incapable } => {
+                assert_eq!(target, 5);
+                assert_eq!(incapable, vec![(1u64, 4u8), (3u64, 4u8)]);
+            }
+            other => panic!("expected MembersBelowTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn activation_member_unreachable_maps_to_driver_with_detail() {
+        use tsoracle_driver_openraft::FormatActivationError as FAE;
+        match map_activation_error(FAE::MemberUnreachable {
+            node_id: 2,
+            detail: "timeout".into(),
+        }) {
+            AdminError::Driver(s) => {
+                assert!(s.contains("member 2"), "missing node id in {s:?}");
+                assert!(s.contains("timeout"), "missing detail in {s:?}");
+            }
+            other => panic!("expected Driver, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn activation_membership_changed_maps_correctly() {
+        use tsoracle_driver_openraft::FormatActivationError as FAE;
+        match map_activation_error(FAE::MembershipChangedSinceGate { target: 5 }) {
+            AdminError::MembershipChangedSinceGate { target } => {
+                assert_eq!(target, 5);
+            }
+            other => panic!("expected MembershipChangedSinceGate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn activation_proposal_failed_maps_to_driver_with_detail() {
+        use tsoracle_driver_openraft::FormatActivationError as FAE;
+        match map_activation_error(FAE::ProposalFailed("write failed".into())) {
+            AdminError::Driver(s) => {
+                assert!(s.contains("write failed"), "missing detail in {s:?}");
+            }
+            other => panic!("expected Driver, got {other:?}"),
+        }
     }
 }

--- a/crates/tsoracle-standalone/src/admin/service.rs
+++ b/crates/tsoracle-standalone/src/admin/service.rs
@@ -36,8 +36,8 @@ use crate::admin_proto::membership_admin_server::{
     MembershipAdmin as GrpcAdmin, MembershipAdminServer,
 };
 use crate::admin_proto::{
-    AddLearnerRequest, AdminErrorKind, ChangeResponse, ListMembersRequest, MemberEntry, MemberRole,
-    MembershipView, PromoteRequest, RemoveNodeRequest,
+    ActivateFormatRequest, AddLearnerRequest, AdminErrorKind, ChangeResponse, ListMembersRequest,
+    MemberEntry, MemberRole, MembershipView, PromoteRequest, RemoveNodeRequest,
 };
 
 /// Admin RPCs carry only ids and host:port strings, so a tight decode/encode
@@ -95,6 +95,23 @@ fn change_err(err: AdminError) -> ChangeResponse {
             "would lose quorum".into(),
         ),
         AdminError::Timeout => (AdminErrorKind::Timeout, String::new(), "timed out".into()),
+        AdminError::MembersBelowTarget { target, incapable } => (
+            AdminErrorKind::MembersBelowTarget,
+            String::new(),
+            format!(
+                "format activation to target {target} blocked: members below target: {incapable:?}"
+            ),
+        ),
+        AdminError::TargetOutOfRange { target, min, max } => (
+            AdminErrorKind::TargetOutOfRange,
+            String::new(),
+            format!("format activation: target {target} outside readable range [{min}, {max}]"),
+        ),
+        AdminError::MembershipChangedSinceGate { target } => (
+            AdminErrorKind::MembershipChanged,
+            String::new(),
+            format!("format activation to target {target} no-op: membership changed since gate"),
+        ),
         AdminError::Driver(detail) => (AdminErrorKind::Driver, String::new(), detail),
     };
     ChangeResponse {
@@ -175,6 +192,25 @@ impl GrpcAdmin for AdminServiceImpl {
     ) -> Result<Response<ChangeResponse>, Status> {
         Ok(Response::new(change_response(
             self.admin.remove(req.into_inner().id).await,
+        )))
+    }
+
+    async fn activate_format(
+        &self,
+        req: Request<ActivateFormatRequest>,
+    ) -> Result<Response<ChangeResponse>, Status> {
+        let target_u32 = req.into_inner().target;
+        // proto3 has no uint8; validate that the value fits u8 before
+        // forwarding to the driver layer. Out-of-u8-range is an obvious
+        // client bug — bail with INVALID_ARGUMENT rather than passing a
+        // truncated value into the activation gate.
+        let Ok(target) = u8::try_from(target_u32) else {
+            return Err(Status::invalid_argument(format!(
+                "target {target_u32} does not fit in u8 (0..=255)"
+            )));
+        };
+        Ok(Response::new(change_response(
+            self.admin.activate_format(target).await,
         )))
     }
 }

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -22,7 +22,7 @@
 //
 
 mod handoff;
-mod network;
+pub(crate) mod network;
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -291,13 +291,29 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
     let raft_for_admin = raft.clone();
     let my_id = cfg.id;
 
-    let host = StandaloneHost::new(raft, state_machine_for_host);
-    // OpenraftDriver::new returns Arc<Self> — do NOT wrap again.
-    let driver = OpenraftDriver::new(host);
+    // Wrap host in Arc so both the driver and the membership admin can hold
+    // it. OpenraftDriver has two constructors: `new(host: H)` and
+    // `from_arc(host: Arc<H>)` — use the Arc form here (driver.rs:77).
+    let host = std::sync::Arc::new(StandaloneHost::new(raft, state_machine_for_host));
+    let driver = OpenraftDriver::from_arc(host.clone());
 
-    let admin: std::sync::Arc<dyn crate::admin::MembershipAdmin> = std::sync::Arc::new(
-        crate::admin::openraft::OpenraftMembershipAdmin::new(raft_for_admin),
+    // First production caller of PeerCapabilitySource (it has been
+    // #[allow(dead_code)] in network.rs:273-285 waiting for this wire-up).
+    // The peer TLS config is `Option<PeerTlsMaterial>` (mod.rs:210-211);
+    // extract the client side with `.as_ref().map(|m| m.client.clone())`
+    // — same pattern the existing peer factory uses at mod.rs:216.
+    let capability_source = std::sync::Arc::new(
+        crate::drivers::openraft::network::PeerCapabilitySource::new(
+            peer_tls.as_ref().map(|m| m.client.clone()),
+        ),
     );
+
+    let admin: std::sync::Arc<dyn crate::admin::MembershipAdmin> =
+        std::sync::Arc::new(crate::admin::openraft::OpenraftMembershipAdmin::new(
+            raft_for_admin,
+            host.clone(),
+            capability_source,
+        ));
 
     let (admin_transport, admin_listen_addr) = match cfg.admin_listen {
         Some(listen) => {

--- a/crates/tsoracle-standalone/src/drivers/openraft/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/network.rs
@@ -271,11 +271,6 @@ pub struct PeerCapabilitySource {
 }
 
 impl PeerCapabilitySource {
-    // The only in-workspace caller today is the round-trip test; a later
-    // phase wires this into the production `initiate_format_activation`
-    // path. `pub` is the intended surface — this `allow` documents that and
-    // unblocks the workspace build's `-D warnings` lint.
-    #[allow(dead_code)]
     pub fn new(tls: Option<ClientTlsConfig>) -> Self {
         Self {
             pool: Arc::new(Mutex::new(HashMap::new())),

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -47,7 +47,11 @@ pub use drivers::file::init_file_seeded;
 mod error;
 pub use error::StandaloneError;
 
-mod admin;
+/// Driver-agnostic membership-admin surface. Re-exported types at the crate
+/// root preserve the original public surface; the module itself is also
+/// public so the `test_support` sub-module is reachable when its feature is
+/// enabled.
+pub mod admin;
 pub use admin::{
     AdminError, MemberEntry, MemberRole, MembershipAdmin, MembershipView, NewMember,
     UnsupportedAdmin,

--- a/crates/tsoracle-standalone/tests/activation_admin_rpc.rs
+++ b/crates/tsoracle-standalone/tests/activation_admin_rpc.rs
@@ -1,0 +1,163 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Handler-layer mapping test for `ActivateFormat`. Drives `AdminServiceImpl`
+//! directly with a fake `MembershipAdmin` that returns each `AdminError`
+//! variant in turn, asserting the resulting `ChangeResponse` carries the
+//! correct `AdminErrorKind`. Complements the trait-level mapping tests in
+//! `src/admin/openraft.rs` (`FormatActivationError -> AdminError`); this
+//! file pins the next hop (`AdminError -> AdminErrorKind` over the wire).
+
+#![cfg(all(feature = "openraft", feature = "test-support"))]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tonic::Request;
+use tsoracle_standalone::admin::{AdminError, MembershipAdmin, MembershipView, NewMember};
+use tsoracle_standalone::admin_proto::membership_admin_server::MembershipAdmin as GrpcAdmin;
+use tsoracle_standalone::admin_proto::{ActivateFormatRequest, AdminErrorKind};
+
+/// Fake admin returning a one-shot configured outcome for `activate_format`.
+/// Other membership ops are unused by these tests — they return Unsupported.
+struct ProgrammableAdmin {
+    result: tokio::sync::Mutex<Option<Result<(), AdminError>>>,
+}
+
+impl ProgrammableAdmin {
+    fn new(result: Result<(), AdminError>) -> Self {
+        Self {
+            result: tokio::sync::Mutex::new(Some(result)),
+        }
+    }
+}
+
+#[async_trait]
+impl MembershipAdmin for ProgrammableAdmin {
+    async fn list_members(&self) -> Result<MembershipView, AdminError> {
+        Err(AdminError::Unsupported)
+    }
+    async fn add_learner(&self, _: NewMember) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+    async fn promote(&self, _: u64) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+    async fn remove(&self, _: u64) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+    async fn activate_format(&self, _target: u8) -> Result<(), AdminError> {
+        self.result
+            .lock()
+            .await
+            .take()
+            .expect("activate_format called more than once")
+    }
+}
+
+fn handler(admin: ProgrammableAdmin) -> impl GrpcAdmin {
+    tsoracle_standalone::admin::test_support::admin_service(Arc::new(admin))
+}
+
+async fn call_activate(
+    handler: &impl GrpcAdmin,
+    target: u32,
+) -> tsoracle_standalone::admin_proto::ChangeResponse {
+    handler
+        .activate_format(Request::new(ActivateFormatRequest { target }))
+        .await
+        .expect("handler returned Status err on a value-domain mapping path")
+        .into_inner()
+}
+
+#[tokio::test]
+async fn ok_maps_to_ok() {
+    let h = handler(ProgrammableAdmin::new(Ok(())));
+    let resp = call_activate(&h, 5).await;
+    assert!(resp.ok);
+    assert_eq!(resp.error, AdminErrorKind::Unspecified as i32);
+}
+
+#[tokio::test]
+async fn members_below_target_maps_to_dedicated_kind() {
+    let h = handler(ProgrammableAdmin::new(Err(
+        AdminError::MembersBelowTarget {
+            target: 5,
+            incapable: vec![(1, 4), (3, 4)],
+        },
+    )));
+    let resp = call_activate(&h, 5).await;
+    assert!(!resp.ok);
+    assert_eq!(resp.error, AdminErrorKind::MembersBelowTarget as i32);
+    assert!(resp.message.contains("members below target"));
+}
+
+#[tokio::test]
+async fn target_out_of_range_maps_to_dedicated_kind() {
+    let h = handler(ProgrammableAdmin::new(Err(AdminError::TargetOutOfRange {
+        target: 99,
+        min: 4,
+        max: 5,
+    })));
+    let resp = call_activate(&h, 99).await;
+    assert!(!resp.ok);
+    assert_eq!(resp.error, AdminErrorKind::TargetOutOfRange as i32);
+}
+
+#[tokio::test]
+async fn membership_changed_maps_to_dedicated_kind() {
+    let h = handler(ProgrammableAdmin::new(Err(
+        AdminError::MembershipChangedSinceGate { target: 5 },
+    )));
+    let resp = call_activate(&h, 5).await;
+    assert!(!resp.ok);
+    assert_eq!(resp.error, AdminErrorKind::MembershipChanged as i32);
+}
+
+#[tokio::test]
+async fn not_leader_maps_to_not_leader_without_endpoint() {
+    let h = handler(ProgrammableAdmin::new(Err(AdminError::NotLeader {
+        leader_admin_endpoint: None,
+    })));
+    let resp = call_activate(&h, 5).await;
+    assert!(!resp.ok);
+    assert_eq!(resp.error, AdminErrorKind::NotLeader as i32);
+    // Activation NotLeader never carries an endpoint
+    // (`FormatActivationError::NotLeader` is a unit variant — see
+    // `admin/openraft.rs` map_activation_error). The shell relies on this.
+    assert!(resp.leader_admin_endpoint.is_empty());
+}
+
+#[tokio::test]
+async fn target_out_of_u8_range_rejected_with_invalid_argument() {
+    // The handler should reject before ever calling the admin trait, so the
+    // configured result is unreached. Park an Unsupported in the slot — if
+    // the handler ever does call us this test will fail later by reading
+    // the wrong kind back rather than panicking on the take().
+    let h = handler(ProgrammableAdmin::new(Err(AdminError::Unsupported)));
+    let err = h
+        .activate_format(Request::new(ActivateFormatRequest { target: 300 }))
+        .await
+        .expect_err("expected Status err for out-of-u8-range target");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+}

--- a/crates/tsoracle-standalone/tests/activation_admin_rpc.rs
+++ b/crates/tsoracle-standalone/tests/activation_admin_rpc.rs
@@ -150,10 +150,11 @@ async fn not_leader_maps_to_not_leader_without_endpoint() {
 
 #[tokio::test]
 async fn target_out_of_u8_range_rejected_with_invalid_argument() {
-    // The handler should reject before ever calling the admin trait, so the
-    // configured result is unreached. Park an Unsupported in the slot — if
-    // the handler ever does call us this test will fail later by reading
-    // the wrong kind back rather than panicking on the take().
+    // The handler should reject before ever calling the admin trait. Park an
+    // Unsupported in the slot purely as a safe fallback for the take() guard
+    // — if the handler regressed and called through, it would return
+    // Ok(Response { error: Unsupported }) and expect_err() below would panic
+    // immediately, making the regression unambiguous.
     let h = handler(ProgrammableAdmin::new(Err(AdminError::Unsupported)));
     let err = h
         .activate_format(Request::new(ActivateFormatRequest { target: 300 }))

--- a/deploy/charts/tsoracle/templates/statefulset.yaml
+++ b/deploy/charts/tsoracle/templates/statefulset.yaml
@@ -48,6 +48,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: PEER_PORT
               value: {{ .Values.ports.peer | quote }}
+            - name: ADMIN_PORT
+              value: {{ .Values.ports.admin | quote }}
             - name: TSO_PORT
               value: {{ .Values.ports.client | quote }}
             - name: DATA_DIR
@@ -69,6 +71,8 @@ spec:
               containerPort: {{ .Values.ports.peer }}
             - name: tso
               containerPort: {{ .Values.ports.client }}
+            - name: admin
+              containerPort: {{ .Values.ports.admin }}
           readinessProbe:
             tcpSocket:
               port: tso

--- a/deploy/charts/tsoracle/values.yaml
+++ b/deploy/charts/tsoracle/values.yaml
@@ -7,6 +7,7 @@ image:
 ports:
   client: 50551
   peer: 51001
+  admin: 51002             # admin/operator gRPC port; loopback-only by default
 tls:
   enabled: false
   secretName: ""            # Secret with tls.crt / tls.key / ca.crt; mounted at /etc/tsoracle/tls

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -53,7 +53,6 @@ openraft|paxos)
     while [ "$i" -lt "$REPLICAS" ]; do
         id=$((i + 1))
         fqdn="${STATEFULSET_NAME}-${i}.${PEER_SERVICE}.${POD_NAMESPACE}.svc.cluster.local"
-        # TODO(admin-listen): --admin-listen flag wired in the CLI task
         members="${members}${members:+,}${id}=${fqdn}:${PEER_PORT}/${fqdn}:${TSO_PORT}/${fqdn}:${ADMIN_PORT}"
         peers="${peers}${peers:+,}${id}=${fqdn}:${PEER_PORT}"
         tso_peers="${tso_peers}${tso_peers:+,}${id}=${fqdn}:${TSO_PORT}"
@@ -66,10 +65,16 @@ openraft|paxos)
             bootstrap="--bootstrap --members $members"
         fi
         # shellcheck disable=SC2086
+        # Loopback-only admin bind: routable bind would trip the secure-by-default
+        # AdminInsecureRoutable guard (drivers/openraft/mod.rs). The kube-e2e
+        # shell reaches admin via `kubectl exec POD -- ... --endpoint http://127.0.0.1:...`.
+        # Operators who want a routable admin port should add admin TLS material
+        # to this entrypoint and bind 0.0.0.0:${ADMIN_PORT} with mTLS.
         exec tsoracle serve openraft \
             --id "$node_id" \
             --raft-addr "0.0.0.0:${PEER_PORT}" \
             --listen "0.0.0.0:${TSO_PORT}" \
+            --admin-listen "127.0.0.1:${ADMIN_PORT}" \
             --raft-dir "${DATA_DIR}/raft" \
             $peer_tls $client_tls $common $bootstrap
     else

--- a/e2e/kube/_assertions_lib.sh
+++ b/e2e/kube/_assertions_lib.sh
@@ -1,0 +1,84 @@
+# Shared helpers for the kube e2e assertion lanes. Sourced by both
+# run-assertions.sh and run-mixed-version-assertions.sh. POSIX-friendly
+# (functions, no arrays).
+
+# Poll a Job to terminal state. Succeeds on .status.succeeded=1, fails on
+# any .status.failed, dumping the Job's logs so the assertion summary is
+# visible.
+wait_job() {
+    local job="$1" timeout="$2" elapsed=0
+    while true; do
+        local succeeded failed
+        succeeded="$(kubectl get job "$job" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)"
+        failed="$(kubectl get job "$job" -o jsonpath='{.status.failed}' 2>/dev/null || true)"
+        if [ "$succeeded" = "1" ]; then
+            echo "$job: succeeded"
+            kubectl logs "job/$job" || true
+            return 0
+        fi
+        if [ -n "$failed" ] && [ "$failed" != "0" ]; then
+            echo "$job: FAILED"
+            kubectl logs "job/$job" || true
+            return 1
+        fi
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "$job: timed out after ${timeout}s"
+            kubectl logs "job/$job" || true
+            return 1
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+}
+
+# Block until a soak-style Job has logged its specific first-success
+# sentinel. The sentinel is explicit (not a substring guess) so a future
+# rename in one mode doesn't silently match the other's log.
+#
+# Args: JOB SENTINEL TIMEOUT_S
+wait_soak_live() {
+    local job="$1" sentinel="$2" timeout="$3" elapsed=0
+    while true; do
+        if kubectl logs "job/$job" 2>/dev/null | grep -qF "$sentinel"; then
+            echo "$job: load is live (sentinel: $sentinel)"
+            return 0
+        fi
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "$job: never became live (sentinel: $sentinel)"
+            kubectl logs "job/$job" || true
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+# Block until POD's tsoracle container reports a specific IMAGE in
+# .status.containerStatuses AND .status.containerStatuses[*].ready=true.
+# Without the image check, an already-Ready baseline pod falsely satisfies
+# a "did the new image land" wait.
+#
+# Args: POD IMAGE TIMEOUT_S
+wait_pod_image_and_ready() {
+    local pod="$1" image="$2" timeout="$3" elapsed=0
+    while true; do
+        local actual_image ready
+        actual_image="$(kubectl get pod "$pod" \
+            -o jsonpath='{.status.containerStatuses[?(@.name=="tsoracle")].image}' \
+            2>/dev/null || true)"
+        ready="$(kubectl get pod "$pod" \
+            -o jsonpath='{.status.containerStatuses[?(@.name=="tsoracle")].ready}' \
+            2>/dev/null || true)"
+        if [ "$actual_image" = "$image" ] && [ "$ready" = "true" ]; then
+            echo "$pod: on image=$image and Ready"
+            return 0
+        fi
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "$pod: timed out (image=$actual_image ready=$ready, want image=$image ready=true)"
+            kubectl describe pod "$pod" || true
+            return 1
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+}

--- a/e2e/kube/_assertions_lib.sh
+++ b/e2e/kube/_assertions_lib.sh
@@ -43,6 +43,17 @@ wait_soak_live() {
             echo "$job: load is live (sentinel: $sentinel)"
             return 0
         fi
+        # Short-circuit on Job failure (image pull / driver panic / cluster
+        # unreachable). Without this check, an immediately-failing Job sits
+        # for the full TIMEOUT_S before surfacing as "never became live",
+        # delaying diagnosis by up to a minute.
+        local failed
+        failed="$(kubectl get job "$job" -o jsonpath='{.status.failed}' 2>/dev/null || true)"
+        if [ -n "$failed" ] && [ "$failed" != "0" ]; then
+            echo "$job: FAILED before sentinel '$sentinel' appeared"
+            kubectl logs "job/$job" || true
+            return 1
+        fi
         if [ "$elapsed" -ge "$timeout" ]; then
             echo "$job: never became live (sentinel: $sentinel)"
             kubectl logs "job/$job" || true

--- a/e2e/kube/_assertions_lib.sh
+++ b/e2e/kube/_assertions_lib.sh
@@ -69,19 +69,29 @@ wait_soak_live() {
 # Without the image check, an already-Ready baseline pod falsely satisfies
 # a "did the new image land" wait.
 #
+# The IMAGE comparison tolerates Kubernetes' canonical-image rewriting:
+# kubelet reports short-form Docker Hub names (e.g. "tsoracle:e2e-next")
+# back as "docker.io/library/tsoracle:e2e-next" in .status.image. We accept
+# either exact match OR a "*/IMAGE" path-boundary suffix match, so a
+# requested "tsoracle:e2e-next" is satisfied by the canonicalized form
+# but NOT by an unrelated "foo-tsoracle:e2e-next".
+#
 # Args: POD IMAGE TIMEOUT_S
 wait_pod_image_and_ready() {
     local pod="$1" image="$2" timeout="$3" elapsed=0
     while true; do
-        local actual_image ready
+        local actual_image ready image_ok=0
         actual_image="$(kubectl get pod "$pod" \
             -o jsonpath='{.status.containerStatuses[?(@.name=="tsoracle")].image}' \
             2>/dev/null || true)"
         ready="$(kubectl get pod "$pod" \
             -o jsonpath='{.status.containerStatuses[?(@.name=="tsoracle")].ready}' \
             2>/dev/null || true)"
-        if [ "$actual_image" = "$image" ] && [ "$ready" = "true" ]; then
-            echo "$pod: on image=$image and Ready"
+        case "$actual_image" in
+            "$image"|*/"$image") image_ok=1 ;;
+        esac
+        if [ "$image_ok" = "1" ] && [ "$ready" = "true" ]; then
+            echo "$pod: on image=$image (reported=$actual_image) and Ready"
             return 0
         fi
         if [ "$elapsed" -ge "$timeout" ]; then

--- a/e2e/kube/run-assertions.sh
+++ b/e2e/kube/run-assertions.sh
@@ -8,52 +8,8 @@ set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
 
-# Poll a Job to terminal state. Succeeds on .status.succeeded=1, fails on any
-# .status.failed, dumping the Job's logs so the assertion summary is visible.
-wait_job() {
-    local job="$1" timeout="$2" elapsed=0
-    while true; do
-        local succeeded failed
-        succeeded="$(kubectl get job "$job" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)"
-        failed="$(kubectl get job "$job" -o jsonpath='{.status.failed}' 2>/dev/null || true)"
-        if [ "$succeeded" = "1" ]; then
-            echo "$job: succeeded"
-            kubectl logs "job/$job" || true
-            return 0
-        fi
-        if [ -n "$failed" ] && [ "$failed" != "0" ]; then
-            echo "$job: FAILED"
-            kubectl logs "job/$job" || true
-            return 1
-        fi
-        if [ "$elapsed" -ge "$timeout" ]; then
-            echo "$job: timed out after ${timeout}s"
-            kubectl logs "job/$job" || true
-            return 1
-        fi
-        sleep 3
-        elapsed=$((elapsed + 3))
-    done
-}
-
-# Block until the soak Job has logged its first-success sentinel, so the cluster
-# is only perturbed once load is provably live.
-wait_soak_live() {
-    local job="$1" timeout="$2" elapsed=0
-    while true; do
-        if kubectl logs "job/$job" 2>/dev/null | grep -q "soak: first GetTs ok"; then
-            echo "$job: load is live"
-            return 0
-        fi
-        if [ "$elapsed" -ge "$timeout" ]; then
-            echo "$job: never became live"
-            kubectl logs "job/$job" || true
-            return 1
-        fi
-        sleep 2
-        elapsed=$((elapsed + 2))
-    done
-}
+# shellcheck source=./_assertions_lib.sh
+source "$here/_assertions_lib.sh"
 
 echo "== step 2: cold-start (each ordinal serves or redirects) =="
 kubectl apply -f "$here/driver/job-cold-start.yaml"
@@ -61,7 +17,7 @@ wait_job tsoracle-e2e-cold-start 120
 
 echo "== step 3: soak across a graceful rolling restart =="
 kubectl apply -f "$here/driver/job-soak.yaml"
-wait_soak_live tsoracle-e2e-soak 60
+wait_soak_live tsoracle-e2e-soak "soak: first GetTs ok" 60
 kubectl rollout restart statefulset/tsoracle
 kubectl rollout status statefulset/tsoracle --timeout=150s
 wait_job tsoracle-e2e-soak 180

--- a/e2e/kube/run-mixed-version-assertions.sh
+++ b/e2e/kube/run-mixed-version-assertions.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Mixed-version soak orchestrator: drives a partial-then-full image rollout
+# against a chart-installed openraft cluster, asserting that:
+#   1. activate-format mid-partial-rollout is rejected by the all-members gate
+#   2. activate-format post-full-rollout succeeds
+#   3. the underlying soak Job reports zero monotonicity violations + <0.5% err
+# Assumes the chart has been installed at image.tag=e2e-baseline and the
+# StatefulSet has reached readiness.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./_assertions_lib.sh
+source "$here/_assertions_lib.sh"
+
+# Activation target. BASELINE_WRITE_VERSION is 4 today; e2e-max-readable-next
+# raises MAX_READABLE_VERSION to BASELINE+1 = 5. If BASELINE bumps, this
+# constant trips a visible mismatch on the next run rather than silently
+# activating to an unintended version.
+ACTIVATION_TARGET=5
+# Loopback admin port; matches deploy/entrypoint.sh:12 ADMIN_PORT default
+# and the chart values.yaml ports.admin entry added in Task 7.
+ADMIN_PORT=51002
+# The kube-e2e-mixed-version.yml workflow tags images as :e2e-baseline and
+# :e2e-next. The Helm install sets the baseline tag.
+NEXT_IMAGE=tsoracle:e2e-next
+
+# Try `tsoracle admin activate-format` against each tsoracle pod's loopback
+# admin in turn. Exit codes (CLI contract, see crates/tsoracle-bin/src/main.rs
+# ActivationOutcome):
+#   0 = success
+#   2 = MEMBERS_BELOW_TARGET (all-members gate rejected — :next leader saw baseline peers)
+#   3 = NOT_LEADER (follower; skip and try next pod)
+#   4 = TARGET_OUT_OF_RANGE (local-range rejected — baseline leader can't read target)
+#   1 = anything else (hard fail)
+# For `expect=REJECTED` we accept EITHER exit 2 OR exit 4 — both are "the
+# activation control plane refused this unsafe state." See spec Component 2
+# for why the e2e doesn't try to force a specific rejection shape (would
+# require a tsoracle admin transfer-leader RPC, out of scope here).
+#
+# Args: TARGET EXPECT (EXPECT in {OK, REJECTED})
+try_activate_format() {
+    local target="$1" expect="$2"
+    local pods
+    pods=$(kubectl get pods -l app.kubernetes.io/name=tsoracle \
+        -o jsonpath='{.items[*].metadata.name}')
+    local last_rc=0
+    for pod in $pods; do
+        local rc=0
+        timeout 30s kubectl exec "$pod" -c tsoracle -- \
+            tsoracle admin activate-format \
+            --endpoint "http://127.0.0.1:${ADMIN_PORT}" \
+            --target "$target" \
+            >&2 || rc=$?
+        case "$rc" in
+            0)
+                if [ "$expect" = OK ]; then
+                    echo "activate-format(target=$target) succeeded on $pod"
+                    return 0
+                fi
+                echo "FAIL: activate-format succeeded on $pod but expected $expect"
+                return 1
+                ;;
+            2|4)
+                if [ "$expect" = REJECTED ]; then
+                    local shape
+                    if [ "$rc" = 2 ]; then
+                        shape="MEMBERS_BELOW_TARGET (gate)"
+                    else
+                        shape="TARGET_OUT_OF_RANGE (local-range)"
+                    fi
+                    echo "activate-format(target=$target) safely rejected ($shape) on $pod"
+                    return 0
+                fi
+                echo "FAIL: activate-format rejected on $pod (rc=$rc) but expected $expect"
+                return 1
+                ;;
+            3)
+                last_rc=3
+                continue
+                ;;
+            *)
+                echo "FAIL: activate-format on $pod: rc=$rc"
+                return 1
+                ;;
+        esac
+    done
+    echo "FAIL: no pod accepted activate-format (last_rc=$last_rc)"
+    return 1
+}
+
+echo "== step 1: start mixed-version soak (load is live before any perturbation) =="
+kubectl apply -f "$here/driver/job-mixed-version-soak.yaml"
+wait_soak_live tsoracle-e2e-mixed-version-soak \
+    "mixed-version-soak: first GetTs ok" 60
+
+echo "== step 2: partition=2; roll only ordinal 2 to :e2e-next =="
+kubectl patch sts/tsoracle --type=strategic \
+    -p '{"spec":{"updateStrategy":{"rollingUpdate":{"partition":2}}}}'
+kubectl set image sts/tsoracle "tsoracle=${NEXT_IMAGE}"
+wait_pod_image_and_ready tsoracle-2 "${NEXT_IMAGE}" 120
+
+echo "== step 3: activation MUST be safely rejected (mixed-version state) =="
+try_activate_format "$ACTIVATION_TARGET" REJECTED
+
+echo "== step 4: partition=0; complete the rollout =="
+kubectl patch sts/tsoracle --type=strategic \
+    -p '{"spec":{"updateStrategy":{"rollingUpdate":{"partition":0}}}}'
+kubectl rollout status sts/tsoracle --timeout=180s
+
+echo "== step 5: activation MUST succeed (all members on :e2e-next) =="
+try_activate_format "$ACTIVATION_TARGET" OK
+
+echo "== step 6: drain the soak (zero monotonicity violations + <0.5% errors) =="
+wait_job tsoracle-e2e-mixed-version-soak 180
+
+echo "== all mixed-version assertions passed =="

--- a/e2e/kube/run-mixed-version-assertions.sh
+++ b/e2e/kube/run-mixed-version-assertions.sh
@@ -24,6 +24,23 @@ ADMIN_PORT=51002
 # :e2e-next. The Helm install sets the baseline tag.
 NEXT_IMAGE=tsoracle:e2e-next
 
+# Locate a `timeout` implementation. GNU coreutils' `timeout` is standard on
+# Linux (the CI lane) but absent from stock macOS — `coreutils` from brew
+# installs it as `gtimeout`. The admin CLI itself has no per-RPC deadline,
+# so this safety net IS load-bearing: without it a hung admin RPC would
+# block the whole orchestrator until the test job's activeDeadlineSeconds
+# expires. Fail loudly if neither is on PATH so the failure mode is
+# obvious instead of silently leaking via missing-binary rc=127.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=timeout
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=gtimeout
+else
+    echo "FATAL: neither 'timeout' nor 'gtimeout' is on PATH." >&2
+    echo "       Install GNU coreutils (Linux: apt/yum install coreutils; macOS: brew install coreutils)." >&2
+    exit 1
+fi
+
 # Try `tsoracle admin activate-format` against each tsoracle pod's loopback
 # admin in turn. Exit codes (CLI contract, see crates/tsoracle-bin/src/main.rs
 # ActivationOutcome):
@@ -46,7 +63,7 @@ try_activate_format() {
     local last_rc=0
     for pod in $pods; do
         local rc=0
-        timeout 30s kubectl exec "$pod" -c tsoracle -- \
+        "$TIMEOUT_CMD" 30s kubectl exec "$pod" -c tsoracle -- \
             tsoracle admin activate-format \
             --endpoint "http://127.0.0.1:${ADMIN_PORT}" \
             --target "$target" \


### PR DESCRIPTION
Closes #484.

## Summary

Wires `e2e/kube/driver/job-mixed-version-soak.yaml` (added in #470) into a CI lane that proves the openraft format-activation control plane works under sustained client load + a partial-then-full image rollout. The issue's "Suggested orchestration" required an externally-callable activation surface, which didn't exist — `StandaloneHost::initiate_format_activation` was a Rust method with no gRPC or CLI surface. So this branch also lands that surface end-to-end.

**Three independent assertions per CI run:**

1. Activation mid-partial-rollout is **safely rejected** — exit code 2 (`MEMBERS_BELOW_TARGET`, gate fired) OR exit code 4 (`TARGET_OUT_OF_RANGE`, local-range check fired on a baseline-binary leader). Both prove the activation control plane refused an unsafe state. Local kind verification confirmed the latter shape fires when ordinal 0 leads the partial-rollout cluster.
2. Activation post-full-rollout **succeeds** — apply-keyed flip lands; active write version flips 4 → 5.
3. Soak Job: **zero monotonicity violations** + < 0.5% error rate across the whole sequence.

## What's in the diff (20 files, +956/−67, 18 commits)

**Library surface** (`crates/tsoracle-standalone/`)
- New `ActivateFormat` RPC on the `MembershipAdmin` proto service + three new `AdminErrorKind` variants (`MEMBERS_BELOW_TARGET`, `TARGET_OUT_OF_RANGE`, `MEMBERSHIP_CHANGED`)
- `MembershipAdmin::activate_format` trait method + `OpenraftMembershipAdmin` impl (delegates to `StandaloneHost::initiate_format_activation`); `UnsupportedAdmin` returns `Unsupported` for paxos/file
- `build_openraft` now wraps `StandaloneHost` in `Arc` and constructs `PeerCapabilitySource` (first production caller — previously `#[allow(dead_code)]`)
- gRPC handler with `u8::try_from` overflow validation
- Six handler-mapping unit tests + six `map_activation_error` unit tests

**CLI** (`crates/tsoracle-bin/`)
- New `tsoracle admin activate-format --endpoint <addr> --target <N>` subcommand
- Four-way exit-code contract: `0` success, `2` MEMBERS_BELOW_TARGET, `3` NOT_LEADER, `4` TARGET_OUT_OF_RANGE, `1` other. Lets the shell do ordinal-walk leader discovery and accept either rejection shape without parsing stderr
- Pure `classify_activation` + impure `report_activation` split for testability; six unit tests

**Cargo features**
- `e2e-max-readable-next` pass-through `tsoracle-bin → tsoracle-standalone → tsoracle-driver-openraft → tsoracle-openraft-toolkit`, gated via `?` so the feature can't silently activate the optional driver dep

**Chart admin-port wiring** (`deploy/`)
- `entrypoint.sh` now passes `--admin-listen 127.0.0.1:51002` for openraft (loopback-only by design — routable bind would trip the secure-by-default `AdminInsecureRoutable` guard). Closes the long-standing `TODO(admin-listen)` comment
- `statefulset.yaml`: new `ADMIN_PORT` env + `admin` containerPort
- `values.yaml`: new `ports.admin: 51002`

**E2E shell + workflow** (`e2e/kube/`, `.github/workflows/`)
- New `_assertions_lib.sh` extracted from `run-assertions.sh`; `wait_soak_live` now takes an explicit sentinel arg; new `wait_pod_image_and_ready` helper; `wait_soak_live` short-circuits on Job failure
- New `run-mixed-version-assertions.sh` orchestrator with ordinal-walk leader discovery
- New `kube-e2e-mixed-version.yml` workflow (`workflow_dispatch` only) — builds two cluster images per run (`:e2e-baseline` openraft-only, `:e2e-next` openraft+e2e-max-readable-next), loads into kind, runs the assertions script. 60-min timeout absorbs both builds + the rollout sequence
- Drive-by fix: `kube-e2e.yml` now passes `--set tls.allowInsecurePeer=true` to satisfy the secure-by-default chart guard from #452 (the existing lane has likely been silently broken on first re-run since #452)

## Pre-merge verification

- Full workspace `cargo test --workspace --features openraft,test-support`: 120 test binaries, 0 failures
- `cargo clippy --workspace --all-features -- -D warnings`: clean
- `actionlint .github/workflows/kube-e2e-mixed-version.yml`: clean
- `helm template tsoracle deploy/charts/tsoracle --set driver=openraft,replicas=3,tls.allowInsecurePeer=true`: renders cleanly with `ADMIN_PORT=51002` env + `admin` containerPort
- **Local kind end-to-end (`./e2e/kube/run-mixed-version-assertions.sh` against a real 3-node cluster):** PASS. Soak Job tracker: `calls=52947 errors=0 error_rate=0.0000% monotonicity_violations=0 → PASS`. The local run also surfaced two latent assertion-harness defects that would have failed CI on first run (kubelet's canonical image-name rewriting + macOS-only `gtimeout` fallback); both are fixed in the last two commits.

## Test plan

- [ ] CI: workflow_dispatch on `kube-e2e-mixed-version.yml` against this branch → expect the same PASS shape as local kind (~16 min wall-clock)
- [ ] CI: workflow_dispatch on the existing `kube-e2e.yml` → confirm the `tls.allowInsecurePeer=true` drive-by fix unbroke it
- [ ] Spec + plan included under `docs/superpowers/{specs,plans}/2026-05-26-mixed-version-soak-wiring*.md` for posterity (NOT load-bearing on the implementation)

## Out of scope (sibling open issues)

- #482 paxos driver lane — paxos returns `AdminError::Unsupported` for activation
- #483 TLS-enabled deploy lane — admin stays loopback-only here; routable admin with mTLS is a future operator opt-in
- #485 SIGKILL leader during activation — separate ungraceful-crash lane
- Auto-trigger on push/PR (issue #488) — workflow stays `workflow_dispatch` only here