### PR TITLE
test(kube-e2e): add SIGKILL-leader assertion (issue #485)

### DIFF
--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -52,7 +52,7 @@ jobs:
             --wait --timeout 5m
       - name: wait for cluster formation (TCP readiness)
         run: kubectl rollout status statefulset/tsoracle --timeout=300s
-      - name: run e2e assertions (cold-start + soak across rollout)
+      - name: run e2e assertions (cold-start + soak across rollout + sigkill leader)
         run: ./e2e/kube/run-assertions.sh
       - name: dump diagnostics on failure
         if: failure()
@@ -61,4 +61,5 @@ jobs:
           kubectl describe statefulset/tsoracle || true
           kubectl logs job/tsoracle-e2e-cold-start || true
           kubectl logs job/tsoracle-e2e-soak || true
+          kubectl logs job/tsoracle-e2e-sigkill-soak || true
           kubectl get events --sort-by=.lastTimestamp || true

--- a/e2e/kube/driver/job-sigkill-soak.yaml
+++ b/e2e/kube/driver/job-sigkill-soak.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-sigkill-soak
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=sigkill-soak
+            # All replica endpoints (not the Service VIP) so the client has a
+            # known-live peer to fail over to when the leader pod is
+            # force-deleted — matching how a real tsoracle client is
+            # configured (leader-hint failover assumes the client knows every
+            # replica).
+            - --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051
+            # Longer than the plain soak: must cover the kubelet's pod
+            # re-creation latency (10-30s) + new pod start + cluster rejoin +
+            # leader re-election after the SIGKILL. 240s leaves ample headroom
+            # above the observed end-to-end recovery window; tune alongside
+            # the orchestrator step in run-assertions.sh.
+            - --duration-secs=240

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -45,6 +45,16 @@ enum Mode {
     /// live. The driver itself is a pure observer of monotonicity — it does not
     /// perform the rollout or the activation; the orchestrator does.
     MixedVersionSoak,
+    /// Soak variant for the SIGKILL-leader assertion (issue #485): sustain load
+    /// with the same zero-monotonicity-violation invariant but a looser final
+    /// error tolerance ([`MAX_SIGKILL_SOAK_ERROR_RATE`]) while the orchestrator
+    /// force-deletes the current leader pod (`kubectl delete pod ... --force
+    /// --grace-period=0`) and waits for the StatefulSet to bring a replacement
+    /// up. Distinct sentinel (`sigkill-soak: first GetTs ok`) so the
+    /// orchestrator only severs the leader once load is provably live. The
+    /// driver remains a pure observer of monotonicity; the orchestrator picks
+    /// the leader and issues the kill.
+    SigkillSoak,
 }
 
 #[derive(Parser, Debug)]
@@ -74,6 +84,14 @@ struct Cli {
 /// above the observed teardown rate while still catching a real regression.
 const MAX_SOAK_ERROR_RATE: f64 = 0.005;
 
+/// SIGKILL-leader soak error budget. A force-deleted leader severs every
+/// in-flight RPC to that pod at once (no graceful shutdown, no
+/// `transfer_leader`, no draining) and re-election typically takes longer
+/// than a graceful step-down. The budget is looser than [`MAX_SOAK_ERROR_RATE`]
+/// because the client retry cannot mask the simultaneous burst of transport
+/// errors. Placeholder; tune downward against baseline runs per issue #485.
+const MAX_SIGKILL_SOAK_ERROR_RATE: f64 = 0.05;
+
 /// A budget generous enough that a single-pod restart's brief re-election is
 /// masked by the client's retry + leader-redirect, so a "final error" really
 /// means the client gave up.
@@ -93,6 +111,9 @@ async fn main() -> Result<()> {
         Mode::Soak => run_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?,
         Mode::MixedVersionSoak => {
             run_mixed_version_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
+        }
+        Mode::SigkillSoak => {
+            run_sigkill_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
         }
     };
     if !passed {
@@ -130,7 +151,7 @@ async fn run_cold_start(endpoints: &[String], count: u32) -> Result<bool> {
 /// on the first success so the workflow knows load is live before it restarts
 /// the StatefulSet.
 async fn run_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
-    sustain_load(endpoints, duration, "soak").await
+    sustain_load(endpoints, duration, "soak", MAX_SOAK_ERROR_RATE).await
 }
 
 /// Sustain GetTs load while the orchestrator performs a mixed-version rolling
@@ -142,14 +163,43 @@ async fn run_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
 /// load is provably live, mirroring how the existing soak lane sequences a
 /// rolling restart.
 async fn run_mixed_version_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
-    sustain_load(endpoints, duration, "mixed-version-soak").await
+    sustain_load(
+        endpoints,
+        duration,
+        "mixed-version-soak",
+        MAX_SOAK_ERROR_RATE,
+    )
+    .await
 }
 
-/// Shared body of [`run_soak`] and [`run_mixed_version_soak`]. The `label` is
-/// the per-mode prefix used in the first-success sentinel, the per-error log
-/// line, and the final-verdict tracker report — so the orchestrator can grep
-/// for the right mode unambiguously.
-async fn sustain_load(endpoints: &[String], duration: Duration, label: &str) -> Result<bool> {
+/// Sustain GetTs load while the orchestrator force-deletes the current leader
+/// pod. Same zero-monotonicity-violation invariant as the other soak modes,
+/// but with the looser [`MAX_SIGKILL_SOAK_ERROR_RATE`] budget because a
+/// SIGKILL severs every in-flight RPC to the leader simultaneously. The
+/// distinct sentinel (`sigkill-soak: first GetTs ok`) lets the orchestrator
+/// only kill the leader after load is provably live.
+async fn run_sigkill_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
+    sustain_load(
+        endpoints,
+        duration,
+        "sigkill-soak",
+        MAX_SIGKILL_SOAK_ERROR_RATE,
+    )
+    .await
+}
+
+/// Shared body of the three soak modes. The `label` is the per-mode prefix
+/// used in the first-success sentinel, the per-error log line, and the final-
+/// verdict tracker report — so the orchestrator can grep for the right mode
+/// unambiguously. `max_error_rate` is passed through to the tracker because
+/// the SIGKILL lane needs a looser budget than the graceful rollouts (see
+/// [`MAX_SIGKILL_SOAK_ERROR_RATE`]).
+async fn sustain_load(
+    endpoints: &[String],
+    duration: Duration,
+    label: &str,
+    max_error_rate: f64,
+) -> Result<bool> {
     let client = ClientBuilder::endpoints(endpoints.to_vec())
         .retry_policy(generous_policy())
         .build()
@@ -176,7 +226,7 @@ async fn sustain_load(endpoints: &[String], duration: Duration, label: &str) -> 
             }
         }
     }
-    Ok(tracker.report_within_error_tolerance(label, MAX_SOAK_ERROR_RATE))
+    Ok(tracker.report_within_error_tolerance(label, max_error_rate))
 }
 
 #[cfg(test)]
@@ -221,6 +271,23 @@ mod cli_tests {
             "--duration-secs=180",
         ]);
         assert_eq!(cli.mode, Mode::MixedVersionSoak);
+        assert_eq!(cli.endpoints.len(), 3);
+        assert_eq!(cli.duration_secs, 180);
+    }
+
+    #[test]
+    fn sigkill_soak_mode_parses() {
+        // Like the other soaks, the SIGKILL mode shares the soak CLI surface;
+        // only `--mode` differs. The orchestrator picks the leader pod via
+        // `tsoracle admin members` (loopback admin port; see issue #485) and
+        // routes traffic at the same three replica endpoints the soak uses.
+        let cli = Cli::parse_from([
+            "kube-e2e-driver",
+            "--mode=sigkill-soak",
+            "--endpoints=a:5051,b:5051,c:5051",
+            "--duration-secs=180",
+        ]);
+        assert_eq!(cli.mode, Mode::SigkillSoak);
         assert_eq!(cli.endpoints.len(), 3);
         assert_eq!(cli.duration_secs, 180);
     }

--- a/e2e/kube/run-assertions.sh
+++ b/e2e/kube/run-assertions.sh
@@ -2,14 +2,70 @@
 # Orchestrates the kind e2e assertions against the current kubectl context:
 #   1. cold-start: every ordinal serves or redirects (proves 3-node formation)
 #   2. soak: zero final client errors + monotonicity across a graceful rollout
+#   3. sigkill-soak: monotonicity holds across a force-deleted leader pod
+#      (no graceful shutdown, no transfer_leader, no draining) — exercises the
+#      crash-recovery paths that #427 (barrier-seq durable seed) and #426
+#      (snapshot-publish TOCTOU) fixed, currently covered only by failpoint
+#      unit tests. See issue #485.
 # Assumes the chart has been installed (helm install tsoracle deploy/charts/tsoracle)
-# and the StatefulSet has reached readiness.
+# and the StatefulSet has reached readiness. Step 4 additionally assumes the
+# chart's openraft serve invocation binds the admin listener (see the
+# entrypoint.sh `--admin-listen 127.0.0.1:${ADMIN_PORT}` wire-up); without it
+# `tsoracle admin members` inside the pod cannot reach the admin gRPC server.
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
 
 # shellcheck source=./_assertions_lib.sh
 source "$here/_assertions_lib.sh"
+
+# Query `tsoracle admin members` via the loopback admin port inside a tsoracle
+# pod and print the pod name of the current leader (e.g. "tsoracle-1"). Retries
+# until the responding node reports a known leader or the timeout elapses —
+# briefly returning "leader: none" mid-election is normal.
+#
+# The query targets tsoracle-0 unconditionally. ListMembers is locally
+# answerable on any node, so the responder need not BE the leader; if the
+# leader happens to be tsoracle-0, we still get its id back and the subsequent
+# delete proceeds normally. The admin gRPC server binds 127.0.0.1:${ADMIN_PORT}
+# (default 51002) per the chart's entrypoint.sh — kubectl exec reaches it via
+# loopback without any Service/NetworkPolicy plumbing.
+find_leader_pod() {
+    local timeout="$1" elapsed=0 admin_port="${ADMIN_PORT:-51002}"
+    while true; do
+        local out leader_id raft_field pod_name
+        # `|| true` so the loop survives a transient "Error from server" during
+        # admin server startup; the next iteration re-queries.
+        out="$(kubectl exec tsoracle-0 -c tsoracle -- \
+            tsoracle admin members --endpoint "http://127.0.0.1:${admin_port}" \
+            2>/dev/null || true)"
+        leader_id="$(printf '%s\n' "$out" | awk '/^leader: / { print $2 }')"
+        if [ -n "$leader_id" ] && [ "$leader_id" != "none" ]; then
+            # Each member line is `  id=N role=... raft=HOST:PORT service=... admin=...`.
+            # Pick the raft field for the leader's row and strip everything from
+            # the first dot onward — the pod name is the bare hostname label.
+            raft_field="$(printf '%s\n' "$out" | awk -v id="id=${leader_id}" '
+                $1 == id {
+                    for (i=2; i<=NF; i++) if (substr($i,1,5) == "raft=") {
+                        print substr($i,6); exit
+                    }
+                }')"
+            pod_name="${raft_field%%.*}"
+            if [ -n "$pod_name" ]; then
+                echo "$pod_name"
+                return 0
+            fi
+        fi
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "find_leader_pod: no leader within ${timeout}s" >&2
+            echo "last admin members output:" >&2
+            printf '%s\n' "$out" >&2
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
 
 echo "== step 2: cold-start (each ordinal serves or redirects) =="
 kubectl apply -f "$here/driver/job-cold-start.yaml"
@@ -21,5 +77,18 @@ wait_soak_live tsoracle-e2e-soak "soak: first GetTs ok" 60
 kubectl rollout restart statefulset/tsoracle
 kubectl rollout status statefulset/tsoracle --timeout=150s
 wait_job tsoracle-e2e-soak 180
+
+echo "== step 4: sigkill-soak (monotonicity across a force-deleted leader) =="
+kubectl apply -f "$here/driver/job-sigkill-soak.yaml"
+wait_soak_live tsoracle-e2e-sigkill-soak "sigkill-soak: first GetTs ok" 60
+leader_pod="$(find_leader_pod 60)"
+echo "step 4: killing leader pod $leader_pod"
+kubectl delete pod "$leader_pod" --grace-period=0 --force
+# The StatefulSet must bring the deleted pod back and reach all-ready before
+# we trust the soak's final verdict; otherwise a flaky pod-recreate would
+# masquerade as a real monotonicity regression. 180s covers the kubelet's
+# pod-recreate latency + image pull (IfNotPresent in CI) + cluster rejoin.
+kubectl rollout status statefulset/tsoracle --timeout=180s
+wait_job tsoracle-e2e-sigkill-soak 300
 
 echo "== all assertions passed =="


### PR DESCRIPTION
## Summary

- Adds a new `Mode::SigkillSoak` to the kube-e2e driver + `job-sigkill-soak.yaml` + step 4 in `run-assertions.sh` that picks the current leader pod via `tsoracle admin members` (loopback admin port introduced in #503), force-deletes it (`kubectl delete pod --grace-period=0 --force`), waits for StatefulSet recovery, and asserts the soak's monotonicity invariant held across the kill.
- Closes the gap between the existing graceful-rollout soak (step 3 — `shutdown_signal` + `transfer_leader` + clean recovery) and the SIGKILL/eviction/OOM crash path that #427 (barrier-seq durable seed) and #426 (snapshot-publish TOCTOU) fixed but only failpoint-tested.
- New `MAX_SIGKILL_SOAK_ERROR_RATE = 5%` budget — looser than the 0.5% graceful budget because a force-delete severs every in-flight RPC simultaneously and the client retry cannot mask the burst. Placeholder; tune downward against baseline runs per the issue.

Closes #485.

## Test plan

- [x] `cargo test -p kube-e2e-driver` — 13/13 pass (12 existing + new `sigkill_soak_mode_parses`).
- [x] `cargo check --workspace --all-features` clean.
- [x] `cargo clippy -p kube-e2e-driver --all-targets -- -D warnings` clean.
- [x] `bash -n e2e/kube/run-assertions.sh` syntactically valid.
- [x] `scripts/check-ts-header.py` clean.
- [ ] **kube-e2e `workflow_dispatch` run on a real kind cluster** — validates step 4 end-to-end. The admin-listen wiring this depends on (entrypoint.sh `--admin-listen 127.0.0.1:51002` + `ports.admin: 51002` in chart values) landed in #503, so this should now run.
- [ ] Confirm `find_leader_pod` parses `tsoracle admin members` output cleanly against a real openraft cluster (specifically the `raft=HOST:PORT` field extraction).
- [ ] Run 2-3 baselines and tune `MAX_SIGKILL_SOAK_ERROR_RATE` downward from the conservative 5% if the observed teardown rate allows.

## Notes for review

- `wait_job` + `wait_soak_live` are sourced from the shared `_assertions_lib.sh` (also added in #503); only the sigkill-specific `find_leader_pod` helper lives inline in `run-assertions.sh` since no other lane needs it.
- `ListMembers` is locally answerable on any node, so the script queries `tsoracle-0` unconditionally — if `tsoracle-0` is itself the leader, we still get the right id back and the subsequent delete proceeds normally.
- Job duration is 240s vs the soak's 120s to cover kubelet pod-recreate latency + image pull (`IfNotPresent` in CI) + cluster rejoin + leader re-election after the kill.