### PR TITLE
fix(ci): correct codeql-action/upload-sarif SHA in scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@051e2f90686233507fe9283ff167d2e709304b30  # v3.36.0
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Replace the bogus `github/codeql-action/upload-sarif` SHA `051e2f9…` (pinned by #502) with the actual `v3.36.0` SHA `03e4368a…`. The previous SHA does not exist in `github/codeql-action` — `gh api repos/github/codeql-action/commits/051e2f9…` returns `422 No commit found`.
- Fixes the Scorecard supply-chain security workflow, which has been failing on every push to `main` since #502 ([run 26467449997](https://github.com/prisma-risk/tsoracle/actions/runs/26467449997/job/77931456638) on commit `f4b3abf`).

## Why it failed only at publish time

The bogus SHA never tripped GitHub Actions' own `uses:` resolution because the `Upload to code-scanning` step never ran — step 4 (`Run analysis`, the `ossf/scorecard-action` container) exit-coded first when it tried to publish the signed results bundle to scorecard.dev.

The webapp pulls the calling workflow file from the signed commit and runs an imposter-commit check on every `uses:` (`app/server/github_verifier.go` in `ossf/scorecard-webapp`): 100 most-recent tags → default-branch reachability → up to 10 release branches. `051e2f9…` fails all three because it isn't in the repo at all, so the webapp returns:

```
error sending scorecard results to webapp: http response 400
imposter commit: 051e2f90686233507fe9283ff167d2e709304b30 does not belong to github/codeql-action/upload-sarif
```

## Downstream impact since #502

- Scorecard badge / score on scorecard.dev haven't updated (cached at score 5.4 → 7.0 was the latest computed but never published).
- SARIF upload to GitHub code-scanning is silently skipped (downstream of the failed `Run analysis` step), degrading the SAST signal that next week's Scorecard run reads back.

## Test plan

- [ ] Push triggers `Scorecard supply-chain security` workflow on `main`. The `Run analysis` step completes without the `imposter commit` 400 from scorecard.dev. `Upload to code-scanning` runs (no longer skipped) and surfaces results in the Security tab.
- [ ] `gh api repos/github/codeql-action/commits/03e4368ac7daa2bd82b3e85262f3bf87ee112f57 --jq .commit.message` resolves to a real commit on the codeql-action `v3.36.0` tag.