### PR TITLE
docs: adopt Code of Conduct + document contribution licensing and license-header rule

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opening a private report at https://github.com/prisma-risk/tsoracle/security/advisories/new (the same private intake channel used for security reports). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 Thanks for your interest in tsoracle. This guide covers the local setup, the checks CI will run on your PR, and the conventions we follow.
 
+## Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). By participating in the project — issues, PRs, discussions, or any other channel tied to the repo — you agree to uphold it. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for the full text and the private reporting channel.
+
+## Licensing of contributions
+
+tsoracle is licensed under [Apache-2.0](LICENSE), and so is every crate published from this repository (`license = "Apache-2.0"` in each `Cargo.toml`). Contributions you submit follow the standard **inbound = outbound** convention: the changes you contribute are offered under the same Apache-2.0 terms as the project itself, per [section 5 of the license](LICENSE) and [GitHub's Terms of Service §D.6](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license). No separate CLA or DCO sign-off is required — opening a PR is the contribution grant. Every new first-party `.rs` file carries the canonical short license header (see [License headers on Rust source](#license-headers-on-rust-source) below).
+
 ## Setup
 
 This is a Rust project. The toolchain channel is pinned in [`rust-toolchain.toml`](rust-toolchain.toml); running any `cargo` command will install the matching version for you.
@@ -142,6 +150,19 @@ Example:
 )]
 let key = MetadataKey::from_bytes(KEY.as_bytes()).expect("valid key");
 ```
+
+## License headers on Rust source
+
+Every first-party `.rs` file carries the canonical short license header at the very top — above any `#![...]` inner attributes, since those are part of compilation and not a shebang. The header is checked in CI by the `header-check` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), which runs [`scripts/check-ts-header.py`](scripts/check-ts-header.py) across the whole tree. A missing or stale header is a hard build failure.
+
+When you add a new `.rs` file (or land a refactor that moves files around), run:
+
+```bash
+python3 scripts/check-ts-header.py --fix           # repair missing/stale headers in the whole repo
+python3 scripts/check-ts-header.py path/to/file.rs # check (or repair, with --fix) a specific file or directory
+```
+
+The pre-commit hook does **not** check headers — it runs `cargo fmt` and clippy only — so run `--fix` locally before pushing if you've added or moved `.rs` files. The canonical header text lives in a sibling file next to the script so non-Python tooling can read the same string; do not paste a hand-edited variant.
 
 ## Performance-critical-path rules
 


### PR DESCRIPTION
## Summary

While going through the OpenSSF Best Practices dev application, three adjacent requirements under `contribution_requirements` (and the related `code_of_conduct` criterion) weren't yet documented even though two of them already exist as project rules:

- **Code of Conduct.** None was on disk. Adopts Contributor Covenant v2.1 verbatim in a new `CODE_OF_CONDUCT.md`. The enforcement contact is the same private GitHub security-advisory channel `SECURITY.md` already routes to — no new mailbox to operate, no exposed personal address.
- **Licensing of contributions.** Adds an explicit "Apache-2.0 inbound = outbound, no CLA / DCO required" statement to `CONTRIBUTING.md`, citing LICENSE §5 and GitHub ToS §D.6. This is how the project has operated since day one; documenting it just makes the legal basis legible.
- **License headers on Rust source.** Documents the *existing* `header-check` CI job and the `scripts/check-ts-header.py --fix` workflow contributors should run when they add or move `.rs` files. Calls out the gotcha that the pre-commit hook does **not** run the header check.

After this PR, the single URL submitted to OpenSSF (`CONTRIBUTING.md`) covers `contribution_requirements`, transitively links to `CODE_OF_CONDUCT.md` for `code_of_conduct`, and reinforces `floss_license_osi`.

No source code changes — pure docs.

## Test plan

- [x] `python3 scripts/check-ts-header.py` — `checked 264 file(s): all headers OK.`
- [x] Pre-commit hook (`cargo fmt --check` + `cargo clippy --workspace --all-targets --all-features -- -D warnings`) — passed on commit.
- [x] All relative links in the edited markdown resolve: `LICENSE`, `CODE_OF_CONDUCT.md`, `scripts/check-ts-header.py`, `.github/workflows/ci.yml`, in-page anchor `#license-headers-on-rust-source`.
- [x] `CODE_OF_CONDUCT.md` fetched verbatim from `contributor-covenant.org` (sha256 `977d781349351fd7c1f076e4c7dc7de2a05b40e12c773542c3815dd4ce7f37ba`); only the `[INSERT CONTACT METHOD]` placeholder was substituted.