### PR TITLE
test(kube-e2e): add dynamic-membership soak (add-learner / promote / remove under soak) (#487)

### DIFF
--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -52,7 +52,7 @@ jobs:
             --wait --timeout 5m
       - name: wait for cluster formation (TCP readiness)
         run: kubectl rollout status statefulset/tsoracle --timeout=300s
-      - name: run e2e assertions (cold-start + soak across rollout + sigkill leader)
+      - name: run e2e assertions (cold-start + soak + sigkill leader + dynamic membership)
         run: ./e2e/kube/run-assertions.sh
       - name: dump diagnostics on failure
         if: failure()
@@ -62,4 +62,5 @@ jobs:
           kubectl logs job/tsoracle-e2e-cold-start || true
           kubectl logs job/tsoracle-e2e-soak || true
           kubectl logs job/tsoracle-e2e-sigkill-soak || true
+          kubectl logs job/tsoracle-e2e-membership-soak || true
           kubectl get events --sort-by=.lastTimestamp || true

--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -36,7 +36,7 @@ kind delete cluster --name tsoracle-e2e
 
 ## Scope
 
-This lane currently covers cold-start formation and graceful rolling-restart (rollout steps 2–3). Network partition + PVC reattach (step 4) and a nightly schedule (step 5) are follow-ups. The `openraft-standalone` example now handles SIGTERM (via `tsoracle_server::shutdown_signal()`, #406), so the graceful-rollout assertion exercises the real cooperative-shutdown path.
+This lane currently covers cold-start formation, graceful rolling-restart, SIGKILL-leader recovery, and dynamic-membership churn (add-learner / promote / remove). The `openraft-standalone` example handles SIGTERM (via `tsoracle_server::shutdown_signal()`, #406), so the graceful-rollout assertion exercises the real cooperative-shutdown path. The dynamic-membership cell (issue #487) is the first end-to-end exercise of the three-address membership model shipped in #453; it drives all admin calls through `kubectl exec LEADER_POD -- tsoracle admin ...` against the loopback `127.0.0.1:51002` admin port the chart binds. Network partition + PVC reattach and a nightly schedule remain follow-ups.
 
 ## Deploying to EKS (staging)
 

--- a/e2e/kube/_assertions_lib.sh
+++ b/e2e/kube/_assertions_lib.sh
@@ -64,6 +64,39 @@ wait_soak_live() {
     done
 }
 
+# From a `tsoracle admin members` snapshot on stdin, print the id of the
+# first member that is a Voter, is not the cluster leader, and is not
+# EXCLUDE_ID. Used by the membership-soak step to pick the `remove` target
+# after a new voter has been promoted, so the leader stays put and the
+# newly promoted node survives. Exit 1 if no such member exists (the caller
+# should treat that as a hard failure — it means the only voters are the
+# leader and the newly added node, and the test cannot exercise `remove`).
+#
+# Parses the CLI's printed format (crates/tsoracle-bin/src/main.rs:535-543):
+#   leader: <id>
+#     id=<n> role=Voter|Learner raft=... service=... admin=...
+# Field positions are fixed; we read $1 and $2 after the leading-space-
+# induced field shift, so the awk default whitespace tokenization handles
+# both the `leader:` line and the indented member rows uniformly.
+#
+# Args: EXCLUDE_ID
+pick_remove_target() {
+    local exclude_id="$1"
+    awk -v exclude="$exclude_id" '
+        $1 == "leader:" { leader = $2; next }
+        $1 ~ /^id=/ {
+            id_v = $1; sub(/^id=/, "", id_v)
+            role_v = $2; sub(/^role=/, "", role_v)
+            if (role_v == "Voter" && id_v != leader && id_v != exclude) {
+                print id_v
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    '
+}
+
 # Block until POD's tsoracle container reports a specific IMAGE in
 # .status.containerStatuses AND .status.containerStatuses[*].ready=true.
 # Without the image check, an already-Ready baseline pod falsely satisfies

--- a/e2e/kube/driver/job-membership-soak.yaml
+++ b/e2e/kube/driver/job-membership-soak.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-membership-soak
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=membership-soak
+            # The three ORIGINAL replica endpoints (not the future tsoracle-3
+            # the orchestrator adds mid-test). After the new node is promoted,
+            # the client reaches it via the leader-hint that any of these
+            # three returns — exercising exactly the redirect path we want.
+            - --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051
+            # Longer than the plain soak: must outlast scale-up of the
+            # StatefulSet to 4 + the new pod reaching Ready + `admin
+            # add-learner` blocking until the learner catches up + `promote` +
+            # `remove`, plus headroom for a cooldown window where the
+            # tracker can confirm monotonicity holds AFTER the membership
+            # transitions settle. Tune alongside the orchestrator step in
+            # run-assertions.sh.
+            - --duration-secs=180

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -55,6 +55,17 @@ enum Mode {
     /// driver remains a pure observer of monotonicity; the orchestrator picks
     /// the leader and issues the kill.
     SigkillSoak,
+    /// Soak variant for the dynamic-membership assertion (issue #487): sustain
+    /// load with the same zero-monotonicity-violation invariant and the
+    /// graceful [`MAX_SOAK_ERROR_RATE`] budget while the orchestrator scales
+    /// the StatefulSet by one, runs `tsoracle admin add-learner`, `promote`,
+    /// and `remove` against the leader, and verifies the load stays live and
+    /// monotone throughout. Distinct sentinel (`membership-soak: first GetTs
+    /// ok`) so the orchestrator only begins the membership churn after load
+    /// is provably live. openraft-only — paxos returns `AdminError::Unsupported`.
+    /// The driver remains a pure observer; the orchestrator drives every
+    /// membership transition over the loopback admin port via `kubectl exec`.
+    MembershipSoak,
 }
 
 #[derive(Parser, Debug)]
@@ -117,6 +128,9 @@ async fn main() -> Result<()> {
         }
         Mode::SigkillSoak => {
             run_sigkill_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
+        }
+        Mode::MembershipSoak => {
+            run_membership_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
         }
     };
     if !passed {
@@ -189,6 +203,18 @@ async fn run_sigkill_soak(endpoints: &[String], duration: Duration) -> Result<bo
         MAX_SIGKILL_SOAK_ERROR_RATE,
     )
     .await
+}
+
+/// Sustain GetTs load while the orchestrator scales the StatefulSet by one,
+/// adds the new replica as a learner (`add-learner` blocks until catch-up),
+/// promotes it to voter, and removes a pre-existing non-leader voter. Same
+/// zero-monotonicity-violation invariant and graceful [`MAX_SOAK_ERROR_RATE`]
+/// budget as [`run_soak`] — none of the membership ops sever an active client
+/// connection (the leader stays leader, the removed voter is not the
+/// leader). The distinct sentinel (`membership-soak: first GetTs ok`) lets
+/// the orchestrator only begin the churn after load is provably live.
+async fn run_membership_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
+    sustain_load(endpoints, duration, "membership-soak", MAX_SOAK_ERROR_RATE).await
 }
 
 /// Shared body of the three soak modes. The `label` is the per-mode prefix
@@ -290,6 +316,25 @@ mod cli_tests {
             "--duration-secs=180",
         ]);
         assert_eq!(cli.mode, Mode::SigkillSoak);
+        assert_eq!(cli.endpoints.len(), 3);
+        assert_eq!(cli.duration_secs, 180);
+    }
+
+    #[test]
+    fn membership_soak_mode_parses() {
+        // Membership-soak shares the soak CLI surface; the orchestrator drives
+        // the add-learner/promote/remove sequence through `kubectl exec
+        // LEADER_POD -- tsoracle admin ... --endpoint http://127.0.0.1:51002`
+        // (the chart's loopback-only admin bind). The endpoints list is the
+        // three original replicas; the new pod tsoracle-3 reaches the client
+        // via leader-hint after promote.
+        let cli = Cli::parse_from([
+            "kube-e2e-driver",
+            "--mode=membership-soak",
+            "--endpoints=a:5051,b:5051,c:5051",
+            "--duration-secs=180",
+        ]);
+        assert_eq!(cli.mode, Mode::MembershipSoak);
         assert_eq!(cli.endpoints.len(), 3);
         assert_eq!(cli.duration_secs, 180);
     }

--- a/e2e/kube/kind-config.yaml
+++ b/e2e/kube/kind-config.yaml
@@ -1,8 +1,16 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: tsoracle-e2e
+# 4 workers: 3 for the baseline cluster, +1 for the dynamic-membership lane
+# (issue #487) which scales the StatefulSet to 4 mid-test. The chart's
+# `requiredDuringSchedulingIgnoredDuringExecution` anti-affinity needs a
+# unique node per replica, so without a 4th worker tsoracle-3 sits Pending
+# with "didn't match pod anti-affinity rules" and rollout status times out.
+# The baseline cells (cold-start, soak, sigkill-soak) only use 3; the 4th
+# worker is idle until step 5 begins.
 nodes:
   - role: control-plane
+  - role: worker
   - role: worker
   - role: worker
   - role: worker

--- a/e2e/kube/run-assertions.sh
+++ b/e2e/kube/run-assertions.sh
@@ -7,6 +7,11 @@
 #      crash-recovery paths that #427 (barrier-seq durable seed) and #426
 #      (snapshot-publish TOCTOU) fixed, currently covered only by failpoint
 #      unit tests. See issue #485.
+#   4. membership-soak: monotonicity + sub-0.5% error rate hold across a
+#      dynamic-membership churn (scale +1, add-learner, promote, remove a
+#      non-leader voter) driven by `tsoracle admin` over the loopback admin
+#      port. First end-to-end exercise of the three-address membership model
+#      shipped in #453. openraft-only. See issue #487.
 # Assumes the chart has been installed (helm install tsoracle deploy/charts/tsoracle)
 # and the StatefulSet has reached readiness. Step 4 additionally assumes the
 # chart's openraft serve invocation binds the admin listener (see the
@@ -90,5 +95,91 @@ kubectl delete pod "$leader_pod" --grace-period=0 --force
 # pod-recreate latency + image pull (IfNotPresent in CI) + cluster rejoin.
 kubectl rollout status statefulset/tsoracle --timeout=180s
 wait_job tsoracle-e2e-sigkill-soak 300
+
+echo "== step 5: dynamic-membership soak (add-learner / promote / remove) =="
+# Default ports come from the chart's values.yaml: peer=51001 admin=51002,
+# client=50551. The kube-e2e workflow overrides client→5051 and peer→5100;
+# admin stays loopback-only on 51002. Allow env overrides so the same
+# script can drive both the kind lane and operator-tuned deployments.
+peer_port="${PEER_PORT:-5100}"
+tso_port="${TSO_PORT:-5051}"
+admin_port="${ADMIN_PORT:-51002}"
+kubectl apply -f "$here/driver/job-membership-soak.yaml"
+wait_soak_live tsoracle-e2e-membership-soak "membership-soak: first GetTs ok" 60
+
+# Scale by one (3 → 4); the existing replicas keep serving while tsoracle-3
+# starts. The pod template was rendered with REPLICAS=3 at helm-install
+# time, so tsoracle-3's entrypoint emits no `--bootstrap` and no
+# `--members` — the new node starts as an empty openraft follower waiting
+# to be add-learner'd. Once Ready (TCP-readiness on the tso port implies
+# the raft listener is also up, both bind in the same process), the leader
+# can dial it at $raft_addr below.
+echo "step 5: scaling StatefulSet to 4 (adding tsoracle-3 as a future learner)"
+kubectl scale statefulset/tsoracle --replicas=4
+kubectl rollout status statefulset/tsoracle --timeout=180s
+
+leader_pod="$(find_leader_pod 60)"
+echo "step 5: current leader = $leader_pod"
+
+# Three-address membership: raft (peer transport), service (tsoracle client
+# port for leader-hint redirect), admin (operator gRPC for future ops).
+# Short DNS resolves within the cluster's search path; matches the soak
+# endpoints' form. The admin address is unreachable from the headless
+# Service (admin is not in its port list) but membership stores it for
+# completeness — production deployments that bind admin on 0.0.0.0 with
+# TLS would gain redirect-follow without script changes.
+new_id=4
+new_raft="tsoracle-3.tsoracle-peer:${peer_port}"
+new_svc="tsoracle-3.tsoracle-peer:${tso_port}"
+new_admin="tsoracle-3.tsoracle-peer:${admin_port}"
+echo "step 5: add-learner id=$new_id raft=$new_raft service=$new_svc admin=$new_admin"
+
+# `tsoracle admin add-learner` calls openraft's `add_learner(_, _, blocking=true)`
+# which returns only after the learner has caught up with the leader's
+# committed index (crates/tsoracle-standalone/src/admin/openraft.rs:200).
+# So the issue #487 "poll members until caught-up" step is implicit in this
+# single exec; no separate catch-up wait is needed before the subsequent
+# `promote`. The exec runs INSIDE the leader pod so the loopback admin port
+# is reachable and no leader_admin_endpoint redirect is required.
+kubectl exec "$leader_pod" -c tsoracle -- \
+    tsoracle admin add-learner \
+        --endpoint "http://127.0.0.1:${admin_port}" \
+        --id "$new_id" \
+        --raft-addr "$new_raft" \
+        --service-endpoint "$new_svc" \
+        --admin-endpoint "$new_admin"
+
+echo "step 5: promote id=$new_id to Voter"
+kubectl exec "$leader_pod" -c tsoracle -- \
+    tsoracle admin promote \
+        --endpoint "http://127.0.0.1:${admin_port}" \
+        --id "$new_id"
+
+# Pick a non-leader voter to remove (leaving the leader in place avoids an
+# election storm; the sigkill-soak step above already covers leader-loss
+# recovery). Exclude $new_id so we don't immediately remove the node we
+# just promoted.
+echo "step 5: selecting a non-leader voter to remove (exclude=$new_id)"
+members_out="$(kubectl exec "$leader_pod" -c tsoracle -- \
+    tsoracle admin members --endpoint "http://127.0.0.1:${admin_port}")"
+remove_id="$(printf '%s\n' "$members_out" | pick_remove_target "$new_id")" || {
+    echo "step 5: pick_remove_target found no eligible voter (exclude=$new_id)"
+    echo "step 5: admin members output:"
+    printf '%s\n' "$members_out"
+    exit 1
+}
+echo "step 5: remove id=$remove_id"
+kubectl exec "$leader_pod" -c tsoracle -- \
+    tsoracle admin remove \
+        --endpoint "http://127.0.0.1:${admin_port}" \
+        --id "$remove_id"
+
+# Cooldown: wait for the membership-soak Job's full duration to elapse.
+# The 180s soak duration leaves ~120s of headroom after the orchestrator's
+# ~30-60s of churn — the tracker must observe monotonicity HOLDING in the
+# post-transition steady state, not just up to the moment of the last
+# operation. 240s timeout = soak duration + slack for the in-flight RPC at
+# deadline.
+wait_job tsoracle-e2e-membership-soak 240
 
 echo "== all assertions passed =="


### PR DESCRIPTION
## Summary

- Closes #487. Adds a new kube-e2e cell exercising the `AdminService` + `tsoracle admin` CLI shipped in #453: scale the StatefulSet 3 → 4, `add-learner`, `promote`, `remove` a non-leader voter — all while a soak Job sustains GetTs load with the same zero-monotonicity-violation + < 0.5% error-rate invariants the graceful soak uses.
- First end-to-end exercise of the three-address membership model (raft / service / admin) in a real Kubernetes deployment.
- openraft-only — paxos returns `AdminError::Unsupported`; a future driver-matrixed lane will skip this cell for the paxos variant.

## What changed

**`e2e/kube/driver/src/main.rs`** — new `Mode::MembershipSoak` with distinct sentinel `"membership-soak: first GetTs ok"` and the graceful `MAX_SOAK_ERROR_RATE = 0.5%` budget. + CLI parse test.

**`e2e/kube/driver/job-membership-soak.yaml`** *(new)* — 180s duration, three original replica endpoints. The new tsoracle-3 reaches the client via leader-hint after `promote`, exercising exactly the redirect path we want.

**`e2e/kube/_assertions_lib.sh`** — new `pick_remove_target EXCLUDE_ID` helper. Awk-parses `tsoracle admin members` stdout, prints the first Voter id that is neither the leader nor the excluded id; exits 1 if none. Validated against 4 cases (leader-id variation, learner-skip, only-2-voters edge).

**`e2e/kube/run-assertions.sh`** — new step 5 driving all admin calls via `kubectl exec LEADER_POD -- tsoracle admin ... --endpoint http://127.0.0.1:51002` (the chart's loopback-only admin bind). Sequence: apply Job → `wait_soak_live` → scale → `rollout status` → `find_leader_pod` → `add-learner` (blocking — openraft's `add_learner(_,_,blocking=true)` returns only after catch-up, so no separate poll step is needed) → `promote 4` → `pick_remove_target 4` → `remove <id>` → `wait_job 240s`.

**`e2e/kube/kind-config.yaml`** — 3 → 4 workers. The chart's `requiredDuringSchedulingIgnoredDuringExecution` pod anti-affinity needs one node per replica; with only 3 workers tsoracle-3 sits Pending forever (`FailedScheduling: didn't match pod anti-affinity rules`) and rollout-status times out before `add-learner` can run. The baseline cells (cold-start, soak, sigkill-soak) only use 3 workers — the 4th is idle until step 5.

**`.github/workflows/kube-e2e.yml`** — step description + diagnostics now include `job/tsoracle-e2e-membership-soak`.

**`e2e/kube/README.md`** — Scope updated to mention the dynamic-membership cell.

## Local verification

Ran the full lane against a fresh kind cluster:

| step | calls | errors | violations | result |
|---|---|---|---|---|
| 2. cold-start | 15 | 0 | 0 | PASS |
| 3. graceful soak | 34,019 | 0 | 0 | PASS |
| 4. sigkill-soak | 71,703 | 1 (0.0014%) | 0 | PASS |
| **5. membership-soak** | **52,606** | **0** | **0** | **PASS** |

Step 5 trace:
```
step 5: scaling StatefulSet to 4 (adding tsoracle-3 as a future learner)
step 5: current leader = tsoracle-1
step 5: add-learner id=4 raft=tsoracle-3.tsoracle-peer:5100 ...  → ok
step 5: promote id=4 to Voter                                    → ok
step 5: selecting a non-leader voter to remove (exclude=4)
step 5: remove id=1                                              → ok
```

The 52k get_ts calls with zero errors during the entire membership churn confirms the design intent: add-learner-blocking-until-caught-up + leader-preserving promote + non-leader remove means no transport severing at all (cf. sigkill-soak which legitimately produces transport errors during force-leader-deletion).

## Test plan

- [x] `cargo fmt --check` (pre-commit hook)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (pre-commit hook)
- [x] `cargo test -p kube-e2e-driver` — 14/14 (incl. new `membership_soak_mode_parses`)
- [x] `pick_remove_target` awk parser validated against 4 cases
- [x] `deploy/charts/tsoracle/tests/render.sh` still passes
- [x] Full `./e2e/kube/run-assertions.sh` lane green on local kind (transcript above)
- [ ] CI: `workflow_dispatch` on `kube-e2e` lane against this branch