### PR TITLE
test(kube-e2e): add TLS-enabled deploy cell + verify chart secure-by-default render

### DIFF
--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -42,7 +42,14 @@ jobs:
       - name: install helm
         run: |
           curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
-      - name: deploy chart
+      # ── insecure cell ─────────────────────────────────────────────────────
+      # Smoke path. `tls.allowInsecurePeer=true` is the explicit opt-out that
+      # the chart's secure-by-default render guard (PR #452) requires for HA
+      # deployments without TLS material. We accept plaintext consensus here
+      # because the goal is exercising the deployment envelope under kube
+      # DNS / Pod-IP rotation, not authentication; the TLS cell below proves
+      # the peer mTLS path. See issue #483.
+      - name: deploy chart (insecure cell)
         run: |
           ./linux-amd64/helm install tsoracle deploy/charts/tsoracle \
             --set image.repository=tsoracle,image.tag=e2e \
@@ -50,17 +57,79 @@ jobs:
             --set ports.client=5051,ports.peer=5100 \
             --set tls.allowInsecurePeer=true \
             --wait --timeout 5m
-      - name: wait for cluster formation (TCP readiness)
+      - name: wait for cluster formation (insecure cell, TCP readiness)
         run: kubectl rollout status statefulset/tsoracle --timeout=300s
-      - name: run e2e assertions (cold-start + soak + sigkill leader + dynamic membership)
+      - name: run e2e assertions — insecure cell (cold-start + soak + sigkill + dynamic membership)
         run: ./e2e/kube/run-assertions.sh
+
+      # ── TLS cell ──────────────────────────────────────────────────────────
+      # Exercises the chart's secure-by-default render guard's *happy path*
+      # (PR #452 — `tls.enabled=true` rendering without the insecure opt-out),
+      # the peer mTLS handshake under realistic kube DNS / Pod-IP rotation,
+      # and cross-pod trust via the cluster-dedicated peer CA model (PR #445).
+      # Runs in its own namespace (`e2e-tls`) of the same kind cluster so the
+      # insecure cell's release is undisturbed; the kubectl context is moved
+      # so run-assertions.sh's bare `kubectl ...` calls auto-target it.
+      # See issue #483.
+      - name: create e2e-tls namespace and switch context
+        run: |
+          kubectl create namespace e2e-tls
+          kubectl config set-context --current --namespace=e2e-tls
+      - name: mint test CA + fan-SAN leaf cert
+        run: |
+          mkdir -p /tmp/tsoracle-tls
+          # `--replicas 4` (not 3) so `tsoracle-tls-3.tsoracle-tls-peer.e2e-tls.svc.cluster.local`
+          # is in the leaf cert's SAN list from the start. The dynamic-
+          # membership step (#487) scales the StatefulSet to 4 mid-soak; a
+          # cert minted for only the initial 3 pods would fail the SNI
+          # check the first time the client is leader-hint-redirected to
+          # the new pod, surfacing as a flake that has nothing to do with
+          # the membership transition the step actually validates.
+          cargo run -q -p kube-e2e-driver --bin gen-certs -- \
+            --out /tmp/tsoracle-tls \
+            --release tsoracle-tls \
+            --namespace e2e-tls \
+            --replicas 4
+      - name: create TLS Secret in e2e-tls namespace
+        run: |
+          kubectl -n e2e-tls create secret generic tsoracle-tls-certs \
+            --from-file=tls.crt=/tmp/tsoracle-tls/tls.crt \
+            --from-file=tls.key=/tmp/tsoracle-tls/tls.key \
+            --from-file=ca.crt=/tmp/tsoracle-tls/ca.crt
+      - name: deploy chart (TLS cell)
+        run: |
+          ./linux-amd64/helm install tsoracle-tls deploy/charts/tsoracle \
+            --namespace e2e-tls \
+            --set image.repository=tsoracle,image.tag=e2e \
+            --set driver=openraft,replicas=3 \
+            --set ports.client=5051,ports.peer=5100 \
+            --set tls.enabled=true \
+            --set tls.secretName=tsoracle-tls-certs \
+            --wait --timeout 5m
+      - name: wait for cluster formation (TLS cell, TCP readiness)
+        run: kubectl rollout status statefulset/tsoracle-tls --timeout=300s
+      - name: run e2e assertions — TLS cell (cold-start + soak + sigkill + dynamic membership)
+        env:
+          RELEASE: tsoracle-tls
+          JOB_DIR: ${{ github.workspace }}/e2e/kube/driver/tls
+        run: ./e2e/kube/run-assertions.sh
+
       - name: dump diagnostics on failure
         if: failure()
         run: |
-          kubectl get pods -o wide || true
-          kubectl describe statefulset/tsoracle || true
-          kubectl logs job/tsoracle-e2e-cold-start || true
-          kubectl logs job/tsoracle-e2e-soak || true
-          kubectl logs job/tsoracle-e2e-sigkill-soak || true
-          kubectl logs job/tsoracle-e2e-membership-soak || true
-          kubectl get events --sort-by=.lastTimestamp || true
+          echo "── insecure cell (namespace: default) ──"
+          kubectl -n default get pods -o wide || true
+          kubectl -n default describe statefulset/tsoracle || true
+          kubectl -n default logs job/tsoracle-e2e-cold-start || true
+          kubectl -n default logs job/tsoracle-e2e-soak || true
+          kubectl -n default logs job/tsoracle-e2e-sigkill-soak || true
+          kubectl -n default logs job/tsoracle-e2e-membership-soak || true
+          kubectl -n default get events --sort-by=.lastTimestamp || true
+          echo "── TLS cell (namespace: e2e-tls) ──"
+          kubectl -n e2e-tls get pods -o wide || true
+          kubectl -n e2e-tls describe statefulset/tsoracle-tls || true
+          kubectl -n e2e-tls logs job/tsoracle-e2e-cold-start || true
+          kubectl -n e2e-tls logs job/tsoracle-e2e-soak || true
+          kubectl -n e2e-tls logs job/tsoracle-e2e-sigkill-soak || true
+          kubectl -n e2e-tls logs job/tsoracle-e2e-membership-soak || true
+          kubectl -n e2e-tls get events --sort-by=.lastTimestamp || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,9 @@ version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
+ "rcgen",
  "tokio",
+ "tonic",
  "tsoracle-client",
 ]
 

--- a/docs/kubernetes-e2e.md
+++ b/docs/kubernetes-e2e.md
@@ -98,3 +98,19 @@ Recommendation: **do not** make it a stress topology. The stress harness's whole
 1. **A Dockerfile and Helm chart.** Both live in `deploy/`: `deploy/Dockerfile` builds the multi-driver image and `deploy/charts/tsoracle` is the chart used by CI and production.
 2. **SIGTERM handling in the example binaries.** Done (#406): the standalone examples now feed `serve_with_shutdown` the shared `tsoracle_server::shutdown_signal()` future, which resolves on SIGTERM and SIGINT. The graceful rolling-restart assertion in the kube lane exercises this path.
 3. **Optional: `grpc.health.v1.Health`.** Adding the standard gRPC health service would let probes use `grpc_health_probe` and report leader/serving state precisely. Not required for the TCP-based contract above, but a clean follow-up.
+
+## TLS cell
+
+The workflow runs the assertions twice against two helm releases in two namespaces of the same kind cluster — once with plaintext consensus (`tls.allowInsecurePeer=true`, the legacy "insecure cell") and once with `tls.enabled=true` plus minted certs (the "TLS cell"). The TLS cell exists because the chart's secure-by-default render guard from PR #452 forces HA deployments to either opt out explicitly or supply TLS material, and only the latter exercises the peer mTLS path that PR #445 introduced. See issue #483.
+
+The two cells share one kind cluster because `podAntiAffinity` in the chart's StatefulSet keys on `app.kubernetes.io/instance: <Release.Name>` — so an insecure-cell pod and a TLS-cell pod can coexist on the same worker without violating the anti-affinity rule. They live in separate namespaces (`default` and `e2e-tls`) so the same Helm release name isn't needed (and the second `helm install` doesn't trample the first's state).
+
+The chart mounts ONE Secret cluster-wide, so each pod must use the same leaf cert. Per-pod identity (Vault- or cert-manager-style) is out of scope for this fixture. Instead, `cargo run -p kube-e2e-driver --bin gen-certs` (on the GitHub runner, before `helm install`) signs a single leaf cert whose SANs cover *every* pod FQDN (`tsoracle-tls-{0..N-1}.tsoracle-tls-peer.e2e-tls.svc.cluster.local`) plus both Service DNS names. That cert is sufficient because PR #445's peer authorization is CA-based: any cert chaining to the configured peer CA is accepted, and the SNI match on each peer dial is satisfied by the per-pod SAN. The CA private key is discarded after signing (one-shot fixture mint).
+
+The assertion driver (`kube-e2e-driver`) speaks TLS via a `--tls-ca` flag that points at the mounted Secret's `ca.crt`. Bare `host:port` endpoints are rewritten by `tsoracle-client` to `https://host:port` when a `ClientTlsConfig` is set (see `crates/tsoracle-client/src/transport.rs`), so SNI defaults to the host component of each endpoint URL. Job manifests in `e2e/kube/driver/tls/` use the full FQDN form in `--endpoints` (not the shorter `pod.peer-svc:port`) so SNI matches a SAN on the chart's leaf.
+
+What the TLS cell proves that the insecure cell does not:
+
+1. The chart's render guard accepts the happy path (`tls.enabled=true` with `tls.secretName`) without `tls.allowInsecurePeer`.
+2. Peer mTLS handshakes survive rolling restarts and SIGKILL-leader recovery: kube DNS / Pod-IP rotation does not invalidate the per-pod SNI against the fan-SAN leaf.
+3. The driver's TLS client (configured with the cluster's CA) interoperates with the chart's server-auth TLS on the client API, including under leader-redirect across cells.

--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -38,6 +38,27 @@ kind delete cluster --name tsoracle-e2e
 
 This lane currently covers cold-start formation, graceful rolling-restart, SIGKILL-leader recovery, and dynamic-membership churn (add-learner / promote / remove). The `openraft-standalone` example handles SIGTERM (via `tsoracle_server::shutdown_signal()`, #406), so the graceful-rollout assertion exercises the real cooperative-shutdown path. The dynamic-membership cell (issue #487) is the first end-to-end exercise of the three-address membership model shipped in #453; it drives all admin calls through `kubectl exec LEADER_POD -- tsoracle admin ...` against the loopback `127.0.0.1:51002` admin port the chart binds. Network partition + PVC reattach and a nightly schedule remain follow-ups.
 
+## Cells: insecure + TLS
+
+The CI workflow runs the same assertion lane twice against two helm releases in two namespaces of the same kind cluster (issue #483):
+
+- **Insecure cell** (`tsoracle` in `default`) — `tls.allowInsecurePeer=true`. Exercises the deployment envelope (DNS / Pod-IP rotation, lifecycle events) under plaintext consensus. This is the legacy cell that has always been here.
+- **TLS cell** (`tsoracle-tls` in `e2e-tls`) — `tls.enabled=true` plus a Secret minted on the runner by `cargo run -p kube-e2e-driver --bin gen-certs` (a fan-SAN leaf cert covering every pod FQDN, signed by a one-shot test CA). Exercises the chart's secure-by-default render guard's *happy path* (PR #452), peer mTLS under realistic kube DNS rotation, and cross-pod trust via the cluster-dedicated peer CA model (PR #445).
+
+Both cells share `run-assertions.sh`, which reads `RELEASE` and `JOB_DIR` env vars to know which release to drive and which Job manifest set to apply. The TLS cell's Job manifests live in `driver/tls/` and mount the cluster's TLS Secret so the driver client trusts the same CA the cluster's server cert chains to.
+
+To run only the TLS cell locally, after the kind cluster is up:
+
+```sh
+kubectl create namespace e2e-tls
+kubectl config set-context --current --namespace=e2e-tls
+mkdir -p /tmp/tsoracle-tls
+cargo run -p kube-e2e-driver --bin gen-certs -- --out /tmp/tsoracle-tls --release tsoracle-tls --namespace e2e-tls --replicas 3
+kubectl -n e2e-tls create secret generic tsoracle-tls-certs --from-file=tls.crt=/tmp/tsoracle-tls/tls.crt --from-file=tls.key=/tmp/tsoracle-tls/tls.key --from-file=ca.crt=/tmp/tsoracle-tls/ca.crt
+helm install tsoracle-tls deploy/charts/tsoracle -n e2e-tls --set image.repository=tsoracle,image.tag=e2e --set driver=openraft,replicas=3 --set ports.client=5051,ports.peer=5100 --set tls.enabled=true --set tls.secretName=tsoracle-tls-certs --wait --timeout 5m
+RELEASE=tsoracle-tls JOB_DIR=$(pwd)/e2e/kube/driver/tls ./e2e/kube/run-assertions.sh
+```
+
 ## Deploying to EKS (staging)
 
 The kind flow above is fully local. To deploy the same `openraft-standalone` cluster onto the real **staging** EKS cluster (arm64, real EBS) for a manual smoke test, the Kubernetes manifests live in the **infra** repo at `k8s/tsoracle-e2e/`; this repo only builds and pushes the images.

--- a/e2e/kube/driver/Cargo.toml
+++ b/e2e/kube/driver/Cargo.toml
@@ -12,8 +12,18 @@ publish                = false
 name = "kube-e2e-driver"
 path = "src/main.rs"
 
+# Generates a test CA + fan-SAN leaf cert for the kube-e2e TLS cell (issue #483).
+# Runs on the workflow runner (not in-cluster) so the CA private key never
+# leaves the build host; only `ca.crt` / `tls.crt` / `tls.key` are copied into
+# a kubernetes.io/tls Secret before `helm install`.
+[[bin]]
+name = "gen-certs"
+path = "src/bin/gen-certs.rs"
+
 [dependencies]
 tsoracle-client = { path = "../../../crates/tsoracle-client", version = "0.2.6" }
 anyhow          = { workspace = true }
 clap            = { workspace = true }
+rcgen           = { workspace = true }
 tokio           = { workspace = true }
+tonic           = { workspace = true }

--- a/e2e/kube/driver/src/bin/gen-certs.rs
+++ b/e2e/kube/driver/src/bin/gen-certs.rs
@@ -1,0 +1,192 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Mint a test CA + a single fan-SAN leaf cert covering every replica's pod
+//! FQDN and the client/headless Service DNS. Used by the kube-e2e TLS cell
+//! (issue #483) to populate the chart's `tls.secretName` Secret before
+//! `helm install`.
+//!
+//! ## Why one shared cert
+//!
+//! The chart from #452 mounts a single Secret cluster-wide at `/etc/tsoracle/tls`
+//! and PR #445's peer authorization is CA-based: any cert chaining to the
+//! configured peer CA is accepted. So every pod presenting one shared leaf
+//! that has SANs for *all* pod FQDNs is sufficient — when pod A dials pod B,
+//! SNI on the dial is B's FQDN, B's cert has B's FQDN in its SAN list, the
+//! handshake succeeds.
+//!
+//! Per-pod identity (Vault/cert-manager-style) is out of scope for the kind
+//! e2e fixture; this binary exists only to give the lane real TLS material
+//! against which the chart's secure-by-default render guard's happy path can
+//! be exercised under realistic kube DNS rotation.
+//!
+//! ## Output
+//!
+//! Writes three files into `--out`, named so they line up with the chart's
+//! expected Secret keys (tls.crt / tls.key / ca.crt — see
+//! `deploy/entrypoint.sh`):
+//!
+//!   - `ca.crt`  — CA certificate (trust anchor mounted on every pod)
+//!   - `tls.crt` — leaf cert with SANs covering every pod FQDN + service DNS
+//!   - `tls.key` — leaf private key
+//!
+//! The CA private key is intentionally discarded once the leaf is signed —
+//! this is a one-shot fixture mint with no follow-up signing.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+    KeyUsagePurpose,
+};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "gen-certs",
+    about = "Mint a test CA + fan-SAN leaf cert for the kube-e2e TLS cell (issue #483)"
+)]
+struct Cli {
+    /// Output directory; created if it does not exist.
+    #[arg(long)]
+    out: PathBuf,
+
+    /// Helm release name. Per-pod FQDNs are
+    /// `<release>-<i>.<release>-peer.<namespace>.svc.cluster.local`.
+    #[arg(long, default_value = "tsoracle")]
+    release: String,
+
+    /// Kubernetes namespace into which the chart will be installed.
+    #[arg(long, default_value = "default")]
+    namespace: String,
+
+    /// Number of replicas in the StatefulSet (ordinals 0..N go into the SAN list).
+    #[arg(long, default_value_t = 3)]
+    replicas: u32,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let sans = build_sans(&cli.release, &cli.namespace, cli.replicas);
+
+    let ca_name = format!("tsoracle-e2e-{}-ca", cli.release);
+    let ca_key = KeyPair::generate().context("CA keypair")?;
+    let mut ca_params = CertificateParams::new(vec![ca_name.clone()]).context("CA params")?;
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, ca_name);
+    let ca_cert = ca_params.self_signed(&ca_key).context("CA self-sign")?;
+
+    let leaf_key = KeyPair::generate().context("leaf keypair")?;
+    let mut leaf_params = CertificateParams::new(sans).context("leaf params")?;
+    leaf_params.distinguished_name.push(
+        DnType::CommonName,
+        format!("{}.{}", cli.release, cli.namespace),
+    );
+    // The shared leaf cert serves three roles simultaneously: peer-as-server
+    // when a sibling dials in, peer-as-client when this pod dials a sibling,
+    // and the client-API server cert that the driver Job validates. Hence
+    // both ServerAuth and ClientAuth EKUs.
+    leaf_params.extended_key_usages = vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+    let leaf_cert = leaf_params
+        .signed_by(&leaf_key, &ca_cert, &ca_key)
+        .context("leaf sign")?;
+
+    std::fs::create_dir_all(&cli.out)
+        .with_context(|| format!("create_dir_all({})", cli.out.display()))?;
+    let ca_path = cli.out.join("ca.crt");
+    let cert_path = cli.out.join("tls.crt");
+    let key_path = cli.out.join("tls.key");
+    std::fs::write(&ca_path, ca_cert.pem())
+        .with_context(|| format!("write {}", ca_path.display()))?;
+    std::fs::write(&cert_path, leaf_cert.pem())
+        .with_context(|| format!("write {}", cert_path.display()))?;
+    std::fs::write(&key_path, leaf_key.serialize_pem())
+        .with_context(|| format!("write {}", key_path.display()))?;
+
+    println!(
+        "gen-certs: wrote ca.crt + tls.crt + tls.key to {}",
+        cli.out.display()
+    );
+    Ok(())
+}
+
+/// SANs the leaf cert must cover for the chart-rendered topology.
+///
+/// The chart exposes consensus + client + DNS surfaces:
+///   * peer dial inside the cluster: `<release>-<i>.<release>-peer.<ns>.svc.cluster.local`
+///   * headless peer Service DNS:    `<release>-peer.<ns>.svc.cluster.local`
+///   * client Service VIP DNS:       `<release>.<ns>.svc.cluster.local`
+///
+/// `localhost`/`127.0.0.1` are added so loopback probes (e.g. the chart's
+/// admin port bound at `127.0.0.1`) can use the same fixture if a future
+/// operator adds admin TLS material to the entrypoint.
+fn build_sans(release: &str, namespace: &str, replicas: u32) -> Vec<String> {
+    let mut sans = Vec::with_capacity((replicas as usize) + 4);
+    for i in 0..replicas {
+        sans.push(format!(
+            "{release}-{i}.{release}-peer.{namespace}.svc.cluster.local"
+        ));
+    }
+    sans.push(format!("{release}-peer.{namespace}.svc.cluster.local"));
+    sans.push(format!("{release}.{namespace}.svc.cluster.local"));
+    sans.push("localhost".to_string());
+    sans.push("127.0.0.1".to_string());
+    sans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sans_cover_each_pod_fqdn_and_services() {
+        let sans = build_sans("tsoracle-tls", "e2e-tls", 3);
+        for i in 0..3 {
+            let want = format!("tsoracle-tls-{i}.tsoracle-tls-peer.e2e-tls.svc.cluster.local");
+            assert!(sans.contains(&want), "missing pod FQDN SAN {want}");
+        }
+        assert!(sans.contains(&"tsoracle-tls-peer.e2e-tls.svc.cluster.local".to_string()));
+        assert!(sans.contains(&"tsoracle-tls.e2e-tls.svc.cluster.local".to_string()));
+        assert!(sans.contains(&"localhost".to_string()));
+        assert!(sans.contains(&"127.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn sans_scale_with_replicas() {
+        let sans = build_sans("foo", "bar", 5);
+        for i in 0..5 {
+            let want = format!("foo-{i}.foo-peer.bar.svc.cluster.local");
+            assert!(sans.contains(&want), "missing {want}");
+        }
+        // No phantom ordinals beyond `replicas`.
+        let phantom = "foo-5.foo-peer.bar.svc.cluster.local".to_string();
+        assert!(!sans.contains(&phantom), "unexpected SAN {phantom}");
+    }
+}

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -23,10 +23,12 @@
 
 mod tracker;
 
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, ValueEnum};
+use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 use tsoracle_client::{ClientBuilder, RetryPolicy};
 
 use crate::tracker::Tracker;
@@ -86,6 +88,25 @@ struct Cli {
     /// soak: how long to sustain load, in seconds.
     #[arg(long, default_value_t = 120)]
     duration_secs: u64,
+
+    /// CA cert (PEM) used to trust the cluster's client-API server cert.
+    /// Setting this enables TLS on every endpoint; bare `host:port` entries
+    /// in `--endpoints` are dialled as `https://host:port` and SNI matches the
+    /// host component (the chart's leaf cert covers each pod FQDN as a SAN).
+    /// Issue #483 TLS cell: required.
+    #[arg(long)]
+    tls_ca: Option<PathBuf>,
+
+    /// Client identity cert (PEM) for the optional client-mTLS path. Must be
+    /// paired with `--tls-key`. The default chart deployment runs with
+    /// `tls.clientMtls=false`, in which case server-auth alone is sufficient
+    /// and this flag is omitted.
+    #[arg(long, requires = "tls_key")]
+    tls_cert: Option<PathBuf>,
+
+    /// Client identity private key (PEM); paired with `--tls-cert`.
+    #[arg(long, requires = "tls_cert")]
+    tls_key: Option<PathBuf>,
 }
 
 /// Soak error budget: monotonicity is the hard invariant (zero tolerance), but
@@ -120,17 +141,23 @@ fn generous_policy() -> RetryPolicy {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+    let tls = build_tls_config(
+        cli.tls_ca.as_deref(),
+        cli.tls_cert.as_deref(),
+        cli.tls_key.as_deref(),
+    )?;
     let passed = match cli.mode {
-        Mode::ColdStart => run_cold_start(&cli.endpoints, cli.count).await?,
-        Mode::Soak => run_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?,
+        Mode::ColdStart => run_cold_start(&cli.endpoints, cli.count, tls).await?,
+        Mode::Soak => run_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs), tls).await?,
         Mode::MixedVersionSoak => {
-            run_mixed_version_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
+            run_mixed_version_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs), tls)
+                .await?
         }
         Mode::SigkillSoak => {
-            run_sigkill_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
+            run_sigkill_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs), tls).await?
         }
         Mode::MembershipSoak => {
-            run_membership_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs)).await?
+            run_membership_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs), tls).await?
         }
     };
     if !passed {
@@ -139,15 +166,64 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Build the optional TLS config for the in-cluster driver client. Returns
+/// `Ok(None)` when no TLS flags are set (plaintext smoke path), `Ok(Some(cfg))`
+/// with a CA trust root and, if the `--tls-cert` / `--tls-key` pair was
+/// supplied, a client identity for mTLS.
+///
+/// Files are read eagerly so a bad path fails the Job immediately rather than
+/// surfacing as a confusing "transport error" on the first GetTs — tonic's
+/// `from_pem` constructors do not parse until the channel is actually built,
+/// and even then a malformed PEM tends to surface as a generic connect error.
+fn build_tls_config(
+    ca: Option<&std::path::Path>,
+    cert: Option<&std::path::Path>,
+    key: Option<&std::path::Path>,
+) -> Result<Option<ClientTlsConfig>> {
+    let Some(ca_path) = ca else {
+        // No CA → plaintext. clap's `requires` keeps cert/key from arriving
+        // alone, but a CA-less cert+key would be meaningless: there's no
+        // trust root to validate the server with.
+        if cert.is_some() || key.is_some() {
+            bail!("--tls-cert/--tls-key require --tls-ca (no trust root without a CA)");
+        }
+        return Ok(None);
+    };
+    let ca_pem = std::fs::read(ca_path).with_context(|| format!("read {}", ca_path.display()))?;
+    let mut cfg = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca_pem));
+    if let (Some(cert_path), Some(key_path)) = (cert, key) {
+        let cert_pem =
+            std::fs::read(cert_path).with_context(|| format!("read {}", cert_path.display()))?;
+        let key_pem =
+            std::fs::read(key_path).with_context(|| format!("read {}", key_path.display()))?;
+        cfg = cfg.identity(Identity::from_pem(cert_pem, key_pem));
+    }
+    Ok(Some(cfg))
+}
+
+/// Apply an optional TLS config to a `ClientBuilder`. Pulled out so the three
+/// call sites all opt in identically.
+fn apply_tls(builder: ClientBuilder, tls: Option<ClientTlsConfig>) -> ClientBuilder {
+    match tls {
+        Some(cfg) => builder.tls_config(cfg),
+        None => builder,
+    }
+}
+
 /// Probe each ordinal endpoint independently. A fresh single-endpoint client
 /// forces traffic at that specific pod; a follower replies with a leader-hint
 /// the in-cluster client follows. Any endpoint that cannot ultimately produce a
 /// timestamp fails the run, which is what proves all three nodes participate.
-async fn run_cold_start(endpoints: &[String], count: u32) -> Result<bool> {
+async fn run_cold_start(
+    endpoints: &[String],
+    count: u32,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
     let mut tracker: Tracker<_> = Tracker::new();
     for endpoint in endpoints {
-        let client = ClientBuilder::endpoints(vec![endpoint.clone()])
-            .retry_policy(generous_policy())
+        let builder =
+            ClientBuilder::endpoints(vec![endpoint.clone()]).retry_policy(generous_policy());
+        let client = apply_tls(builder, tls.clone())
             .build()
             .await
             .with_context(|| format!("build client for {endpoint}"))?;
@@ -167,8 +243,12 @@ async fn run_cold_start(endpoints: &[String], count: u32) -> Result<bool> {
 /// Sustain GetTs load across the whole list for `duration`. Prints a sentinel
 /// on the first success so the workflow knows load is live before it restarts
 /// the StatefulSet.
-async fn run_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
-    sustain_load(endpoints, duration, "soak", MAX_SOAK_ERROR_RATE).await
+async fn run_soak(
+    endpoints: &[String],
+    duration: Duration,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
+    sustain_load(endpoints, duration, "soak", MAX_SOAK_ERROR_RATE, tls).await
 }
 
 /// Sustain GetTs load while the orchestrator performs a mixed-version rolling
@@ -179,12 +259,17 @@ async fn run_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
 /// lets the orchestrator sequence the partial upgrade + activation only after
 /// load is provably live, mirroring how the existing soak lane sequences a
 /// rolling restart.
-async fn run_mixed_version_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
+async fn run_mixed_version_soak(
+    endpoints: &[String],
+    duration: Duration,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
     sustain_load(
         endpoints,
         duration,
         "mixed-version-soak",
         MAX_SOAK_ERROR_RATE,
+        tls,
     )
     .await
 }
@@ -195,12 +280,17 @@ async fn run_mixed_version_soak(endpoints: &[String], duration: Duration) -> Res
 /// the client's retry + leader-redirect masks entirely (0 errors observed).
 /// The distinct sentinel (`sigkill-soak: first GetTs ok`) lets the orchestrator
 /// only kill the leader after load is provably live.
-async fn run_sigkill_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
+async fn run_sigkill_soak(
+    endpoints: &[String],
+    duration: Duration,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
     sustain_load(
         endpoints,
         duration,
         "sigkill-soak",
         MAX_SIGKILL_SOAK_ERROR_RATE,
+        tls,
     )
     .await
 }
@@ -213,8 +303,19 @@ async fn run_sigkill_soak(endpoints: &[String], duration: Duration) -> Result<bo
 /// connection (the leader stays leader, the removed voter is not the
 /// leader). The distinct sentinel (`membership-soak: first GetTs ok`) lets
 /// the orchestrator only begin the churn after load is provably live.
-async fn run_membership_soak(endpoints: &[String], duration: Duration) -> Result<bool> {
-    sustain_load(endpoints, duration, "membership-soak", MAX_SOAK_ERROR_RATE).await
+async fn run_membership_soak(
+    endpoints: &[String],
+    duration: Duration,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
+    sustain_load(
+        endpoints,
+        duration,
+        "membership-soak",
+        MAX_SOAK_ERROR_RATE,
+        tls,
+    )
+    .await
 }
 
 /// Shared body of the three soak modes. The `label` is the per-mode prefix
@@ -227,9 +328,10 @@ async fn sustain_load(
     duration: Duration,
     label: &str,
     max_error_rate: f64,
+    tls: Option<ClientTlsConfig>,
 ) -> Result<bool> {
-    let client = ClientBuilder::endpoints(endpoints.to_vec())
-        .retry_policy(generous_policy())
+    let builder = ClientBuilder::endpoints(endpoints.to_vec()).retry_policy(generous_policy());
+    let client = apply_tls(builder, tls)
         .build()
         .await
         .with_context(|| format!("build {label} client"))?;
@@ -337,5 +439,59 @@ mod cli_tests {
         assert_eq!(cli.mode, Mode::MembershipSoak);
         assert_eq!(cli.endpoints.len(), 3);
         assert_eq!(cli.duration_secs, 180);
+    }
+
+    #[test]
+    fn tls_ca_alone_parses() {
+        // The TLS-cell server-auth-only path: only `--tls-ca` is needed because
+        // the chart default is `tls.clientMtls=false`.
+        let cli = Cli::parse_from([
+            "kube-e2e-driver",
+            "--mode=soak",
+            "--endpoints=a:5051",
+            "--tls-ca=/etc/tsoracle/tls/ca.crt",
+        ]);
+        assert_eq!(
+            cli.tls_ca.as_deref(),
+            Some(std::path::Path::new("/etc/tsoracle/tls/ca.crt"))
+        );
+        assert!(cli.tls_cert.is_none());
+        assert!(cli.tls_key.is_none());
+    }
+
+    #[test]
+    fn tls_cert_without_key_is_rejected() {
+        // Clap's `requires` enforces the all-or-nothing client-mTLS pair so
+        // that an operator who forgets `--tls-key` fails fast at flag-parse
+        // time rather than at first connect.
+        let result = Cli::try_parse_from([
+            "kube-e2e-driver",
+            "--mode=soak",
+            "--endpoints=a:5051",
+            "--tls-ca=/etc/tsoracle/tls/ca.crt",
+            "--tls-cert=/etc/tsoracle/tls/tls.crt",
+        ]);
+        assert!(result.is_err(), "missing --tls-key should fail parse");
+    }
+
+    #[test]
+    fn build_tls_config_returns_none_when_no_flags() {
+        let cfg = build_tls_config(None, None, None).expect("plaintext path");
+        assert!(cfg.is_none());
+    }
+
+    #[test]
+    fn build_tls_config_rejects_cert_without_ca() {
+        // Defense in depth: clap blocks this via `requires`, but a programmatic
+        // caller could still feed cert+key with no CA; bail rather than silently
+        // build a no-trust-root identity-only config.
+        let dir = std::env::temp_dir();
+        let cert = dir.join("nonexistent.crt");
+        let key = dir.join("nonexistent.key");
+        let err = build_tls_config(None, Some(&cert), Some(&key)).unwrap_err();
+        assert!(
+            err.to_string().contains("--tls-ca"),
+            "expected --tls-ca message, got: {err}"
+        );
     }
 }

--- a/e2e/kube/driver/tls/README.md
+++ b/e2e/kube/driver/tls/README.md
@@ -1,0 +1,11 @@
+# TLS-cell driver Job manifests
+
+These manifests are the TLS-cell counterparts of `e2e/kube/driver/job-*.yaml`, used by the kube-e2e TLS cell (issue #483). The lane orchestrator (`e2e/kube/run-assertions.sh`) picks this directory by setting `JOB_DIR=$here/driver/tls` and pointing the kubectl context at the TLS-cell namespace (`e2e-tls`).
+
+The three Jobs (`cold-start`, `soak`, `sigkill-soak`) share these properties with their plaintext siblings:
+
+  * same `metadata.name` — the namespace separates them from the insecure cell.
+  * same args except: `--endpoints` use the TLS-cell pod FQDNs (full DNS form so SNI matches a SAN on the chart's leaf cert) and a `--tls-ca` flag points at the mounted Secret's `ca.crt`.
+  * an extra `tls` volume mount that exposes the same Secret the chart's pods consume (so the driver trusts the same CA the cluster's server cert chains to).
+
+The Secret name (`tsoracle-tls-certs`) is fixed across these manifests and matches the `--set tls.secretName=` passed to `helm install` in the workflow. A `gen-certs` invocation on the runner produces the PEM trio populating that Secret before `helm install`.

--- a/e2e/kube/driver/tls/job-cold-start.yaml
+++ b/e2e/kube/driver/tls/job-cold-start.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-cold-start
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+    app.kubernetes.io/component: tls-cell
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+        app.kubernetes.io/component: tls-cell
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=cold-start
+            # Full FQDN form: SNI on each dial = the FQDN, which matches a SAN
+            # on the chart's fan-SAN leaf cert minted by `gen-certs`. The
+            # plaintext cell uses a shorter `pod.peer-svc:port` form; the TLS
+            # cell can't because the short form's host wouldn't match the cert.
+            - --endpoints=tsoracle-tls-0.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-1.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-2.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051
+            - --tls-ca=/etc/tsoracle/tls/ca.crt
+            - --count=5
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tsoracle/tls
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            # Matches `--set tls.secretName=tsoracle-tls-certs` in the workflow's
+            # TLS-cell helm install. The Job mounts the same trio the chart's
+            # pods mount, so the driver's CA trust root is the cluster's CA.
+            secretName: tsoracle-tls-certs

--- a/e2e/kube/driver/tls/job-membership-soak.yaml
+++ b/e2e/kube/driver/tls/job-membership-soak.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-membership-soak
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+    app.kubernetes.io/component: tls-cell
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+        app.kubernetes.io/component: tls-cell
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=membership-soak
+            # The three ORIGINAL replica endpoints (not the future tsoracle-tls-3
+            # the orchestrator adds mid-test). After the new node is promoted,
+            # the client reaches it via the leader-hint that any of these
+            # three returns — exercising exactly the redirect path we want.
+            # Full FQDN form is required so the TLS handshake's SNI matches a
+            # SAN on the chart's leaf cert. tsoracle-tls-3's FQDN is *also*
+            # covered by gen-certs (replicas=4 in the workflow's mint step)
+            # so once it's promoted and the leader-hint redirects to it,
+            # the client-side TLS handshake at that FQDN still validates.
+            - --endpoints=tsoracle-tls-0.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-1.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-2.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051
+            - --tls-ca=/etc/tsoracle/tls/ca.crt
+            # Longer than the plain soak: must outlast scale-up of the
+            # StatefulSet to 4 + the new pod reaching Ready + `admin
+            # add-learner` blocking until the learner catches up + `promote` +
+            # `remove`, plus headroom for a cooldown window where the
+            # tracker can confirm monotonicity holds AFTER the membership
+            # transitions settle. Tune alongside the orchestrator step in
+            # run-assertions.sh.
+            - --duration-secs=180
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tsoracle/tls
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: tsoracle-tls-certs

--- a/e2e/kube/driver/tls/job-sigkill-soak.yaml
+++ b/e2e/kube/driver/tls/job-sigkill-soak.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-sigkill-soak
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+    app.kubernetes.io/component: tls-cell
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+        app.kubernetes.io/component: tls-cell
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=sigkill-soak
+            # All replica endpoints (not the Service VIP) so the client has a
+            # known-live peer to fail over to when the leader pod is
+            # force-deleted — matching how a real tsoracle client is
+            # configured (leader-hint failover assumes the client knows every
+            # replica). Full FQDN form is required so the TLS handshake's
+            # SNI matches a SAN on the chart's leaf cert.
+            - --endpoints=tsoracle-tls-0.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-1.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-2.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051
+            - --tls-ca=/etc/tsoracle/tls/ca.crt
+            # Longer than the plain soak: must cover the kubelet's pod
+            # re-creation latency (10-30s) + new pod start + cluster rejoin +
+            # leader re-election after the SIGKILL. 240s leaves ample headroom
+            # above the observed end-to-end recovery window; tune alongside
+            # the orchestrator step in run-assertions.sh.
+            - --duration-secs=240
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tsoracle/tls
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: tsoracle-tls-certs

--- a/e2e/kube/driver/tls/job-soak.yaml
+++ b/e2e/kube/driver/tls/job-soak.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-soak
+  labels:
+    app.kubernetes.io/name: tsoracle-e2e-driver
+    app.kubernetes.io/component: tls-cell
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-e2e-driver
+        app.kubernetes.io/component: tls-cell
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: driver
+          image: tsoracle-e2e-driver:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=soak
+            # All replica endpoints (not the Service VIP) so the client has a
+            # known-live peer to fail over to when the pod it is bound to is
+            # torn down during the rolling restart — matching how a real
+            # tsoracle client is configured (leader-hint failover assumes the
+            # client knows every replica). Full FQDN form is required so the
+            # TLS handshake's SNI matches a SAN on the chart's leaf cert.
+            - --endpoints=tsoracle-tls-0.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-1.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051,tsoracle-tls-2.tsoracle-tls-peer.e2e-tls.svc.cluster.local:5051
+            - --tls-ca=/etc/tsoracle/tls/ca.crt
+            - --duration-secs=120
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tsoracle/tls
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: tsoracle-tls-certs

--- a/e2e/kube/run-assertions.sh
+++ b/e2e/kube/run-assertions.sh
@@ -17,9 +17,25 @@
 # chart's openraft serve invocation binds the admin listener (see the
 # entrypoint.sh `--admin-listen 127.0.0.1:${ADMIN_PORT}` wire-up); without it
 # `tsoracle admin members` inside the pod cannot reach the admin gRPC server.
+#
+# The lane is invoked once per "cell" of the workflow (insecure / TLS — see
+# issue #483). Each cell sets the kubectl context's namespace to its own NS
+# (`kubectl config set-context --current --namespace=...`) so the bare `kubectl
+# ...` calls below auto-target it without needing a `-n` flag everywhere. The
+# RELEASE / JOB_DIR env vars below capture the *other* per-cell knobs:
+#
+#   RELEASE   — Helm release name; drives StatefulSet name + pod ordinal naming
+#               (`<RELEASE>-0`, etc.). Default `tsoracle` (insecure cell).
+#   JOB_DIR   — Directory containing the four Job manifests. Default
+#               `<this dir>/driver` (plaintext driver Jobs). TLS cell points
+#               at `<this dir>/driver/tls` (Jobs that mount the TLS Secret and
+#               dial `https://...`).
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
+
+RELEASE="${RELEASE:-tsoracle}"
+JOB_DIR="${JOB_DIR:-$here/driver}"
 
 # shellcheck source=./_assertions_lib.sh
 source "$here/_assertions_lib.sh"
@@ -29,9 +45,9 @@ source "$here/_assertions_lib.sh"
 # until the responding node reports a known leader or the timeout elapses —
 # briefly returning "leader: none" mid-election is normal.
 #
-# The query targets tsoracle-0 unconditionally. ListMembers is locally
+# The query targets <RELEASE>-0 unconditionally. ListMembers is locally
 # answerable on any node, so the responder need not BE the leader; if the
-# leader happens to be tsoracle-0, we still get its id back and the subsequent
+# leader happens to be <RELEASE>-0, we still get its id back and the subsequent
 # delete proceeds normally. The admin gRPC server binds 127.0.0.1:${ADMIN_PORT}
 # (default 51002) per the chart's entrypoint.sh — kubectl exec reaches it via
 # loopback without any Service/NetworkPolicy plumbing.
@@ -41,7 +57,7 @@ find_leader_pod() {
         local out leader_id raft_field pod_name
         # `|| true` so the loop survives a transient "Error from server" during
         # admin server startup; the next iteration re-queries.
-        out="$(kubectl exec tsoracle-0 -c tsoracle -- \
+        out="$(kubectl exec "${RELEASE}-0" -c tsoracle -- \
             tsoracle admin members --endpoint "http://127.0.0.1:${admin_port}" \
             2>/dev/null || true)"
         leader_id="$(printf '%s\n' "$out" | awk '/^leader: / { print $2 }')"
@@ -73,18 +89,18 @@ find_leader_pod() {
 }
 
 echo "== step 2: cold-start (each ordinal serves or redirects) =="
-kubectl apply -f "$here/driver/job-cold-start.yaml"
+kubectl apply -f "$JOB_DIR/job-cold-start.yaml"
 wait_job tsoracle-e2e-cold-start 120
 
 echo "== step 3: soak across a graceful rolling restart =="
-kubectl apply -f "$here/driver/job-soak.yaml"
+kubectl apply -f "$JOB_DIR/job-soak.yaml"
 wait_soak_live tsoracle-e2e-soak "soak: first GetTs ok" 60
-kubectl rollout restart statefulset/tsoracle
-kubectl rollout status statefulset/tsoracle --timeout=150s
+kubectl rollout restart "statefulset/${RELEASE}"
+kubectl rollout status "statefulset/${RELEASE}" --timeout=150s
 wait_job tsoracle-e2e-soak 180
 
 echo "== step 4: sigkill-soak (monotonicity across a force-deleted leader) =="
-kubectl apply -f "$here/driver/job-sigkill-soak.yaml"
+kubectl apply -f "$JOB_DIR/job-sigkill-soak.yaml"
 wait_soak_live tsoracle-e2e-sigkill-soak "sigkill-soak: first GetTs ok" 60
 leader_pod="$(find_leader_pod 60)"
 echo "step 4: killing leader pod $leader_pod"
@@ -93,7 +109,7 @@ kubectl delete pod "$leader_pod" --grace-period=0 --force
 # we trust the soak's final verdict; otherwise a flaky pod-recreate would
 # masquerade as a real monotonicity regression. 180s covers the kubelet's
 # pod-recreate latency + image pull (IfNotPresent in CI) + cluster rejoin.
-kubectl rollout status statefulset/tsoracle --timeout=180s
+kubectl rollout status "statefulset/${RELEASE}" --timeout=180s
 wait_job tsoracle-e2e-sigkill-soak 300
 
 echo "== step 5: dynamic-membership soak (add-learner / promote / remove) =="
@@ -104,19 +120,19 @@ echo "== step 5: dynamic-membership soak (add-learner / promote / remove) =="
 peer_port="${PEER_PORT:-5100}"
 tso_port="${TSO_PORT:-5051}"
 admin_port="${ADMIN_PORT:-51002}"
-kubectl apply -f "$here/driver/job-membership-soak.yaml"
+kubectl apply -f "$JOB_DIR/job-membership-soak.yaml"
 wait_soak_live tsoracle-e2e-membership-soak "membership-soak: first GetTs ok" 60
 
-# Scale by one (3 → 4); the existing replicas keep serving while tsoracle-3
-# starts. The pod template was rendered with REPLICAS=3 at helm-install
-# time, so tsoracle-3's entrypoint emits no `--bootstrap` and no
-# `--members` — the new node starts as an empty openraft follower waiting
-# to be add-learner'd. Once Ready (TCP-readiness on the tso port implies
-# the raft listener is also up, both bind in the same process), the leader
-# can dial it at $raft_addr below.
-echo "step 5: scaling StatefulSet to 4 (adding tsoracle-3 as a future learner)"
-kubectl scale statefulset/tsoracle --replicas=4
-kubectl rollout status statefulset/tsoracle --timeout=180s
+# Scale by one (3 → 4); the existing replicas keep serving while
+# <RELEASE>-3 starts. The pod template was rendered with REPLICAS=3 at
+# helm-install time, so the new pod's entrypoint emits no `--bootstrap` and
+# no `--members` — the new node starts as an empty openraft follower
+# waiting to be add-learner'd. Once Ready (TCP-readiness on the tso port
+# implies the raft listener is also up, both bind in the same process),
+# the leader can dial it at $new_raft below.
+echo "step 5: scaling StatefulSet to 4 (adding ${RELEASE}-3 as a future learner)"
+kubectl scale "statefulset/${RELEASE}" --replicas=4
+kubectl rollout status "statefulset/${RELEASE}" --timeout=180s
 
 leader_pod="$(find_leader_pod 60)"
 echo "step 5: current leader = $leader_pod"
@@ -129,9 +145,9 @@ echo "step 5: current leader = $leader_pod"
 # completeness — production deployments that bind admin on 0.0.0.0 with
 # TLS would gain redirect-follow without script changes.
 new_id=4
-new_raft="tsoracle-3.tsoracle-peer:${peer_port}"
-new_svc="tsoracle-3.tsoracle-peer:${tso_port}"
-new_admin="tsoracle-3.tsoracle-peer:${admin_port}"
+new_raft="${RELEASE}-3.${RELEASE}-peer:${peer_port}"
+new_svc="${RELEASE}-3.${RELEASE}-peer:${tso_port}"
+new_admin="${RELEASE}-3.${RELEASE}-peer:${admin_port}"
 echo "step 5: add-learner id=$new_id raft=$new_raft service=$new_svc admin=$new_admin"
 
 # `tsoracle admin add-learner` calls openraft's `add_learner(_, _, blocking=true)`


### PR DESCRIPTION
Closes #483.

## Summary

The kube-e2e workflow previously had only the insecure cell, which passes `tls.allowInsecurePeer=true` to opt out of #452's secure-by-default render guard without a comment explaining the choice. This PR:

1. Adds an explanatory comment on the existing insecure cell (item 1(a) of #483).
2. Adds a second cell in the same kind cluster (release `tsoracle-tls` in namespace `e2e-tls`) that:
   - mints test certs on the runner via a new `kube-e2e-driver` `gen-certs` binary (rcgen, fan-SAN leaf covering every pod FQDN);
   - creates a `tsoracle-tls-certs` Secret;
   - installs the chart with `tls.enabled=true,tls.secretName=...`;
   - runs the same cold-start + soak + sigkill + dynamic-membership assertion lane.

The TLS cell exercises the chart render guard's happy path, the peer mTLS handshake under realistic kube DNS / Pod-IP rotation, and cross-pod trust via the cluster-dedicated peer CA model from PR #445.

## Notable design choices

- **One kind cluster, two namespaces.** The chart's `podAntiAffinity` keys on `app.kubernetes.io/instance: <Release.Name>` so the two releases coexist; the kubectl context is moved per cell so the shared `run-assertions.sh` script's bare `kubectl ...` calls auto-target the right namespace.
- **`run-assertions.sh` is parameterised** by `RELEASE` (default `tsoracle`) and `JOB_DIR` (default `e2e/kube/driver`) env vars. Defaults preserve the insecure cell's prior behaviour exactly.
- **The driver gains `--tls-ca`/`--tls-cert`/`--tls-key` flags** wired through every soak mode (including the new `MembershipSoak` from #511). Clap's `requires` keeps the mTLS pair all-or-nothing; `build_tls_config` bails when a cert+key arrive without a CA.
- **`gen-certs --replicas 4`** in the workflow (not 3): the dynamic-membership step scales the StatefulSet to 4 mid-soak. A cert minted for only the initial 3 pods would fail the SNI check the first time the client is leader-hint-redirected to the new pod, surfacing as a flake unrelated to the membership transition.
- **Full pod FQDNs in TLS Job endpoints** (`tsoracle-tls-0.tsoracle-tls-peer.e2e-tls.svc.cluster.local`, not the shorter `pod.peer-svc` form the plaintext Jobs use) so SNI matches a SAN on the chart's leaf cert.

## Test plan

Verified locally:

- [x] `cargo test -p kube-e2e-driver` — 18 + 2 tests pass (new clap-parse tests for `--tls-*` flags, new `build_tls_config` tests, new `build_sans` tests on the gen-certs side).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `deploy/charts/tsoracle/tests/render.sh` passes (chart's TLS-on render path was already covered).
- [x] `python3 scripts/check-ts-header.py` — 265 files OK (new `gen-certs.rs` has the canonical header).
- [x] `bash -n` + `ruby -ryaml` syntax checks on the new Job manifests + workflow.
- [x] `gen-certs --replicas 4` smoke-test: cert correctly includes `tsoracle-tls-{0..3}.tsoracle-tls-peer.e2e-tls.svc.cluster.local`, both Service FQDNs, `localhost`, and `127.0.0.1`.

Not verifiable from a local host:

- [ ] **Actual `workflow_dispatch` run against a real kind cluster.** The lane is opt-in and only the GH runner can do that. Please trigger the `kube-e2e` workflow on this branch to confirm both cells pass end-to-end before merge.

## Cross-references

- #483 — issue being closed.
- #452 — chart secure-by-default render guard (whose happy path the TLS cell now exercises).
- #445 — peer TLS/mTLS in the standalone crate (the underlying cluster behaviour the TLS cell validates).
- #511 — dynamic-membership soak (landed mid-work; the TLS cell rebases cleanly on top and extends its membership coverage with `--replicas 4` cert SANs).