### PR TITLE
test(kube-e2e): probe the chart NetworkPolicy from outside the StatefulSet

### DIFF
--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -74,7 +74,18 @@ jobs:
         run: kubectl rollout status statefulset/tsoracle --timeout=300s
       - name: run e2e assertions — insecure cell (cold-start + soak + sigkill + dynamic membership)
         run: ./e2e/kube/run-assertions.sh
-
+      # NetworkPolicy probe: the chart's NetworkPolicy (introduced in PR #452)
+      # restricts the peer port to sibling replicas while leaving the client
+      # `tso` port open. Run from a *different* namespace with non-matching
+      # pod labels to assert peer is DENIED and tso is ALLOWED. kindnet (the
+      # CNI helm/kind-action ships) enforces NetworkPolicy out of the box at
+      # the version pinned by this workflow. See issue #486.
+      - name: NetworkPolicy probe — insecure cell
+        env:
+          TARGET_RELEASE: tsoracle
+          TARGET_NAMESPACE: default
+          PROBE_NAMESPACE: e2e-netpol-probe-insecure
+        run: ./e2e/kube/probe/run-netpol-probe.sh
       # ── TLS cell ──────────────────────────────────────────────────────────
       # Exercises the chart's secure-by-default render guard's *happy path*
       # (PR #452 — `tls.enabled=true` rendering without the insecure opt-out),
@@ -126,6 +137,16 @@ jobs:
           RELEASE: tsoracle-tls
           JOB_DIR: ${{ github.workspace }}/e2e/kube/driver/tls
         run: ./e2e/kube/run-assertions.sh
+      # Same probe as the insecure cell but pointed at the TLS-cell release.
+      # The chart's NetworkPolicy is independent of TLS, so the assertion is
+      # identical: peer denied from outside the StatefulSet, tso allowed.
+      # See issue #486.
+      - name: NetworkPolicy probe — TLS cell
+        env:
+          TARGET_RELEASE: tsoracle-tls
+          TARGET_NAMESPACE: e2e-tls
+          PROBE_NAMESPACE: e2e-netpol-probe-tls
+        run: ./e2e/kube/probe/run-netpol-probe.sh
 
       - name: dump diagnostics on failure
         if: failure()
@@ -146,3 +167,8 @@ jobs:
           kubectl -n e2e-tls logs job/tsoracle-e2e-sigkill-soak || true
           kubectl -n e2e-tls logs job/tsoracle-e2e-membership-soak || true
           kubectl -n e2e-tls get events --sort-by=.lastTimestamp || true
+          echo "── NetworkPolicy probes (#486) ──"
+          kubectl -n e2e-netpol-probe-insecure get pods,jobs -o wide || true
+          kubectl -n e2e-netpol-probe-insecure logs job/tsoracle-e2e-netpol-probe || true
+          kubectl -n e2e-netpol-probe-tls get pods,jobs -o wide || true
+          kubectl -n e2e-netpol-probe-tls logs job/tsoracle-e2e-netpol-probe || true

--- a/docs/kubernetes-e2e.md
+++ b/docs/kubernetes-e2e.md
@@ -114,3 +114,11 @@ What the TLS cell proves that the insecure cell does not:
 1. The chart's render guard accepts the happy path (`tls.enabled=true` with `tls.secretName`) without `tls.allowInsecurePeer`.
 2. Peer mTLS handshakes survive rolling restarts and SIGKILL-leader recovery: kube DNS / Pod-IP rotation does not invalidate the per-pod SNI against the fan-SAN leaf.
 3. The driver's TLS client (configured with the cluster's CA) interoperates with the chart's server-auth TLS on the client API, including under leader-redirect across cells.
+
+## NetworkPolicy probe
+
+After each cell's assertion lane completes, the workflow runs a small probe Job (`e2e/kube/probe/`) from a *separate* namespace (`e2e-netpol-probe-insecure` / `e2e-netpol-probe-tls`) with intentionally non-matching pod labels. The probe asserts that the chart's NetworkPolicy from PR #452 actually applies at runtime: the `peer` consensus port is DENIED to any source outside the StatefulSet's labels, and the `tso` client port is ALLOWED. Issue #486.
+
+The probe runs against both cells because the chart's NetworkPolicy is rendered independently of TLS — any HA driver with `networkPolicy.enabled=true` (the chart default) gets it. Catching a future widening of the peer-port `from:` clause in either cell is the test the issue called for.
+
+CNI requirement: kindnet's bundled `kube-network-policies` sidecar enforces NetworkPolicy as of kind v0.27+. The workflow's `helm/kind-action@v1.14.0` pins kind v0.31.0, comfortably above that floor, so no CNI swap was needed. A regression that downgrades the action below v0.27 would not silently mask the test — the policy would become unenforced, the peer port would become reachable, and the probe would FAIL on the deny assertion.

--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -47,6 +47,8 @@ The CI workflow runs the same assertion lane twice against two helm releases in 
 
 Both cells share `run-assertions.sh`, which reads `RELEASE` and `JOB_DIR` env vars to know which release to drive and which Job manifest set to apply. The TLS cell's Job manifests live in `driver/tls/` and mount the cluster's TLS Secret so the driver client trusts the same CA the cluster's server cert chains to.
 
+After each cell's assertion lane, the workflow runs a NetworkPolicy enforcement probe (`probe/run-netpol-probe.sh`) from a separate namespace with non-matching labels to confirm the chart's NetworkPolicy actually denies the peer port and allows the `tso` port from outside the StatefulSet. See `probe/README.md` and issue #486.
+
 To run only the TLS cell locally, after the kind cluster is up:
 
 ```sh

--- a/e2e/kube/probe/README.md
+++ b/e2e/kube/probe/README.md
@@ -1,0 +1,27 @@
+# NetworkPolicy enforcement probe
+
+Asserts that the chart's NetworkPolicy (introduced in PR #452) actually applies at runtime: the `peer` consensus port must be DENIED to any source outside the StatefulSet's labels, and the `tso` client port must be ALLOWED to everyone. Issue #486.
+
+The chart's NetworkPolicy renders for any HA driver (`openraft` or `paxos`) when `networkPolicy.enabled` is true (the chart default). Its `from:` clause keys on `app.kubernetes.io/name=tsoracle` + `app.kubernetes.io/instance=<release>`, so a pod with a different name or in a different namespace satisfies neither — exactly the negative test we want.
+
+`run-netpol-probe.sh` applies `job-netpol-probe.yaml` into a *separate* namespace (passed as `PROBE_NAMESPACE`) with `app.kubernetes.io/name: tsoracle-netpol-probe` labels and a small busybox-`nc` script that:
+
+  * Probes `<TARGET_RELEASE>-0.<TARGET_RELEASE>-peer.<TARGET_NAMESPACE>.svc.cluster.local:5100` and asserts the connect times out (NetworkPolicy DENIED).
+  * Probes the same FQDN on port 5051 and asserts the connect succeeds (NetworkPolicy ALLOWED).
+
+Selective `envsubst '${TARGET_RELEASE} ${TARGET_NAMESPACE}'` substitutes only those two variables; every other `${...}` in the manifest is a shell reference that the container resolves at runtime.
+
+## CNI requirement
+
+kindnet's bundled `kube-network-policies` sidecar enforces NetworkPolicy as of kind v0.31.0 (the default version helm/kind-action@v1.14.0 ships). The kube-e2e workflow uses that version, so no CNI swap is needed. If you point this probe at a kind cluster older than v0.27 you may see false PASSes (the probe expects the peer port to be unreachable, and an unenforced policy actually leaves it reachable — `wrapper-ec=1` then). The current workflow's `helm/kind-action@v1.14.0` pin keeps us above that threshold.
+
+## Run locally
+
+Against a chart deployment in the `default` namespace:
+
+```sh
+helm install tsoracle deploy/charts/tsoracle --set driver=openraft,replicas=3,ports.client=5051,ports.peer=5100,tls.allowInsecurePeer=true --wait
+TARGET_RELEASE=tsoracle TARGET_NAMESPACE=default PROBE_NAMESPACE=e2e-netpol-probe-insecure ./e2e/kube/probe/run-netpol-probe.sh
+```
+
+To verify the probe correctly catches a regression, `kubectl delete networkpolicy <release>-peer` and re-run — the probe should exit non-zero with `FAIL: peer port ... reachable`.

--- a/e2e/kube/probe/job-netpol-probe.yaml
+++ b/e2e/kube/probe/job-netpol-probe.yaml
@@ -1,0 +1,80 @@
+# NetworkPolicy enforcement probe — runs in a namespace separate from the
+# chart's, with labels that intentionally do NOT match the chart's podSelector,
+# and confirms that:
+#
+#   - the peer port (`peer`, default 5100 under the kube-e2e workflow) is
+#     DROPPED by the chart's NetworkPolicy because the prober is neither a
+#     sibling replica nor in the chart's namespace. The `nc -z` connect should
+#     time out at the iptables drop (no RST), so we use `-w 8` to bound the
+#     wait and `! ` to flip the expected failure into a positive assertion.
+#   - the `tso` port (default 5051) is ALLOWED for any source (the chart's
+#     ingress rule on `tso` has no `from:` clause).
+#
+# Issue #486. The chart's NetworkPolicy is rendered for any HA driver
+# (openraft|paxos) with `networkPolicy.enabled=true` (the default); PR #452
+# introduced both the policy and a values default that keeps it on. kindnet's
+# bundled kube-network-policies sidecar enforces NetworkPolicy as of the kind
+# version helm/kind-action@v1.14.0 ships (v0.31.0), so no CNI swap is needed.
+#
+# TARGET_RELEASE / TARGET_NAMESPACE are envsubst'd in the workflow so one
+# manifest covers both the insecure and TLS cells.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tsoracle-e2e-netpol-probe
+  labels:
+    # Explicitly NOT `app.kubernetes.io/name=tsoracle` — the chart's
+    # NetworkPolicy `from:` clause keys on that label, so a mis-named prober
+    # is exactly the negative test we want.
+    app.kubernetes.io/name: tsoracle-netpol-probe
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tsoracle-netpol-probe
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: probe
+          # alpine ships busybox `nc` which supports `-z`/`-v`/`-w`. ~5 MB
+          # image — pulls fast in CI even without registry mirroring.
+          image: alpine:3.20
+          env:
+            - name: TARGET_RELEASE
+              value: "${TARGET_RELEASE}"
+            - name: TARGET_NAMESPACE
+              value: "${TARGET_NAMESPACE}"
+            # Port numbers track the workflow's `--set ports.client=5051,ports.peer=5100`.
+            # If those ever drift, this probe drifts with them; we don't want a
+            # silently-green probe if the workflow remaps ports.
+            - name: PEER_PORT
+              value: "5100"
+            - name: TSO_PORT
+              value: "5051"
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              TARGET="${TARGET_RELEASE}-0.${TARGET_RELEASE}-peer.${TARGET_NAMESPACE}.svc.cluster.local"
+              echo "probe: target=${TARGET} peer=${PEER_PORT} tso=${TSO_PORT}"
+
+              echo "== probing peer port ${PEER_PORT} (NetworkPolicy must DENY) =="
+              # busybox nc: -z connect-only, -v verbose, -w timeout-secs.
+              # Without enforcement, the SYN/SYN-ACK completes in <100ms and
+              # the probe fails. Under enforcement, the SYN is silently dropped
+              # and nc gives up at -w; we positively assert that here.
+              if nc -zv -w 8 "$TARGET" "$PEER_PORT" 2>&1; then
+                  echo "FAIL: peer port ${PEER_PORT} reachable from outside the StatefulSet labels — NetworkPolicy did not deny"
+                  exit 1
+              fi
+              echo "OK: peer port blocked"
+
+              echo "== probing tso port ${TSO_PORT} (NetworkPolicy must ALLOW) =="
+              if ! nc -zv -w 8 "$TARGET" "$TSO_PORT" 2>&1; then
+                  echo "FAIL: tso port ${TSO_PORT} unreachable — NetworkPolicy or routing rejected an ALLOWED port"
+                  exit 1
+              fi
+              echo "OK: tso port reachable"
+
+              echo "netpol probe passed"

--- a/e2e/kube/probe/run-netpol-probe.sh
+++ b/e2e/kube/probe/run-netpol-probe.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Apply the NetworkPolicy enforcement probe (issue #486) against a tsoracle
+# chart deployment. Confirms that:
+#
+#   - the `peer` port is DENIED from a pod that lives outside the StatefulSet
+#     (different namespace, different labels).
+#   - the `tso` port is ALLOWED from that same outside pod.
+#
+# Used by the kube-e2e workflow once per cell (insecure + TLS). The probe Job
+# is applied to a *separate* namespace from the chart's, so the chart's
+# NetworkPolicy `from:` rule (sibling-pod match) cannot match it — that is the
+# negative test we want. The chart-side NetworkPolicy is rendered for any HA
+# driver (openraft|paxos) with `networkPolicy.enabled=true` (the default;
+# introduced by PR #452).
+#
+# Required env vars:
+#   TARGET_RELEASE   — Helm release name to probe (e.g. `tsoracle`).
+#   TARGET_NAMESPACE — Namespace the chart was installed into (e.g. `default`).
+#   PROBE_NAMESPACE  — Namespace into which the probe Job is applied
+#                      (created if missing). Must differ from TARGET_NAMESPACE
+#                      so the probe pod's labels can't satisfy the chart's
+#                      sibling-pod `from:` clause.
+#
+# Optional:
+#   PROBE_TIMEOUT    — Seconds to wait for the Job to reach a terminal state.
+#                      Default 120 (image pull + two 8s nc probes + slack).
+set -euo pipefail
+
+: "${TARGET_RELEASE:?TARGET_RELEASE must be set (chart release name)}"
+: "${TARGET_NAMESPACE:?TARGET_NAMESPACE must be set (chart namespace)}"
+: "${PROBE_NAMESPACE:?PROBE_NAMESPACE must be set (separate namespace for the probe)}"
+PROBE_TIMEOUT="${PROBE_TIMEOUT:-120}"
+
+if [ "$PROBE_NAMESPACE" = "$TARGET_NAMESPACE" ]; then
+    echo "PROBE_NAMESPACE must differ from TARGET_NAMESPACE so the probe pod" >&2
+    echo "is outside the chart's namespace; got both='${PROBE_NAMESPACE}'" >&2
+    exit 1
+fi
+
+here="$(cd "$(dirname "$0")" && pwd)"
+
+# Idempotent namespace bootstrap so the workflow can re-run a failed cell
+# without manual cleanup. `--dry-run=client -o yaml | kubectl apply -f -` is
+# the standard "ensure exists" pattern; plain `kubectl create namespace`
+# errors when the namespace already exists.
+kubectl create namespace "$PROBE_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+# Render the static manifest with selective envsubst. Without the explicit
+# allow-list, envsubst would clobber `${TARGET}`/`${PEER_PORT}`/`${TSO_PORT}`
+# in the *shell* script inside the Job's `args:` — those should reach the
+# container untouched and be resolved by sh at runtime. Naming the two host-
+# side substitutions explicitly leaves every other `${...}` alone.
+# shellcheck disable=SC2016 # single quotes are intentional: envsubst reads
+# them as a literal allow-list of variable names, not shell-expanded values.
+envsubst '${TARGET_RELEASE} ${TARGET_NAMESPACE}' < "$here/job-netpol-probe.yaml" \
+    | kubectl apply -n "$PROBE_NAMESPACE" -f -
+
+# Poll for terminal state. Two conditions matter: Complete (probe passed) or
+# Failed (one of the assertions did not hold). `kubectl wait` can only race
+# one condition at a time, so we poll both manually.
+elapsed=0
+while [ "$elapsed" -lt "$PROBE_TIMEOUT" ]; do
+    succeeded="$(kubectl -n "$PROBE_NAMESPACE" get job tsoracle-e2e-netpol-probe \
+        -o jsonpath='{.status.succeeded}' 2>/dev/null || true)"
+    failed="$(kubectl -n "$PROBE_NAMESPACE" get job tsoracle-e2e-netpol-probe \
+        -o jsonpath='{.status.failed}' 2>/dev/null || true)"
+    if [ "$succeeded" = "1" ]; then
+        echo "netpol probe: succeeded (release=${TARGET_RELEASE} ns=${TARGET_NAMESPACE})"
+        kubectl -n "$PROBE_NAMESPACE" logs job/tsoracle-e2e-netpol-probe || true
+        exit 0
+    fi
+    if [ -n "$failed" ] && [ "$failed" != "0" ]; then
+        echo "netpol probe: FAILED (release=${TARGET_RELEASE} ns=${TARGET_NAMESPACE})" >&2
+        kubectl -n "$PROBE_NAMESPACE" logs job/tsoracle-e2e-netpol-probe || true
+        exit 1
+    fi
+    sleep 3
+    elapsed=$((elapsed + 3))
+done
+
+echo "netpol probe: timed out after ${PROBE_TIMEOUT}s (release=${TARGET_RELEASE})" >&2
+kubectl -n "$PROBE_NAMESPACE" logs job/tsoracle-e2e-netpol-probe || true
+kubectl -n "$PROBE_NAMESPACE" describe job tsoracle-e2e-netpol-probe || true
+exit 1


### PR DESCRIPTION
Closes #486.

## Summary

The chart's NetworkPolicy from PR #452 restricts the peer consensus port to sibling replicas while leaving the client (`tso`) port open to all sources. Until now no e2e probe verified this — a future chart change that widened the policy would not be caught.

This adds a small probe Job (`e2e/kube/probe/job-netpol-probe.yaml`) that runs in a SEPARATE namespace with intentionally non-matching pod labels (`app.kubernetes.io/name=tsoracle-netpol-probe`, deliberately not `tsoracle`). The Job uses busybox `nc -zv -w 8` to:

1. attempt TCP connect to `<release>-0.<release>-peer.<ns>.svc.cluster.local:5100` → expect time-out (DENIED);
2. attempt TCP connect to the same FQDN on port 5051 → expect success (ALLOWED).

A wrapper script (`e2e/kube/probe/run-netpol-probe.sh`) renders the manifest via selective `envsubst '${TARGET_RELEASE} ${TARGET_NAMESPACE}'` (named explicitly so the `${...}` shell references inside the Job's bash script aren't clobbered) and polls both the `Complete` and `Failed` Job conditions so a regression surfaces in <30s rather than timing out at 120s.

The kube-e2e workflow now runs the probe twice — once per cell — in fresh `e2e-netpol-probe-{insecure,tls}` namespaces. The failure-dump step also dumps both probe namespaces.

## CNI

kindnet's bundled `kube-network-policies` sidecar **does enforce NetworkPolicy** as of kind v0.27+. `helm/kind-action@v1.14.0` pins kind v0.31.0, comfortably above that floor, so no CNI swap (Calico / Cilium) was needed. I confirmed empirically — see Test plan below.

A future downgrade of the action below v0.27 would not silently mask the test: the policy would become unenforced, the peer port would become reachable, and the probe would FAIL on the deny assertion.

## Why a separate namespace, not just non-matching labels

A pod in the same namespace with different labels would test "labels-mismatch denies". A pod in *another* namespace simultaneously tests both label-mismatch AND any future regression where the chart adds a `namespaceSelector` that accidentally matches sibling pods cluster-wide. The issue's first suggestion (different namespace) is the strictly stronger test, so that's what the probe does.

## Test plan

- [x] Empirically verified kindnet enforces NetworkPolicy on the kind version this workflow uses (kind v0.31.0 / kindnet v0.29.0-alpha). Spun up the project's `e2e/kube/kind-config.yaml` locally, applied a chart-shaped synthetic target (StatefulSet-style pod + headless Service + the chart's rendered NetworkPolicy verbatim), and ran the probe.
- [x] **Positive case**: probe Job completes (`Complete=true`, ec=0) with `OK: peer port blocked` (peer connect times out at the 8s `-w` window) + `OK: tso port reachable`.
- [x] **Negative case**: after `kubectl delete networkpolicy <release>-peer`, the probe correctly fails (`Failed=true`, ec=1) with `FAIL: peer port 5100 reachable from outside the StatefulSet labels — NetworkPolicy did not deny`.
- [x] YAML syntax (`ruby -ryaml`), bash syntax (`bash -n`), `shellcheck` all clean (`SC2016` suppressed where envsubst's single-quote-allow-list is intentional).
- [x] `deploy/charts/tsoracle/tests/render.sh` still passes.

**Not verified locally**: a real `helm install deploy/charts/tsoracle` with the chart's e2e image, end-to-end through the workflow. The image at `ghcr.io/prisma-risk/tsoracle:0.1.13` is not anonymously pullable, so I tested against a hand-applied NetworkPolicy that matches the chart's render shape rather than helm's own apply. The chart's render-test confirms `helm template | grep NetworkPolicy` produces the structure I tested against.

Recommend running `workflow_dispatch` after this PR is approved to confirm both cells' probes pass end-to-end in CI.

## Cross-references

- #486 — issue being closed.
- #452 — introduced the NetworkPolicy and the `networkPolicy.enabled` value (chart default `true` for HA drivers).
- #483 — introduced the TLS cell that this probe also covers.