### PR TITLE
fix(kube-e2e): register new member with FQDN so TLS cell's SAN check matches

### DIFF
--- a/e2e/kube/run-assertions.sh
+++ b/e2e/kube/run-assertions.sh
@@ -120,6 +120,13 @@ echo "== step 5: dynamic-membership soak (add-learner / promote / remove) =="
 peer_port="${PEER_PORT:-5100}"
 tso_port="${TSO_PORT:-5051}"
 admin_port="${ADMIN_PORT:-51002}"
+# Namespace of the current kubectl context; used to compose full pod FQDNs
+# for the new member's three addresses. Required under the TLS cell so the
+# stored addresses match a SAN on the chart's leaf cert (see comment above
+# the new_raft/new_svc/new_admin construction below). Empty for the insecure
+# cell's context — fall back to `default` to keep one code path.
+namespace="$(kubectl config view --minify -o jsonpath='{..namespace}' 2>/dev/null || true)"
+namespace="${namespace:-default}"
 kubectl apply -f "$JOB_DIR/job-membership-soak.yaml"
 wait_soak_live tsoracle-e2e-membership-soak "membership-soak: first GetTs ok" 60
 
@@ -138,16 +145,24 @@ leader_pod="$(find_leader_pod 60)"
 echo "step 5: current leader = $leader_pod"
 
 # Three-address membership: raft (peer transport), service (tsoracle client
-# port for leader-hint redirect), admin (operator gRPC for future ops).
-# Short DNS resolves within the cluster's search path; matches the soak
-# endpoints' form. The admin address is unreachable from the headless
-# Service (admin is not in its port list) but membership stores it for
-# completeness — production deployments that bind admin on 0.0.0.0 with
-# TLS would gain redirect-follow without script changes.
+# port for leader-hint redirect), admin (operator gRPC for future ops). The
+# FQDN form is REQUIRED under the TLS cell: openraft peer transport dials
+# `https://{raft_addr}` (drivers/openraft/network.rs) and the tsoracle client
+# uses {service_endpoint} as the TLS authority on a leader-hint redirect, so
+# both must match a SAN on the chart's leaf cert. `gen-certs` only emits
+# `<release>-<i>.<release>-peer.<ns>.svc.cluster.local` — the short form
+# `<release>-<i>.<release>-peer` is NOT in the SAN list. The insecure cell
+# also constructs the FQDN here; plaintext consensus doesn't require it, but
+# one code path keeps the two cells in sync (cluster DNS resolves the FQDN
+# just as readily as the short form). The admin address is loopback-only at
+# runtime (the chart binds admin on 127.0.0.1) but membership stores it for
+# completeness — production deployments that bind admin on 0.0.0.0 with TLS
+# would gain redirect-follow without script changes.
 new_id=4
-new_raft="${RELEASE}-3.${RELEASE}-peer:${peer_port}"
-new_svc="${RELEASE}-3.${RELEASE}-peer:${tso_port}"
-new_admin="${RELEASE}-3.${RELEASE}-peer:${admin_port}"
+new_host="${RELEASE}-3.${RELEASE}-peer.${namespace}.svc.cluster.local"
+new_raft="${new_host}:${peer_port}"
+new_svc="${new_host}:${tso_port}"
+new_admin="${new_host}:${admin_port}"
 echo "step 5: add-learner id=$new_id raft=$new_raft service=$new_svc admin=$new_admin"
 
 # `tsoracle admin add-learner` calls openraft's `add_learner(_, _, blocking=true)`


### PR DESCRIPTION
## Summary

- TLS e2e dynamic-membership step in `e2e/kube/run-assertions.sh` was registering the new learner's three addresses (`raft_addr` / `service_endpoint` / `admin_endpoint`) as the short DNS form `<rel>-3.<rel>-peer:<port>` while `gen-certs` only emits SANs for the full FQDN form `<rel>-<i>.<rel>-peer.<ns>.svc.cluster.local`.
- openraft peer transport dials `https://{raft_addr}` (`crates/tsoracle-standalone/src/drivers/openraft/network.rs:327-334`) and the tsoracle client uses the stored `service_endpoint` as the TLS authority on a leader-hint redirect — both fail SNI/hostname verification against the fan-SAN leaf cert. PoC: `openssl verify -verify_hostname tsoracle-tls-3.tsoracle-tls-peer ...` returns `error 62 ... hostname mismatch`; the FQDN form returns `OK`.
- Detect the kubectl context's namespace at step 5 and compose the three addresses as the same FQDN form the chart's `deploy/entrypoint.sh:55` already uses for the initial members 0/1/2. Insecure cell composes the FQDN too — plaintext consensus doesn't need it, but one code path keeps the two cells in sync. `find_leader_pod`'s `${raft_field%%.*}` parser still strips at the first dot, so the change is transparent to it.

This is a confined, e2e-correctness fix: the chart's bootstrap path was already doing the right thing; the dynamic-membership orchestration was the lone holdout. Reported by Codex (low) as a non-security functional bug — the TLS cell would have started flaking once a leader-hint redirect to the new node, or any peer dial to the new node under TLS, surfaced the SAN mismatch.

## Test plan

- [x] `bash -n e2e/kube/run-assertions.sh` — clean
- [x] `shellcheck -x` (from `e2e/kube/`) — clean
- [x] Replay finding's PoC: `cargo run -q -p kube-e2e-driver --bin gen-certs -- --out /tmp/tsoracle-tls-poc --release tsoracle-tls --namespace e2e-tls --replicas 4` + `openssl verify -CAfile ca.crt -verify_hostname tsoracle-tls-3.tsoracle-tls-peer.e2e-tls.svc.cluster.local tls.crt` → `OK`; short form still produces `error 62 ... hostname mismatch` (regression demo).
- [x] Pre-commit `cargo fmt --check` + `cargo clippy` — clean (gated by husky).
- [ ] `workflow_dispatch` the `kube-e2e` workflow on this branch to confirm the TLS cell's step 5 now passes through `add-learner → promote → remove` without any SNI mismatch surfacing in the membership-soak Job's logs (the lane wasn't running on green main before this PR because step 5 is the first thing that would dial the new pod under TLS).