### PR TITLE
fix(release-sign): upload .intoto.jsonl ourselves to support immutable releases

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -162,20 +162,20 @@ jobs:
     permissions:
       actions: read       # generator inspects the workflow to record build metadata
       id-token: write     # OIDC token for Sigstore (Fulcio) keyless signing
-      contents: write     # upload the .intoto.jsonl to the GH Release
+    # upload-assets stays false (the default). The generator's upload path
+    # PATCHes the release record (target_commitish) via softprops/action-gh-release,
+    # which fails on repos with immutable releases enabled with:
+    #   "target_commitish cannot be changed when release is immutable".
+    # Instead the generator emits the .intoto.jsonl as a workflow artifact,
+    # and the attach job below uploads it alongside the .crate + .sha256
+    # via `gh release upload`, which only touches asset slots (mutation-safe).
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.subjects }}
       provenance-name: ${{ needs.build.outputs.provenance-name }}
-      upload-assets: true
-      # Explicit on both auto + workflow_dispatch paths: the reusable workflow
-      # falls back to github.ref for the upload tag, which is refs/heads/main
-      # (not a tag ref) on workflow_dispatch. Don't remove this without
-      # restructuring the trigger contract.
-      upload-tag-name: ${{ needs.build.outputs.tag }}
 
   attach:
-    name: attach .crate to release
+    name: attach .crate + provenance to release
     needs: [build, provenance]
     runs-on: ubuntu-latest
     permissions:
@@ -187,18 +187,28 @@ jobs:
           name: crate-artifacts
           path: artifacts
 
+      - name: Download SLSA provenance
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          name: ${{ needs.provenance.outputs.provenance-download-name }}
+          path: artifacts
+
       - name: Upload to release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.build.outputs.tag }}
           CRATE_FILE: ${{ needs.build.outputs.crate-file }}
+          PROVENANCE_FILE: ${{ needs.build.outputs.provenance-name }}
         run: |
           set -euo pipefail
           # --clobber: idempotent on re-run; replaces any existing asset of the
           # same name (e.g. backfill rerun after a workflow change). gh does
           # not retry internally; a transient failure here is safe to re-run.
+          # Only asset slots are touched — release metadata is left untouched,
+          # so this works against immutable releases.
           gh release upload "$TAG" \
             "artifacts/$CRATE_FILE" \
             "artifacts/${CRATE_FILE}.sha256" \
+            "artifacts/$PROVENANCE_FILE" \
             --clobber \
             --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

Backfill run [26474552375](https://github.com/prisma-risk/tsoracle/actions/runs/26474552375/job/77957094100) failed at the SLSA generator's `upload-assets` step with:

> Validation Failed: target_commitish cannot be changed when release is immutable

The generator's upload path is `softprops/action-gh-release`, which PATCHes the release record (including `target_commitish`) even when the upload is asset-only. Repos with **Make release tags immutable** enabled reject that PATCH. Plain asset uploads (`gh release upload`) work fine — only release metadata is immutable, not asset slots.

## Fix

- `upload-assets: false` (default) in the `provenance` job — the generator still emits the `.intoto.jsonl` as a workflow artifact named via `provenance-name`.
- New `Download SLSA provenance` step in `attach` consumes that artifact via `needs.provenance.outputs.provenance-download-name`.
- `gh release upload --clobber` now uploads all three assets together (`.crate`, `.crate.sha256`, `.crate.intoto.jsonl`) — one uploader, one failure mode, no release-metadata mutation.
- Dropped `contents: write` from the `provenance` job (no longer needed when not uploading) and `upload-tag-name` (only meaningful with upload-assets).

## Why this is a strict improvement

- **Immutable-release-safe**: `gh release upload` only touches asset slots.
- **Fewer moving parts**: one uploader (`gh`) instead of two (`gh` for .crate, `softprops/action-gh-release` via the generator for .intoto.jsonl).
- **Same fail-closed shape**: `attach` still `needs: [build, provenance]` — provenance failure still skips attachment.
- **Verification recipe unchanged**: docs already note `--source-branch main` for backfill runs; the SLSA provenance's recorded source ref doesn't depend on upload mechanism.

## Test plan

- [ ] Merge.
- [ ] Re-run `release-sign.yml` via `workflow_dispatch` for `tsoracle-driver-openraft-v0.3.3` (the run that just failed).
- [ ] Confirm all three assets land on the release.
- [ ] Verify with `slsa-verifier verify-artifact --source-branch main ...`.
- [ ] Backfill the other four 2026-05-26 tags.
- [ ] `gh workflow run scorecard.yml` → expect `Signed-Releases: 10`.