### PR TITLE
chore(site): remove unused locals flagged by codeql in diagram scripts

### DIFF
--- a/site/static/diagrams/cluster-state.js
+++ b/site/static/diagrams/cluster-state.js
@@ -22,7 +22,6 @@ export default function init(figure) {
     const layoutRadius = Math.min(width, height) / 2 - 90;
 
     const accent = getComputedStyle(figure).getPropertyValue('--accent').trim() || '#FFB000';
-    const fgDim = getComputedStyle(figure).getPropertyValue('--fg-dim').trim() || '#8A8A86';
 
     // Arrowhead marker
     const markerId = 'arrow-' + Math.random().toString(36).slice(2, 8);

--- a/site/static/diagrams/raft-animation.js
+++ b/site/static/diagrams/raft-animation.js
@@ -82,7 +82,6 @@ export default function init(figure) {
         .attr('font-family', 'JetBrainsMono, ui-monospace, monospace')
         .attr('font-size', 16);
 
-    const annotationMaxWidth = 680;
     const annotationCharsPerLine = 68;
 
     function setAnnotationText(text) {


### PR DESCRIPTION
## Summary

- `site/static/diagrams/raft-animation.js`: drop dead `annotationMaxWidth` — the line-wrap routine measures by character count via `annotationCharsPerLine`, not by pixel width, so the constant was never read.
- `site/static/diagrams/cluster-state.js`: drop unused `fgDim` — this file styles via CSS classes (`diagram-node--leader`) and `var(--bg)` rather than JS-resolved CSS custom-property values, so the resolved color was never consumed. Looks like residue from copying the color-resolution block out of `raft-animation.js`.

Both are CodeQL "unused-variable" findings. Verified by grepping `site/` for any remaining references (only the legitimate same-named `fgDim` const in `raft-animation.js` and `paxos-animation.js` shows up, in actively-used positions). `paxos-animation.js` does not have the `annotationMaxWidth` pattern.

## Test plan

- [x] Pre-commit hooks (cargo fmt + clippy) pass — these JS files aren't part of the Rust build, but the hooks ran on the workspace and remained green.
- [ ] Visually verify the diagrams still render (no behavior change expected — both removed values were dead).