### PR TITLE
ci(kube-e2e): trigger on deploy/chart/e2e changes

### DIFF
--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -31,6 +31,14 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+      # `tsoracle-proto`'s build.rs runs prost-build, which shells out to
+      # `protoc`. The cluster + driver image builds get it from the in-Dockerfile
+      # `apt-get install protobuf-compiler` lines, but the TLS cell's
+      # "mint test CA + fan-SAN leaf cert" step below runs
+      # `cargo run -p kube-e2e-driver --bin gen-certs` directly on the runner,
+      # where ubuntu-latest does not ship `protoc` by default. Install it here.
+      - name: install protoc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
       - name: build cluster image
         run: docker build -f deploy/Dockerfile -t tsoracle:e2e .
       - name: build driver image

--- a/.github/workflows/kube-e2e.yml
+++ b/.github/workflows/kube-e2e.yml
@@ -2,6 +2,11 @@ name: kube-e2e
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'deploy/**'
+      - 'e2e/kube/**'
+      - '.github/workflows/kube-e2e.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- `kube-e2e.yml` was `workflow_dispatch:`-only — PRs touching the deploy or e2e surface shipped with no kube-e2e signal until someone hand-triggered the lane.
- Add a path-filtered `pull_request:` trigger (`deploy/**`, `e2e/kube/**`, `.github/workflows/kube-e2e.yml`) so the lane runs automatically on the paths that move its behavior, while staying off Rust-only PRs that don't move the kind cluster's outcome.
- Per-PR cost is acceptable: existing `timeout-minutes: 45`, kind setup ~10–15 min on `ubuntu-latest`, `free-disk-space` already in place, `Swatinem/rust-cache` keeps the two image builds warm across runs.

Closes #488.

## Test plan

- [ ] Self-validation: this PR modifies `.github/workflows/kube-e2e.yml`, which is itself in the new `paths:` filter, so the kube-e2e workflow fires on this PR as its own proof.
- [ ] Both `insecure cell` and `TLS cell` deploy steps go green on the runner (these are the cells that exercise the secure-by-default render guard from #452 and the peer mTLS path from #445).
- [ ] All four assertion jobs report success across both cells: `cold-start`, `soak`, `sigkill-soak`, `membership-soak`.
- [ ] After merge, push a no-op commit to a branch touching only Rust code (e.g., a crate under `crates/`) and confirm kube-e2e does *not* run — the path filter is the cost guard.

## Notes

- No `concurrency:` block added: matches existing convention across `ci.yml`, `fuzz-pr.yml`, and all other workflows. If rapid PR pushes pile up 15-min runs, that becomes a separate follow-up.
- PR-only trigger (no `push: branches: [main]`): matches the issue's proposed shape. Post-merge regression coverage on `main` is a separate question worth a follow-up issue if desired.