### PR TITLE
fix(release-sign): grant provenance job contents:read

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -161,6 +161,7 @@ jobs:
     needs: build
     permissions:
       actions: read       # generator inspects the workflow to record build metadata
+      contents: read      # generator job checks out the source for provenance
       id-token: write     # OIDC token for Sigstore (Fulcio) keyless signing
     # upload-assets stays false (the default). The generator's upload path
     # PATCHes the release record (target_commitish) via softprops/action-gh-release,


### PR DESCRIPTION
## Summary

PR #521 dropped `contents: write` from the `provenance` job's permissions block (correctly — it was only needed for the `upload-assets` path we no longer use). But declaring a job-level `permissions:` block **overrides** the workflow-level default — unlisted permissions become `none`, not the workflow default. As a result, GitHub Actions failed to even parse the workflow on merge:

```
Error calling workflow 'slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@…'.
The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
The nested job 'generator' is requesting 'contents: read', but is only allowed 'contents: none'.
```

The generator's internal `generator` job runs `actions/checkout` on the source repo, which needs `contents: read`. Adding it explicitly to the `provenance` job's permissions block.

## Test plan

- [ ] Merge.
- [ ] Re-run `release-sign.yml` via `workflow_dispatch` for `tsoracle-driver-openraft-v0.3.3`.
- [ ] Confirm all three assets land on the release: `.crate`, `.crate.sha256`, `.crate.intoto.jsonl`.
- [ ] Verify with `slsa-verifier verify-artifact --source-branch main ...`.
- [ ] If green, backfill the other four 2026-05-26 tags.