### PR TITLE
fix(release-sign): grant provenance job contents:write for parse-time validation

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -161,7 +161,13 @@ jobs:
     needs: build
     permissions:
       actions: read       # generator inspects the workflow to record build metadata
-      contents: read      # generator job checks out the source for provenance
+      contents: write     # parse-time satisfaction for the generator's upload-assets
+                          # nested job. We gate it off with `upload-assets: false`
+                          # below, so the job is skipped at runtime and the PATCH
+                          # against an immutable release never happens — but GH
+                          # Actions validates the declared permissions of every
+                          # nested job at parse time regardless of `if:` conditions,
+                          # so `contents: read` is rejected at workflow load.
       id-token: write     # OIDC token for Sigstore (Fulcio) keyless signing
     # upload-assets stays false (the default). The generator's upload path
     # PATCHes the release record (target_commitish) via softprops/action-gh-release,


### PR DESCRIPTION
## Summary

PR #526 dropped `contents: write` from the `provenance` job's permissions block on the (correct, runtime-only) reasoning that `upload-assets: false` means the generator's upload-assets nested job is skipped. But GH Actions validates the declared permissions of **every nested job in a reusable workflow at parse time**, regardless of `if:` conditions. Result on the next backfill attempt:

```
The nested job 'upload-assets' is requesting 'contents: write',
but is only allowed 'contents: read'.
```

(Run [26477192619](https://github.com/prisma-risk/tsoracle/actions/runs/26477192619).)

## Fix

Restore `contents: write` to the provenance job. The upload-assets nested job is still gated off by `upload-assets: false` in `with:`, so the PATCH that originally broke PR #521 still never runs — the workflow just parses cleanly now.

Added a comment at the permission line explaining the parse-time vs. runtime distinction so a future maintainer following least-privilege doesn't strip it again.

## Test plan

- [ ] Merge.
- [ ] `gh workflow run release-sign.yml -f tag=tsoracle-driver-openraft-v0.3.3`.
- [ ] Verify all three assets land on the release: `.crate`, `.crate.sha256`, `.crate.intoto.jsonl`.
- [ ] Verify with `slsa-verifier verify-artifact --source-branch main ...`.
- [ ] If green, backfill the other four 2026-05-26 tags.
- [ ] `gh workflow run scorecard.yml` → expect `Signed-Releases: 10`.