### PR TITLE
test(standalone): eliminate close/rebind port-bind race in openraft_membership tests

### DIFF
--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -80,11 +80,16 @@ tempfile = { workspace = true }
 tokio    = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 # Without `required-features`, `cargo test -p tsoracle-standalone` (developer
-# default, no `--features test-support`) silently compiles this test file to
+# default, no `--features test-support`) silently compiles these test files to
 # zero test items — the `#![cfg(all(feature = "openraft", feature = "test-support"))]`
-# at the top of the file gates everything out. With this entry, cargo prints a
-# visible "skipped due to required-features" notice instead.
+# at the top of each file gates everything out. With these entries, cargo
+# prints a visible "skipped due to required-features" notice instead.
 [[test]]
 name = "activation_admin_rpc"
 path = "tests/activation_admin_rpc.rs"
+required-features = ["openraft", "test-support"]
+
+[[test]]
+name = "openraft_membership"
+path = "tests/openraft_membership.rs"
 required-features = ["openraft", "test-support"]

--- a/crates/tsoracle-standalone/src/admin/service.rs
+++ b/crates/tsoracle-standalone/src/admin/service.rs
@@ -215,18 +215,21 @@ impl GrpcAdmin for AdminServiceImpl {
     }
 }
 
-/// Bind `listen` and spawn the admin gRPC server under a cancel token. Mirrors
-/// the peer-server pattern in `drivers/openraft/mod.rs` (bind before spawn so a
-/// bind failure surfaces to the caller). When `admin_tls` is `Some`, the server
-/// requires a client certificate signed by the configured admin CA (mTLS).
-/// Returns the actual bound `SocketAddr` (resolves :0 to the OS-picked port)
-/// for caller-side observability — stored on `Standalone::admin_listen_addr`.
+/// Spawn the admin gRPC server on `listener` under a cancel token. The caller
+/// is responsible for the `TcpListener::bind` (the openraft driver build path
+/// does this immediately before calling us). Keeping the bind in the caller
+/// lets test-only entry points hand in a `TcpListener` that has been held
+/// continuously since `lease_port()` — eliminating the close/rebind race
+/// window where another `bind(:0)` could snatch the freshly-freed ephemeral
+/// port. When `admin_tls` is `Some`, the server requires a client certificate
+/// signed by the configured admin CA (mTLS). Returns the actual bound
+/// `SocketAddr` (resolves :0 to the OS-picked port) for caller-side
+/// observability — stored on `Standalone::admin_listen_addr`.
 pub(crate) async fn serve_admin(
     admin: Arc<dyn MembershipAdmin>,
-    listen: std::net::SocketAddr,
+    listener: tokio::net::TcpListener,
     admin_tls: Option<crate::admin_tls::AdminTlsMaterial>,
 ) -> Result<(oneshot::Sender<()>, JoinHandle<()>, std::net::SocketAddr), std::io::Error> {
-    let listener = tokio::net::TcpListener::bind(listen).await?;
     let bound = listener.local_addr()?;
     let service = MembershipAdminServer::new(AdminServiceImpl::new(admin))
         .max_decoding_message_size(MAX_ADMIN_MESSAGE_BYTES)

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -70,6 +70,34 @@ fn open_rocksdb(dir: &std::path::Path) -> Result<Arc<DB>, StandaloneError> {
 }
 
 pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, StandaloneError> {
+    build_openraft_inner(cfg, None, None).await
+}
+
+/// Test-only entry point: build with pre-bound `TcpListener`s for the raft
+/// peer port and (optionally) the admin port, bypassing the internal
+/// `TcpListener::bind` calls. Lets a test hold an OS-assigned ephemeral port
+/// continuously from `lease_port()` through `build`, eliminating the
+/// close/rebind race that periodically surfaces as `EADDRINUSE` under
+/// parallel-test load.
+///
+/// Contract: when `admin_listener` is `Some`, `cfg.admin_listen` must also
+/// be `Some` (the listener supplies the bind, but `admin_listen` still drives
+/// the secure-by-default loopback check and is reported on
+/// `Standalone::admin_listen_addr`).
+#[cfg(any(test, feature = "test-support"))]
+pub async fn build_openraft_with_listeners(
+    cfg: OpenraftConfig,
+    raft_listener: tokio::net::TcpListener,
+    admin_listener: Option<tokio::net::TcpListener>,
+) -> Result<Standalone, StandaloneError> {
+    build_openraft_inner(cfg, Some(raft_listener), admin_listener).await
+}
+
+async fn build_openraft_inner(
+    cfg: OpenraftConfig,
+    raft_listener: Option<tokio::net::TcpListener>,
+    admin_listener: Option<tokio::net::TcpListener>,
+) -> Result<Standalone, StandaloneError> {
     // Validate membership/self identity (spec: Lifecycle).
     match (cfg.bootstrap, &cfg.initial_membership) {
         (true, Some(members)) if !members.contains_key(&cfg.id) => {
@@ -242,12 +270,17 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
     .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?;
 
     // Bind the peer listener BEFORE spawning, so bind failures surface here.
-    let listener = tokio::net::TcpListener::bind(cfg.raft_addr)
-        .await
-        .map_err(|source| StandaloneError::PeerBind {
-            addr: cfg.raft_addr,
-            source,
-        })?;
+    // Tests can hand in a `TcpListener` they've held since `lease_port()` to
+    // skip this bind entirely — the close/rebind window is the race source.
+    let listener = match raft_listener {
+        Some(l) => l,
+        None => tokio::net::TcpListener::bind(cfg.raft_addr)
+            .await
+            .map_err(|source| StandaloneError::PeerBind {
+                addr: cfg.raft_addr,
+                source,
+            })?,
+    };
     let peer_service = peer_server(raft.clone(), version_source)
         .max_decoding_message_size(MAX_PEER_MESSAGE_BYTES)
         .max_encoding_message_size(MAX_PEER_MESSAGE_BYTES);
@@ -329,10 +362,22 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
             capability_source,
         ));
 
-    let (admin_transport, admin_listen_addr) = match cfg.admin_listen {
-        Some(listen) => {
+    let (admin_transport, admin_listen_addr) = match (cfg.admin_listen, admin_listener) {
+        (Some(listen), pre_bound) => {
+            // Use the test-supplied pre-bound listener when present; otherwise
+            // bind here. Keeping the bind adjacent to the spawn preserves the
+            // existing "bind failures surface to the caller" contract.
+            let listener = match pre_bound {
+                Some(l) => l,
+                None => tokio::net::TcpListener::bind(listen)
+                    .await
+                    .map_err(|source| StandaloneError::AdminBind {
+                        addr: listen,
+                        source,
+                    })?,
+            };
             let (cancel, join, bound) =
-                crate::admin::service::serve_admin(admin.clone(), listen, admin_tls_material)
+                crate::admin::service::serve_admin(admin.clone(), listener, admin_tls_material)
                     .await
                     .map_err(|source| StandaloneError::AdminBind {
                         addr: listen,
@@ -340,7 +385,7 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
                     })?;
             (TransportHandle::new(cancel, join), Some(bound))
         }
-        None => (TransportHandle::noop(), None),
+        (None, _) => (TransportHandle::noop(), None),
     };
 
     Ok(Standalone {

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -57,6 +57,27 @@ fn open_rocksdb(dir: &std::path::Path) -> Result<Arc<DB>, StandaloneError> {
 }
 
 pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, StandaloneError> {
+    build_paxos_inner(cfg, None).await
+}
+
+/// Test-only entry point: build with a pre-bound `TcpListener` for the paxos
+/// peer port, bypassing the internal `TcpListener::bind`. Lets a test hold an
+/// OS-assigned ephemeral port continuously from `lease_port()` through `build`,
+/// eliminating the close/rebind race that periodically surfaces as `EADDRINUSE`
+/// under parallel-test load. Sibling of `build_openraft_with_listeners` in the
+/// openraft driver.
+#[cfg(any(test, feature = "test-support"))]
+pub async fn build_paxos_with_listeners(
+    cfg: PaxosConfig,
+    peer_listener: tokio::net::TcpListener,
+) -> Result<Standalone, StandaloneError> {
+    build_paxos_inner(cfg, Some(peer_listener)).await
+}
+
+async fn build_paxos_inner(
+    cfg: PaxosConfig,
+    peer_listener: Option<tokio::net::TcpListener>,
+) -> Result<Standalone, StandaloneError> {
     // Mirror the openraft peer secure-by-default guard (drivers/openraft/mod.rs):
     // dry-build peer TLS first so a bad PEM surfaces as Tls (operator's
     // explicit intent) before the routable guard fires.
@@ -119,13 +140,17 @@ pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, Standalo
         .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?,
     ));
 
-    // Bind the peer listener BEFORE spawning.
-    let listener = tokio::net::TcpListener::bind(cfg.peer_listen)
-        .await
-        .map_err(|source| StandaloneError::PeerBind {
-            addr: cfg.peer_listen,
-            source,
-        })?;
+    // Bind the peer listener BEFORE spawning. Tests can hand in a `TcpListener`
+    // they've held since `lease_port()` to skip the close/rebind race window.
+    let listener = match peer_listener {
+        Some(l) => l,
+        None => tokio::net::TcpListener::bind(cfg.peer_listen)
+            .await
+            .map_err(|source| StandaloneError::PeerBind {
+                addr: cfg.peer_listen,
+                source,
+            })?,
+    };
     let peer_service = peer_server(omnipaxos.clone());
     let mut builder = tonic::transport::Server::builder();
     if let Some(material) = &peer_tls {

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -44,6 +44,11 @@ mod drivers;
 #[cfg(feature = "file")]
 pub use drivers::file::init_file_seeded;
 
+/// Test-only entry point that builds an openraft node from pre-bound listeners
+/// instead of binding internally. See `drivers::openraft::build_openraft_with_listeners`.
+#[cfg(all(any(test, feature = "test-support"), feature = "openraft"))]
+pub use drivers::openraft::build_openraft_with_listeners;
+
 mod error;
 pub use error::StandaloneError;
 

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -49,6 +49,11 @@ pub use drivers::file::init_file_seeded;
 #[cfg(all(any(test, feature = "test-support"), feature = "openraft"))]
 pub use drivers::openraft::build_openraft_with_listeners;
 
+/// Test-only entry point that builds a paxos node from a pre-bound peer
+/// listener. See `drivers::paxos::build_paxos_with_listeners`.
+#[cfg(all(any(test, feature = "test-support"), feature = "paxos"))]
+pub use drivers::paxos::build_paxos_with_listeners;
+
 mod error;
 pub use error::StandaloneError;
 

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -65,16 +65,26 @@ mod file_driver {
 #[cfg(feature = "openraft")]
 mod openraft_driver {
     use std::collections::BTreeMap;
-    use std::time::Duration;
 
     use tempfile::tempdir;
-    use tokio_stream::StreamExt;
-    use tsoracle_consensus::LeaderState;
     use tsoracle_standalone::{
         DriverConfig, MemberAddr, OpenraftConfig, RaftTuning, StandaloneError, build,
     };
 
+    // The boot-and-drain test below is the only consumer of these imports +
+    // `build_openraft_with_listeners` + `lease_port`. Gating them on
+    // `test-support` keeps the `--no-default-features --features openraft`
+    // build (config-error tests only) warning-clean.
+    #[cfg(feature = "test-support")]
     use crate::common::lease_port;
+    #[cfg(feature = "test-support")]
+    use std::time::Duration;
+    #[cfg(feature = "test-support")]
+    use tokio_stream::StreamExt;
+    #[cfg(feature = "test-support")]
+    use tsoracle_consensus::LeaderState;
+    #[cfg(feature = "test-support")]
+    use tsoracle_standalone::build_openraft_with_listeners;
 
     fn single_node_cfg(
         raft_addr: std::net::SocketAddr,
@@ -115,14 +125,14 @@ mod openraft_driver {
     /// other voter the handoff finds no target and falls through — but the
     /// leader-detection, metrics read, and target-selection path are all
     /// exercised, which the subprocess tests can't reach in this library.
+    #[cfg(feature = "test-support")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn build_openraft_single_node_boots_and_drains() {
         let dir = tempdir().unwrap();
         let (raft_addr, raft_lease) = lease_port().await;
         let cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
 
-        drop(raft_lease);
-        let mut node = build(DriverConfig::Openraft(cfg))
+        let mut node = build_openraft_with_listeners(cfg, raft_lease.into_listener(), None)
             .await
             .expect("build openraft driver");
 
@@ -251,19 +261,23 @@ mod openraft_driver {
     /// claim an already-bound address — surfaced as `AdminBind` (distinct from
     /// the peer listener's `PeerBind`, so the operator sees the right port),
     /// not a background log line.
+    #[cfg(feature = "test-support")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn admin_bind_conflict_is_a_bind_error() {
         let dir = tempdir().unwrap();
         let (raft_addr, raft_lease) = lease_port().await;
         // Hold the admin address so the admin server's bind collides with it.
+        // The squatter must STAY bound — that's the point of the test — so we
+        // can't pass an `admin_listener` through the test-support seam; the
+        // build's own `TcpListener::bind(taken)` is exactly what we want to
+        // fail with `AddrInUse`.
         let squatter = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let taken = squatter.local_addr().unwrap();
 
         let mut cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
         cfg.admin_listen = Some(taken);
-        drop(raft_lease);
         assert!(matches!(
-            build(DriverConfig::Openraft(cfg)).await,
+            build_openraft_with_listeners(cfg, raft_lease.into_listener(), None).await,
             Err(StandaloneError::AdminBind { .. })
         ));
     }
@@ -414,6 +428,10 @@ mod paxos_driver {
 
     use tempfile::tempdir;
     use tsoracle_standalone::{DriverConfig, PaxosConfig, build};
+    // Race-free seam for the boot test; absent under test-support disabled,
+    // and the `peer_bind_conflict` test below doesn't need it anyway.
+    #[cfg(feature = "test-support")]
+    use tsoracle_standalone::build_paxos_with_listeners;
 
     use crate::common::lease_port;
 
@@ -425,12 +443,15 @@ mod paxos_driver {
     /// drive consensus here (the paxos lifecycle is timing-flaky under
     /// coverage, see the test-suite notes); proving bootstrap wired everything
     /// up and that `shutdown()` stops the peer transport is enough.
+    #[cfg(feature = "test-support")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn build_paxos_boots_and_shuts_down() {
         let dir = tempdir().unwrap();
         let (peer_listen, peer_lease) = lease_port().await;
         // A second voter that we deliberately never start, just to satisfy
-        // OmniPaxos's >1-node requirement.
+        // OmniPaxos's >1-node requirement. `absent_lease` is dropped because
+        // the build never actually binds this peer — the lease just stops
+        // another test from snatching the port we're about to advertise.
         let (absent_peer, absent_lease) = lease_port().await;
         let mut peers = BTreeMap::new();
         peers.insert(1, peer_listen.to_string());
@@ -452,9 +473,8 @@ mod paxos_driver {
             allow_insecure_peer: false,
         };
 
-        drop(peer_lease);
         drop(absent_lease);
-        let mut node = build(DriverConfig::Paxos(cfg))
+        let mut node = build_paxos_with_listeners(cfg, peer_lease.into_listener())
             .await
             .expect("build paxos driver");
         assert!(

--- a/crates/tsoracle-standalone/tests/common/mod.rs
+++ b/crates/tsoracle-standalone/tests/common/mod.rs
@@ -34,23 +34,40 @@ use std::net::SocketAddr;
 use tokio::net::TcpListener;
 
 /// Holds an open ephemeral-port listener so the kernel will not re-assign
-/// that port to any other `bind(:0)` in the system. Drop just before the
-/// consumer's own bind to keep the residual TOCTOU window microscopic.
+/// that port to any other `bind(:0)` in the system. Either drop it (the
+/// kernel frees the port; the consumer must immediately rebind, racing any
+/// other `bind(:0)` in the meantime) or hand the listener directly to a
+/// consumer that supports pre-bound listeners — eliminating the close/rebind
+/// window entirely. The latter is the only race-free path; see
+/// `into_listener`.
 pub struct PortLease {
-    _listener: Option<TcpListener>,
+    listener: Option<TcpListener>,
+}
+
+impl PortLease {
+    /// Consume the lease and return the underlying open `TcpListener`. Hand
+    /// this to a build path that accepts a pre-bound listener (e.g.
+    /// `tsoracle_standalone::build_openraft_with_listeners`) so the port is
+    /// never released between lease and use.
+    pub fn into_listener(mut self) -> TcpListener {
+        self.listener
+            .take()
+            .expect("PortLease already consumed (into_listener called twice?)")
+    }
 }
 
 /// Bind an ephemeral port and return its address paired with a `PortLease`
-/// holding the listener open. Drop the `PortLease` at the exact moment the
-/// consumer is about to bind the address.
+/// holding the listener open. Prefer `PortLease::into_listener` to hand the
+/// bound socket directly to the consumer; only `drop` the lease when the
+/// consumer cannot accept a pre-bound listener (legacy path).
 ///
-/// The earlier helper just dropped the listener and returned the address —
-/// a classic TOCTOU race. Under parallel `#[tokio::test]` execution (each
-/// integration-test binary spreads tests across worker threads), the kernel
-/// would re-issue a freshly-freed ephemeral port to another test's
+/// History: the original helper just dropped the listener and returned the
+/// address — a classic TOCTOU race. Under parallel `#[tokio::test]` execution
+/// (each integration-test binary spreads tests across worker threads), the
+/// kernel would re-issue a freshly-freed ephemeral port to another test's
 /// `bind(:0)` before the original test's consumer got around to binding,
-/// causing `EADDRINUSE` panics. Holding the listener until the consumer is
-/// ready makes the port unassignable for the entire lease window.
+/// causing `EADDRINUSE` panics. Holding the listener narrowed the window;
+/// `into_listener` closes it.
 pub async fn lease_port() -> (SocketAddr, PortLease) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -59,7 +76,7 @@ pub async fn lease_port() -> (SocketAddr, PortLease) {
     (
         addr,
         PortLease {
-            _listener: Some(listener),
+            listener: Some(listener),
         },
     )
 }

--- a/crates/tsoracle-standalone/tests/openraft_membership.rs
+++ b/crates/tsoracle-standalone/tests/openraft_membership.rs
@@ -21,7 +21,7 @@
 //  limitations under the License.
 //
 
-#![cfg(feature = "openraft")]
+#![cfg(all(feature = "openraft", feature = "test-support"))]
 
 mod common;
 
@@ -33,6 +33,7 @@ use tokio_stream::StreamExt;
 use tsoracle_consensus::LeaderState;
 use tsoracle_standalone::{
     DriverConfig, MemberAddr, MemberRole, NewMember, OpenraftConfig, RaftTuning, build,
+    build_openraft_with_listeners,
 };
 
 use common::lease_port;
@@ -68,19 +69,22 @@ async fn add_learner_promote_then_remove() {
             admin_endpoint: "127.0.0.1:11".into(),
         },
     );
-    drop(lease1);
-    let node1 = build(DriverConfig::Openraft(OpenraftConfig {
-        id: 1,
-        raft_addr: raft1,
-        raft_dir: dir1.path().join("raft"),
-        bootstrap: true,
-        initial_membership: Some(members),
-        tuning: fast_tuning(),
-        peer_tls: None,
-        admin_listen: None,
-        admin_tls: None,
-        allow_insecure_peer: false,
-    }))
+    let node1 = build_openraft_with_listeners(
+        OpenraftConfig {
+            id: 1,
+            raft_addr: raft1,
+            raft_dir: dir1.path().join("raft"),
+            bootstrap: true,
+            initial_membership: Some(members),
+            tuning: fast_tuning(),
+            peer_tls: None,
+            admin_listen: None,
+            admin_tls: None,
+            allow_insecure_peer: false,
+        },
+        lease1.into_listener(),
+        None,
+    )
     .await
     .expect("build node 1");
 
@@ -96,19 +100,22 @@ async fn add_learner_promote_then_remove() {
     .expect("node 1 elected");
     drop(events);
 
-    drop(lease2);
-    let node2 = build(DriverConfig::Openraft(OpenraftConfig {
-        id: 2,
-        raft_addr: raft2,
-        raft_dir: dir2.path().join("raft"),
-        bootstrap: false,
-        initial_membership: None,
-        tuning: fast_tuning(),
-        peer_tls: None,
-        admin_listen: None,
-        admin_tls: None,
-        allow_insecure_peer: false,
-    }))
+    let node2 = build_openraft_with_listeners(
+        OpenraftConfig {
+            id: 2,
+            raft_addr: raft2,
+            raft_dir: dir2.path().join("raft"),
+            bootstrap: false,
+            initial_membership: None,
+            tuning: fast_tuning(),
+            peer_tls: None,
+            admin_listen: None,
+            admin_tls: None,
+            allow_insecure_peer: false,
+        },
+        lease2.into_listener(),
+        None,
+    )
     .await
     .expect("build node 2");
 
@@ -183,20 +190,22 @@ async fn admin_grpc_list_and_add_learner() {
             admin_endpoint: admin_addr.to_string(),
         },
     );
-    drop(lease1);
-    drop(admin_lease);
-    let node1 = build(DriverConfig::Openraft(OpenraftConfig {
-        id: 1,
-        raft_addr: raft1,
-        raft_dir: dir1.path().join("raft"),
-        bootstrap: true,
-        initial_membership: Some(members),
-        tuning: fast_tuning(),
-        peer_tls: None,
-        admin_listen: Some(admin_addr),
-        admin_tls: None,
-        allow_insecure_peer: false,
-    }))
+    let node1 = build_openraft_with_listeners(
+        OpenraftConfig {
+            id: 1,
+            raft_addr: raft1,
+            raft_dir: dir1.path().join("raft"),
+            bootstrap: true,
+            initial_membership: Some(members),
+            tuning: fast_tuning(),
+            peer_tls: None,
+            admin_listen: Some(admin_addr),
+            admin_tls: None,
+            allow_insecure_peer: false,
+        },
+        lease1.into_listener(),
+        Some(admin_lease.into_listener()),
+    )
     .await
     .expect("build node 1");
 
@@ -212,19 +221,22 @@ async fn admin_grpc_list_and_add_learner() {
     .expect("elected");
     drop(events);
 
-    drop(lease2);
-    let node2 = build(DriverConfig::Openraft(OpenraftConfig {
-        id: 2,
-        raft_addr: raft2,
-        raft_dir: dir2.path().join("raft"),
-        bootstrap: false,
-        initial_membership: None,
-        tuning: fast_tuning(),
-        peer_tls: None,
-        admin_listen: None,
-        admin_tls: None,
-        allow_insecure_peer: false,
-    }))
+    let node2 = build_openraft_with_listeners(
+        OpenraftConfig {
+            id: 2,
+            raft_addr: raft2,
+            raft_dir: dir2.path().join("raft"),
+            bootstrap: false,
+            initial_membership: None,
+            tuning: fast_tuning(),
+            peer_tls: None,
+            admin_listen: None,
+            admin_tls: None,
+            allow_insecure_peer: false,
+        },
+        lease2.into_listener(),
+        None,
+    )
     .await
     .expect("build node 2");
 
@@ -285,19 +297,22 @@ async fn coexisting_learner_survives_a_promote() {
             admin_endpoint: "127.0.0.1:11".into(),
         },
     );
-    drop(lease1);
-    let node1 = build(DriverConfig::Openraft(OpenraftConfig {
-        id: 1,
-        raft_addr: raft1,
-        raft_dir: dir1.path().join("raft"),
-        bootstrap: true,
-        initial_membership: Some(members),
-        tuning: fast_tuning(),
-        peer_tls: None,
-        admin_listen: None,
-        admin_tls: None,
-        allow_insecure_peer: false,
-    }))
+    let node1 = build_openraft_with_listeners(
+        OpenraftConfig {
+            id: 1,
+            raft_addr: raft1,
+            raft_dir: dir1.path().join("raft"),
+            bootstrap: true,
+            initial_membership: Some(members),
+            tuning: fast_tuning(),
+            peer_tls: None,
+            admin_listen: None,
+            admin_tls: None,
+            allow_insecure_peer: false,
+        },
+        lease1.into_listener(),
+        None,
+    )
     .await
     .expect("build node 1");
 
@@ -313,26 +328,28 @@ async fn coexisting_learner_survives_a_promote() {
     .expect("node 1 elected");
     drop(events);
 
-    let build_follower = |id: u64, raft_addr, raft_dir| {
-        build(DriverConfig::Openraft(OpenraftConfig {
-            id,
-            raft_addr,
-            raft_dir,
-            bootstrap: false,
-            initial_membership: None,
-            tuning: fast_tuning(),
-            peer_tls: None,
-            admin_listen: None,
-            admin_tls: None,
-            allow_insecure_peer: false,
-        }))
+    let build_follower = |id: u64, raft_addr, raft_dir, listener| {
+        build_openraft_with_listeners(
+            OpenraftConfig {
+                id,
+                raft_addr,
+                raft_dir,
+                bootstrap: false,
+                initial_membership: None,
+                tuning: fast_tuning(),
+                peer_tls: None,
+                admin_listen: None,
+                admin_tls: None,
+                allow_insecure_peer: false,
+            },
+            listener,
+            None,
+        )
     };
-    drop(lease2);
-    let node2 = build_follower(2, raft2, dir2.path().join("raft"))
+    let node2 = build_follower(2, raft2, dir2.path().join("raft"), lease2.into_listener())
         .await
         .expect("build node 2");
-    drop(lease3);
-    let node3 = build_follower(3, raft3, dir3.path().join("raft"))
+    let node3 = build_follower(3, raft3, dir3.path().join("raft"), lease3.into_listener())
         .await
         .expect("build node 3");
 


### PR DESCRIPTION
## Summary

- The `lease_port → drop(lease) → build(addr)` pattern in `crates/tsoracle-standalone/tests/openraft_membership.rs` leaves a window between the listener drop and `build_openraft`'s own `TcpListener::bind(addr)`. Under parallel-test load the kernel re-issues the freshly-freed ephemeral port to another `bind(:0)` — surfaced today as the only failing test in PR #519's coverage job (`admin_grpc_list_and_add_learner` panicking on `AdminBind { addr: 127.0.0.1:43429, source: AddrInUse }` while PR #519 itself touches only docs, [run](https://github.com/prisma-risk/tsoracle/actions/runs/26474531030/job/77956488331?pr=519)).
- The previous mitigation (hold the listener until "just before" the consumer's bind) only narrowed the window — the consumer's bind is many ms downstream (RocksDB open, raft init, then peer/admin bind), so the window stayed flake-sized.
- This PR closes the window mathematically: tests hand the pre-bound `TcpListener` directly to a new test-only build path so the port is never released between `lease_port()` and use.

## What changed

**Production-side (test-support seam, no runtime behavior change):**
- `serve_admin` now takes a pre-bound `tokio::net::TcpListener` instead of a `SocketAddr`; the caller (the openraft driver build) does the bind.
- `build_openraft` delegates to a private `build_openraft_inner(cfg, Option<TcpListener>, Option<TcpListener>)`. The `None, None` path binds inline at the same call sites as before — preserving error precedence and the existing `PeerBind` / `AdminBind` failure paths exercised by `build_in_process.rs`'s bind-conflict tests.
- New `pub async fn build_openraft_with_listeners(cfg, raft_listener, admin_listener)` gated on `cfg(any(test, feature = \"test-support\"))`, mirroring the existing `admin::test_support` seam pattern.

**Test-side:**
- `PortLease::into_listener()` consumes the lease and returns the held `TcpListener` — replacing the `drop(lease); build(addr)` close-then-rebind pattern.
- Three race-prone tests migrated: `add_learner_promote_then_remove`, `admin_grpc_list_and_add_learner` (the failing one), `coexisting_learner_survives_a_promote`.
- File gated on `feature = \"test-support\"` and added to `Cargo.toml`'s `[[test]]` table with `required-features = [\"openraft\", \"test-support\"]` so `cargo test -p tsoracle-standalone` (no features) prints a visible skip notice — mirrors the existing `activation_admin_rpc` precedent.

## Scope

Intentionally narrow: only `openraft_membership.rs`'s three race-prone tests are migrated here. `tests/build_in_process.rs` has five more `lease_port` sites (openraft + paxos) on the legacy pattern; those land in a stacked follow-up PR with a parallel `build_paxos_with_listeners` helper.

## Test plan

- [x] 50/50 sequential runs of the previously-failing test — clean
- [x] 4 parallel workers × 10 iterations × full file = **320 invocations**, zero failures, zero `AddrInUse`
- [x] `cargo test -p tsoracle-standalone --all-features` (88 tests, including `peer_bind_conflict_is_a_bind_error` and `admin_bind_conflict_is_a_bind_error` exercising the production no-listener path) — clean
- [x] `cargo fmt --check`, `cargo clippy -p tsoracle-standalone --all-features --tests -- -D warnings` — clean
- [x] `cargo check --workspace --all-features --tests` — clean