### PR TITLE
test(standalone): migrate build_in_process race-prone tests to the listener seam

### DIFF
--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -57,6 +57,27 @@ fn open_rocksdb(dir: &std::path::Path) -> Result<Arc<DB>, StandaloneError> {
 }
 
 pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, StandaloneError> {
+    build_paxos_inner(cfg, None).await
+}
+
+/// Test-only entry point: build with a pre-bound `TcpListener` for the paxos
+/// peer port, bypassing the internal `TcpListener::bind`. Lets a test hold an
+/// OS-assigned ephemeral port continuously from `lease_port()` through `build`,
+/// eliminating the close/rebind race that periodically surfaces as `EADDRINUSE`
+/// under parallel-test load. Sibling of `build_openraft_with_listeners` in the
+/// openraft driver.
+#[cfg(any(test, feature = "test-support"))]
+pub async fn build_paxos_with_listeners(
+    cfg: PaxosConfig,
+    peer_listener: tokio::net::TcpListener,
+) -> Result<Standalone, StandaloneError> {
+    build_paxos_inner(cfg, Some(peer_listener)).await
+}
+
+async fn build_paxos_inner(
+    cfg: PaxosConfig,
+    peer_listener: Option<tokio::net::TcpListener>,
+) -> Result<Standalone, StandaloneError> {
     let peer_tls = match &cfg.peer_tls {
         Some(p) => Some(crate::peer_tls::build_peer_tls(p)?),
         None => None,
@@ -103,13 +124,17 @@ pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, Standalo
         .map_err(|e| StandaloneError::Bootstrap(Box::new(e)))?,
     ));
 
-    // Bind the peer listener BEFORE spawning.
-    let listener = tokio::net::TcpListener::bind(cfg.peer_listen)
-        .await
-        .map_err(|source| StandaloneError::PeerBind {
-            addr: cfg.peer_listen,
-            source,
-        })?;
+    // Bind the peer listener BEFORE spawning. Tests can hand in a `TcpListener`
+    // they've held since `lease_port()` to skip the close/rebind race window.
+    let listener = match peer_listener {
+        Some(l) => l,
+        None => tokio::net::TcpListener::bind(cfg.peer_listen)
+            .await
+            .map_err(|source| StandaloneError::PeerBind {
+                addr: cfg.peer_listen,
+                source,
+            })?,
+    };
     let peer_service = peer_server(omnipaxos.clone());
     let mut builder = tonic::transport::Server::builder();
     if let Some(material) = &peer_tls {

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -49,6 +49,11 @@ pub use drivers::file::init_file_seeded;
 #[cfg(all(any(test, feature = "test-support"), feature = "openraft"))]
 pub use drivers::openraft::build_openraft_with_listeners;
 
+/// Test-only entry point that builds a paxos node from a pre-bound peer
+/// listener. See `drivers::paxos::build_paxos_with_listeners`.
+#[cfg(all(any(test, feature = "test-support"), feature = "paxos"))]
+pub use drivers::paxos::build_paxos_with_listeners;
+
 mod error;
 pub use error::StandaloneError;
 

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -65,16 +65,26 @@ mod file_driver {
 #[cfg(feature = "openraft")]
 mod openraft_driver {
     use std::collections::BTreeMap;
-    use std::time::Duration;
 
     use tempfile::tempdir;
-    use tokio_stream::StreamExt;
-    use tsoracle_consensus::LeaderState;
     use tsoracle_standalone::{
         DriverConfig, MemberAddr, OpenraftConfig, RaftTuning, StandaloneError, build,
     };
 
+    // The boot-and-drain test below is the only consumer of these imports +
+    // `build_openraft_with_listeners` + `lease_port`. Gating them on
+    // `test-support` keeps the `--no-default-features --features openraft`
+    // build (config-error tests only) warning-clean.
+    #[cfg(feature = "test-support")]
     use crate::common::lease_port;
+    #[cfg(feature = "test-support")]
+    use std::time::Duration;
+    #[cfg(feature = "test-support")]
+    use tokio_stream::StreamExt;
+    #[cfg(feature = "test-support")]
+    use tsoracle_consensus::LeaderState;
+    #[cfg(feature = "test-support")]
+    use tsoracle_standalone::build_openraft_with_listeners;
 
     fn single_node_cfg(
         raft_addr: std::net::SocketAddr,
@@ -114,14 +124,14 @@ mod openraft_driver {
     /// other voter the handoff finds no target and falls through — but the
     /// leader-detection, metrics read, and target-selection path are all
     /// exercised, which the subprocess tests can't reach in this library.
+    #[cfg(feature = "test-support")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn build_openraft_single_node_boots_and_drains() {
         let dir = tempdir().unwrap();
         let (raft_addr, raft_lease) = lease_port().await;
         let cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
 
-        drop(raft_lease);
-        let mut node = build(DriverConfig::Openraft(cfg))
+        let mut node = build_openraft_with_listeners(cfg, raft_lease.into_listener(), None)
             .await
             .expect("build openraft driver");
 
@@ -247,19 +257,23 @@ mod openraft_driver {
     /// claim an already-bound address — surfaced as `AdminBind` (distinct from
     /// the peer listener's `PeerBind`, so the operator sees the right port),
     /// not a background log line.
+    #[cfg(feature = "test-support")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn admin_bind_conflict_is_a_bind_error() {
         let dir = tempdir().unwrap();
         let (raft_addr, raft_lease) = lease_port().await;
         // Hold the admin address so the admin server's bind collides with it.
+        // The squatter must STAY bound — that's the point of the test — so we
+        // can't pass an `admin_listener` through the test-support seam; the
+        // build's own `TcpListener::bind(taken)` is exactly what we want to
+        // fail with `AddrInUse`.
         let squatter = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let taken = squatter.local_addr().unwrap();
 
         let mut cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
         cfg.admin_listen = Some(taken);
-        drop(raft_lease);
         assert!(matches!(
-            build(DriverConfig::Openraft(cfg)).await,
+            build_openraft_with_listeners(cfg, raft_lease.into_listener(), None).await,
             Err(StandaloneError::AdminBind { .. })
         ));
     }
@@ -272,6 +286,10 @@ mod paxos_driver {
 
     use tempfile::tempdir;
     use tsoracle_standalone::{DriverConfig, PaxosConfig, build};
+    // Race-free seam for the boot test; absent under test-support disabled,
+    // and the `peer_bind_conflict` test below doesn't need it anyway.
+    #[cfg(feature = "test-support")]
+    use tsoracle_standalone::build_paxos_with_listeners;
 
     use crate::common::lease_port;
 
@@ -283,12 +301,15 @@ mod paxos_driver {
     /// drive consensus here (the paxos lifecycle is timing-flaky under
     /// coverage, see the test-suite notes); proving bootstrap wired everything
     /// up and that `shutdown()` stops the peer transport is enough.
+    #[cfg(feature = "test-support")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn build_paxos_boots_and_shuts_down() {
         let dir = tempdir().unwrap();
         let (peer_listen, peer_lease) = lease_port().await;
         // A second voter that we deliberately never start, just to satisfy
-        // OmniPaxos's >1-node requirement.
+        // OmniPaxos's >1-node requirement. `absent_lease` is dropped because
+        // the build never actually binds this peer — the lease just stops
+        // another test from snatching the port we're about to advertise.
         let (absent_peer, absent_lease) = lease_port().await;
         let mut peers = BTreeMap::new();
         peers.insert(1, peer_listen.to_string());
@@ -309,9 +330,8 @@ mod paxos_driver {
             peer_tls: None,
         };
 
-        drop(peer_lease);
         drop(absent_lease);
-        let mut node = build(DriverConfig::Paxos(cfg))
+        let mut node = build_paxos_with_listeners(cfg, peer_lease.into_listener())
             .await
             .expect("build paxos driver");
         assert!(


### PR DESCRIPTION
## Summary

Follow-up to #530 — extends the close/rebind race fix to the three remaining race-prone `lease_port → drop(lease) → build()` callsites in `tests/build_in_process.rs`. Adds a parallel `build_paxos_with_listeners` so the paxos boot test can use the same seam as the openraft tests.

> **Stacked on #530.** Base is `test/openraft-membership-port-race`; the GitHub diff therefore shows only this PR's changes. Merge #530 first (or merge this with the \"squash and merge\" target rebased to main).

## Tests migrated

- **openraft** `build_openraft_single_node_boots_and_drains` — only openraft holdout on the legacy pattern. Now uses `build_openraft_with_listeners(cfg, raft_lease.into_listener(), None)`.
- **openraft** `admin_bind_conflict_is_a_bind_error` — migrated the raft port only. The admin \"squatter\" listener must stay bound (it's the address the build is supposed to collide with), so the build's own `TcpListener::bind(taken)` remains the bind site that fails with `AddrInUse`.
- **paxos** `build_paxos_boots_and_shuts_down` — needed a new helper. Adds `build_paxos_with_listeners(cfg, peer_listener)` in `drivers/paxos/mod.rs` under `cfg(any(test, feature = \"test-support\"))`, re-exported from `lib.rs`. The `build_paxos` public API is unchanged — it delegates to a private `build_paxos_inner(cfg, None)`.

## Intentionally untouched

Two `lease_port` sites stay on the legacy drop pattern because the build **never binds** their addresses:

- paxos boot test's `absent_lease` — advertises a second voter address that no listener is ever bound to (just satisfies OmniPaxos's >1-node requirement).
- paxos `peer_bind_conflict_is_a_bind_error`'s `unused_lease` — same shape: a stable \"second voter\" address string in the peers map; no listener.

## cfg-gating discipline

The `openraft_driver` and `paxos_driver` mods stay gated only on their driver feature (not on `test-support`) so the existing config-error tests continue to run under `--no-default-features --features openraft` / `paxos`. Only the tests that consume the new helpers carry `#[cfg(feature = \"test-support\")]`, along with their helper-only imports (`Duration`, `StreamExt`, `LeaderState`, `lease_port`, both `build_*_with_listeners` helpers) so the no-test-support build stays warning-clean.

## Test plan

- [x] `cargo test -p tsoracle-standalone --all-features` (88 tests incl. the migrated build_in_process suite) — clean
- [x] `cargo test -p tsoracle-standalone --no-default-features --features file,openraft,paxos --test build_in_process` (race-prone tests correctly gated out, 7/7 ungated tests pass) — no unused-import warnings
- [x] 4 parallel workers × 12 iterations of build_in_process = **480 invocations**, zero `AddrInUse`, zero failures
- [x] `cargo fmt --check`, `cargo clippy -p tsoracle-standalone --all-features --tests -- -D warnings`, `cargo check --workspace --all-features --tests` — all clean