### PR TITLE
fix(release-sign): use @v2.1.0 tag ref (SLSA generator rejects SHA pins)

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -176,7 +176,12 @@ jobs:
     # Instead the generator emits the .intoto.jsonl as a workflow artifact,
     # and the attach job below uploads it alongside the .crate + .sha256
     # via `gh release upload`, which only touches asset slots (mutation-safe).
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
+    # SLSA generator does NOT support SHA pins. Its generate-builder.sh
+    # parses the calling ref expecting `refs/tags/vX.Y.Z`, fails with
+    # "Invalid ref: <sha>" otherwise. Integrity is anchored upstream by a
+    # hardcoded SHA256 of the generator binary baked into the workflow at
+    # each tagged release. Bump this tag intentionally; do not SHA-pin.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.subjects }}
       provenance-name: ${{ needs.build.outputs.provenance-name }}


### PR DESCRIPTION
## Summary

Run [26478005951](https://github.com/prisma-risk/tsoracle/actions/runs/26478005951) failed with the surface symptoms:

- `provenance / generator`: `/home/runner/work/tsoracle/tsoracle/slsa-generator-generic-linux-amd64: No such file or directory` (exit 127)
- Followed by `Input required and not supplied: path` on the artifact upload

Root cause buried in the same job's log:

```
Fetching the builder with ref: f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
Invalid ref: f7dd8c54c2067bafc12ca7a55595d5ee9b75204a. Expected ref of the form refs/tags/vX.Y.Z
Process completed with exit code 2.
```

The SLSA generator's `generate-builder.sh` parses the calling ref expecting `refs/tags/vX.Y.Z` and refuses anything else. That's because it downloads the prebuilt generator binary from the GitHub release matching the tag — there's no equivalent operation keyed on a commit SHA. When that step fails, later steps invoking `$BUILDER_BINARY` fail with "No such file" because the binary was never fetched.

The SLSA project anchors integrity differently from typical actions: the hash of the generator binary is hardcoded in the workflow at each tagged release. SHA-pinning the reusable workflow file is intentionally not supported by upstream.

## Fix

Switch from `@f7dd8c54…  # v2.1.0` to plain `@v2.1.0`. Added a comment at this one `uses:` line explaining the departure from the repo's "all actions SHA-pinned" convention so it doesn't get re-SHA-pinned during a future audit.

## Test plan

- [ ] Merge.
- [ ] `gh workflow run release-sign.yml -f tag=tsoracle-driver-openraft-v0.3.3`.
- [ ] Confirm all three jobs (`build`, `provenance`, `attach`) reach success.
- [ ] Verify all three assets land on the release: `.crate`, `.crate.sha256`, `.crate.intoto.jsonl`.
- [ ] Verify with `slsa-verifier verify-artifact --source-branch main ...`.
- [ ] Backfill the remaining four 2026-05-26 tags.
- [ ] `gh workflow run scorecard.yml` → expect `Signed-Releases: 10`.