### PR TITLE
fix(release-sign): pass SLSA subjects in SHA256SUMS format, not JSON

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -139,12 +139,17 @@ jobs:
             exit 1
           fi
           SHA256="$(sha256sum "$CRATE_PATH" | awk '{print $1}')"
-          # SLSA subjects format: JSON array of {name, digest{sha256}}.
-          SUBJECTS_JSON="$(printf '[{"name":"%s","digest":{"sha256":"%s"}}]' "$CRATE_FILE" "$SHA256")"
-          SUBJECTS_B64="$(printf '%s' "$SUBJECTS_JSON" | base64 -w0)"
+          # SLSA generic generator v2.x expects base64-subjects to be the
+          # SHA256SUMS line(s) (`<sha256>  <name>` — two spaces between),
+          # NOT a JSON array. Feeding it JSON triggers the generator binary
+          # to parse the JSON blob as the SHA field and fail with:
+          #   sha: unexpected sha256 hash format for "[{...}]"
+          # Identical content goes into the .sha256 sidecar we upload, so
+          # build the line once and reuse.
+          SHA256SUMS_LINE="$(printf '%s  %s\n' "$SHA256" "$CRATE_FILE")"
+          SUBJECTS_B64="$(printf '%s' "$SHA256SUMS_LINE" | base64 -w0)"
           echo "subjects=$SUBJECTS_B64" >> "$GITHUB_OUTPUT"
-          # Also write the sha256 file we'll upload in the attach job.
-          printf '%s  %s\n' "$SHA256" "$CRATE_FILE" > "target/package/${CRATE_FILE}.sha256"
+          printf '%s\n' "$SHA256SUMS_LINE" > "target/package/${CRATE_FILE}.sha256"
           [ -f "target/package/${CRATE_FILE}.sha256" ] || { echo "::error::sha256 file not written" >&2; exit 1; }
 
       - name: Upload .crate + .sha256 for downstream jobs


### PR DESCRIPTION
## Summary

After [PR #533](https://github.com/prisma-risk/tsoracle/pull/533) unblocked the generator binary download, run [26478817397](https://github.com/prisma-risk/tsoracle/actions/runs/26478817397) exposed the next failure layer in the SLSA generator's `Create and sign provenance` step:

```
sha: unexpected sha256 hash format for "[{\"name\":\"tsoracle-driver-openraft-0.3.3.crate\",\"digest\":{\"sha256\":\"...\"}}]"
##[error]Process completed with exit code 1.
```

The SLSA generic generator v2.x expects `base64-subjects` to be a **SHA256SUMS payload** — lines of `<sha256-hex>  <filename>` (two spaces between) — NOT the v1.x-style JSON array I'd been producing. The generator binary parses the input with sha256sum -c style logic; the JSON blob ends up read as a single line, and the "first field" (`[{"name":...`) fails the SHA256 hex format check.

## Fix

Switch the build job's `Compute SLSA subjects` step to emit a single SHA256SUMS line. Same content already goes to the `.sha256` sidecar, so build the line once and reuse:

```bash
SHA256SUMS_LINE="$(printf '%s  %s\n' "$SHA256" "$CRATE_FILE")"
SUBJECTS_B64="$(printf '%s' "$SHA256SUMS_LINE" | base64 -w0)"
printf '%s\n' "$SHA256SUMS_LINE" > "target/package/${CRATE_FILE}.sha256"
```

Verified the round-trip locally:

```
$ printf '%s  %s\n' <sha> <name> | base64 | base64 -d
<sha>  <name>
```

## Test plan

- [ ] Merge.
- [ ] `gh workflow run release-sign.yml -f tag=tsoracle-driver-openraft-v0.3.3`.
- [ ] Confirm `provenance/generator` reaches success on the `Create and sign provenance` step.
- [ ] Confirm `attach` runs end-to-end and uploads all three assets: `.crate`, `.crate.sha256`, `.crate.intoto.jsonl`.
- [ ] Verify with `slsa-verifier verify-artifact --source-branch main ...`.
- [ ] Backfill the remaining four 2026-05-26 tags.
- [ ] `gh workflow run scorecard.yml` → expect `Signed-Releases: 10`.
