### PR TITLE
chore(scorecard): annotate SLSA generator pin exemption (remediated)

### DIFF
--- a/.github/scorecard.yml
+++ b/.github/scorecard.yml
@@ -1,0 +1,40 @@
+# OpenSSF Scorecard configuration.
+#
+# Annotations document accepted exceptions for individual checks. They do not
+# change the numerical score; they surface a machine-readable rationale to
+# downstream report consumers (scorecard.dev, deps.dev, SARIF in code-scanning).
+# Schema: https://github.com/ossf/scorecard/blob/main/config/annotations.go
+#   - `reason` must be one of: test-data, remediated, not-applicable,
+#     not-supported, not-detected (kebab-case; enforced by isValidReason()).
+#   - There is no `comment:` field in the schema; rationale lives in YAML
+#     comments only (yaml.v3 silently drops unknown fields).
+#
+# ---------------------------------------------------------------------------
+# pinned-dependencies / remediated
+# ---------------------------------------------------------------------------
+# The reusable workflow
+#   slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
+# at .github/workflows/release-sign.yml is referenced by tag (@vX.Y.Z), not by
+# SHA. This is required by the upstream generator: its generate-builder.sh
+# parses the calling ref expecting `refs/tags/vX.Y.Z` and exits with
+# `Invalid ref: <sha>` when SHA-pinned (see commit 5fbdb68 for the failed pin
+# attempt; release-sign.yml has an inline comment block at the call site).
+#
+# Mitigation: integrity is anchored upstream by a hardcoded SHA256 of the
+# generator binary baked into the workflow at each tagged release, and the
+# generator itself is SLSA-attested. Every other third-party action across
+# .github/workflows/ is SHA-pinned (verified by:
+#   grep -rEn 'uses: [^@]+@(v?[0-9]|main|master|HEAD)' .github/workflows/
+# ).
+#
+# This annotation applies to the pinned-dependencies check as a whole, so any
+# future tag-pinned third-party action would be implicitly covered. Re-audit
+# this exemption when adding new external actions or when SLSA generator
+# upstream gains SHA-ref support (track:
+#   https://github.com/slsa-framework/slsa-github-generator
+# ).
+annotations:
+  - checks:
+      - pinned-dependencies
+    reasons:
+      - reason: remediated


### PR DESCRIPTION
## Summary

- Add `.github/scorecard.yml` annotating the `pinned-dependencies` check as `remediated` for the SLSA generator reusable workflow at `release-sign.yml:184`.
- The upstream generator's `generate-builder.sh` parses `GITHUB_JOB_WORKFLOW_REF` as `refs/tags/vX.Y.Z` and exits `Invalid ref: <sha>` when SHA-pinned. Commit 5fbdb68 walked back the failed SHA-pin attempt and `release-sign.yml` carries an inline comment block at the call site.
- Integrity is anchored upstream by the hardcoded SHA256 of the generator binary baked into the workflow at each tagged release, and the generator is itself SLSA-attested. Every other third-party action across `.github/workflows/` is SHA-pinned (verified by `grep -rEn 'uses: [^@]+@(v?[0-9]|main|master|HEAD)' .github/workflows/`).

## What this does and doesn't do

- Surfaces the rationale to downstream consumers (scorecard.dev, deps.dev, code-scanning SARIF) alongside the finding.
- Does NOT change the numerical Pinned-Dependencies score (9/10). Scorecard annotations are documentary by design.
- The annotation applies to the `pinned-dependencies` check as a whole; re-audit if a new external action is added or if upstream SLSA generator gains SHA-ref support.

## Schema notes

- `ReasonGroup` has only a `reason` field (no `comment:`); rationale must live in YAML `#` comments. Scorecard uses `yaml.Unmarshal` without `KnownFields(true)`, so unknown keys would be silently dropped.
- Valid `reason` values are kebab-case: `test-data`, `remediated`, `not-applicable`, `not-supported`, `not-detected` (per `config/annotations.go`).

## Test plan

- [x] YAML parses cleanly (Ruby `YAML.load_file`).
- [x] Shape + reason enum validated against the `Annotation`/`ReasonGroup` Go structs in `github.com/ossf/scorecard/v5/config/annotations.go`.
- [x] Authoritative: file parsed by `ossf/scorecard/v5/config.Parse()` — the same code path the GitHub Action runs — returns 1 annotation group, no errors.
- [x] Pre-commit `cargo fmt --check` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass.
- [ ] After merge: confirm the next scheduled `.github/workflows/scorecard.yml` run picks up the annotation and surfaces the remediated reason in the SARIF output.