### PR TITLE
feat: peer-listener secure-by-default guard + chart pass-through (closes #481)

### DIFF
--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -192,7 +192,7 @@ pub struct OpenraftArgs {
     /// This node's numeric raft id (unique across the cluster).
     #[arg(long)]
     pub id: u64,
-    /// Address to listen for raft peer RPCs. UNAUTHENTICATED plaintext — bind only on a trusted network.
+    /// Address to listen for raft peer RPCs. Plaintext on loopback; routable bind requires --peer-tls-{cert,key,ca} or --allow-insecure-peer.
     #[arg(long)]
     pub raft_addr: SocketAddr,
     /// Directory for raft log + state-machine data.
@@ -231,6 +231,12 @@ pub struct OpenraftArgs {
     /// PEM CA (cluster-dedicated) to verify connecting peers.
     #[arg(long)]
     pub peer_tls_ca: Option<std::path::PathBuf>,
+    /// Opt out of the peer-listener secure-by-default guard. Allows
+    /// routable bind without --peer-tls-*. Matches the helm chart's
+    /// tls.allowInsecurePeer. Intended for single-host dev or
+    /// service-mesh-terminated mTLS only.
+    #[arg(long)]
+    pub allow_insecure_peer: bool,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -240,7 +246,7 @@ pub struct PaxosArgs {
     /// This node's OmniPaxos pid (unique across the cluster).
     #[arg(long)]
     pub node_id: u64,
-    /// Address to listen for paxos peer RPCs. UNAUTHENTICATED plaintext — bind only on a trusted network.
+    /// Address to listen for paxos peer RPCs. Plaintext on loopback; routable bind requires --peer-tls-{cert,key,ca} or --allow-insecure-peer.
     #[arg(long)]
     pub peer_listen: SocketAddr,
     /// Comma-separated `id=host:port` paxos peer addresses (required every start).
@@ -263,6 +269,12 @@ pub struct PaxosArgs {
     /// PEM CA (cluster-dedicated) to verify connecting peers.
     #[arg(long)]
     pub peer_tls_ca: Option<std::path::PathBuf>,
+    /// Opt out of the peer-listener secure-by-default guard. Allows
+    /// routable bind without --peer-tls-*. Matches the helm chart's
+    /// tls.allowInsecurePeer. Intended for single-host dev or
+    /// service-mesh-terminated mTLS only.
+    #[arg(long)]
+    pub allow_insecure_peer: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -144,7 +144,7 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         args.admin_tls_key,
                         args.admin_tls_ca,
                     )?,
-                    allow_insecure_peer: false, // TODO Task 5: wire to args.allow_insecure_peer
+                    allow_insecure_peer: args.allow_insecure_peer,
                 });
                 run_serve(args.common, cfg).await
             }
@@ -171,7 +171,7 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         args.peer_tls_key,
                         args.peer_tls_ca,
                     )?,
-                    allow_insecure_peer: false, // TODO Task 5: wire to args.allow_insecure_peer
+                    allow_insecure_peer: args.allow_insecure_peer,
                 });
                 run_serve(args.common, cfg).await
             }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -144,6 +144,7 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         args.admin_tls_key,
                         args.admin_tls_ca,
                     )?,
+                    allow_insecure_peer: false, // TODO Task 5: wire to args.allow_insecure_peer
                 });
                 run_serve(args.common, cfg).await
             }
@@ -170,6 +171,7 @@ async fn dispatch_serve(serve: ServeCmd) -> Result<()> {
                         args.peer_tls_key,
                         args.peer_tls_ca,
                     )?,
+                    allow_insecure_peer: false, // TODO Task 5: wire to args.allow_insecure_peer
                 });
                 run_serve(args.common, cfg).await
             }

--- a/crates/tsoracle-standalone/src/config.rs
+++ b/crates/tsoracle-standalone/src/config.rs
@@ -109,6 +109,12 @@ pub struct OpenraftConfig {
     /// loopback only; routable `admin_listen` without TLS is rejected at
     /// build() (see `StandaloneError::AdminInsecureRoutable`).
     pub admin_tls: Option<AdminTlsConfig>,
+    /// When `false`, a non-loopback `raft_addr` without `peer_tls` is
+    /// rejected at build() (see `StandaloneError::PeerInsecureRoutable`).
+    /// Set `true` to opt out — intended only for single-host dev or
+    /// service-mesh-terminated mTLS, and matches the helm chart's
+    /// `tls.allowInsecurePeer`.
+    pub allow_insecure_peer: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -123,6 +129,12 @@ pub struct PaxosConfig {
     pub data_dir: PathBuf,
     pub tick_interval: Duration,
     pub peer_tls: Option<PeerTlsConfig>,
+    /// When `false`, a non-loopback `peer_listen` without `peer_tls` is
+    /// rejected at build() (see `StandaloneError::PeerInsecureRoutable`).
+    /// Set `true` to opt out — intended only for single-host dev or
+    /// service-mesh-terminated mTLS, and matches the helm chart's
+    /// `tls.allowInsecurePeer`.
+    pub allow_insecure_peer: bool,
 }
 
 pub enum DriverConfig {

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -147,12 +147,12 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         Some(p) => Some(crate::peer_tls::build_peer_tls(p)?),
         None => None,
     };
-    if peer_tls.is_none() && !cfg.raft_addr.ip().is_loopback() && !cfg.allow_insecure_peer {
-        return Err(StandaloneError::PeerInsecureRoutable {
-            addr: cfg.raft_addr,
-        });
-    }
-    if cfg.allow_insecure_peer && peer_tls.is_none() && !cfg.raft_addr.ip().is_loopback() {
+    if peer_tls.is_none() && !cfg.raft_addr.ip().is_loopback() {
+        if !cfg.allow_insecure_peer {
+            return Err(StandaloneError::PeerInsecureRoutable {
+                addr: cfg.raft_addr,
+            });
+        }
         tracing::warn!(
             addr = %cfg.raft_addr,
             "peer listener bound without TLS via --allow-insecure-peer; \
@@ -314,9 +314,8 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
 
     // First production caller of PeerCapabilitySource (it has been
     // #[allow(dead_code)] in network.rs:273-285 waiting for this wire-up).
-    // The peer TLS config is `Option<PeerTlsMaterial>` (mod.rs:210-211);
-    // extract the client side with `.as_ref().map(|m| m.client.clone())`
-    // — same pattern the existing peer factory uses at mod.rs:216.
+    // The peer TLS config is `Option<PeerTlsMaterial>`; extract the client
+    // side with `.as_ref().map(|m| m.client.clone())`.
     let capability_source = std::sync::Arc::new(
         crate::drivers::openraft::network::PeerCapabilitySource::new(
             peer_tls.as_ref().map(|m| m.client.clone()),

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -140,6 +140,26 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         return Err(StandaloneError::AdminInsecureRoutable { addr: listen });
     }
 
+    // Mirror the admin secure-by-default guard for the peer listener.
+    // Dry-build peer TLS first so a bad PEM surfaces as Tls (operator's
+    // explicit intent) before the routable guard fires.
+    let peer_tls = match &cfg.peer_tls {
+        Some(p) => Some(crate::peer_tls::build_peer_tls(p)?),
+        None => None,
+    };
+    if peer_tls.is_none() && !cfg.raft_addr.ip().is_loopback() && !cfg.allow_insecure_peer {
+        return Err(StandaloneError::PeerInsecureRoutable {
+            addr: cfg.raft_addr,
+        });
+    }
+    if cfg.allow_insecure_peer && peer_tls.is_none() && !cfg.raft_addr.ip().is_loopback() {
+        tracing::warn!(
+            addr = %cfg.raft_addr,
+            "peer listener bound without TLS via --allow-insecure-peer; \
+             relying on out-of-band transport security"
+        );
+    }
+
     std::fs::create_dir_all(&cfg.raft_dir).map_err(|source| StandaloneError::Storage {
         path: cfg.raft_dir.clone(),
         source: Box::new(source),
@@ -206,11 +226,6 @@ pub(crate) async fn build_openraft(cfg: OpenraftConfig) -> Result<Standalone, St
         .validate()
         .map_err(|e| StandaloneError::Config(e.to_string()))?,
     );
-
-    let peer_tls = match &cfg.peer_tls {
-        Some(p) => Some(crate::peer_tls::build_peer_tls(p)?),
-        None => None,
-    };
 
     let network = PeerFactory::new(
         peer_tls.as_ref().map(|m| m.client.clone()),

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -210,6 +210,7 @@ mod tests {
             data_dir: std::path::PathBuf::from("/this/path/must/not/be/touched"),
             tick_interval: Duration::from_millis(20),
             peer_tls: None,
+            allow_insecure_peer: false,
         };
         match build_paxos(cfg).await {
             Err(StandaloneError::Config(_)) => {}

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -57,6 +57,9 @@ fn open_rocksdb(dir: &std::path::Path) -> Result<Arc<DB>, StandaloneError> {
 }
 
 pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, StandaloneError> {
+    // Mirror the openraft peer secure-by-default guard (drivers/openraft/mod.rs):
+    // dry-build peer TLS first so a bad PEM surfaces as Tls (operator's
+    // explicit intent) before the routable guard fires.
     let peer_tls = match &cfg.peer_tls {
         Some(p) => Some(crate::peer_tls::build_peer_tls(p)?),
         None => None,

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -62,6 +62,19 @@ pub(crate) async fn build_paxos(cfg: PaxosConfig) -> Result<Standalone, Standalo
         None => None,
     };
 
+    if peer_tls.is_none() && !cfg.peer_listen.ip().is_loopback() {
+        if !cfg.allow_insecure_peer {
+            return Err(StandaloneError::PeerInsecureRoutable {
+                addr: cfg.peer_listen,
+            });
+        }
+        tracing::warn!(
+            addr = %cfg.peer_listen,
+            "peer listener bound without TLS via --allow-insecure-peer; \
+             relying on out-of-band transport security"
+        );
+    }
+
     // Validate self identity (spec: Lifecycle): a node absent from its own
     // ClusterConfig.nodes can never be elected.
     if !cfg.peers.contains_key(&cfg.node_id) {

--- a/crates/tsoracle-standalone/src/error.rs
+++ b/crates/tsoracle-standalone/src/error.rs
@@ -50,6 +50,11 @@ pub enum StandaloneError {
          (only loopback addresses may bind without admin TLS)"
     )]
     AdminInsecureRoutable { addr: SocketAddr },
+    #[error(
+        "peer listener on {addr} requires --peer-tls-{{cert,key,ca}} or \
+         --allow-insecure-peer (only loopback addresses may bind without peer TLS)"
+    )]
+    PeerInsecureRoutable { addr: SocketAddr },
     #[error("driver bootstrap failed: {0}")]
     Bootstrap(Box<dyn std::error::Error + Send + Sync>),
     #[error("invalid configuration: {0}")]

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -106,6 +106,7 @@ mod openraft_driver {
             peer_tls: None,
             admin_listen: None,
             admin_tls: None,
+            allow_insecure_peer: false,
         }
     }
 
@@ -163,6 +164,7 @@ mod openraft_driver {
             peer_tls: None,
             admin_listen: None,
             admin_tls: None,
+            allow_insecure_peer: false,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -191,6 +193,7 @@ mod openraft_driver {
             peer_tls: None,
             admin_listen: None,
             admin_tls: None,
+            allow_insecure_peer: false,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -219,6 +222,7 @@ mod openraft_driver {
             peer_tls: None,
             admin_listen: None,
             admin_tls: None,
+            allow_insecure_peer: false,
         };
         assert!(matches!(
             build(DriverConfig::Openraft(cfg)).await,
@@ -307,6 +311,7 @@ mod paxos_driver {
             data_dir: dir.path().join("paxos"),
             tick_interval: Duration::from_millis(20),
             peer_tls: None,
+            allow_insecure_peer: false,
         };
 
         drop(peer_lease);
@@ -335,6 +340,7 @@ mod paxos_driver {
             data_dir: std::path::PathBuf::from("/this/path/must/not/be/touched"),
             tick_interval: Duration::from_millis(20),
             peer_tls: None,
+            allow_insecure_peer: false,
         };
         assert!(matches!(
             build(DriverConfig::Paxos(cfg)).await,
@@ -362,6 +368,7 @@ mod paxos_driver {
             data_dir: dir.path().join("paxos"),
             tick_interval: Duration::from_millis(20),
             peer_tls: None,
+            allow_insecure_peer: false,
         };
         drop(unused_lease);
         assert!(matches!(

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -514,4 +514,121 @@ mod paxos_driver {
             Err(tsoracle_standalone::StandaloneError::PeerBind { .. })
         ));
     }
+
+    #[tokio::test]
+    async fn paxos_peer_insecure_routable_bind_rejected_at_build() {
+        let data_dir = tempdir().unwrap();
+        let data_dir_path = data_dir.path().to_path_buf();
+        let mut peers = BTreeMap::new();
+        peers.insert(1, "0.0.0.0:1".to_string());
+        peers.insert(2, "127.0.0.1:2".to_string());
+        let cfg = PaxosConfig {
+            node_id: 1,
+            peer_listen: "0.0.0.0:0".parse().unwrap(),
+            peers,
+            tso_peers: BTreeMap::new(),
+            data_dir: data_dir_path.clone(),
+            tick_interval: Duration::from_millis(20),
+            peer_tls: None,
+            allow_insecure_peer: false,
+        };
+
+        let err = match build(DriverConfig::Paxos(cfg)).await {
+            Ok(_) => panic!("expected PeerInsecureRoutable"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(
+                err,
+                tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }
+            ),
+            "got {err:?}"
+        );
+        let entries = std::fs::read_dir(&data_dir_path)
+            .expect("data_dir is the tempdir, still present")
+            .count();
+        assert_eq!(
+            entries, 0,
+            "guard must run before open_rocksdb; data_dir should be untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn paxos_peer_loopback_no_tls_allowed() {
+        let dir = tempdir().unwrap();
+        let (peer_listen, peer_lease) = lease_port().await;
+        let (absent_peer, absent_lease) = lease_port().await;
+        assert!(peer_listen.ip().is_loopback());
+        let mut peers = BTreeMap::new();
+        peers.insert(1, peer_listen.to_string());
+        peers.insert(2, absent_peer.to_string());
+        let cfg = PaxosConfig {
+            node_id: 1,
+            peer_listen,
+            peers,
+            tso_peers: BTreeMap::new(),
+            data_dir: dir.path().join("paxos"),
+            tick_interval: Duration::from_millis(20),
+            peer_tls: None,
+            allow_insecure_peer: false,
+        };
+        drop(peer_lease);
+        drop(absent_lease);
+        let node = build(DriverConfig::Paxos(cfg))
+            .await
+            .expect("loopback + no peer_tls should build");
+        node.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn paxos_peer_routable_opt_out_allowed() {
+        let dir = tempdir().unwrap();
+        let mut peers = BTreeMap::new();
+        peers.insert(1, "0.0.0.0:0".to_string());
+        peers.insert(2, "127.0.0.1:2".to_string());
+        let cfg = PaxosConfig {
+            node_id: 1,
+            peer_listen: "0.0.0.0:0".parse().unwrap(),
+            peers,
+            tso_peers: BTreeMap::new(),
+            data_dir: dir.path().join("paxos"),
+            tick_interval: Duration::from_millis(20),
+            peer_tls: None,
+            allow_insecure_peer: true,
+        };
+        match build(DriverConfig::Paxos(cfg)).await {
+            Ok(node) => node.shutdown().await,
+            Err(tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }) => {
+                panic!("opt-out should bypass the guard")
+            }
+            Err(_) => {} // any other error is fine for guard-bypass
+        }
+    }
+
+    #[tokio::test]
+    async fn paxos_peer_routable_with_tls_allowed() {
+        use tsoracle_standalone::PeerTlsConfig;
+        let dir = tempdir().unwrap();
+        let (cert, key, ca) = crate::common::write_peer_pems(dir.path());
+        let mut peers = BTreeMap::new();
+        peers.insert(1, "0.0.0.0:0".to_string());
+        peers.insert(2, "127.0.0.1:2".to_string());
+        let cfg = PaxosConfig {
+            node_id: 1,
+            peer_listen: "0.0.0.0:0".parse().unwrap(),
+            peers,
+            tso_peers: BTreeMap::new(),
+            data_dir: dir.path().join("paxos"),
+            tick_interval: Duration::from_millis(20),
+            peer_tls: Some(PeerTlsConfig { cert, key, ca }),
+            allow_insecure_peer: false,
+        };
+        match build(DriverConfig::Paxos(cfg)).await {
+            Ok(node) => node.shutdown().await,
+            Err(tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }) => {
+                panic!("routable + peer_tls should bypass the guard")
+            }
+            Err(_) => {} // any other error is fine
+        }
+    }
 }

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -517,6 +517,9 @@ mod paxos_driver {
 
     #[tokio::test]
     async fn paxos_peer_insecure_routable_bind_rejected_at_build() {
+        // Mirrors openraft_peer_insecure_routable_bind_rejected_at_build:
+        // guard runs at the top of build_paxos, before open_rocksdb,
+        // so data_dir stays untouched.
         let data_dir = tempdir().unwrap();
         let data_dir_path = data_dir.path().to_path_buf();
         let mut peers = BTreeMap::new();
@@ -555,10 +558,15 @@ mod paxos_driver {
 
     #[tokio::test]
     async fn paxos_peer_loopback_no_tls_allowed() {
+        // Loopback binds are allowed plaintext for local-dev / sidecar.
         let dir = tempdir().unwrap();
         let (peer_listen, peer_lease) = lease_port().await;
         let (absent_peer, absent_lease) = lease_port().await;
-        assert!(peer_listen.ip().is_loopback());
+        assert!(
+            peer_listen.ip().is_loopback(),
+            "lease_port returns loopback"
+        );
+        // peer_tls None, allow_insecure_peer false — loopback carve-out wins.
         let mut peers = BTreeMap::new();
         peers.insert(1, peer_listen.to_string());
         peers.insert(2, absent_peer.to_string());
@@ -577,11 +585,18 @@ mod paxos_driver {
         let node = build(DriverConfig::Paxos(cfg))
             .await
             .expect("loopback + no peer_tls should build");
+        // Don't bother driving consensus — boot was the assertion.
         node.shutdown().await;
     }
 
     #[tokio::test]
     async fn paxos_peer_routable_opt_out_allowed() {
+        // allow_insecure_peer=true opts the routable bind in;
+        // build() must succeed past the guard. We don't drive consensus
+        // (would need a real listener-bind on 0.0.0.0); proving the guard
+        // is bypassed is the assertion, so the test uses 0.0.0.0:0 and
+        // expects either Ok() or a downstream error other than
+        // PeerInsecureRoutable.
         let dir = tempdir().unwrap();
         let mut peers = BTreeMap::new();
         peers.insert(1, "0.0.0.0:0".to_string());
@@ -601,12 +616,16 @@ mod paxos_driver {
             Err(tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }) => {
                 panic!("opt-out should bypass the guard")
             }
-            Err(_) => {} // any other error is fine for guard-bypass
+            Err(_) => {
+                // Any other error is acceptable for this guard-bypass test
+                // (we only care that PeerInsecureRoutable did not fire).
+            }
         }
     }
 
     #[tokio::test]
     async fn paxos_peer_routable_with_tls_allowed() {
+        // peer_tls Some(...) bypasses the guard regardless of bind address.
         use tsoracle_standalone::PeerTlsConfig;
         let dir = tempdir().unwrap();
         let (cert, key, ca) = crate::common::write_peer_pems(dir.path());
@@ -628,7 +647,10 @@ mod paxos_driver {
             Err(tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }) => {
                 panic!("routable + peer_tls should bypass the guard")
             }
-            Err(_) => {} // any other error is fine
+            Err(_) => {
+                // Any other error is acceptable for this guard-bypass test
+                // (we only care that PeerInsecureRoutable did not fire).
+            }
         }
     }
 }

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -267,6 +267,144 @@ mod openraft_driver {
             Err(StandaloneError::AdminBind { .. })
         ));
     }
+
+    #[tokio::test]
+    async fn openraft_peer_insecure_routable_bind_rejected_at_build() {
+        // Mirrors admin_insecure_routable_bind_rejected_at_build:
+        // guard runs at the top of build_openraft, before open_rocksdb,
+        // so raft_dir stays untouched.
+        let raft_dir = tempdir().unwrap();
+        let raft_dir_path = raft_dir.path().to_path_buf();
+        let cfg = OpenraftConfig {
+            id: 1,
+            raft_addr: "0.0.0.0:0".parse().unwrap(),
+            raft_dir: raft_dir_path.clone(),
+            bootstrap: true,
+            initial_membership: Some(BTreeMap::from([(
+                1u64,
+                MemberAddr {
+                    raft_addr: "127.0.0.1:9".into(),
+                    service_endpoint: "127.0.0.1:8".into(),
+                    admin_endpoint: "127.0.0.1:7".into(),
+                },
+            )])),
+            tuning: RaftTuning::default(),
+            peer_tls: None,
+            admin_listen: None,
+            admin_tls: None,
+            allow_insecure_peer: false,
+        };
+
+        let err = match build(DriverConfig::Openraft(cfg)).await {
+            Ok(_) => panic!("expected PeerInsecureRoutable"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(
+                err,
+                tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }
+            ),
+            "got {err:?}"
+        );
+        let entries = std::fs::read_dir(&raft_dir_path)
+            .expect("raft_dir is the tempdir, still present")
+            .count();
+        assert_eq!(
+            entries, 0,
+            "guard must run before open_rocksdb; raft_dir should be untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn openraft_peer_loopback_no_tls_allowed() {
+        // Loopback binds are allowed plaintext for local-dev / sidecar.
+        let dir = tempdir().unwrap();
+        let (raft_addr, raft_lease) = lease_port().await;
+        let cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
+        assert!(raft_addr.ip().is_loopback(), "lease_port returns loopback");
+        // peer_tls None, allow_insecure_peer false — loopback carve-out wins.
+        drop(raft_lease);
+        let node = build(DriverConfig::Openraft(cfg))
+            .await
+            .expect("loopback + no peer_tls should build");
+        // Don't bother driving consensus — boot was the assertion.
+        node.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn openraft_peer_routable_opt_out_allowed() {
+        // allow_insecure_peer=true opts the routable bind in;
+        // build() must succeed past the guard. We don't drive consensus
+        // (would need a real listener-bind on 0.0.0.0); proving the guard
+        // is bypassed is the assertion, so the test uses 0.0.0.0:0 and
+        // expects either Ok() or a downstream error other than
+        // PeerInsecureRoutable.
+        let dir = tempdir().unwrap();
+        let raft_dir_path = dir.path().join("raft");
+        let cfg = OpenraftConfig {
+            id: 1,
+            raft_addr: "0.0.0.0:0".parse().unwrap(),
+            raft_dir: raft_dir_path,
+            bootstrap: true,
+            initial_membership: Some(BTreeMap::from([(
+                1u64,
+                MemberAddr {
+                    raft_addr: "127.0.0.1:9".into(),
+                    service_endpoint: "127.0.0.1:8".into(),
+                    admin_endpoint: "127.0.0.1:7".into(),
+                },
+            )])),
+            tuning: RaftTuning::default(),
+            peer_tls: None,
+            admin_listen: None,
+            admin_tls: None,
+            allow_insecure_peer: true,
+        };
+        match build(DriverConfig::Openraft(cfg)).await {
+            Ok(node) => node.shutdown().await,
+            Err(tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }) => {
+                panic!("opt-out should bypass the guard")
+            }
+            Err(_) => {
+                // Any other error is acceptable for this guard-bypass test
+                // (we only care that PeerInsecureRoutable did not fire).
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn openraft_peer_routable_with_tls_allowed() {
+        // peer_tls Some(...) bypasses the guard regardless of bind address.
+        use tsoracle_standalone::PeerTlsConfig;
+        let dir = tempdir().unwrap();
+        let (cert, key, ca) = crate::common::write_peer_pems(dir.path());
+        let cfg = OpenraftConfig {
+            id: 1,
+            raft_addr: "0.0.0.0:0".parse().unwrap(),
+            raft_dir: dir.path().join("raft"),
+            bootstrap: true,
+            initial_membership: Some(BTreeMap::from([(
+                1u64,
+                MemberAddr {
+                    raft_addr: "127.0.0.1:9".into(),
+                    service_endpoint: "127.0.0.1:8".into(),
+                    admin_endpoint: "127.0.0.1:7".into(),
+                },
+            )])),
+            tuning: RaftTuning::default(),
+            peer_tls: Some(PeerTlsConfig { cert, key, ca }),
+            admin_listen: None,
+            admin_tls: None,
+            allow_insecure_peer: false,
+        };
+        match build(DriverConfig::Openraft(cfg)).await {
+            Ok(node) => node.shutdown().await,
+            Err(tsoracle_standalone::StandaloneError::PeerInsecureRoutable { .. }) => {
+                panic!("routable + peer_tls should bypass the guard")
+            }
+            Err(_) => {} // any other error is fine for guard-bypass
+        }
+    }
 }
 
 #[cfg(feature = "paxos")]

--- a/crates/tsoracle-standalone/tests/common/mod.rs
+++ b/crates/tsoracle-standalone/tests/common/mod.rs
@@ -63,3 +63,33 @@ pub async fn lease_port() -> (SocketAddr, PortLease) {
         },
     )
 }
+
+/// Mint a self-signed CA + node leaf (SAN `127.0.0.1`) and write all
+/// three PEMs into `dir`. Returns `(cert, key, ca)` as paths — the
+/// triple consumed by `tsoracle_standalone::PeerTlsConfig`.
+///
+/// Suitable for build-time guard tests: the cert is well-formed enough
+/// to pass `peer_tls::build_peer_tls` dry-validation, which is all the
+/// `peer_tls.is_some()` arm of the guard needs.
+pub fn write_peer_pems(
+    dir: &std::path::Path,
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+
+    let ca_key = KeyPair::generate().unwrap();
+    let mut ca_params = CertificateParams::new(vec!["tso-peer-ca".into()]).unwrap();
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+    let node_key = KeyPair::generate().unwrap();
+    let node_params = CertificateParams::new(vec!["127.0.0.1".into()]).unwrap();
+    let node_cert = node_params.signed_by(&node_key, &ca_cert, &ca_key).unwrap();
+
+    let cert_path = dir.join("peer.crt");
+    let key_path = dir.join("peer.key");
+    let ca_path = dir.join("peer-ca.crt");
+    std::fs::write(&cert_path, node_cert.pem()).unwrap();
+    std::fs::write(&key_path, node_key.serialize_pem()).unwrap();
+    std::fs::write(&ca_path, ca_cert.pem()).unwrap();
+    (cert_path, key_path, ca_path)
+}

--- a/crates/tsoracle-standalone/tests/openraft_membership.rs
+++ b/crates/tsoracle-standalone/tests/openraft_membership.rs
@@ -79,6 +79,7 @@ async fn add_learner_promote_then_remove() {
         peer_tls: None,
         admin_listen: None,
         admin_tls: None,
+        allow_insecure_peer: false,
     }))
     .await
     .expect("build node 1");
@@ -106,6 +107,7 @@ async fn add_learner_promote_then_remove() {
         peer_tls: None,
         admin_listen: None,
         admin_tls: None,
+        allow_insecure_peer: false,
     }))
     .await
     .expect("build node 2");
@@ -193,6 +195,7 @@ async fn admin_grpc_list_and_add_learner() {
         peer_tls: None,
         admin_listen: Some(admin_addr),
         admin_tls: None,
+        allow_insecure_peer: false,
     }))
     .await
     .expect("build node 1");
@@ -220,6 +223,7 @@ async fn admin_grpc_list_and_add_learner() {
         peer_tls: None,
         admin_listen: None,
         admin_tls: None,
+        allow_insecure_peer: false,
     }))
     .await
     .expect("build node 2");
@@ -292,6 +296,7 @@ async fn coexisting_learner_survives_a_promote() {
         peer_tls: None,
         admin_listen: None,
         admin_tls: None,
+        allow_insecure_peer: false,
     }))
     .await
     .expect("build node 1");
@@ -319,6 +324,7 @@ async fn coexisting_learner_survives_a_promote() {
             peer_tls: None,
             admin_listen: None,
             admin_tls: None,
+            allow_insecure_peer: false,
         }))
     };
     drop(lease2);
@@ -411,6 +417,7 @@ async fn admin_insecure_routable_bind_rejected_at_build() {
         peer_tls: None,
         admin_listen: Some(routable),
         admin_tls: None,
+        allow_insecure_peer: false,
     };
 
     let err = match build(DriverConfig::Openraft(cfg)).await {
@@ -480,6 +487,7 @@ async fn shared_ca_for_peer_and_admin_rejected_at_build() {
             key: key_path,
             ca: ca_path,
         }),
+        allow_insecure_peer: false,
     };
 
     let err = match build(DriverConfig::Openraft(cfg)).await {
@@ -574,6 +582,7 @@ async fn admin_mtls_listener_serves_with_matching_client_cert() {
         peer_tls: None,
         admin_listen: Some("127.0.0.1:0".parse().unwrap()),
         admin_tls: Some(admin_tls),
+        allow_insecure_peer: false,
     };
 
     let node = build(DriverConfig::Openraft(cfg))
@@ -652,6 +661,7 @@ async fn admin_mtls_listener_rejects_no_client_cert() {
         peer_tls: None,
         admin_listen: Some("127.0.0.1:0".parse().unwrap()),
         admin_tls: Some(admin_tls),
+        allow_insecure_peer: false,
     };
 
     let node = build(DriverConfig::Openraft(cfg)).await.unwrap();

--- a/deploy/charts/tsoracle/templates/statefulset.yaml
+++ b/deploy/charts/tsoracle/templates/statefulset.yaml
@@ -66,6 +66,10 @@ spec:
             - name: CLIENT_MTLS
               value: {{ .Values.tls.clientMtls | quote }}
             {{- end }}
+            {{- if and (ne .Values.driver "file") (not .Values.tls.enabled) .Values.tls.allowInsecurePeer }}
+            - name: ALLOW_INSECURE_PEER
+              value: "true"
+            {{- end }}
           ports:
             - name: peer
               containerPort: {{ .Values.ports.peer }}

--- a/deploy/charts/tsoracle/tests/render.sh
+++ b/deploy/charts/tsoracle/tests/render.sh
@@ -47,6 +47,22 @@ fi
 helm template t "$chart" --set driver=openraft,tls.allowInsecurePeer=true | grep -q "kind: NetworkPolicy" \
     || { echo "allowInsecurePeer: NetworkPolicy not emitted"; exit 1; }
 
+# opt-out: allowInsecurePeer also injects ALLOW_INSECURE_PEER env (Task 6: chart -> binary pass-through)
+helm template t "$chart" --set driver=openraft,tls.allowInsecurePeer=true | grep -q "ALLOW_INSECURE_PEER" \
+    || { echo "allowInsecurePeer: ALLOW_INSECURE_PEER env not injected (openraft)"; exit 1; }
+helm template t "$chart" --set driver=paxos,tls.allowInsecurePeer=true | grep -q "ALLOW_INSECURE_PEER" \
+    || { echo "allowInsecurePeer: ALLOW_INSECURE_PEER env not injected (paxos)"; exit 1; }
+
+# TLS enabled MUST suppress ALLOW_INSECURE_PEER injection (TLS path wins; opt-out would be a no-op or mask a bad Secret)
+if helm template t "$chart" --set driver=openraft,tls.enabled=true,tls.secretName=certs,tls.allowInsecurePeer=true | grep -q "ALLOW_INSECURE_PEER"; then
+    echo "tls.enabled=true must suppress ALLOW_INSECURE_PEER env"; exit 1
+fi
+
+# file driver has no peer surface; ALLOW_INSECURE_PEER must never be injected
+if helm template t "$chart" --set driver=file,replicas=1,tls.allowInsecurePeer=true | grep -q "ALLOW_INSECURE_PEER"; then
+    echo "file driver must not inject ALLOW_INSECURE_PEER"; exit 1
+fi
+
 # networkPolicy.enabled=false suppresses the policy
 if helm template t "$chart" --set driver=openraft,tls.allowInsecurePeer=true,networkPolicy.enabled=false | grep -q "kind: NetworkPolicy"; then
     echo "networkPolicy.enabled=false still emitted a NetworkPolicy"; exit 1

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -23,6 +23,11 @@ if [ -n "${TLS_DIR:-}" ] && [ -f "${TLS_DIR}/tls.crt" ]; then
     peer_tls="--peer-tls-cert ${TLS_DIR}/tls.crt --peer-tls-key ${TLS_DIR}/tls.key --peer-tls-ca ${TLS_DIR}/ca.crt"
 fi
 
+allow_insecure_peer=""
+if [ -z "${TLS_DIR:-}" ] && [ "${ALLOW_INSECURE_PEER:-false}" = "true" ]; then
+    allow_insecure_peer="--allow-insecure-peer"
+fi
+
 # Server knobs common to every serve subcommand (the bin reads --log as its
 # tracing filter; RUST_LOG is not consulted).
 : "${WINDOW_AHEAD:=3s}"
@@ -76,7 +81,7 @@ openraft|paxos)
             --listen "0.0.0.0:${TSO_PORT}" \
             --admin-listen "127.0.0.1:${ADMIN_PORT}" \
             --raft-dir "${DATA_DIR}/raft" \
-            $peer_tls $client_tls $common $bootstrap
+            $peer_tls $client_tls $common $bootstrap $allow_insecure_peer
     else
         # shellcheck disable=SC2086
         exec tsoracle serve paxos \
@@ -86,7 +91,7 @@ openraft|paxos)
             --peers "$peers" \
             --tso-peers "$tso_peers" \
             --data-dir "${DATA_DIR}" \
-            $peer_tls $client_tls $common
+            $peer_tls $client_tls $common $allow_insecure_peer
     fi
     ;;
 *)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -62,6 +62,7 @@ helm install tso oci://ghcr.io/prisma-risk/charts/tsoracle \
 | `tls.enabled` | `false` | Enable TLS on the client-facing gRPC port. Requires `tls.secretName` to be set. |
 | `tls.secretName` | `""` | Name of a Kubernetes Secret containing `tls.crt`, `tls.key`, and `ca.crt`. |
 | `tls.clientMtls` | `false` | Require client certificates on the API port (mutual TLS). Only meaningful when `tls.enabled=true`. |
+| `tls.allowInsecurePeer` | `false` | HA drivers (`openraft`, `paxos`) refuse to render with `tls.enabled=false` unless this is set. Setting it injects `ALLOW_INSECURE_PEER=true` into the container env, which the entrypoint translates to `--allow-insecure-peer` on the binary — opting out the peer-listener secure-by-default guard at both render and runtime. See [Peer-port trust boundary](operations.md#peer-port-trust-boundary). |
 | `server.windowAhead` | `1s` | How far ahead the allocator extends the high-water on each window extension. See [Sizing window_ahead](operations.md#sizing-window_ahead). |
 | `server.failoverAdvance` | `1s` | How far past `serving_floor` the failover fence advances the high-water on leadership gain. See [Sizing failover_advance](operations.md#sizing-failover_advance). |
 | `server.logLevel` | `info` | Log level passed to the server (`error`, `warn`, `info`, `debug`, `trace`). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -62,7 +62,7 @@ helm install tso oci://ghcr.io/prisma-risk/charts/tsoracle \
 | `tls.enabled` | `false` | Enable TLS on the client-facing gRPC port. Requires `tls.secretName` to be set. |
 | `tls.secretName` | `""` | Name of a Kubernetes Secret containing `tls.crt`, `tls.key`, and `ca.crt`. |
 | `tls.clientMtls` | `false` | Require client certificates on the API port (mutual TLS). Only meaningful when `tls.enabled=true`. |
-| `tls.allowInsecurePeer` | `false` | HA drivers (`openraft`, `paxos`) refuse to render with `tls.enabled=false` unless this is set. Setting it injects `ALLOW_INSECURE_PEER=true` into the container env, which the entrypoint translates to `--allow-insecure-peer` on the binary — opting out the peer-listener secure-by-default guard at both render and runtime. See [Peer-port trust boundary](operations.md#peer-port-trust-boundary). |
+| `tls.allowInsecurePeer` | `false` | Required to render HA drivers (`openraft`, `paxos`) with `tls.enabled=false`. Opts out the peer-listener secure-by-default guard at both render and runtime. See [Peer-port trust boundary](operations.md#peer-port-trust-boundary). |
 | `server.windowAhead` | `1s` | How far ahead the allocator extends the high-water on each window extension. See [Sizing window_ahead](operations.md#sizing-window_ahead). |
 | `server.failoverAdvance` | `1s` | How far past `serving_floor` the failover fence advances the high-water on leadership gain. See [Sizing failover_advance](operations.md#sizing-failover_advance). |
 | `server.logLevel` | `info` | Log level passed to the server (`error`, `warn`, `info`, `debug`, `trace`). |

--- a/docs/interface-reference.md
+++ b/docs/interface-reference.md
@@ -230,7 +230,7 @@ Common flags (above), plus:
 | Flag | Type | Default | Meaning |
 |---|---|---|---|
 | `--id` | `u64` | *required* | This node's numeric raft id. Must be unique across the cluster. |
-| `--raft-addr` | `SocketAddr` | *required* | Bind address for the raft peer transport (consensus traffic). **Plaintext and unauthenticated unless `--peer-tls-*` is set.** |
+| `--raft-addr` | `SocketAddr` | *required* | Bind address for the raft peer transport (consensus traffic). Plaintext on loopback; routable bind requires the `--peer-tls-*` triple or `--allow-insecure-peer`. See [Peer-port trust boundary](operations.md#peer-port-trust-boundary). |
 | `--raft-dir` | path | *required* | Directory for raft log + state-machine data. Persisted across restarts. |
 | `--bootstrap` | bool | `false` | Initialize the cluster on this node, first boot only. Used exactly once per cluster lifetime. |
 | `--members` | string | — | Initial membership, **only valid with `--bootstrap`**. Format: `id=raft_host:port/service_host:port/admin_host:port,...`. |
@@ -244,6 +244,7 @@ Common flags (above), plus:
 | `--peer-tls-cert` | path | — | PEM node certificate for the peer transport. Enables peer mTLS — needs all three `--peer-tls-*` flags. |
 | `--peer-tls-key` | path | — | PEM private key paired with `--peer-tls-cert`. |
 | `--peer-tls-ca` | path | — | PEM CA used to verify connecting peers. Cluster-dedicated. |
+| `--allow-insecure-peer` | bool | `false` | Opt out of the peer-listener secure-by-default guard. Allows routable bind without `--peer-tls-*`. Matches the helm chart's `tls.allowInsecurePeer`. Intended for single-host dev or service-mesh-terminated mTLS only. |
 
 ### `tsoracle serve paxos`
 
@@ -254,7 +255,7 @@ Common flags (above), plus:
 | Flag | Type | Default | Meaning |
 |---|---|---|---|
 | `--node-id` | `u64` | *required* | This node's OmniPaxos pid. Must be unique across the cluster. |
-| `--peer-listen` | `SocketAddr` | *required* | Bind address for the paxos peer transport. **Plaintext and unauthenticated unless `--peer-tls-*` is set.** |
+| `--peer-listen` | `SocketAddr` | *required* | Bind address for the paxos peer transport. Plaintext on loopback; routable bind requires the `--peer-tls-*` triple or `--allow-insecure-peer`. See [Peer-port trust boundary](operations.md#peer-port-trust-boundary). |
 | `--peers` | string | *required* | Comma-separated `id=host:port` paxos peer addresses. Required at every start, not just bootstrap. |
 | `--tso-peers` | string | *required* | Comma-separated `id=host:port` tsoracle service addresses (per-node `TsoService` ports), used to populate `LeaderHint` for follower redirects. |
 | `--data-dir` | path | *required* | Directory for the paxos log + meta. |
@@ -262,6 +263,7 @@ Common flags (above), plus:
 | `--peer-tls-cert` | path | — | PEM node certificate for the peer transport. Enables peer mTLS — needs all three `--peer-tls-*` flags. |
 | `--peer-tls-key` | path | — | PEM private key paired with `--peer-tls-cert`. |
 | `--peer-tls-ca` | path | — | PEM CA used to verify connecting peers. |
+| `--allow-insecure-peer` | bool | `false` | Opt out of the peer-listener secure-by-default guard. Allows routable bind without `--peer-tls-*`. Matches the helm chart's `tls.allowInsecurePeer`. Intended for single-host dev or service-mesh-terminated mTLS only. |
 
 ### `tsoracle init`
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -99,16 +99,16 @@ The client gives `FAILED_PRECONDITION` special handling: it parses the `tsoracle
 
 Cert and key shapes follow tonic: `ServerTlsConfig::new().identity(Identity::from_pem(cert, key))` for plain TLS; add `.client_ca_root(Certificate::from_pem(ca))` for mTLS.
 
-The stock `tsoracle` CLI exposes `--peer-tls-{cert,key,ca}` for peer mTLS, `--admin-tls-{cert,key,ca}` for the membership-admin gRPC server, and `--tls-cert / --tls-key / --tls-client-ca` for the client-facing gRPC port. See the [HA driver flag tables](../interface-reference.md#tsoracle-serve-openraft) for the per-flag wiring.
+The stock `tsoracle` CLI exposes `--peer-tls-{cert,key,ca}` for peer mTLS, `--admin-tls-{cert,key,ca}` for the membership-admin gRPC server, and `--tls-cert / --tls-key / --tls-client-ca` for the client-facing gRPC port. See the [HA driver flag tables](../interface-reference.md#tsoracle-serve-openraft) for the per-flag wiring. For a runnable wiring example see [`examples/tls-mtls`](../examples/tls-mtls/).
 
 ## Peer-port trust boundary
 
-`tsoracle serve openraft --raft-addr` and `tsoracle serve paxos --peer-listen` bind the consensus peer transport. The binary refuses a routable bind without peer TLS unless explicitly opted-out:
+`tsoracle serve openraft --raft-addr` and `tsoracle serve paxos --peer-listen` bind the consensus peer transport. The binary refuses a routable bind without peer TLS unless the operator explicitly sets `--allow-insecure-peer`:
 
-- **Loopback** (`127.0.0.0/8`, `::1`) — plaintext allowed. Intended for local-dev and same-pod sidecar callers.
-- **Routable** without `--peer-tls-{cert,key,ca}` — rejected at startup with `PeerInsecureRoutable` before storage is opened.
+- **Loopback** (`127.0.0.0/8`, `::1/128`) — plaintext allowed. Intended for local-dev and same-pod sidecar callers.
+- **Routable** without `--peer-tls-{cert,key,ca}` — rejected at startup with `PeerInsecureRoutable` before the data directory is created.
 - **Routable** with `--peer-tls-{cert,key,ca}` — peer mTLS; the cluster CA is the trust root for both directions.
-- **Routable** with `--allow-insecure-peer` — the secure-by-default guard is opted out. A `tracing::warn!` line emits at startup naming the bind address. Intended only for single-host dev or deployments where peer security is terminated out-of-band (e.g. a service mesh's pod-to-pod mTLS, or a strict NetworkPolicy + dedicated CNI).
+- **Routable** with `--allow-insecure-peer` — the secure-by-default guard is opted out. A startup warning is logged with the bind address: `peer listener bound without TLS via --allow-insecure-peer; relying on out-of-band transport security`. Intended only for single-host dev or deployments where peer security is terminated out-of-band (e.g. a service mesh's pod-to-pod mTLS, or a strict NetworkPolicy + dedicated CNI).
 
 ### Helm chart composition
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -99,4 +99,22 @@ The client gives `FAILED_PRECONDITION` special handling: it parses the `tsoracle
 
 Cert and key shapes follow tonic: `ServerTlsConfig::new().identity(Identity::from_pem(cert, key))` for plain TLS; add `.client_ca_root(Certificate::from_pem(ca))` for mTLS.
 
-The stock `tsoracle` CLI does not currently expose TLS flags. If you need TLS today, embed the library — see [`examples/tls-mtls`](../examples/tls-mtls/) for a runnable starting point.
+The stock `tsoracle` CLI exposes `--peer-tls-{cert,key,ca}` for peer mTLS, `--admin-tls-{cert,key,ca}` for the membership-admin gRPC server, and `--tls-cert / --tls-key / --tls-client-ca` for the client-facing gRPC port. See the [HA driver flag tables](../interface-reference.md#tsoracle-serve-openraft) for the per-flag wiring.
+
+## Peer-port trust boundary
+
+`tsoracle serve openraft --raft-addr` and `tsoracle serve paxos --peer-listen` bind the consensus peer transport. The binary refuses a routable bind without peer TLS unless explicitly opted-out:
+
+- **Loopback** (`127.0.0.0/8`, `::1`) — plaintext allowed. Intended for local-dev and same-pod sidecar callers.
+- **Routable** without `--peer-tls-{cert,key,ca}` — rejected at startup with `PeerInsecureRoutable` before storage is opened.
+- **Routable** with `--peer-tls-{cert,key,ca}` — peer mTLS; the cluster CA is the trust root for both directions.
+- **Routable** with `--allow-insecure-peer` — the secure-by-default guard is opted out. A `tracing::warn!` line emits at startup naming the bind address. Intended only for single-host dev or deployments where peer security is terminated out-of-band (e.g. a service mesh's pod-to-pod mTLS, or a strict NetworkPolicy + dedicated CNI).
+
+### Helm chart composition
+
+The Helm chart's `tls.allowInsecurePeer` value gates **both** layers:
+
+- **Render-time:** `_helpers.tpl` refuses to render a HA driver with `tls.enabled=false` unless `tls.allowInsecurePeer=true` is also set.
+- **Runtime:** when both `tls.enabled=false` and `tls.allowInsecurePeer=true`, the statefulset injects `ALLOW_INSECURE_PEER=true` into the container env, and `entrypoint.sh` translates that to `--allow-insecure-peer` on the binary's argv.
+
+A single intentional opt-in carries through to both layers; the chart will never render a configuration that the binary then crashes on.

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -110,6 +110,7 @@ async fn main() -> Result<()> {
         peer_tls,
         admin_listen: None,
         admin_tls: None,
+        allow_insecure_peer: false,
     });
     let mut node = build(cfg).await?;
     let drain = node.take_drain();

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -72,6 +72,7 @@ async fn main() -> Result<()> {
         data_dir: cli.data_dir,
         tick_interval: Duration::from_millis(20),
         peer_tls,
+        allow_insecure_peer: false,
     });
     let mut node = build(cfg).await?;
     let drain = node.take_drain();


### PR DESCRIPTION
## Summary

Closes #481. Adds a binary-layer secure-by-default guard rejecting routable `--raft-addr` (openraft) / `--peer-listen` (paxos) binds without peer TLS, mirroring the existing `AdminInsecureRoutable` guard at the admin port. Introduces `--allow-insecure-peer` opt-out plumbed end-to-end from the Helm chart's `tls.allowInsecurePeer` value, so a single intentional opt-in carries through both render-time and runtime layers (the chart will never render a configuration that the binary then crashes on).

**Binary changes**
- New `StandaloneError::PeerInsecureRoutable { addr: SocketAddr }` variant.
- `allow_insecure_peer: bool` field on `OpenraftConfig` and `PaxosConfig` (file driver unchanged — no peer surface).
- Nested guard in both `drivers/{openraft,paxos}/mod.rs`: dry-builds peer TLS first (bad PEM surfaces as `Tls`), runs **before** `open_rocksdb` / socket bind, fail-closed without TLS + opt-out, `tracing::warn!` on opt-out.
- New `--allow-insecure-peer` CLI flag on both HA `serve` subcommands; help text on `--raft-addr` / `--peer-listen` revised to point at the guard.

**Chart changes**
- `statefulset.yaml`: conditional `ALLOW_INSECURE_PEER=true` env, triple-guarded on `driver != file AND not tls.enabled AND tls.allowInsecurePeer`.
- `entrypoint.sh`: translates env to `--allow-insecure-peer` argv on both HA arms; file arm untouched. TLS material present always wins (the shell guard requires `TLS_DIR` to be unset).
- `tests/render.sh`: new assertions that the env injects in the opt-in cell and does NOT inject when TLS is on or when driver is file.

**Docs**
- `operations.md`: new `## Peer-port trust boundary` section (4 cases + Helm chart composition subsection); deletes the obsolete "stock CLI does not currently expose TLS flags" paragraph (false since #438).
- `interface-reference.md`: revised `--raft-addr` / `--peer-listen` rows; new `--allow-insecure-peer` rows in both HA flag tables.
- `deployment.md`: `tls.allowInsecurePeer` row added to the values table.

**Design notes**
- Auto-pass-through of the chart's `tls.allowInsecurePeer` value to the binary's `--allow-insecure-peer` flag. Splitting the knob would imply asymmetric cases that have no operational use (chart-render-only opt-out → CrashLoopBackOff; runtime-only opt-out → unreachable, chart blocks render at `_helpers.tpl:12`).
- The openraft guard required lifting the existing `let peer_tls = match cfg.peer_tls { … }` from line 210 to alongside the admin guard so the guard runs before storage open; paxos already built peer_tls at the top so no lift was needed.

Spec: `docs/superpowers/specs/2026-05-26-peer-listener-secure-by-default-design.md`

## Test Plan

- [x] `cargo test --workspace --all-features` — all suites pass (incl. 8 new build-time guard tests in `tests/build_in_process.rs`, 4 per driver: routable-rejected, loopback-allowed, TLS-allowed, opt-out-honored).
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean.
- [x] `sh deploy/charts/tsoracle/tests/render.sh` — passes, including new env-injection assertions.
- [x] Manual end-to-end smoke (`tsoracle serve openraft --raft-addr 0.0.0.0:9700 …`): without `--allow-insecure-peer`, exits with `PeerInsecureRoutable` and the `raft_dir` stays empty (guard runs before storage open). Adding `--allow-insecure-peer` lets it start with a visible `WARN peer listener bound without TLS via --allow-insecure-peer; relying on out-of-band transport security addr=0.0.0.0:9700`.
- [x] `helm template` of the `tls.enabled=false, tls.allowInsecurePeer=true` cell injects `ALLOW_INSECURE_PEER=true`; `tls.enabled=true` and `driver=file` both suppress the env.

## Known pre-existing (not introduced by this branch)

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` fails with 6 stale intra-doc-link errors in `tsoracle-driver-openraft`, `tsoracle-openraft-toolkit`, `tsoracle-server-testkit`, and `examples/paxos-piggyback`. The same errors occur on `main`; this branch touches none of those files. Worth a follow-up PR.