### PR TITLE
docs(security): document the SLSA-generator tag-ref exception

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -181,11 +181,11 @@ jobs:
     # Instead the generator emits the .intoto.jsonl as a workflow artifact,
     # and the attach job below uploads it alongside the .crate + .sha256
     # via `gh release upload`, which only touches asset slots (mutation-safe).
-    # SLSA generator does NOT support SHA pins. Its generate-builder.sh
-    # parses the calling ref expecting `refs/tags/vX.Y.Z`, fails with
-    # "Invalid ref: <sha>" otherwise. Integrity is anchored upstream by a
-    # hardcoded SHA256 of the generator binary baked into the workflow at
-    # each tagged release. Bump this tag intentionally; do not SHA-pin.
+    # SLSA generator does NOT support SHA pins (its generate-builder.sh
+    # rejects refs that don't match refs/tags/vX.Y.Z, exit 2). Tag ref is
+    # intentional and matches what scorecard's own goreleaser.yaml does.
+    # Full rationale + upstream issue links: SECURITY.md "Documented
+    # exception" section. Bump this tag intentionally; do not SHA-pin.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.subjects }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,24 @@ Out of scope:
 - Vulnerabilities that require a pre-compromised host, root on the same machine as the server, or physical access.
 - Denial-of-service vectors that require unbounded resources beyond what a well-provisioned operator would allow.
 
+## Supply chain integrity
+
+Releases ship with [SLSA v1.0 build provenance](docs/release-signatures.md) signed transparently through Sigstore (Fulcio + Rekor). The `.intoto.jsonl` attestation attached to each GitHub Release proves that the `.crate` came from this repository's CI, at the commit pointed at by the release tag, on GitHub-hosted runners.
+
+Every GitHub Action and reusable workflow in `.github/workflows/` is pinned to a full commit SHA, with the human-readable version in a trailing comment — with one documented exception.
+
+### Documented exception: `slsa-framework/slsa-github-generator`
+
+The SLSA generic generator's reusable workflow (`.github/workflows/release-sign.yml`) is referenced by tag (`@v2.1.0`) rather than by commit SHA. This is intentional and unavoidable:
+
+- The generator's `generate-builder.sh` script validates the calling ref against `refs/tags/vX.Y.Z` and exits 2 with `Invalid ref: <sha>. Expected ref of the form refs/tags/vX.Y.Z` when SHA-pinned. The builder binary is fetched from the GitHub release matching the tag — there is no equivalent operation keyed on a commit SHA.
+- Upstream tracks this constraint in [slsa-github-generator#722](https://github.com/slsa-framework/slsa-github-generator/issues/722) and [slsa-verifier#12](https://github.com/slsa-framework/slsa-verifier/issues/12); the [SLSA README](https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators) acknowledges this departs from GitHub's general best practice.
+- OpenSSF Scorecard's `Pinned-Dependencies` check ([#2174](https://github.com/ossf/scorecard/issues/2174), closed-completed) flags this single line. There is no in-line suppression mechanism; a policy-file allowlist is tracked as [scorecard#1406](https://github.com/ossf/scorecard/issues/1406).
+
+We accept the resulting ~1-point deduction on Pinned-Dependencies. The Scorecard project itself uses the same tag-ref pattern in its own [`goreleaser.yaml`](https://github.com/ossf/scorecard/blob/main/.github/workflows/goreleaser.yaml) for the same reason.
+
+Integrity for the SLSA generator is anchored differently from typical actions: the SHA-256 of the generator binary is hardcoded into the reusable workflow at each tagged release, so the tag itself is the security boundary. Dependabot is configured to bump the tag when a new SLSA generator release lands.
+
 ## Public disclosure
 
 Once a fix is released, we will publish the advisory with credit to the reporter and a CVE identifier (requested via GitHub's CNA when the impact warrants one).


### PR DESCRIPTION
## Summary

OpenSSF Scorecard's \`Pinned-Dependencies\` check flags \`.github/workflows/release-sign.yml:189\` for using a tag ref on the SLSA reusable workflow:

> third-party GitHubAction not pinned by hash

This is unavoidable: the SLSA generator's \`generate-builder.sh\` explicitly rejects SHA pins (exit 2, \`Invalid ref: <sha>. Expected ref of the form refs/tags/vX.Y.Z\`). Two upstream OpenSSF projects with overlapping mandates are at impasse — neither offers a clean resolution.

Researched what other projects do; the community pattern is unambiguous: **accept the ~1-point Pinned-Dependencies deduction**. Scorecard itself uses the same tag-ref pattern in its own [\`goreleaser.yaml\`](https://github.com/ossf/scorecard/blob/main/.github/workflows/goreleaser.yaml).

## Changes

- **SECURITY.md**: new \"Supply chain integrity\" section that
  - describes the SLSA v1.0 build provenance shipped per release (links to existing \`docs/release-signatures.md\` verification recipe),
  - documents the SLSA generator tag-ref exception with upstream issue links ([slsa-github-generator#722](https://github.com/slsa-framework/slsa-github-generator/issues/722), [slsa-verifier#12](https://github.com/slsa-framework/slsa-verifier/issues/12), [scorecard#2174](https://github.com/ossf/scorecard/issues/2174), [scorecard#1406](https://github.com/ossf/scorecard/issues/1406)),
  - notes that scorecard's own project uses the same pattern as canonical precedent.
- **\`.github/workflows/release-sign.yml\`**: tightens the inline comment at the SLSA \`uses:\` line to point at SECURITY.md rather than duplicating the rationale.

## Score impact

- Signed-Releases stays 10/10 (this is purely documentation).
- Pinned-Dependencies still shows the one finding; that's expected and now auditable to the SECURITY.md section.

## Test plan

- [ ] PR merges cleanly (no functional changes to the workflow).
- [ ] On next Scorecard run, the Pinned-Dependencies finding on line 189 is the only one — confirms no other regressions snuck in.