### PR TITLE
docs: governance, roadmap, assurance case, contributor onboarding (OpenSSF Silver PR 1/3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,21 @@ You'll also need:
 - **[`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny)** (optional) — CI runs `cargo deny check` against [`deny.toml`](deny.toml) to enforce the license allow-list and advisory policy.
 - **[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)** (optional, only needed to reproduce coverage locally) — CI runs `cargo llvm-cov` and uploads the resulting `lcov.info` to [Coveralls](https://coveralls.io/github/prisma-risk/tsoracle). Install with `cargo install cargo-llvm-cov`. Coverage is reported only — the build does not fail on a coverage drop.
 
+## Where to start
+
+If you're new to the project, a few entry points:
+
+- Issues labeled [`good first issue`](https://github.com/prisma-risk/tsoracle/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are small, well-scoped, and don't require deep context on the consensus internals.
+- Issues labeled [`help wanted`](https://github.com/prisma-risk/tsoracle/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are larger but maintainer-flagged as places where outside help is welcome.
+
+Three areas that frequently have well-bounded contribution opportunities:
+
+1. **Documentation polish** — fixing broken links in `docs/`, clarifying CLI examples, expanding `getting-started.md` for additional platforms.
+2. **Additional fuzz targets** — the harnesses under [`fuzz/fuzz_targets/`](fuzz/fuzz_targets/) focus on decoder paths; new targets exercising codec roundtrips or protocol invariants are welcome.
+3. **Additional integration tests** — tests under `crates/*/tests/` are composable; new scenarios exercising specific fault patterns (network jitter, slow disks, partial partitions) add coverage without requiring driver-internal changes.
+
+If you have an idea outside these areas, open a discussion issue first to confirm direction before investing time.
+
 ## Workspace layout
 
 The repo is a Cargo workspace. The crates under `crates/` are:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,103 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Governance
+
+This document describes how the tsoracle project is governed. It is the canonical reference for project roles, decision-making, and continuity of access. It supplements (and does not replace) [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), and [`SECURITY.md`](SECURITY.md).
+
+## 1. Mission
+
+tsoracle is an Apache-2.0 timestamp oracle providing strictly monotonic, linearizable timestamps backed by pluggable consensus drivers (openraft, paxos). See [`README.md`](README.md) for the full value proposition.
+
+## 2. Project structure
+
+- **Source repository**: <https://github.com/prisma-risk/tsoracle> — monorepo, Cargo workspace.
+- **Crate registry**: each workspace crate publishes independently to <https://crates.io>.
+- **Container registry**: images are published to `ghcr.io/prisma-risk/tsoracle*`.
+- **Documentation site**: <https://www.tsoracle.rs> (deployed by the `pages.yml` workflow on every push to `main`).
+
+## 3. Roles and responsibilities
+
+### 3.1 Maintainer
+
+The maintainer holds final design, merge, and release authority.
+
+- Currently: **Sebastian Thiebaud** (`@sebastianthiebaud`, <sebastian@prismarisk.com>).
+- Authorities and responsibilities:
+  - Final design and merge authority on all PRs.
+  - `crates.io` release authority (per workspace crate).
+  - `ghcr.io` image release authority.
+  - Security advisory authority (CVE coordination via the GitHub CNA, per [`SECURITY.md`](SECURITY.md)).
+  - Code-of-Conduct enforcement, except where the maintainer is involved in the report — see §6.
+
+### 3.2 Reviewer
+
+Anyone listed in [`.github/CODEOWNERS`](.github/CODEOWNERS). The maintainer is currently the only code owner. As outside contributors land sustained substantive PRs, the maintainer will invite them to `CODEOWNERS` for the area they contribute to.
+
+Reviewer authority: approve PRs, request changes, request additional review.
+
+### 3.3 Contributor
+
+Anyone opening a PR. Contributor responsibilities:
+
+- Follow [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- Sign off on commits per the project's Developer Certificate of Origin (see CONTRIBUTING.md "Developer Certificate of Origin" section).
+- Accept Apache-2.0 inbound = outbound licensing.
+
+## 4. Decision-making
+
+### 4.1 Day-to-day
+
+PRs are decided by the maintainer with CI required-checks gating merge. Substantive design changes (new crate, protocol change, breaking change) should be initiated by opening an issue at <https://github.com/prisma-risk/tsoracle/issues> to discuss the approach **before** submitting a pull request, so the design conversation happens up front rather than as back-and-forth on a PR whose implementation is already done.
+
+### 4.2 Contentious decisions
+
+Lazy consensus on the issue or PR thread. If consensus cannot be reached, the maintainer breaks the tie and records the rationale on the thread.
+
+### 4.3 Security decisions
+
+Follow [`SECURITY.md`](SECURITY.md): 24h acknowledgment, 72h triage, ≤30d coordinated disclosure, CVE via the GitHub CNA when impact warrants. The maintainer is the single point of decision; the secondary contact (§6) is informed.
+
+### 4.4 Releases
+
+Releases are automated via release-plz on every `feat:`/`fix:`/`perf:` merge to `main`. The maintainer is the trust root for the `crates.io` owner and `ghcr.io` push credentials. Release tags are annotated and signed via Sigstore gitsign (keyless, transparency-log anchored); see [`docs/release-signatures.md`](docs/release-signatures.md).
+
+## 5. Becoming a maintainer
+
+Path: sustained substantive contributions (typically ≥6 months, ≥10 non-trivial PRs in code, docs, or test infrastructure) plus alignment with project direction. The current maintainer invites by issue or PR discussion. Once designated, the new maintainer is added to:
+
+- [`.github/CODEOWNERS`](.github/CODEOWNERS) for the relevant areas (or `*` for full).
+- The GitHub repository admin team.
+- `crates.io` owners for the crates they will publish.
+- The continuity-of-access section (§6) below.
+
+## 6. Continuity of access
+
+This section is the canonical list of credential surfaces. Each row names who holds it today and who can recover it if the holder becomes unavailable.
+
+| Credential surface | Holder | Backup / recovery path |
+| --- | --- | --- |
+| `github.com/prisma-risk` organization admin | Sebastian Thiebaud (<sebastian@prismarisk.com>) | Charles Merill (<charles@prismarisk.com>) |
+| `crates.io` owners — `tsoracle` and all workspace crates | Sebastian Thiebaud | Owner-add by the holder; team-owner addition planned. Recovery via `crates.io` support if the holder is unreachable. |
+| `ghcr.io/prisma-risk` package maintainers | Members of the `prisma-risk` org with `write` permission | GitHub org admin can add members. |
+| Sigstore signing identity (release SLSA provenance and tag signing) | Per-workflow OIDC token (no long-lived key) | No recovery needed — keyless. |
+| GitHub Pages deployment / DNS for `tsoracle.rs` | GitHub Pages + the DNS provider account | DNS recovery via the domain registrar (account held by maintainer). |
+
+### 6.1 Secondary contact
+
+**Charles Merill** (<charles@prismarisk.com>) is the designated secondary contact. The secondary contact:
+
+- Holds read-only access to the credential inventory above (the specific mechanism — shared password manager vault — is recorded outside the repository).
+- Acts as the Code-of-Conduct escalation point for conflicts involving the maintainer.
+- Is not currently an active maintainer (does not review PRs or cut releases). The OpenSSF `bus_factor` criterion is about active maintainership, not access continuity, and is therefore not considered met by this designation alone.
+
+### 6.2 If the maintainer becomes unavailable
+
+1. The secondary contact (§6.1) opens an issue at <https://github.com/prisma-risk/tsoracle/issues> titled "Maintainer transition" referencing this document.
+2. GitHub Support is asked to transfer organization admin per the inactive-account-recovery policy (<https://docs.github.com/en/site-policy/other-site-policies/github-inactive-account-policy>) if the maintainer is unreachable for more than 90 days.
+3. `crates.io` owners are added via the existing owner's `cargo owner --add`, or via `crates.io` support if no existing owner can act.
+4. `ghcr.io` packages are migrated via GitHub Container Registry org admin.
+5. A new release with the transition announcement is published; the project README and SECURITY.md are updated with the new primary contact.
+
+## 7. Document maintenance
+
+- Roles and continuity details are reviewed at every major release (≥0.X feature releases) and when any credential surface changes.
+- Changes to this document are made via PR like any other code change.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ tsoracle is a small, embeddable Rust implementation. The consensus layer is left
 - [DeepWiki](https://deepwiki.com/prisma-risk/tsoracle) — prose documentation covering the window allocator, the `ConsensusDriver` contract, and operational topics (fsync cost, leader handoff, deployment topologies).
 - [docs.rs/tsoracle-server](https://docs.rs/tsoracle-server) — generated API reference.
 
+## Project documents
+
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — Contributor Covenant v2.1.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to contribute, including the DCO sign-off requirement.
+- [`GOVERNANCE.md`](GOVERNANCE.md) — roles, decision-making, and continuity-of-access plan.
+- [`ROADMAP.md`](ROADMAP.md) — near / mid / long-term direction.
+- [`SECURITY.md`](SECURITY.md) — vulnerability reporting and response commitments.
+- [`docs/assurance-case.md`](docs/assurance-case.md) — safety and security claims with supporting evidence.
+- [`docs/release-signatures.md`](docs/release-signatures.md) — verifying release provenance and signed tags.
+
 ## Examples
 
 - [examples/embedded-server](examples/embedded-server) — embed `tsoracle-server` with the file driver in your own binary, with graceful shutdown.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,51 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Roadmap
+
+Last updated: 2026-05-26.
+
+This roadmap captures direction at three horizons. Specific issues track in <https://github.com/prisma-risk/tsoracle/issues>; this document is the narrative arc.
+
+## Near term (0–3 months)
+
+### OpenSSF Best Practices — closing Silver fixable gaps
+
+- Land governance documentation (this `ROADMAP.md`, [`GOVERNANCE.md`](GOVERNANCE.md), [`docs/assurance-case.md`](docs/assurance-case.md)).
+- Enable DCO sign-off and refresh CONTRIBUTING.md.
+- Sign release tags via Sigstore gitsign (keyless), matching the existing SLSA provenance signing model.
+- Triage existing issues for `good first issue` / `help wanted` labels.
+- Refresh [`.bestpractices.json`](.bestpractices.json) to flip 9 criteria to Met and refine the remaining 3 organizational criteria with concrete action plans.
+
+### Stability and operations
+
+- Transport-crate extraction: carve per-driver transport out of `tsoracle-standalone` into `tsoracle-transport-openraft` and `tsoracle-transport-paxos`.
+- Wire the mixed-version-soak Job into the kube-e2e orchestration so format-evolution soak runs alongside the existing acceptance lane.
+- Peer-listener secure-by-default in the binary layer (issue [#481](https://github.com/prisma-risk/tsoracle/issues/481)) — mirror the Helm chart's `tls.allowInsecurePeer` guard at the openraft `raft_addr` and paxos `peer_listen` call sites in the binary.
+
+### Contributor onboarding
+
+- Triage existing issues for the `good first issue` / `help wanted` labels.
+- Publish this roadmap on the documentation site (`tsoracle.rs`).
+
+## Mid term (3–12 months)
+
+### OpenSSF Best Practices — Gold
+
+- Branch coverage measurement (`cargo-llvm-cov --branch`) and an ≥80% branch coverage CI gate.
+- Reproducible-build CI lane (diffoscope-driven), gated against Rust toolchain reproducibility maturity upstream.
+- Third-party security review ahead of 1.0.
+
+### Project maturity
+
+- Designate a second active maintainer (not just continuity contact) and update [`GOVERNANCE.md`](GOVERNANCE.md) §6.1 accordingly. This is the prerequisite for flipping `bus_factor` to Met.
+- Enable branch protection `required reviewers ≥ 2` once the second maintainer is active.
+- Continue growing the contributor base; aim for the `contributors_unassociated` criterion.
+
+### Consensus and storage
+
+- File-driver hardening: more failpoint coverage, durability invariants, snapshot-publish correctness audit.
+- Continued zero-downtime format evolution under the framework shipped in PRs #454–#479.
+
+## Long term (12+ months)
+
+- Additional consensus backends (currently file, openraft, paxos — additional backends evaluated on demand).
+- Public conformance suite that downstream operators can run against any tsoracle deployment.

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -1,0 +1,119 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Assurance case
+
+This document presents the project's safety and security claims with their supporting arguments and evidence. It supplements the architectural documentation ([`docs/architecture-deep-dive.md`](architecture-deep-dive.md)) and is structured as a claims → arguments → evidence tree.
+
+It is also the canonical answer to the OpenSSF Best Practices `assurance_case` criterion.
+
+## Claim 1 (Safety): Strict timestamp monotonicity under fault
+
+**Claim**: tsoracle preserves strict monotonicity of allocated timestamps under
+
+- process crashes (any node, any time),
+- network partitions,
+- leader handoff (planned, via the openraft graceful-handoff path; unplanned, via election after failure),
+- rolling restarts (every-pod-restart soak in Kubernetes),
+- mixed-version operation (during in-place format upgrade).
+
+### Argument 1.1: Deterministic in-process integration tests
+
+**Sub-claim**: The monotonicity property holds across all consensus drivers under deterministic test conditions.
+
+**Evidence**:
+
+- [`crates/tsoracle-driver-openraft/tests/`](../crates/tsoracle-driver-openraft/tests/) — single_node, restart_replay, partition_churn, snapshot_restart, and additional scenarios under the same directory.
+- [`crates/tsoracle-server/tests/`](../crates/tsoracle-server/tests/) — server-level integration including `serve_shutdown.rs`, `leader_watch.rs`, `leadership_churn.rs`, `fence_yieldpoint.rs`, and the `e2e.rs` end-to-end harness.
+- [`crates/tsoracle-tests/tests/`](../crates/tsoracle-tests/tests/) — cross-driver integration tests including leadership_churn and client interaction patterns.
+- These run on every PR via the `test` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) with `cargo test --workspace --all-features --locked`.
+
+### Argument 1.2: Real-cluster acceptance + soak with measured error budget
+
+**Sub-claim**: The monotonicity property holds under real Kubernetes failure modes — cold-start, rolling-restart, leader-SIGKILL, add-learner / promote / remove during steady state, mixed-version upgrade.
+
+**Evidence**:
+
+- [`.github/workflows/kube-e2e.yml`](../.github/workflows/kube-e2e.yml) — cold-start and rolling-restart soak against a real `kind` cluster.
+- [`.github/workflows/kube-e2e-mixed-version.yml`](../.github/workflows/kube-e2e-mixed-version.yml) — mixed-version-soak exercising in-place format upgrade under steady-state load.
+- [`e2e/kube/run-assertions.sh`](../e2e/kube/run-assertions.sh) — soak error budget enforcement at 0.05%.
+- The `kube-e2e-driver` crate (in-cluster Job topology) runs the driver from inside the cluster so it can follow leader-hint redirects to pod DNS.
+
+### Argument 1.3: Stress lane with positive-control detector validation
+
+**Sub-claim**: The monotonicity detector itself is verified to fire on a known violation. Absence-of-failure in stress runs therefore implies absence-of-violation, not absence-of-detection.
+
+**Evidence**:
+
+- `stress-smoke` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) — mem, raft, paxos, and process topologies.
+- The `inject-violation` positive-control step in the stress lane must exit `1` to prove the supervisor still catches monotonicity breaks; the CI step fails the job if the detector does not fire.
+- [`.github/workflows/stress-nightly.yml`](../.github/workflows/stress-nightly.yml) — extended stress runs nightly.
+
+### Argument 1.4: Software-fault injection at safety-critical paths
+
+**Sub-claim**: The monotonicity property holds when faults are deliberately injected at identified critical points (lock acquisition order, snapshot publish, fence enter, leader watch, etc.).
+
+**Evidence**:
+
+- [`docs/failpoint-testing.md`](failpoint-testing.md) — the failpoint feature suite, run as `cargo test --workspace --features failpoints`.
+- [`docs/yieldpoint-testing.md`](yieldpoint-testing.md) — the yieldpoint feature suite for deterministic interleaving.
+- Recent regression tests anchored on this scaffolding: barrier-seq durable seed, snapshot publish TOCTOU, WatchGuard drop sync step-down, openraft graceful handoff, paxos lease generation wrap.
+
+### Argument 1.5: Decoder-path fuzzing
+
+**Sub-claim**: Malformed wire input or malformed on-disk records cannot induce a safety-relevant state.
+
+**Evidence**:
+
+- [`fuzz/fuzz_targets/`](../fuzz/fuzz_targets/) — 15 libFuzzer harnesses covering codec roundtrip, log entry decode, openraft entry/meta decode, paxos codec/log/meta-ballot/snapshot decode, proto request/response/leader-hint decode, record decode/roundtrip, snapshot payload decode, toolkit codec decode.
+- [`.github/workflows/fuzz-pr.yml`](../.github/workflows/fuzz-pr.yml) — per-PR fuzz lane.
+- [`.github/workflows/fuzz-nightly.yml`](../.github/workflows/fuzz-nightly.yml) — nightly fuzz lane (30 min per target).
+- Crashes auto-file as GitHub issues with the offending input.
+
+## Claim 2 (Security): No unauthenticated peer/admin RPCs in secure-by-default deployment
+
+**Claim**: tsoracle does not admit unauthenticated peer or admin RPC traffic in its secure-by-default deployment posture.
+
+### Argument 2.1: Helm chart secure-by-default render guard
+
+**Sub-claim**: An operator who installs the default chart cannot accidentally deploy an HA cluster (openraft / paxos) with plaintext peer traffic.
+
+**Evidence**:
+
+- [`deploy/charts/tsoracle/templates/_helpers.tpl`](../deploy/charts/tsoracle/templates/_helpers.tpl) contains a render-guard `fail` block that aborts `helm install` when `.Values.driver` is `openraft` or `paxos`, `tls.enabled` is `false`, and `tls.allowInsecurePeer` is unset.
+- [`deploy/charts/tsoracle/values.yaml`](../deploy/charts/tsoracle/values.yaml) — `tls.allowInsecurePeer` defaults to `false`.
+- The chart's `NOTES.txt` warns operators if `tls.allowInsecurePeer` is explicitly set to `true`.
+- The chart test suite under `deploy/charts/tsoracle/tests/` exercises both the secure-by-default render and the `allowInsecurePeer` opt-out paths.
+
+### Argument 2.2: Admin port `AdminInsecureRoutable` guard
+
+**Sub-claim**: The admin gRPC service refuses to bind to a routable address without TLS.
+
+**Evidence**:
+
+- [`crates/tsoracle-standalone/src/drivers/openraft/mod.rs`](../crates/tsoracle-standalone/src/drivers/openraft/mod.rs) contains the `AdminInsecureRoutable` check (line ~140) that returns an error when the admin listener is configured to bind a non-loopback address without TLS.
+- [`crates/tsoracle-standalone/tests/activation_admin_rpc.rs`](../crates/tsoracle-standalone/tests/activation_admin_rpc.rs) exercises the admin RPC path under mTLS.
+
+### Argument 2.3: Client TLS by default with full verification
+
+**Sub-claim**: The client uses TLS 1.3 with full chain + hostname verification.
+
+**Evidence**:
+
+- `ClientTlsConfig` in the `tsoracle-client` crate accepts operator-supplied certificates and CA roots; it does not provide a hook to disable verification.
+- The project uses rustls's default `ServerCertVerifier` (no custom override); rustls performs full chain validation including SAN / CN hostname match.
+- [`crates/tsoracle-tests/tests/client_tls.rs`](../crates/tsoracle-tests/tests/client_tls.rs) — client TLS integration test.
+
+### Argument 2.4: Open gap — peer-listener secure-by-default in the binary
+
+**Sub-claim (open)**: The Helm chart fails closed, but the binary itself does not yet refuse to bind a plaintext peer listener on a routable interface.
+
+**Evidence and action**:
+
+- Tracked at issue [#481](https://github.com/prisma-risk/tsoracle/issues/481).
+- Action: mirror the admin `AdminInsecureRoutable` guard for openraft `raft_addr` and paxos `peer_listen`, gated by an `--allow-insecure-peer` flag matching the chart's `tls.allowInsecurePeer` opt-out.
+- Until this lands, defense-in-depth is provided by the chart guard (Argument 2.1) and operator NetworkPolicy.
+
+## How this document is maintained
+
+- Every PR that touches a safety- or security-critical path updates the relevant Argument section with the new evidence link.
+- The Claim list is not modified without an issue at <https://github.com/prisma-risk/tsoracle/issues> first to discuss the change.
+- This document is reviewed at every major release (≥0.X feature releases) to confirm evidence links still resolve.


### PR DESCRIPTION
## Summary

- Add `GOVERNANCE.md` — project mission, roles (maintainer, reviewer, contributor), decision-making process, named secondary contact (Charles Merill), and continuity-of-access plan.
- Add `ROADMAP.md` — near / mid / long-term direction.
- Add `docs/assurance-case.md` — two top-level claims (consensus safety + transport security) with arguments and evidence links into the existing test/CI surface.
- Add a "Where to start" section to `CONTRIBUTING.md` linking to `good first issue` / `help wanted` GitHub searches and three concrete starter areas.
- Add a "Project documents" nav block to `README.md`.

## OpenSSF Best Practices Silver-tier criteria closed

- `governance` → `GOVERNANCE.md`
- `roles_responsibilities` → `GOVERNANCE.md` §3
- `access_continuity` → `GOVERNANCE.md` §6
- `documentation_roadmap` → `ROADMAP.md`
- `assurance_case` → `docs/assurance-case.md`
- `small_tasks` → `CONTRIBUTING.md` "Where to start" + labels applied to 5 existing issues (4 `help wanted`: #488 #482 #486 #152; 1 `good first issue`: #211)

`.bestpractices.json` is refreshed in a separate follow-up PR after PRs 2 (DCO) and 3 (signed tags) also land.

## Forward references

`GOVERNANCE.md` §3.3 references a "Developer Certificate of Origin" section in `CONTRIBUTING.md` that doesn't exist yet — it's added in PR 2 of this series. Intentional, will resolve when PR 2 lands.

## Test plan

- [ ] Confirm rendered Markdown looks right on github.com.
- [ ] Confirm all relative links in `docs/assurance-case.md` and `README.md` resolve.
- [ ] CI passes (no code changes — should be a no-op on test/clippy/deny/critical-path/header-check).