### PR TITLE
ci(release): sign release tags via Sigstore gitsign (OpenSSF Silver PR 3/3)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,6 +21,7 @@ jobs:
     environment: crates-io
     permissions:
       contents: write
+      id-token: write  # for Sigstore gitsign OIDC (signs release tags)
     # Queue serial — never cancel a publish in flight (a half-done publish
     # could leave the repo with some crates released and others not).
     concurrency:
@@ -46,6 +47,28 @@ jobs:
         with:
           packages: protobuf-compiler clang libclang-dev
           version: 1
+      # Install Sigstore gitsign so release-plz creates annotated, keyless-signed
+      # tags. Signing identity = this workflow's GitHub Actions OIDC token,
+      # attested by Fulcio and logged to Rekor (same trust model as the SLSA
+      # provenance signed by .github/workflows/release-sign.yml).
+      - name: install gitsign
+        env:
+          GITSIGN_VERSION: "0.16.0"
+          GITSIGN_SHA256: "176b77ae1cf57ac73343c378e2f1338346930324bfb20408b600d97d21e45aa1"
+        run: |
+          set -euo pipefail
+          asset="gitsign_${GITSIGN_VERSION}_linux_amd64"
+          curl -sSLo /tmp/gitsign "https://github.com/sigstore/gitsign/releases/download/v${GITSIGN_VERSION}/${asset}"
+          echo "${GITSIGN_SHA256}  /tmp/gitsign" | sha256sum -c -
+          sudo install -m 0755 /tmp/gitsign /usr/local/bin/gitsign
+          rm -f /tmp/gitsign
+          gitsign --version
+      - name: configure git to sign tags via gitsign
+        run: |
+          set -euo pipefail
+          git config --global gpg.x509.program gitsign
+          git config --global gpg.format x509
+          git config --global tag.gpgSign true
       - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db  # v0.5
         with:
           command: release

--- a/docs/release-signatures.md
+++ b/docs/release-signatures.md
@@ -67,11 +67,44 @@ landed) use `--source-tag` per the example above.
 
 `slsa-verifier` confirms, against the Sigstore transparency log:
 
-- The provenance was signed by GitHub's OIDC identity for the
-  `prisma-risk/tsoracle` repository.
-- The `.crate` artifact's SHA-256 matches the digest recorded in the
-  provenance.
+- The provenance was signed by GitHub's OIDC identity for the `prisma-risk/tsoracle` repository.
+- The `.crate` artifact's SHA-256 matches the digest recorded in the provenance.
 - The build ran from the source repository and tag you specified.
 
-Together these prove the artifact you hold was built by *this* repository's
-CI from the source at *this* tag — no manual signing key trust required.
+Together these prove the artifact you hold was built by *this* repository's CI from the source at *this* tag — no manual signing key trust required.
+
+## Verifying release tags
+
+Release tags themselves are also signed (in addition to the release artifacts above). Signing uses [Sigstore gitsign](https://github.com/sigstore/gitsign) — the same keyless, transparency-log-anchored model as the SLSA provenance. The signing identity is the `release-plz` workflow's GitHub Actions OIDC token, attested by Fulcio and logged to Rekor; there is no long-lived key to rotate or revoke.
+
+### Quick verification
+
+For any release tag (e.g., `tsoracle-v1.0.0`):
+
+```sh
+# Fetch tags if you don't have them locally
+git fetch --tags
+
+# Show signature metadata and validate
+git verify-tag --raw tsoracle-v1.0.0
+```
+
+The output includes the Fulcio-issued certificate, the Rekor transparency-log entry, and the OIDC identity (the `release-plz` workflow at `github.com/prisma-risk/tsoracle/.github/workflows/release-plz.yml`).
+
+### Looking up the Sigstore Rekor entry
+
+Each signed tag also has a Rekor entry searchable at <https://search.sigstore.dev/>:
+
+1. Run `git verify-tag --raw <tag>` and copy the Rekor `logIndex` or entry UUID from the output.
+2. Open `https://search.sigstore.dev/?logIndex=<INDEX>` (or `?uuid=<UUID>`) in a browser.
+3. Confirm the entry's subject identity matches the expected GitHub Actions workflow.
+
+### Trust model
+
+Tag signatures attest to **build provenance**: a specific workflow run, at a specific commit, on a specific branch, in a specific repository, signed by GitHub's OIDC. They do not attest to human review of the released content; that is gated separately by branch protection on `main` and the project's required CI checks.
+
+Because the signature identity is the workflow, not a person, the verification target is the workflow identity, not a key fingerprint. Rotating the signing identity therefore means changing the workflow definition (and a future tag will sign under the new identity); there is no key to rotate or revoke.
+
+### Pre-gitsign tags
+
+Releases tagged before the gitsign integration landed are annotated but unsigned. `git verify-tag` will report `no signature found` for those tags; their provenance is still verifiable via the `.intoto.jsonl` SLSA attestation as documented above.


### PR DESCRIPTION
## Summary

- Install [`sigstore/gitsign`](https://github.com/sigstore/gitsign) v0.16.0 (SHA256-pinned: `176b77ae...e45aa1`) in the release-plz `release` job.
- Configure git globally: `gpg.x509.program gitsign`, `gpg.format x509`, `tag.gpgSign true` so `release-plz` (which shells out to `git tag -a`) produces signed tags.
- Grant the job `id-token: write` permission for the Sigstore OIDC flow.
- Add a "Verifying release tags" section to `docs/release-signatures.md`.

## OpenSSF Best Practices Silver-tier criterion closed

- `version_tags_signed` → release tags signed via Sigstore gitsign (keyless, transparency-log anchored).

## Note on the prior tag state

The `.bestpractices.json` justification on `main` says release-plz creates "lightweight (unsigned) tags". The first half is wrong — `git for-each-ref` confirms existing tags are already **annotated** (`objecttype=tag`). They are just unsigned. This PR adds the signature; PR 4 will refresh the `.bestpractices.json` justification accordingly.

## Pre-merge verification recommendation

The release-plz workflow only triggers on `push: main`, so we cannot fully exercise the new gitsign + git-config + `git tag -s` chain from a feature branch. Two options before merging:

1. **Trust + verify on first real release.** Merge this PR, then watch the next release-plz run. If gitsign fails to sign, the resulting tag is unsigned but still valid (release artifacts are still SLSA-attested); we can revert quickly. Low blast radius.
2. **Dry-run via temporary `workflow_dispatch` trigger.** Add `workflow_dispatch:` to the trigger list on this branch, manually run the workflow, confirm the gitsign install + git config steps succeed. Revert the trigger addition before merge.

Option 1 is simpler and the failure mode is benign. I'd lean Option 1 unless reviewers want stronger pre-merge proof.

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the [DCO requirement](../CONTRIBUTING.md#developer-certificate-of-origin) (use `git commit -s`).
- [x] `actionlint` passes on `release-plz.yml`.
- [ ] CI passes (no Rust code changes — should be a no-op on test/clippy/deny/critical-path/header-check).
- [ ] After merge: the next release-plz run produces signed tags verifiable by `git verify-tag --raw <tag>`.

## Post-merge follow-ups

- [ ] Confirm the next release's tag verifies via `git verify-tag --raw` and resolves at <https://search.sigstore.dev/>.
- [ ] PR 4 will refresh the `.bestpractices.json` justification for `version_tags_signed`.