### PR TITLE
chore(husky): auto-append DCO Signed-off-by trailer in prepare-commit-msg

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Prepare-commit-msg hook: auto-append a DCO `Signed-off-by` trailer to every
+# commit if one isn't already present. The repository's CONTRIBUTING.md
+# requires DCO sign-off on every commit and the DCO GitHub App enforces it
+# at merge time; this hook removes the friction of remembering `git commit -s`.
+#
+# Auto-installed by husky-rs alongside `.husky/pre-commit` on the first
+# `cargo test` of this clone — husky-rs sets `core.hooksPath = .husky`.
+#
+# Bypass intentionally with `git commit --no-verify` (will fail DCO at CI).
+# To override the trailer identity, set git config user.name / user.email.
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+COMMIT_SOURCE="${2:-}"
+
+# Skip for merge commits and squash commits — they synthesize messages from
+# the commits being combined, which already carry their own sign-offs.
+case "$COMMIT_SOURCE" in
+    merge|squash)
+        exit 0
+        ;;
+esac
+
+# If a Signed-off-by trailer is already present (e.g. user ran `git commit -s`
+# or amended a previously-signed commit), don't add a duplicate.
+if grep -qE '^Signed-off-by: ' "$COMMIT_MSG_FILE"; then
+    exit 0
+fi
+
+NAME=$(git config user.name || true)
+EMAIL=$(git config user.email || true)
+
+if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
+    echo "prepare-commit-msg: skipping auto-signoff — git user.name or user.email not configured" >&2
+    exit 0
+fi
+
+git interpret-trailers --in-place \
+    --if-exists addIfDifferent \
+    --trailer "Signed-off-by: $NAME <$EMAIL>" \
+    "$COMMIT_MSG_FILE"


### PR DESCRIPTION
## Summary

Follow-up to PR #543 (DCO sign-off): add `.husky/prepare-commit-msg` that auto-appends a `Signed-off-by` trailer to every commit if one isn't already present. Removes the friction of remembering `git commit -s` once the DCO requirement is enforced.

## Behavior

- **New commit, no signoff** → trailer is appended.
- **Already has `Signed-off-by:`** → no duplicate (idempotent).
- **Merge / squash commits** → skipped (they synthesize from already-signed commits).
- **`git config user.name` or `user.email` empty** → no-op with a warning to stderr.
- **`git commit --no-verify`** → bypassed (intentional escape hatch; will still fail DCO at CI).

## Install

Auto-installs via husky-rs alongside the existing `.husky/pre-commit` on the first `cargo test` of a clone — husky-rs sets `core.hooksPath = .husky`. Manual install: `make install-hooks`.

## Verified locally

- ✅ Plain commit message → `Signed-off-by` appended.
- ✅ Already-signed message → unchanged (no duplicate).
- ✅ `merge` source → unchanged.
- ✅ Executable bit (`100755`) preserved through `git`.

## Dependency note

This PR is independent of PRs #542 / #543 / #544 — it can land before, after, or alongside. It is most useful once PR #543 lands and DCO becomes a required check.

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the DCO requirement (this commit is itself signed off by the hook author manually with `git commit -s`).
- [ ] CI passes (no Rust code changes — should be a no-op on test/clippy/deny/critical-path/header-check).
- [ ] After merge: confirm husky-rs picks up the new hook on a fresh clone (`cargo test` once, then make a test commit and check the trailer).