### PR TITLE
Reapply #513: stabilize all published crates at 1.0.0 (reverts #548)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bench-minimal"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "example-embedded-server"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "tokio",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "example-failover-demo"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "tokio",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "example-metrics-prometheus"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "metrics-exporter-prometheus",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "example-openraft-piggyback"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "example-openraft-standalone"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "example-paxos-embedded"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "example-paxos-piggyback"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "example-paxos-standalone"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "example-tls-mtls"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "kube-e2e-driver"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "stress"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3227,7 +3227,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsoracle"
-version = "0.1.14"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-client"
-version = "0.2.6"
+version = "1.0.0"
 dependencies = [
  "futures",
  "metrics",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-codec"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "postcard",
  "proptest",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-consensus"
-version = "0.1.10"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-core"
-version = "0.2.5"
+version = "1.0.0"
 dependencies = [
  "husky-rs",
  "proptest",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-file"
-version = "0.1.10"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "crc32c",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-openraft"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-paxos"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3377,14 +3377,14 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-failpoint"
-version = "0.1.1"
+version = "1.0.0"
 dependencies = [
  "fail",
 ]
 
 [[package]]
 name = "tsoracle-openraft-toolkit"
-version = "0.2.2"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-paxos-toolkit"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-proto"
-version = "0.2.4"
+version = "1.0.0"
 dependencies = [
  "prost",
  "serde",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-server"
-version = "0.2.9"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-server-testkit"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "async-stream",
  "hyper",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-standalone"
-version = "0.1.3"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-tests"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-yieldpoint"
-version = "0.1.6"
+version = "1.0.0"
 dependencies = [
  "parking_lot",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ default-members = [
 ]
 
 [workspace.package]
-version      = "0.1.4"
+version      = "1.0.0"
 edition      = "2024"
 rust-version = "1.88"
 license      = "Apache-2.0"
@@ -92,9 +92,9 @@ tempfile           = "3"
 thiserror          = "2"
 tokio              = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "fs"] }
 tokio-stream       = { version = "0.1", features = ["sync"] }
-tsoracle-yieldpoint = { path = "crates/tsoracle-yieldpoint", version = "0.1.6" }
-tsoracle-failpoint = { path = "crates/tsoracle-failpoint", version = "0.1.1" }
-tsoracle-codec = { path = "crates/tsoracle-codec", version = "0.1.4" }
+tsoracle-yieldpoint = { path = "crates/tsoracle-yieldpoint", version = "1.0.0" }
+tsoracle-failpoint = { path = "crates/tsoracle-failpoint", version = "1.0.0" }
+tsoracle-codec = { path = "crates/tsoracle-codec", version = "1.0.0" }
 tonic              = "0.14"
 tonic-prost        = "0.14"
 tonic-prost-build  = "0.14"

--- a/benchmarks/minimal/Cargo.toml
+++ b/benchmarks/minimal/Cargo.toml
@@ -26,10 +26,10 @@ tonic              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-tsoracle-server    = { path = "../../crates/tsoracle-server", version = "0.2.9", features = ["test-fakes"] }
-tsoracle-client    = { path = "../../crates/tsoracle-client", version = "0.2.6" }
-tsoracle-core      = { path = "../../crates/tsoracle-core", version = "0.2.5" }
-tsoracle-consensus = { path = "../../crates/tsoracle-consensus", version = "0.1.10" }
+tsoracle-server    = { path = "../../crates/tsoracle-server", version = "1.0.0", features = ["test-fakes"] }
+tsoracle-client    = { path = "../../crates/tsoracle-client", version = "1.0.0" }
+tsoracle-core      = { path = "../../crates/tsoracle-core", version = "1.0.0" }
+tsoracle-consensus = { path = "../../crates/tsoracle-consensus", version = "1.0.0" }
 
 console-subscriber = { version = "0.5", optional = true }
 tracing-flame      = { version = "0.2", optional = true }

--- a/benchmarks/stress/Cargo.toml
+++ b/benchmarks/stress/Cargo.toml
@@ -40,14 +40,14 @@ tonic              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-tsoracle-client          = { path = "../../crates/tsoracle-client", version = "0.2.6" }
-tsoracle-consensus       = { path = "../../crates/tsoracle-consensus", version = "0.1.10" }
-tsoracle-core            = { path = "../../crates/tsoracle-core", version = "0.2.5" }
-tsoracle-driver-openraft = { path = "../../crates/tsoracle-driver-openraft", version = "0.3.3" }
-tsoracle-driver-paxos    = { path = "../../crates/tsoracle-driver-paxos", version = "0.3.3" }
-tsoracle-openraft-toolkit = { path = "../../crates/tsoracle-openraft-toolkit", version = "0.2.2", features = ["test-fakes"] }
-tsoracle-paxos-toolkit   = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.3.3", features = ["rocksdb-storage", "test-fakes"] }
-tsoracle-server          = { path = "../../crates/tsoracle-server", version = "0.2.9", features = ["test-fakes"] }
+tsoracle-client          = { path = "../../crates/tsoracle-client", version = "1.0.0" }
+tsoracle-consensus       = { path = "../../crates/tsoracle-consensus", version = "1.0.0" }
+tsoracle-core            = { path = "../../crates/tsoracle-core", version = "1.0.0" }
+tsoracle-driver-openraft = { path = "../../crates/tsoracle-driver-openraft", version = "1.0.0" }
+tsoracle-driver-paxos    = { path = "../../crates/tsoracle-driver-paxos", version = "1.0.0" }
+tsoracle-openraft-toolkit = { path = "../../crates/tsoracle-openraft-toolkit", version = "1.0.0", features = ["test-fakes"] }
+tsoracle-paxos-toolkit   = { path = "../../crates/tsoracle-paxos-toolkit", version = "1.0.0", features = ["rocksdb-storage", "test-fakes"] }
+tsoracle-server          = { path = "../../crates/tsoracle-server", version = "1.0.0", features = ["test-fakes"] }
 
 fail = { workspace = true, optional = true }
 

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle"
-version      = "0.1.14"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
@@ -35,14 +35,14 @@ tokio                 = { workspace = true, features = ["signal"] }
 tracing               = { workspace = true }
 tracing-subscriber    = { workspace = true }
 tonic                 = { workspace = true, features = ["tls-aws-lc"] }
-tsoracle-core         = { path = "../tsoracle-core", version = "0.2.5" }
-tsoracle-server       = { path = "../tsoracle-server", version = "0.2.9" }
-tsoracle-standalone   = { path = "../tsoracle-standalone", version = "0.1.3", default-features = false }
+tsoracle-core         = { path = "../tsoracle-core", version = "1.0.0" }
+tsoracle-server       = { path = "../tsoracle-server", version = "1.0.0" }
+tsoracle-standalone   = { path = "../tsoracle-standalone", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
-tsoracle-client    = { path = "../tsoracle-client", version = "0.2.6" }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.10" }
-tsoracle-driver-file = { path = "../tsoracle-driver-file", version = "0.1.10" }
+tsoracle-client    = { path = "../tsoracle-client", version = "1.0.0" }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "1.0.0" }
+tsoracle-driver-file = { path = "../tsoracle-driver-file", version = "1.0.0" }
 async-trait        = { workspace = true }
 futures            = { workspace = true }
 parking_lot        = { workspace = true }

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-client"
-version      = "0.2.6"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
@@ -34,8 +34,8 @@ thiserror      = { workspace = true }
 tokio          = { workspace = true }
 tonic          = { workspace = true }
 tracing        = { workspace = true, optional = true }
-tsoracle-core  = { path = "../tsoracle-core", version = "0.2.5" }
-tsoracle-proto = { path = "../tsoracle-proto", version = "0.2.4" }
+tsoracle-core  = { path = "../tsoracle-core", version = "1.0.0" }
+tsoracle-proto = { path = "../tsoracle-proto", version = "1.0.0" }
 
 [dev-dependencies]
 metrics-util       = { workspace = true }

--- a/crates/tsoracle-codec/Cargo.toml
+++ b/crates/tsoracle-codec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-codec"
 description  = "Shared version-prefixed postcard codec: one `[version_byte | postcard(value)]` framing re-used across the tsoracle toolkits so an on-disk layout change fails loudly instead of misdecoding"
-version      = "0.1.4"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-consensus/Cargo.toml
+++ b/crates/tsoracle-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-consensus"
-version      = "0.1.10"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
@@ -25,7 +25,7 @@ rustdoc-args   = ["--cfg", "docsrs"]
 async-trait    = { workspace = true }
 futures        = { workspace = true }
 thiserror      = { workspace = true }
-tsoracle-core  = { path = "../tsoracle-core", version = "0.2.5" }
+tsoracle-core  = { path = "../tsoracle-core", version = "1.0.0" }
 serde          = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/tsoracle-core/Cargo.toml
+++ b/crates/tsoracle-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-core"
 description  = "Sync algorithm core for tsoracle: window allocator, 46/18-bit timestamp packing, monotonicity invariants, and the shared cluster peer type."
-version      = "0.2.5"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-driver-file/Cargo.toml
+++ b/crates/tsoracle-driver-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-driver-file"
-version      = "0.1.10"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
@@ -30,8 +30,8 @@ libc               = "0.2"
 thiserror          = { workspace = true }
 tokio              = { workspace = true }
 tokio-stream       = { workspace = true }
-tsoracle-core      = { path = "../tsoracle-core", version = "0.2.5" }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.10" }
+tsoracle-core      = { path = "../tsoracle-core", version = "1.0.0" }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "1.0.0" }
 tsoracle-failpoint = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-driver-openraft"
 description  = "openraft-backed ConsensusDriver for tsoracle"
-version      = "0.3.3"
+version      = "1.0.0"
 readme       = "README.md"
 edition.workspace      = true
 rust-version.workspace = true
@@ -52,7 +52,7 @@ postcard           = { workspace = true }
 # members that need `RocksdbLogStore` (examples, this crate's dev-deps) opt in
 # explicitly with `features = ["rocksdb-log-store"]` and cargo feature
 # unification re-enables it for their builds.
-tsoracle-openraft-toolkit   = { path = "../tsoracle-openraft-toolkit", version = "0.2.2", default-features = false }
+tsoracle-openraft-toolkit   = { path = "../tsoracle-openraft-toolkit", version = "1.0.0", default-features = false }
 parking_lot        = { workspace = true }
 rocksdb            = { workspace = true, optional = true, features = ["multi-threaded-cf"] }
 serde              = { workspace = true }
@@ -60,12 +60,12 @@ thiserror          = { workspace = true }
 tokio              = { workspace = true }
 tracing            = { workspace = true }
 tsoracle-codec     = { workspace = true }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.10", features = ["serde"] }
-tsoracle-core      = { path = "../tsoracle-core", version = "0.2.5" }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "1.0.0", features = ["serde"] }
+tsoracle-core      = { path = "../tsoracle-core", version = "1.0.0" }
 
 [dev-dependencies]
 anyhow           = { workspace = true }
-tsoracle-openraft-toolkit = { path = "../tsoracle-openraft-toolkit", version = "0.2.2", features = ["rocksdb-log-store", "test-fakes"] }
+tsoracle-openraft-toolkit = { path = "../tsoracle-openraft-toolkit", version = "1.0.0", features = ["rocksdb-log-store", "test-fakes"] }
 metrics-util     = { workspace = true }
 proptest         = { workspace = true }
 rocksdb          = { workspace = true }

--- a/crates/tsoracle-driver-paxos/Cargo.toml
+++ b/crates/tsoracle-driver-paxos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-driver-paxos"
 description  = "OmniPaxos-backed ConsensusDriver for tsoracle"
-version      = "0.3.3"
+version      = "1.0.0"
 readme       = "README.md"
 edition.workspace      = true
 rust-version.workspace = true
@@ -29,9 +29,9 @@ thiserror            = { workspace = true }
 tokio                = { workspace = true }
 tokio-stream         = { workspace = true }
 tracing              = { workspace = true }
-tsoracle-consensus   = { path = "../tsoracle-consensus", version = "0.1.10", features = ["serde"] }
-tsoracle-core        = { path = "../tsoracle-core", version = "0.2.5" }
-tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "0.3.3", default-features = false }
+tsoracle-consensus   = { path = "../tsoracle-consensus", version = "1.0.0", features = ["serde"] }
+tsoracle-core        = { path = "../tsoracle-core", version = "1.0.0" }
+tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "1.0.0", default-features = false }
 tsoracle-yieldpoint  = { workspace = true }
 
 [dev-dependencies]
@@ -43,7 +43,7 @@ tempfile         = { workspace = true }
 tokio            = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 tracing-subscriber = { workspace = true }
 tsoracle-failpoint = { workspace = true }
-tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "0.3.3", features = ["rocksdb-storage", "test-fakes"] }
+tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "1.0.0", features = ["rocksdb-storage", "test-fakes"] }
 
 [[test]]
 name              = "recovery_failpoints"

--- a/crates/tsoracle-failpoint/Cargo.toml
+++ b/crates/tsoracle-failpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-failpoint"
 description  = "Shared fail-rs failpoint macro: one `failpoint!` wrapper re-used across the tsoracle crates, zero-overhead when the feature is off"
-version      = "0.1.1"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-openraft-toolkit/Cargo.toml
+++ b/crates/tsoracle-openraft-toolkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-openraft-toolkit"
 description  = "Reusable openraft glue: TypeConfig macro, RocksDB log store, lifecycle helpers"
-version      = "0.2.2"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-paxos-toolkit/Cargo.toml
+++ b/crates/tsoracle-paxos-toolkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-paxos-toolkit"
 description  = "Reusable OmniPaxos glue: RocksDB storage, lifecycle helpers, test fakes"
-version      = "0.3.3"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
@@ -37,8 +37,8 @@ tokio              = { workspace = true }
 tokio-stream       = { workspace = true }
 tracing            = { workspace = true }
 tsoracle-codec     = { workspace = true }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.10" }
-tsoracle-core      = { path = "../tsoracle-core", version = "0.2.5" }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "1.0.0" }
+tsoracle-core      = { path = "../tsoracle-core", version = "1.0.0" }
 tsoracle-failpoint = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tsoracle-proto/Cargo.toml
+++ b/crates/tsoracle-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-proto"
 description  = "Generated protobuf/gRPC wire types for the timestamp oracle."
-version      = "0.2.4"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/tsoracle-server-testkit/Cargo.toml
+++ b/crates/tsoracle-server-testkit/Cargo.toml
@@ -18,5 +18,5 @@ tokio          = { workspace = true }
 tonic          = { workspace = true }
 tower          = { version = "0.5" }
 turmoil        = { version = "0.7" }
-tsoracle-proto = { path = "../tsoracle-proto", version = "0.2.4" }
-tsoracle-server = { path = "../tsoracle-server", version = "0.2.9" }
+tsoracle-proto = { path = "../tsoracle-proto", version = "1.0.0" }
+tsoracle-server = { path = "../tsoracle-server", version = "1.0.0" }

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "tsoracle-server"
-version      = "0.2.9"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
@@ -42,16 +42,16 @@ tonic              = { workspace = true }
 tonic-prost        = { workspace = true }
 tonic-reflection   = { workspace = true, optional = true }
 tracing            = { workspace = true, optional = true }
-tsoracle-core      = { path = "../tsoracle-core", version = "0.2.5" }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.10" }
-tsoracle-proto     = { path = "../tsoracle-proto", version = "0.2.4" }
+tsoracle-core      = { path = "../tsoracle-core", version = "1.0.0" }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "1.0.0" }
+tsoracle-proto     = { path = "../tsoracle-proto", version = "1.0.0" }
 tsoracle-yieldpoint = { workspace = true }
 tsoracle-failpoint = { workspace = true }
 
 [dev-dependencies]
 tokio        = { workspace = true, features = ["test-util"] }
 metrics-util = { workspace = true }
-tsoracle-core = { path = "../tsoracle-core", version = "0.2.5", features = ["test-clock"] }
+tsoracle-core = { path = "../tsoracle-core", version = "1.0.0", features = ["test-clock"] }
 tracing-subscriber = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/crates/tsoracle-server/src/docs/operations.md
+++ b/crates/tsoracle-server/src/docs/operations.md
@@ -54,7 +54,7 @@ The library is exporter-agnostic: embedders install whichever recorder they want
 
 ```toml
 [dependencies]
-tsoracle-server             = { version = "0.1", features = ["metrics"] }
+tsoracle-server             = { version = "1", features = ["metrics"] }
 metrics-exporter-prometheus = "0.16"
 ```
 

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "tsoracle-standalone"
-version                = "0.1.3"
+version                = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
@@ -38,19 +38,19 @@ e2e-max-readable-next = ["tsoracle-driver-openraft?/e2e-max-readable-next"]
 test-support = []
 
 [dependencies]
-tsoracle-core      = { path = "../tsoracle-core", version = "0.2.5" }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "0.1.10" }
-tsoracle-server    = { path = "../tsoracle-server", version = "0.2.9" }
+tsoracle-core      = { path = "../tsoracle-core", version = "1.0.0" }
+tsoracle-consensus = { path = "../tsoracle-consensus", version = "1.0.0" }
+tsoracle-server    = { path = "../tsoracle-server", version = "1.0.0" }
 tokio              = { workspace = true, features = ["signal", "net", "rt"] }
 tracing            = { workspace = true }
 thiserror          = { workspace = true }
 
 # file
-tsoracle-driver-file = { path = "../tsoracle-driver-file", version = "0.1.10", optional = true }
+tsoracle-driver-file = { path = "../tsoracle-driver-file", version = "1.0.0", optional = true }
 
 # openraft
-tsoracle-driver-openraft = { path = "../tsoracle-driver-openraft", version = "0.3.3", optional = true }
-tsoracle-openraft-toolkit = { path = "../tsoracle-openraft-toolkit", version = "0.2.2", features = ["rocksdb-log-store"], optional = true }
+tsoracle-driver-openraft = { path = "../tsoracle-driver-openraft", version = "1.0.0", optional = true }
+tsoracle-openraft-toolkit = { path = "../tsoracle-openraft-toolkit", version = "1.0.0", features = ["rocksdb-log-store"], optional = true }
 openraft     = { workspace = true, optional = true }
 # `net` is required for tokio_stream::wrappers::TcpListenerStream, used by both
 # HA drivers' bind-before-spawn peer servers (build_openraft / build_paxos).
@@ -59,8 +59,8 @@ async-trait  = { workspace = true }
 futures      = { workspace = true, optional = true }
 
 # paxos
-tsoracle-driver-paxos  = { path = "../tsoracle-driver-paxos", version = "0.3.3", optional = true }
-tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "0.3.3", features = ["rocksdb-storage"], optional = true }
+tsoracle-driver-paxos  = { path = "../tsoracle-driver-paxos", version = "1.0.0", optional = true }
+tsoracle-paxos-toolkit = { path = "../tsoracle-paxos-toolkit", version = "1.0.0", features = ["rocksdb-storage"], optional = true }
 omnipaxos   = { workspace = true, features = ["serde"], optional = true }
 parking_lot = { workspace = true, optional = true }
 

--- a/crates/tsoracle-yieldpoint/Cargo.toml
+++ b/crates/tsoracle-yieldpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "tsoracle-yieldpoint"
 description  = "Async yield points: tokio::sync::Notify-backed test injection sites, the async sibling of fail-rs failpoints"
-version      = "0.1.6"
+version      = "1.0.0"
 edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true

--- a/deploy/charts/tsoracle/Chart.yaml
+++ b/deploy/charts/tsoracle/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tsoracle
 description: Distributed timestamp oracle (file / openraft / paxos drivers)
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "1.0.0"
 home: https://github.com/prisma-risk/tsoracle
 sources:
   - https://github.com/prisma-risk/tsoracle

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -56,8 +56,8 @@ Both libraries are exporter-agnostic: embedders install whichever recorder they 
 
 ```toml
 [dependencies]
-tsoracle-server             = { version = "0.1", features = ["metrics"] }
-tsoracle-client             = { version = "0.1", features = ["metrics"] }
+tsoracle-server             = { version = "1", features = ["metrics"] }
+tsoracle-client             = { version = "1", features = ["metrics"] }
 metrics-exporter-prometheus = "0.16"
 ```
 

--- a/e2e/kube/driver/Cargo.toml
+++ b/e2e/kube/driver/Cargo.toml
@@ -21,7 +21,7 @@ name = "gen-certs"
 path = "src/bin/gen-certs.rs"
 
 [dependencies]
-tsoracle-client = { path = "../../../crates/tsoracle-client", version = "0.2.6" }
+tsoracle-client = { path = "../../../crates/tsoracle-client", version = "1.0.0" }
 anyhow          = { workspace = true }
 clap            = { workspace = true }
 rcgen           = { workspace = true }

--- a/examples/embedded-server/Cargo.toml
+++ b/examples/embedded-server/Cargo.toml
@@ -9,8 +9,8 @@ description            = "tsoracle example: embed FileDriver in your own binary 
 publish                = false
 
 [dependencies]
-tsoracle-server       = { path = "../../crates/tsoracle-server", version = "0.2.9" }
-tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "0.1.10" }
+tsoracle-server       = { path = "../../crates/tsoracle-server", version = "1.0.0" }
+tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "1.0.0" }
 tokio                 = { workspace = true, features = ["signal"] }
 tracing               = { workspace = true }
 tracing-subscriber    = { workspace = true }

--- a/examples/failover-demo/Cargo.toml
+++ b/examples/failover-demo/Cargo.toml
@@ -9,10 +9,10 @@ description            = "tsoracle example: in-process failover fence pedagogy d
 publish                = false
 
 [dependencies]
-tsoracle-core      = { path = "../../crates/tsoracle-core", version = "0.2.5" }
-tsoracle-consensus = { path = "../../crates/tsoracle-consensus", version = "0.1.10" }
-tsoracle-server    = { path = "../../crates/tsoracle-server", version = "0.2.9", features = ["test-fakes"] }
-tsoracle-proto     = { path = "../../crates/tsoracle-proto", version = "0.2.4" }
+tsoracle-core      = { path = "../../crates/tsoracle-core", version = "1.0.0" }
+tsoracle-consensus = { path = "../../crates/tsoracle-consensus", version = "1.0.0" }
+tsoracle-server    = { path = "../../crates/tsoracle-server", version = "1.0.0", features = ["test-fakes"] }
+tsoracle-proto     = { path = "../../crates/tsoracle-proto", version = "1.0.0" }
 tokio              = { workspace = true, features = ["time"] }
 tonic              = { workspace = true }
 anyhow             = { workspace = true }

--- a/examples/metrics-prometheus/Cargo.toml
+++ b/examples/metrics-prometheus/Cargo.toml
@@ -9,9 +9,9 @@ description            = "tsoracle example: embed the server with the metrics fe
 publish                = false
 
 [dependencies]
-tsoracle-server      = { path = "../../crates/tsoracle-server", version = "0.2.9", features = ["metrics"] }
-tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "0.1.10" }
-tsoracle-client      = { path = "../../crates/tsoracle-client", version = "0.2.6" }
+tsoracle-server      = { path = "../../crates/tsoracle-server", version = "1.0.0", features = ["metrics"] }
+tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "1.0.0" }
+tsoracle-client      = { path = "../../crates/tsoracle-client", version = "1.0.0" }
 metrics-exporter-prometheus = { workspace = true }
 tokio                = { workspace = true, features = ["signal"] }
 tracing              = { workspace = true }

--- a/examples/openraft-piggyback/Cargo.toml
+++ b/examples/openraft-piggyback/Cargo.toml
@@ -13,12 +13,12 @@ name = "openraft-piggyback"
 path = "src/main.rs"
 
 [dependencies]
-tsoracle-core            = { path = "../../crates/tsoracle-core", version = "0.2.5" }
-tsoracle-consensus       = { path = "../../crates/tsoracle-consensus", version = "0.1.10" }
-tsoracle-server          = { path = "../../crates/tsoracle-server", version = "0.2.9" }
-tsoracle-client          = { path = "../../crates/tsoracle-client", version = "0.2.6" }
-tsoracle-driver-openraft = { path = "../../crates/tsoracle-driver-openraft", version = "0.3.3" }
-tsoracle-openraft-toolkit         = { path = "../../crates/tsoracle-openraft-toolkit", version = "0.2.2", features = ["rocksdb-log-store", "test-fakes"] }
+tsoracle-core            = { path = "../../crates/tsoracle-core", version = "1.0.0" }
+tsoracle-consensus       = { path = "../../crates/tsoracle-consensus", version = "1.0.0" }
+tsoracle-server          = { path = "../../crates/tsoracle-server", version = "1.0.0" }
+tsoracle-client          = { path = "../../crates/tsoracle-client", version = "1.0.0" }
+tsoracle-driver-openraft = { path = "../../crates/tsoracle-driver-openraft", version = "1.0.0" }
+tsoracle-openraft-toolkit         = { path = "../../crates/tsoracle-openraft-toolkit", version = "1.0.0", features = ["rocksdb-log-store", "test-fakes"] }
 
 openraft           = { workspace = true }
 rocksdb            = { workspace = true }

--- a/examples/openraft-standalone/Cargo.toml
+++ b/examples/openraft-standalone/Cargo.toml
@@ -17,8 +17,8 @@ default    = []
 reflection = ["tsoracle-server/reflection"]
 
 [dependencies]
-tsoracle-server     = { path = "../../crates/tsoracle-server", version = "0.2.9" }
-tsoracle-standalone = { path = "../../crates/tsoracle-standalone", version = "0.1.3", default-features = false, features = ["openraft"] }
+tsoracle-server     = { path = "../../crates/tsoracle-server", version = "1.0.0" }
+tsoracle-standalone = { path = "../../crates/tsoracle-standalone", version = "1.0.0", default-features = false, features = ["openraft"] }
 tokio               = { workspace = true, features = ["signal", "macros", "rt-multi-thread"] }
 clap                = { workspace = true }
 tracing             = { workspace = true }

--- a/examples/paxos-embedded/Cargo.toml
+++ b/examples/paxos-embedded/Cargo.toml
@@ -13,11 +13,11 @@ name = "paxos-embedded"
 path = "src/main.rs"
 
 [dependencies]
-tsoracle-core          = { path = "../../crates/tsoracle-core", version = "0.2.5" }
-tsoracle-consensus     = { path = "../../crates/tsoracle-consensus", version = "0.1.10" }
-tsoracle-server        = { path = "../../crates/tsoracle-server", version = "0.2.9" }
-tsoracle-driver-paxos  = { path = "../../crates/tsoracle-driver-paxos", version = "0.3.3" }
-tsoracle-paxos-toolkit = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.3.3", default-features = false, features = ["test-fakes"] }
+tsoracle-core          = { path = "../../crates/tsoracle-core", version = "1.0.0" }
+tsoracle-consensus     = { path = "../../crates/tsoracle-consensus", version = "1.0.0" }
+tsoracle-server        = { path = "../../crates/tsoracle-server", version = "1.0.0" }
+tsoracle-driver-paxos  = { path = "../../crates/tsoracle-driver-paxos", version = "1.0.0" }
+tsoracle-paxos-toolkit = { path = "../../crates/tsoracle-paxos-toolkit", version = "1.0.0", default-features = false, features = ["test-fakes"] }
 
 omnipaxos          = { workspace = true, features = ["serde"] }
 async-trait        = { workspace = true }

--- a/examples/paxos-piggyback/Cargo.toml
+++ b/examples/paxos-piggyback/Cargo.toml
@@ -16,12 +16,12 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-tsoracle-core          = { path = "../../crates/tsoracle-core", version = "0.2.5" }
-tsoracle-consensus     = { path = "../../crates/tsoracle-consensus", version = "0.1.10" }
-tsoracle-server        = { path = "../../crates/tsoracle-server", version = "0.2.9" }
-tsoracle-client        = { path = "../../crates/tsoracle-client", version = "0.2.6" }
-tsoracle-driver-paxos  = { path = "../../crates/tsoracle-driver-paxos", version = "0.3.3" }
-tsoracle-paxos-toolkit = { path = "../../crates/tsoracle-paxos-toolkit", version = "0.3.3", default-features = false, features = ["test-fakes"] }
+tsoracle-core          = { path = "../../crates/tsoracle-core", version = "1.0.0" }
+tsoracle-consensus     = { path = "../../crates/tsoracle-consensus", version = "1.0.0" }
+tsoracle-server        = { path = "../../crates/tsoracle-server", version = "1.0.0" }
+tsoracle-client        = { path = "../../crates/tsoracle-client", version = "1.0.0" }
+tsoracle-driver-paxos  = { path = "../../crates/tsoracle-driver-paxos", version = "1.0.0" }
+tsoracle-paxos-toolkit = { path = "../../crates/tsoracle-paxos-toolkit", version = "1.0.0", default-features = false, features = ["test-fakes"] }
 
 omnipaxos          = { workspace = true, features = ["serde"] }
 async-trait        = { workspace = true }

--- a/examples/paxos-standalone/Cargo.toml
+++ b/examples/paxos-standalone/Cargo.toml
@@ -17,8 +17,8 @@ default    = []
 reflection = ["tsoracle-server/reflection"]
 
 [dependencies]
-tsoracle-server     = { path = "../../crates/tsoracle-server", version = "0.2.9" }
-tsoracle-standalone = { path = "../../crates/tsoracle-standalone", version = "0.1.3", default-features = false, features = ["paxos"] }
+tsoracle-server     = { path = "../../crates/tsoracle-server", version = "1.0.0" }
+tsoracle-standalone = { path = "../../crates/tsoracle-standalone", version = "1.0.0", default-features = false, features = ["paxos"] }
 tokio               = { workspace = true, features = ["signal", "macros", "rt-multi-thread"] }
 clap                = { workspace = true }
 tracing             = { workspace = true }

--- a/examples/tls-mtls/Cargo.toml
+++ b/examples/tls-mtls/Cargo.toml
@@ -9,9 +9,9 @@ description            = "tsoracle example: TLS and mTLS configuration end-to-en
 publish                = false
 
 [dependencies]
-tsoracle-server      = { path = "../../crates/tsoracle-server", version = "0.2.9" }
-tsoracle-client      = { path = "../../crates/tsoracle-client", version = "0.2.6" }
-tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "0.1.10" }
+tsoracle-server      = { path = "../../crates/tsoracle-server", version = "1.0.0" }
+tsoracle-client      = { path = "../../crates/tsoracle-client", version = "1.0.0" }
+tsoracle-driver-file = { path = "../../crates/tsoracle-driver-file", version = "1.0.0" }
 tonic                = { workspace = true }
 tokio                = { workspace = true, features = ["signal"] }
 futures              = { workspace = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2006,7 +2006,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsoracle-codec"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "postcard",
  "serde",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-consensus"
-version = "0.1.10"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-core"
-version = "0.2.5"
+version = "1.0.0"
 dependencies = [
  "serde",
  "thiserror",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-file"
-version = "0.1.10"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "crc32c",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-openraft"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-driver-paxos"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-failpoint"
-version = "0.1.1"
+version = "1.0.0"
 
 [[package]]
 name = "tsoracle-fuzz"
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-openraft-toolkit"
-version = "0.2.2"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-paxos-toolkit"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-proto"
-version = "0.2.4"
+version = "1.0.0"
 dependencies = [
  "prost",
  "tonic",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "tsoracle-yieldpoint"
-version = "0.1.6"
+version = "1.0.0"
 
 [[package]]
 name = "unicase"


### PR DESCRIPTION
Reverts #548, which itself reverted #513.

## Why

The 1.0.0 artifacts from #513 were already published to crates.io before #548 merged. crates.io versions are permanently consumed — yank or no yank, the `1.0.0` slot on each of the 15 crates is taken forever. With #548 merged, source `Cargo.toml` declared 0.1.4 while the registry held 1.0.0, which would have blocked future `release-plz` publishes (the registry rejects version downgrades).

This PR re-aligns the source tree with the registry. The diff is byte-identical to #513.

## Test plan

- [x] CI passes on the PR
- [x] After merge, the next `feat|fix|perf` commit triggers a release-plz Release PR targeting 1.0.1+ (not 0.x)