### PR TITLE
refactor!: relocate Bt to tsoracle-server, prune vestigial features

### DIFF
--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -19,7 +19,7 @@ file       = ["tsoracle-standalone/file"]
 openraft   = ["tsoracle-standalone/openraft"]
 paxos      = ["tsoracle-standalone/paxos"]
 reflection = ["tsoracle-server/reflection"]
-bt         = ["tsoracle-core/bt", "tsoracle-server/bt"]
+bt         = ["tsoracle-server/bt"]
 # Pass through `e2e-max-readable-next` to the standalone crate so the
 # production image (`deploy/Dockerfile` passing `--build-arg FEATURES=...`)
 # can opt in for the mixed-version kube-e2e lane. NEVER set in production

--- a/crates/tsoracle-client/Cargo.toml
+++ b/crates/tsoracle-client/Cargo.toml
@@ -18,7 +18,6 @@ metrics    = ["dep:metrics"]
 tls-rustls = ["tonic/tls-aws-lc"]
 tls-native = ["tonic/tls-native-roots"]
 tracing    = ["dep:tracing"]
-bt         = ["tsoracle-core/bt"]
 
 [package.metadata.docs.rs]
 features       = ["tls-rustls", "tracing", "metrics"]

--- a/crates/tsoracle-consensus/Cargo.toml
+++ b/crates/tsoracle-consensus/Cargo.toml
@@ -15,7 +15,6 @@ categories    = ["network-programming", "concurrency", "rust-patterns"]
 [features]
 default = []
 serde   = ["dep:serde", "tsoracle-core/serde"]
-bt      = ["tsoracle-core/bt"]
 
 [package.metadata.docs.rs]
 features       = ["serde"]

--- a/crates/tsoracle-core/Cargo.toml
+++ b/crates/tsoracle-core/Cargo.toml
@@ -17,10 +17,6 @@ default    = ["std"]
 std        = []
 serde      = ["dep:serde"]
 test-clock = []
-# Capture a `std::backtrace::Backtrace` in instrumented error variants. With
-# this off, `Bt` is a ZST and `Bt::capture()` is a no-op. With it on, capture
-# is still gated at runtime by `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE`.
-bt = ["std"]
 
 [package.metadata.docs.rs]
 features       = ["std", "serde"]

--- a/crates/tsoracle-core/README.md
+++ b/crates/tsoracle-core/README.md
@@ -10,7 +10,6 @@ No I/O, no async, no tokio. Runtime-neutral, property-testable in microseconds. 
 - `Timestamp` — the 64-bit packed representation. `PHYSICAL_MS_MAX` and `LOGICAL_MAX` document the bit budget; `TimestampError` covers the narrow space of invalid encodings.
 - `Epoch` — the leader-watermark identifier the failover fence checks. Persisted alongside the high water by every `ConsensusDriver` impl.
 - `Clock` + `SystemClock` — the trait for "what time is it" abstraction. `clock::testing` exposes deterministic fakes for property tests.
-- `Bt` — backtrace-on-error helper. ZST and no-op unless the `bt` feature is on; with it on, capture is still gated by `RUST_BACKTRACE` / `RUST_LIB_BACKTRACE`.
 - `CoreError` — the algorithm-level error type. Server, client, and driver crates wrap it in their own variants.
 
 ## Feature flags
@@ -18,7 +17,6 @@ No I/O, no async, no tokio. Runtime-neutral, property-testable in microseconds. 
 - `std` (default) — enables `std`-dependent surface (most of it). Disabling gives a `no_std` core; the public surface shrinks but the allocator + timestamp math still work.
 - `serde` — derives `Serialize` / `Deserialize` on the public types so they cross wire and storage boundaries cleanly.
 - `test-clock` — exposes the `clock::testing` module to downstream test code without needing `cfg(test)` machinery.
-- `bt` — captures `std::backtrace::Backtrace` in instrumented error variants. Off by default to keep cold paths free.
 
 ## Documentation
 

--- a/crates/tsoracle-core/src/lib.rs
+++ b/crates/tsoracle-core/src/lib.rs
@@ -27,7 +27,6 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 mod allocator;
-mod bt;
 mod clock;
 mod epoch;
 mod peer;
@@ -36,7 +35,6 @@ mod timestamp;
 pub mod docs;
 
 pub use allocator::{Allocator, CommitOutcome, CoreError, IgnoreReason, WindowGrant};
-pub use bt::Bt;
 pub use clock::{Clock, SystemClock};
 pub use epoch::Epoch;
 pub use peer::TsoPeer;

--- a/crates/tsoracle-driver-file/Cargo.toml
+++ b/crates/tsoracle-driver-file/Cargo.toml
@@ -15,7 +15,6 @@ categories    = ["database-implementations", "filesystem"]
 [features]
 default    = []
 failpoints = ["tsoracle-failpoint/failpoints"]
-bt         = ["tsoracle-core/bt", "tsoracle-consensus/bt"]
 
 [package.metadata.docs.rs]
 all-features = false

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -23,7 +23,10 @@ tracing    = ["dep:tracing"]
 test-fakes = []
 test-support = ["test-fakes"]
 reflection = ["dep:tonic-reflection", "tsoracle-proto/reflection"]
-bt         = ["tsoracle-core/bt", "tsoracle-consensus/bt"]
+# Capture a `std::backtrace::Backtrace` in instrumented error variants. With
+# this off, `Bt` is a ZST and `Bt::capture()` is a no-op. With it on, capture
+# is still gated at runtime by `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE`.
+bt         = []
 
 [package.metadata.docs.rs]
 features       = ["tls-rustls", "tracing", "reflection", "metrics"]

--- a/crates/tsoracle-server/README.md
+++ b/crates/tsoracle-server/README.md
@@ -10,6 +10,7 @@ Wires four pieces together: the sync window allocator from [`tsoracle-core`](htt
 - `BuildError` — surfaces invalid configurations at build time (missing driver, conflicting TLS settings, …).
 - `ServerError` — runtime errors from the serving task.
 - `ServingState` — observability snapshot for the leader-watch state machine.
+- `Bt` — backtrace-on-error helper embedded in instrumented `ServerError` variants. ZST and no-op unless the `bt` feature is on; with it on, capture is still gated by `RUST_BACKTRACE` / `RUST_LIB_BACKTRACE`.
 
 ## Usage shape
 
@@ -43,6 +44,7 @@ Followers respond to RPCs with `FAILED_PRECONDITION` and a `tsoracle-leader-hint
 - `failpoints` — enables `fail` crate injection for chaos coverage.
 - `yieldpoints` — enables `tsoracle-yieldpoint` injection sites (async sibling of failpoints; off by default since production carries zero overhead).
 - `test-fakes` / `test-support` — test-only fixtures for downstream integration suites.
+- `bt` — captures `std::backtrace::Backtrace` in instrumented `ServerError` variants. Off by default to keep cold paths free.
 
 ## Documentation
 

--- a/crates/tsoracle-server/src/bt.rs
+++ b/crates/tsoracle-server/src/bt.rs
@@ -33,7 +33,7 @@
 //! Embedding `Bt` in a `thiserror` enum variant:
 //!
 //! ```ignore
-//! use tsoracle_core::Bt;
+//! use tsoracle_server::Bt;
 //!
 //! #[derive(Debug, thiserror::Error)]
 //! pub enum MyError {

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -26,6 +26,7 @@
 // for the lib's own unit tests; integration tests are separate compilation units.
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
+mod bt;
 mod fence;
 mod leader_hint;
 mod persist_disposition;
@@ -36,6 +37,7 @@ mod signal;
 
 pub mod docs;
 
+pub use bt::Bt;
 pub use server::{BuildError, Server, ServerBuilder, ServerError, ServingState, WatchGuard};
 pub use signal::shutdown_signal;
 

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -29,11 +29,12 @@ use tokio::sync::watch;
 use tonic::service::Routes;
 use tonic::transport::Server as TonicServer;
 use tsoracle_consensus::ConsensusDriver;
-use tsoracle_core::{Bt, Clock, Epoch, SystemClock};
+use tsoracle_core::{Clock, Epoch, SystemClock};
 #[cfg(any(test, feature = "test-fakes"))]
 use tsoracle_core::{CoreError, WindowGrant};
 use tsoracle_proto::v1::tso_service_server::TsoServiceServer;
 
+use crate::bt::Bt;
 use crate::service::TsoServiceImpl;
 use crate::serving_core::ServingCore;
 


### PR DESCRIPTION
## Summary

`Bt` was workspace-shared error-instrumentation infrastructure in `tsoracle-core`, but `tsoracle-core`'s own `CoreError` never adopted it — `CoreError` derives `PartialEq + Eq`, which `std::backtrace::Backtrace` doesn't satisfy. Workspace-wide, `Bt` has exactly one consumer: `tsoracle-server::ServerError::WatchPanic` (one variant, four `Bt::capture()` call sites).

Three further crates (`tsoracle-consensus`, `tsoracle-driver-file`, `tsoracle-client`) declared and forwarded a `bt` Cargo feature without using `Bt` anywhere in their source — pure vestigial plumbing. This PR drops those alongside the file move so the feature chain matches actual usage.

- Move `src/bt.rs` from `tsoracle-core` to `tsoracle-server` (git records it as a 99 % rename — the only diff is the ignored doc-example's import path, `tsoracle_core::Bt` → `tsoracle_server::Bt`).
- Drop the `bt` Cargo feature from `tsoracle-core`, `tsoracle-consensus`, `tsoracle-driver-file`, and `tsoracle-client`.
- `tsoracle-server`'s `bt` is now `[]` (was forwarding to `tsoracle-core/bt` + `tsoracle-consensus/bt`); std is always present in the server crate so the std-coupling that justified `bt = ["std"]` in core is no longer needed.
- `tsoracle-bin`'s `bt` collapses to `["tsoracle-server/bt"]`.
- Move the `Bt` bullet and `bt` feature entry from the `tsoracle-core` README to the `tsoracle-server` README to follow the type.

No behavior change. `ServerError::WatchPanic` constructions are unchanged and the existing coverage (the `serve_with_listener_translates_watch_panic_to_server_error` integration test plus the four `bt::tests::*` unit tests) all pass under `--all-features`.

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the [DCO requirement](../CONTRIBUTING.md#developer-certificate-of-origin) (use `git commit -s`).
- [x] `cargo check --workspace --all-features` — clean.
- [x] `cargo test -p tsoracle-core -p tsoracle-server --all-features` — all pass, including the four `bt::tests::*` (now homed under `tsoracle-server`) and `serve_with_listener_translates_watch_panic_to_server_error` (which constructs the `WatchPanic { bt: Bt::capture() }` variant via the panic path).
- [x] `cargo check -p tsoracle-core --no-default-features` — clean (no_std mode unaffected by the dropped `bt = ["std"]` feature).
- [x] Pre-commit `cargo fmt --check` and `cargo clippy` hooks pass.
- [x] Workspace-wide `grep` confirms zero remaining references to `tsoracle_core::Bt` or `tsoracle-core/bt`.