### PR TITLE
refactor(core): PeerEndpoint newtype hoists scheme-less contract to type system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,7 @@ dependencies = [
  "husky-rs",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -55,7 +55,7 @@ use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Instant, sleep};
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
-use tsoracle_paxos_toolkit::lifecycle::{MessageSink, TsoPeer};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PeerEndpoint, TsoPeer};
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 use tsoracle_paxos_toolkit::test_fakes::partition::PartitionController;
@@ -188,13 +188,15 @@ fn paxos_config(node_id: u64, cluster: &ClusterConfig) -> OmniPaxosConfig {
 /// ever used as a leader hint, never dialed. See
 /// `build_toolkit_peers_yields_scheme_less_endpoints`.
 #[allow(dead_code)]
+#[allow(clippy::expect_used)] // SocketAddr's Display is provably scheme-less host:port.
 fn build_toolkit_peers(tso_endpoints: &[(u64, SocketAddr)], my_id: u64) -> Vec<TsoPeer> {
     tso_endpoints
         .iter()
         .filter(|(peer_id, _)| *peer_id != my_id)
         .map(|(peer_id, peer_addr)| TsoPeer {
             node_id: *peer_id,
-            endpoint: peer_addr.to_string(),
+            endpoint: PeerEndpoint::try_from(peer_addr.to_string())
+                .expect("SocketAddr's Display is scheme-less host:port"),
         })
         .collect()
 }
@@ -545,13 +547,11 @@ mod tests {
     use super::*;
     use std::time::Instant as StdInstant;
 
-    // The follower-redirect contract this guards is enforced at runtime only by
-    // a `debug_assert` in the server's `run_leader_watch`, which fires solely
-    // when a follower has observed a *stable* leader long enough to surface its
-    // hint. On a fast host the chaos tests finish before that happens, so the
-    // guard's coverage is timing-dependent (it slipped through once, surfacing
-    // as a slow-CI-only flake). This test pins the contract at the construction
-    // site instead — fully deterministic, independent of leader-election timing.
+    // The scheme-less invariant the original form of this test guarded is now
+    // enforced at the type level by `PeerEndpoint::try_from`: a scheme-bearing
+    // endpoint would panic inside `build_toolkit_peers`'s `.expect(...)`
+    // before this assertion runs. The test is kept as a smoke-check that
+    // construction succeeds and the self-filter still holds.
     #[test]
     fn build_toolkit_peers_yields_scheme_less_endpoints() {
         let tso_endpoints: Vec<(u64, SocketAddr)> = vec![
@@ -567,14 +567,6 @@ mod tests {
             peers.iter().all(|peer| peer.node_id != 2),
             "node 2 must be filtered from its own peer list, got {peers:?}"
         );
-        for peer in &peers {
-            assert!(
-                !peer.endpoint.starts_with("http://") && !peer.endpoint.starts_with("https://"),
-                "peer leader_endpoint must be a scheme-less host:port (a TLS client \
-                 drops http(s):// hints); got {:?}",
-                peer.endpoint
-            );
-        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/tsoracle-consensus/src/leadership.rs
+++ b/crates/tsoracle-consensus/src/leadership.rs
@@ -23,7 +23,7 @@
 
 //! Leadership state surfaced to the server's leader-watch task.
 
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, PeerEndpoint};
 
 /// Leadership state surfaced to the server's leader-watch task.
 ///
@@ -43,15 +43,15 @@ pub enum LeaderState {
     /// clients to reject a stale follower's lower-epoch redirect; `None` when
     /// the driver does not surface it.
     ///
-    /// **Contract — endpoint shape:** `leader_endpoint`, when `Some`, MUST be a
-    /// scheme-less `host:port` (e.g. `leader:9000`, `10.0.0.7:50551`), never a
-    /// `http://...` or `https://...` URL. The follower-redirect path surfaces
-    /// this string to clients as a leader hint, and a TLS-configured client
-    /// *silently drops* any `http://` hint (`rejects_plaintext_hint`) to refuse
-    /// a transport downgrade — so a scheme-bearing endpoint makes this leader
-    /// unreachable via redirect, with only a log line as evidence. The shipped
-    /// drivers satisfy this by reading the operator-configured membership
-    /// service endpoint, which is itself contracted scheme-less.
+    /// **Contract — endpoint shape:** `leader_endpoint`, when `Some`, is a
+    /// `tsoracle_core::PeerEndpoint` — a scheme-less `host:port` enforced at
+    /// the type level (the value cannot exist with a `http://` / `https://`
+    /// prefix, since [`PeerEndpoint::try_from`] rejects scheme-bearing input).
+    /// The newtype subsumes the historical `endpoint_is_scheme_less` runtime
+    /// guard that wrapped this field — a TLS-configured client silently drops
+    /// any scheme-bearing hint (`rejects_plaintext_hint`) to refuse a transport
+    /// downgrade, so a contract-violating endpoint would make this leader
+    /// unreachable via redirect with only a log line as evidence.
     ///
     /// **Contract — epoch monotonicity:** `leader_epoch`, across successive
     /// emissions from one node, MUST be non-decreasing. Clients gate redirects
@@ -61,7 +61,7 @@ pub enum LeaderState {
     /// monotonic per node, so the shipped drivers satisfy this by construction;
     /// `None` (an epoch-less hint) is always permitted and gates nothing.
     Follower {
-        leader_endpoint: Option<String>,
+        leader_endpoint: Option<PeerEndpoint>,
         leader_epoch: Option<Epoch>,
     },
     /// No leader is currently known (election in progress, partition, etc.).
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(l1, LeaderState::Leader { epoch: Epoch(1) });
 
         let f_known = LeaderState::Follower {
-            leader_endpoint: Some("node-2".into()),
+            leader_endpoint: Some(PeerEndpoint::try_from("node-2:50051").unwrap()),
             leader_epoch: Some(Epoch(4)),
         };
         let f_unknown = LeaderState::Follower {
@@ -96,7 +96,7 @@ mod tests {
         // Epoch participates in equality so the watch-debounce re-emits on a
         // follower-side epoch change, not just an endpoint change.
         let f_epoch_5 = LeaderState::Follower {
-            leader_endpoint: Some("node-2".into()),
+            leader_endpoint: Some(PeerEndpoint::try_from("node-2:50051").unwrap()),
             leader_epoch: Some(Epoch(5)),
         };
         assert_ne!(f_known, f_epoch_5, "epoch must discriminate followers");

--- a/crates/tsoracle-core/Cargo.toml
+++ b/crates/tsoracle-core/Cargo.toml
@@ -27,5 +27,6 @@ thiserror = { workspace = true }
 serde     = { workspace = true, optional = true }
 
 [dev-dependencies]
-husky-rs = { workspace = true }
-proptest = { workspace = true }
+husky-rs   = { workspace = true }
+proptest   = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/tsoracle-core/src/lib.rs
+++ b/crates/tsoracle-core/src/lib.rs
@@ -37,7 +37,7 @@ pub mod docs;
 pub use allocator::{Allocator, CommitOutcome, CoreError, IgnoreReason, WindowGrant};
 pub use clock::{Clock, SystemClock};
 pub use epoch::Epoch;
-pub use peer::TsoPeer;
+pub use peer::{PeerEndpoint, PeerEndpointError, TsoPeer};
 pub use timestamp::{LOGICAL_MAX, PHYSICAL_MS_MAX, Timestamp, TimestampError};
 
 #[cfg(any(test, feature = "test-clock"))]

--- a/crates/tsoracle-core/src/peer.rs
+++ b/crates/tsoracle-core/src/peer.rs
@@ -23,6 +23,156 @@
 
 //! A consensus peer and the tsoracle service endpoint it advertises.
 
+use core::fmt;
+use core::str::FromStr;
+
+/// Error returned when a string fails the [`PeerEndpoint`] contract.
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PeerEndpointError {
+    /// The endpoint was an empty string. `PeerEndpoint` carries no "absent"
+    /// semantics; callers that need optionality wrap it in `Option`.
+    #[error("peer endpoint must not be empty")]
+    Empty,
+    /// The endpoint begins with `http://` or `https://`. The TLS client
+    /// silently drops scheme-bearing leader hints to refuse a transport
+    /// downgrade, so a scheme-bearing endpoint makes its owner unreachable
+    /// via redirect.
+    #[error("peer endpoint {endpoint:?} must be scheme-less host:port, not a http(s):// URL")]
+    SchemeBearing { endpoint: String },
+    /// The endpoint has no `:port` suffix. A bare host is technically a valid
+    /// authority but is never an intentional production value — the consensus
+    /// drivers always advertise an explicit port.
+    #[error("peer endpoint {endpoint:?} must include an explicit :port")]
+    MissingPort { endpoint: String },
+    /// The host portion before `:port` is empty (e.g. `":50051"`).
+    #[error("peer endpoint {endpoint:?} has an empty host")]
+    EmptyHost { endpoint: String },
+    /// The port portion is empty, non-numeric, or outside `1..=65535`.
+    #[error("peer endpoint {endpoint:?} has an invalid port: {reason}")]
+    InvalidPort {
+        endpoint: String,
+        reason: &'static str,
+    },
+}
+
+/// A scheme-less `host:port` advertising the tsoracle service address of a
+/// peer node.
+///
+/// **Contract (enforced at construction):**
+///
+/// * No `http://` / `https://` prefix. The TLS client silently drops
+///   scheme-bearing leader hints (`rejects_plaintext_hint`) to refuse a
+///   transport downgrade, so a scheme-bearing endpoint would make its owner
+///   unreachable via follower redirect — a silent prod trap. (See
+///   `tsoracle_server::fence::endpoint_is_scheme_less` for the historical
+///   runtime guard this newtype subsumes.)
+/// * Non-empty.
+/// * Includes an explicit `:port` with a numeric port in `1..=65535`.
+/// * Bracketed IPv6 supported (`[::1]:50051`).
+///
+/// Consumers that need to dial this endpoint prepend `http://` / `https://`
+/// at dial time based on their TLS configuration (see e.g.
+/// `tsoracle_client::channel_pool`); the endpoint itself is transport-agnostic.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PeerEndpoint(String);
+
+impl PeerEndpoint {
+    /// Borrow the underlying `host:port` string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume self, returning the underlying `String`.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for PeerEndpoint {
+    type Error = PeerEndpointError;
+
+    fn try_from(endpoint: String) -> Result<Self, Self::Error> {
+        if endpoint.is_empty() {
+            return Err(PeerEndpointError::Empty);
+        }
+        // ASCII-lowercase only, matching the client's `normalize_uri`. An
+        // uppercase variant would already fail to parse downstream.
+        if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+            return Err(PeerEndpointError::SchemeBearing { endpoint });
+        }
+        // `rsplit_once(':')` splits on the LAST colon, which is the port
+        // separator for both `host:port` and the bracketed-IPv6 form
+        // `[::1]:50051` (host=`[::1]`, port=`50051`). `split_once(':')` would
+        // break IPv6 by splitting at the first colon inside the address.
+        let (host, port_str) = match endpoint.rsplit_once(':') {
+            Some(pair) => pair,
+            None => return Err(PeerEndpointError::MissingPort { endpoint }),
+        };
+        if host.is_empty() {
+            return Err(PeerEndpointError::EmptyHost { endpoint });
+        }
+        // `u16::from_str` rejects empty, non-numeric, and `> 65535`. Port 0
+        // parses cleanly but is reserved per RFC 6335; reject it explicitly.
+        let port = port_str
+            .parse::<u16>()
+            .map_err(|_| PeerEndpointError::InvalidPort {
+                endpoint: endpoint.clone(),
+                reason: "must be a base-10 number in 1..=65535",
+            })?;
+        if port == 0 {
+            return Err(PeerEndpointError::InvalidPort {
+                endpoint,
+                reason: "port 0 is reserved",
+            });
+        }
+        Ok(PeerEndpoint(endpoint))
+    }
+}
+
+impl TryFrom<&str> for PeerEndpoint {
+    type Error = PeerEndpointError;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::try_from(s.to_string())
+    }
+}
+
+impl FromStr for PeerEndpoint {
+    type Err = PeerEndpointError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s.to_string())
+    }
+}
+
+impl fmt::Display for PeerEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for PeerEndpoint {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for PeerEndpoint {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for PeerEndpoint {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Re-validate on the way in: a wire-supplied or persisted endpoint
+        // that violates the contract is rejected here, not silently observed
+        // as a runtime trap downstream.
+        let s = String::deserialize(deserializer)?;
+        Self::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
 /// A known peer node and the network endpoint where its TSO service can be
 /// reached for follower-redirect hints.
 ///
@@ -36,36 +186,40 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TsoPeer {
     pub node_id: u64,
-    pub endpoint: String,
+    pub endpoint: PeerEndpoint,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // ---- TsoPeer struct shape (preserved from pre-newtype tests; updated
+    // ---- to use contract-conforming endpoints instead of the http://...
+    // ---- forms that were latent contract violations).
+
     #[test]
     fn carries_node_id_and_endpoint() {
         let peer = TsoPeer {
             node_id: 2,
-            endpoint: "http://node-2:50051".to_string(),
+            endpoint: PeerEndpoint::try_from("node-2:50051").unwrap(),
         };
         assert_eq!(peer.node_id, 2);
-        assert_eq!(peer.endpoint, "http://node-2:50051");
+        assert_eq!(peer.endpoint.as_str(), "node-2:50051");
     }
 
     #[test]
     fn equality_is_by_node_id_and_endpoint() {
         let left = TsoPeer {
             node_id: 1,
-            endpoint: "http://a".to_string(),
+            endpoint: PeerEndpoint::try_from("a:1").unwrap(),
         };
         let same = TsoPeer {
             node_id: 1,
-            endpoint: "http://a".to_string(),
+            endpoint: PeerEndpoint::try_from("a:1").unwrap(),
         };
         let different_endpoint = TsoPeer {
             node_id: 1,
-            endpoint: "http://b".to_string(),
+            endpoint: PeerEndpoint::try_from("b:1").unwrap(),
         };
         assert_eq!(left, same);
         assert_ne!(left, different_endpoint);
@@ -78,13 +232,200 @@ mod tests {
         let mut peers = HashSet::new();
         peers.insert(TsoPeer {
             node_id: 1,
-            endpoint: "http://a".to_string(),
+            endpoint: PeerEndpoint::try_from("a:1").unwrap(),
         });
         let duplicate = peers.insert(TsoPeer {
             node_id: 1,
-            endpoint: "http://a".to_string(),
+            endpoint: PeerEndpoint::try_from("a:1").unwrap(),
         });
         assert!(!duplicate, "an equal peer must hash to the same bucket");
         assert_eq!(peers.len(), 1);
+    }
+
+    // ---- PeerEndpoint: accepted shapes
+
+    #[test]
+    fn accepts_basic_hostname_with_port() {
+        let e = PeerEndpoint::try_from("node-1:50051").unwrap();
+        assert_eq!(e.as_str(), "node-1:50051");
+    }
+
+    #[test]
+    fn accepts_ipv4_with_port() {
+        let e = PeerEndpoint::try_from("10.0.0.7:50551").unwrap();
+        assert_eq!(e.as_str(), "10.0.0.7:50551");
+    }
+
+    #[test]
+    fn accepts_ipv6_bracketed_with_port() {
+        let e = PeerEndpoint::try_from("[::1]:50551").unwrap();
+        assert_eq!(e.as_str(), "[::1]:50551");
+    }
+
+    #[test]
+    fn accepts_fqdn_with_port() {
+        let e = PeerEndpoint::try_from("leader.example.com:9000").unwrap();
+        assert_eq!(e.as_str(), "leader.example.com:9000");
+    }
+
+    #[test]
+    fn accepts_max_port() {
+        let e = PeerEndpoint::try_from("h:65535").unwrap();
+        assert_eq!(e.as_str(), "h:65535");
+    }
+
+    #[test]
+    fn accepts_min_valid_port() {
+        let e = PeerEndpoint::try_from("h:1").unwrap();
+        assert_eq!(e.as_str(), "h:1");
+    }
+
+    // ---- PeerEndpoint: rejected shapes
+
+    #[test]
+    fn rejects_empty() {
+        assert_eq!(PeerEndpoint::try_from(""), Err(PeerEndpointError::Empty),);
+    }
+
+    #[test]
+    fn rejects_http_scheme() {
+        let err = PeerEndpoint::try_from("http://node-1:50051").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::SchemeBearing { .. }),
+            "expected SchemeBearing, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_https_scheme() {
+        let err = PeerEndpoint::try_from("https://node-1:50051").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::SchemeBearing { .. }),
+            "expected SchemeBearing, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_mem_scheme_via_missing_port() {
+        // `mem://foo` is not http(s):// so it bypasses the scheme check, but
+        // it has no numeric port — either the missing-port branch or the
+        // invalid-port branch must reject it. Either is contract-correct;
+        // both are acceptable.
+        let err = PeerEndpoint::try_from("mem://foo").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PeerEndpointError::MissingPort { .. }
+                    | PeerEndpointError::InvalidPort { .. }
+                    | PeerEndpointError::EmptyHost { .. }
+            ),
+            "expected port-shape rejection, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_bare_host_no_port() {
+        let err = PeerEndpoint::try_from("node-1").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::MissingPort { .. }),
+            "expected MissingPort, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_empty_port() {
+        let err = PeerEndpoint::try_from("node-1:").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::InvalidPort { .. }),
+            "expected InvalidPort, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_non_numeric_port() {
+        let err = PeerEndpoint::try_from("node-1:abc").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::InvalidPort { .. }),
+            "expected InvalidPort, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_empty_host() {
+        let err = PeerEndpoint::try_from(":50051").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::EmptyHost { .. }),
+            "expected EmptyHost, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_port_zero() {
+        let err = PeerEndpoint::try_from("h:0").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::InvalidPort { .. }),
+            "expected InvalidPort, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn rejects_port_overflow() {
+        let err = PeerEndpoint::try_from("h:65536").unwrap_err();
+        assert!(
+            matches!(err, PeerEndpointError::InvalidPort { .. }),
+            "expected InvalidPort, got {err:?}",
+        );
+    }
+
+    // ---- PeerEndpoint: API surface
+
+    #[test]
+    fn display_round_trips() {
+        let e = PeerEndpoint::try_from("node-1:50051").unwrap();
+        assert_eq!(format!("{e}"), "node-1:50051");
+    }
+
+    #[test]
+    fn from_str_works() {
+        let e: PeerEndpoint = "node-1:50051".parse().unwrap();
+        assert_eq!(e.as_str(), "node-1:50051");
+    }
+
+    #[test]
+    fn try_from_str_ref_works() {
+        let e: PeerEndpoint = "node-1:50051".try_into().unwrap();
+        assert_eq!(e.as_str(), "node-1:50051");
+    }
+
+    #[test]
+    fn into_inner_returns_string() {
+        let e = PeerEndpoint::try_from("node-1:50051").unwrap();
+        assert_eq!(e.into_inner(), String::from("node-1:50051"));
+    }
+
+    // ---- PeerEndpoint: serde re-validates on deserialize
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trip_preserves_value() {
+        let e = PeerEndpoint::try_from("10.0.0.7:50551").unwrap();
+        let json = serde_json::to_string(&e).unwrap();
+        assert_eq!(json, "\"10.0.0.7:50551\"");
+        let back: PeerEndpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_rejects_scheme_bearing_input() {
+        // A scheme-bearing endpoint that snuck onto the wire must NOT be
+        // observable as a `PeerEndpoint` — re-validate on deserialize.
+        let err = serde_json::from_str::<PeerEndpoint>("\"http://node-1:50051\"")
+            .expect_err("deserialize must reject scheme-bearing input");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("scheme-less") || msg.contains("http"),
+            "error should mention the scheme contract, got: {msg}",
+        );
     }
 }

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -174,8 +174,7 @@ where
             epoch: Epoch(u128::from(term)),
         },
         LeadershipState::Follower { term, leader } => LeaderState::Follower {
-            leader_endpoint: leader
-                .and_then(|(_id, node)| node.service_endpoint().map(str::to_owned)),
+            leader_endpoint: leader.and_then(|(_id, node)| node.service_endpoint()),
             leader_epoch: Some(Epoch(u128::from(term))),
         },
         LeadershipState::Candidate { .. }
@@ -189,7 +188,7 @@ mod tests {
     use super::map_leader_state;
     use crate::type_config::TypeConfig;
     use tsoracle_consensus::LeaderState;
-    use tsoracle_core::Epoch;
+    use tsoracle_core::{Epoch, PeerEndpoint};
     use tsoracle_openraft_toolkit::LeadershipState;
 
     #[test]
@@ -208,7 +207,7 @@ mod tests {
         assert_eq!(
             state,
             LeaderState::Follower {
-                leader_endpoint: Some("node-2:50051".into()),
+                leader_endpoint: Some(PeerEndpoint::try_from("node-2:50051").unwrap()),
                 leader_epoch: Some(Epoch(4)),
             }
         );

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -30,6 +30,7 @@
 use std::io::Cursor;
 
 use serde::{Deserialize, Serialize};
+use tsoracle_core::PeerEndpoint;
 use tsoracle_openraft_toolkit::declare_raft_types_ext;
 
 use crate::log_entry::HighWaterCommand;
@@ -58,21 +59,31 @@ pub struct OpenraftPeer {
     pub admin_endpoint: String,
 }
 
-/// Resolves a membership `Node`'s tsoracle client endpoint for `LeaderHint`
-/// follower redirects. Implemented by every `Node` type used with
-/// [`crate::OpenraftDriver`]; return `None` for nodes that do not redirect
-/// tsoracle clients.
+/// Resolves a membership `Node`'s tsoracle endpoints for follower redirects
+/// (`service_endpoint`) and admin-plane requests (`admin_endpoint`).
+/// Implemented by every `Node` type used with [`crate::OpenraftDriver`];
+/// return `None` for nodes that do not expose the corresponding plane.
+///
+/// **Return-type rationale:** these methods *parse* the stored representation
+/// into a typed [`PeerEndpoint`] on each call. The underlying field on a
+/// concrete `Node` (e.g. [`OpenraftPeer`]) stays `String` to preserve the
+/// postcard wire format used in openraft membership log entries; the typed
+/// projection lives at the read boundary, identical to how `LeaderHint`'s
+/// wire `String` is parsed by `tsoracle_client::leader_hint`. A malformed
+/// or empty value silently maps to `None` — matching the historical
+/// `is_empty -> None` sentinel — rather than panicking, so a misconfigured
+/// peer never crashes the leader-watch task.
 pub trait ServiceEndpoint {
-    fn service_endpoint(&self) -> Option<&str>;
+    fn service_endpoint(&self) -> Option<PeerEndpoint>;
+    fn admin_endpoint(&self) -> Option<PeerEndpoint>;
 }
 
 impl ServiceEndpoint for OpenraftPeer {
-    fn service_endpoint(&self) -> Option<&str> {
-        if self.service_endpoint.is_empty() {
-            None
-        } else {
-            Some(&self.service_endpoint)
-        }
+    fn service_endpoint(&self) -> Option<PeerEndpoint> {
+        PeerEndpoint::try_from(self.service_endpoint.clone()).ok()
+    }
+    fn admin_endpoint(&self) -> Option<PeerEndpoint> {
+        PeerEndpoint::try_from(self.admin_endpoint.clone()).ok()
     }
 }
 
@@ -299,10 +310,15 @@ mod tests {
         use crate::type_config::ServiceEndpoint;
         let with = OpenraftPeer {
             addr: "node-1:50052".to_string(),
-            service_endpoint: "http://node-1:50051".to_string(),
+            service_endpoint: "node-1:50051".to_string(),
             admin_endpoint: String::new(),
         };
-        assert_eq!(with.service_endpoint(), Some("http://node-1:50051"));
+        assert_eq!(
+            with.service_endpoint(),
+            Some(PeerEndpoint::try_from("node-1:50051").unwrap()),
+        );
+        // An empty admin_endpoint is mapped to None.
+        assert_eq!(with.admin_endpoint(), None);
 
         let without = OpenraftPeer {
             addr: "node-1:50052".to_string(),
@@ -310,5 +326,21 @@ mod tests {
             admin_endpoint: String::new(),
         };
         assert_eq!(without.service_endpoint(), None);
+        assert_eq!(without.admin_endpoint(), None);
+    }
+
+    #[test]
+    fn service_endpoint_silently_drops_malformed() {
+        // A persisted-then-recovered scheme-bearing endpoint (e.g. carried
+        // forward from a pre-newtype configuration) must not crash the
+        // leader-watch task; it is treated as "no redirect".
+        use crate::type_config::ServiceEndpoint;
+        let bad = OpenraftPeer {
+            addr: "node-1:50052".to_string(),
+            service_endpoint: "http://node-1:50051".to_string(),
+            admin_endpoint: "https://node-1:50053".to_string(),
+        };
+        assert_eq!(bad.service_endpoint(), None);
+        assert_eq!(bad.admin_endpoint(), None);
     }
 }

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -30,7 +30,7 @@ pub use events::{
     LeaderEventSender, LeaderEventStream, LeaderEventSubscriber, SendError, leader_event_channel,
 };
 pub use state::LeadershipState;
-pub use tsoracle_core::TsoPeer;
+pub use tsoracle_core::{PeerEndpoint, PeerEndpointError, TsoPeer};
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/state.rs
@@ -24,7 +24,7 @@
 //! Maps OmniPaxos leadership observations to `tsoracle_consensus::LeaderState`.
 
 use tsoracle_consensus::LeaderState;
-use tsoracle_core::{Epoch, TsoPeer};
+use tsoracle_core::{Epoch, PeerEndpoint, TsoPeer};
 
 /// Internal leadership observation, mappable to
 /// [`tsoracle_consensus::LeaderState`] via [`Self::to_consensus`].
@@ -38,7 +38,9 @@ pub enum LeadershipState {
     Leader { epoch: Epoch },
     /// This node is a follower; `leader_endpoint` is the elected leader's
     /// advertised tsoracle service address if known.
-    Follower { leader_endpoint: Option<String> },
+    Follower {
+        leader_endpoint: Option<PeerEndpoint>,
+    },
     /// No leader is currently observed (election in progress, partition,
     /// or local-leader observation without an accompanying epoch).
     Unknown,
@@ -123,13 +125,13 @@ mod tests {
     fn leader_is_other_emits_follower_with_endpoint() {
         let peers = vec![TsoPeer {
             node_id: 2,
-            endpoint: "node-2:50051".into(),
+            endpoint: PeerEndpoint::try_from("node-2:50051").unwrap(),
         }];
         let state = LeadershipState::from_omnipaxos(1, Some(2), Some(Epoch(7)), &peers);
         assert_eq!(
             state.to_consensus(),
             LeaderState::Follower {
-                leader_endpoint: Some("node-2:50051".into()),
+                leader_endpoint: Some(PeerEndpoint::try_from("node-2:50051").unwrap()),
                 leader_epoch: None,
             },
         );

--- a/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/lifecycle.rs
@@ -34,7 +34,7 @@ use common::{TestCommand, build_mem_cluster};
 use futures::StreamExt;
 use omnipaxos::messages::Message;
 use tsoracle_consensus::LeaderState;
-use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PaxosRunner, TsoPeer};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PaxosRunner, PeerEndpoint, TsoPeer};
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 
 struct NetworkSink {
@@ -69,7 +69,8 @@ async fn runners_emit_leader_or_follower_event_after_election() {
             .filter(|peer_node| peer_node.node_id != node.node_id)
             .map(|peer_node| TsoPeer {
                 node_id: peer_node.node_id,
-                endpoint: format!("mem://{}", peer_node.node_id),
+                endpoint: PeerEndpoint::try_from(format!("mem-peer-{}:1", peer_node.node_id))
+                    .expect("synthetic peer endpoint is contract-conforming"),
             })
             .collect();
         let mut runner = PaxosRunner::new(

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -77,27 +77,17 @@ fn warn_on_stuck_fence(transient_retries: u32) -> bool {
             == 0
 }
 
-/// Whether `endpoint` is a scheme-less `host:port` — the shape
-/// `LeaderState::Follower::leader_endpoint` is contracted to carry.
+/// Debug-only guard that a driver-surfaced [`LeaderState`] honors the
+/// `LeaderState::Follower` epoch-monotonicity contract (see
+/// [`tsoracle_consensus::LeaderState`]): `leader_epoch` is non-decreasing
+/// across emissions. The client's monotone-forward gate
+/// (`compare_and_set_leader`) drops a hint that cannot outrank the cached
+/// leader, so a regressing epoch makes clients drop valid redirects.
 ///
-/// Match shape mirrors the client's `normalize_uri` / `rejects_plaintext_hint`:
-/// ASCII-lowercase `http://` and `https://` prefixes. An uppercase variant
-/// would already fail to parse downstream, so checking the lowercase form is
-/// sufficient.
-fn endpoint_is_scheme_less(endpoint: &str) -> bool {
-    !endpoint.starts_with("http://") && !endpoint.starts_with("https://")
-}
-
-/// Debug-only guard that a driver-surfaced [`LeaderState`] honors the two
-/// `LeaderState::Follower` contracts (see [`tsoracle_consensus::LeaderState`]):
-///
-///   * `leader_endpoint` is a scheme-less `host:port`. A scheme-bearing hint is
-///     silently dropped by the client's `rejects_plaintext_hint` under TLS, so
-///     a contract-violating driver makes that leader unreachable via redirect.
-///   * `leader_epoch` is non-decreasing across emissions. The client's
-///     monotone-forward gate (`compare_and_set_leader`) drops a hint that
-///     cannot outrank the cached leader, so a regressing epoch makes clients
-///     drop valid redirects.
+/// The companion scheme-less `leader_endpoint` contract is enforced at the
+/// type level by [`tsoracle_core::PeerEndpoint`]: a scheme-bearing string
+/// cannot inhabit the field, so the historical runtime check folded into the
+/// type's constructor.
 ///
 /// Compiled out in release builds (`debug_assert!`), so it costs nothing in
 /// production and fires only in a driver author's own test suite — turning a
@@ -106,18 +96,6 @@ fn endpoint_is_scheme_less(endpoint: &str) -> bool {
 /// (epoch-less paxos hints, `Unknown`) are a documented valid case and advance
 /// nothing.
 fn debug_assert_leader_state_contract(evt: &LeaderState, last_epoch: &mut Option<Epoch>) {
-    if let LeaderState::Follower {
-        leader_endpoint: Some(endpoint),
-        ..
-    } = evt
-    {
-        debug_assert!(
-            endpoint_is_scheme_less(endpoint),
-            "consensus driver surfaced a scheme-bearing leader_endpoint ({endpoint:?}); \
-             LeaderState::Follower::leader_endpoint must be a scheme-less host:port — \
-             the TLS client silently drops http(s):// hints to avoid transport downgrade",
-        );
-    }
     let epoch = match evt {
         LeaderState::Leader { epoch } => Some(*epoch),
         LeaderState::Follower { leader_epoch, .. } => *leader_epoch,
@@ -427,20 +405,7 @@ pub(crate) async fn run_leader_watch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tsoracle_core::Epoch;
-
-    #[test]
-    fn bare_host_port_is_scheme_less() {
-        assert!(endpoint_is_scheme_less("leader:9000"));
-        assert!(endpoint_is_scheme_less("10.9.8.7:50551"));
-        assert!(endpoint_is_scheme_less("node-2"));
-    }
-
-    #[test]
-    fn http_and_https_are_not_scheme_less() {
-        assert!(!endpoint_is_scheme_less("http://leader:9000"));
-        assert!(!endpoint_is_scheme_less("https://leader:9000"));
-    }
+    use tsoracle_core::{Epoch, PeerEndpoint};
 
     #[test]
     fn monotone_sequence_with_bare_endpoints_passes_guard() {
@@ -449,7 +414,7 @@ mod tests {
             LeaderState::Unknown,
             LeaderState::Leader { epoch: Epoch(5) },
             LeaderState::Follower {
-                leader_endpoint: Some("leader:9000".into()),
+                leader_endpoint: Some(PeerEndpoint::try_from("leader:9000").unwrap()),
                 leader_epoch: Some(Epoch(5)),
             },
             LeaderState::Follower {
@@ -465,18 +430,6 @@ mod tests {
 
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "scheme-less host:port")]
-    fn scheme_bearing_follower_endpoint_trips_guard() {
-        let mut last_epoch = None;
-        let evt = LeaderState::Follower {
-            leader_endpoint: Some("http://leader:9000".into()),
-            leader_epoch: Some(Epoch(1)),
-        };
-        debug_assert_leader_state_contract(&evt, &mut last_epoch);
-    }
-
-    #[cfg(debug_assertions)]
-    #[test]
     #[should_panic(expected = "leader_epoch that regressed")]
     fn regressing_epoch_trips_guard() {
         let mut last_epoch = None;
@@ -486,7 +439,7 @@ mod tests {
         );
         debug_assert_leader_state_contract(
             &LeaderState::Follower {
-                leader_endpoint: Some("leader:9000".into()),
+                leader_endpoint: Some(PeerEndpoint::try_from("leader:9000").unwrap()),
                 leader_epoch: Some(Epoch(6)),
             },
             &mut last_epoch,

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -29,7 +29,7 @@ use tokio::sync::watch;
 use tonic::service::Routes;
 use tonic::transport::Server as TonicServer;
 use tsoracle_consensus::ConsensusDriver;
-use tsoracle_core::{Clock, Epoch, SystemClock};
+use tsoracle_core::{Clock, Epoch, PeerEndpoint, SystemClock};
 #[cfg(any(test, feature = "test-fakes"))]
 use tsoracle_core::{CoreError, WindowGrant};
 use tsoracle_proto::v1::tso_service_server::TsoServiceServer;
@@ -79,7 +79,7 @@ pub enum ServerError {
 #[derive(Clone, Debug)]
 pub enum ServingState {
     NotServing {
-        leader_endpoint: Option<String>,
+        leader_endpoint: Option<PeerEndpoint>,
         leader_epoch: Option<Epoch>,
     },
     Serving,
@@ -874,16 +874,15 @@ mod tests {
             .build()
             .expect("build must succeed");
 
-        server
-            .core
-            .step_down(Some("http://new-leader:9000".into()), Some(Epoch(7)));
+        let hint = PeerEndpoint::try_from("new-leader:9000").unwrap();
+        server.core.step_down(Some(hint.clone()), Some(Epoch(7)));
 
         match server.core.serving_state() {
             ServingState::NotServing {
                 leader_endpoint,
                 leader_epoch,
             } => {
-                assert_eq!(leader_endpoint.as_deref(), Some("http://new-leader:9000"));
+                assert_eq!(leader_endpoint, Some(hint));
                 assert_eq!(leader_epoch, Some(Epoch(7)));
             }
             ServingState::Serving => panic!("expected NotServing after step_down"),

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tonic::{Request, Response, Status};
 #[cfg(feature = "metrics")]
 use tsoracle_core::IgnoreReason;
-use tsoracle_core::{CommitOutcome, CoreError, Epoch};
+use tsoracle_core::{CommitOutcome, CoreError, Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{
     EpochWire, GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetTsRequest, GetTsResponse,
     LeaderHint, tso_service_server::TsoService,
@@ -60,7 +60,11 @@ fn leader_hint_from(server: &Server) -> LeaderHint {
         ServingState::Serving => (None, None),
     };
     LeaderHint {
-        leader_endpoint,
+        // Wire-format `LeaderHint.leader_endpoint` stays `Option<String>`
+        // (prost-generated) — the boundary out of the typed `PeerEndpoint` is
+        // here; the boundary back in is in `tsoracle_client::leader_hint`
+        // where every wire-supplied hint runs through `PeerEndpoint::try_from`.
+        leader_endpoint: leader_endpoint.map(PeerEndpoint::into_inner),
         leader_epoch: wire_epoch(leader_epoch),
     }
 }
@@ -402,14 +406,12 @@ mod tests {
             .clock(std::sync::Arc::new(tsoracle_core::SystemClock))
             .build()
             .unwrap();
-        server
-            .core
-            .publish_not_serving(Some("http://other-node:9000".into()), Some(Epoch(7)));
-        let hint = leader_hint_from(&server);
-        assert_eq!(
-            hint.leader_endpoint.as_deref(),
-            Some("http://other-node:9000")
+        server.core.publish_not_serving(
+            Some(PeerEndpoint::try_from("other-node:9000").unwrap()),
+            Some(Epoch(7)),
         );
+        let hint = leader_hint_from(&server);
+        assert_eq!(hint.leader_endpoint.as_deref(), Some("other-node:9000"));
         let (hi, lo) = Epoch(7).to_wire();
         assert_eq!(hint.leader_epoch, Some(EpochWire { hi, lo }));
 

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -52,7 +52,7 @@ use tokio::sync::{
     Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
     watch,
 };
-use tsoracle_core::{Allocator, CommitOutcome, CoreError, Epoch, WindowGrant};
+use tsoracle_core::{Allocator, CommitOutcome, CoreError, Epoch, PeerEndpoint, WindowGrant};
 
 use crate::server::ServingState;
 
@@ -136,7 +136,7 @@ impl ServingCore {
 
     pub(crate) fn publish_not_serving(
         &self,
-        leader_endpoint: Option<String>,
+        leader_endpoint: Option<PeerEndpoint>,
         leader_epoch: Option<Epoch>,
     ) {
         self.state_tx.send_replace(ServingState::NotServing {
@@ -153,7 +153,11 @@ impl ServingCore {
     /// in-flight extension holding the read lock and awaiting `persist_high_water`
     /// would deadlock against a write here. Those in-flights complete cleanly or
     /// fail and reach this method themselves — it is idempotent.
-    pub(crate) fn step_down(&self, leader_endpoint: Option<String>, leader_epoch: Option<Epoch>) {
+    pub(crate) fn step_down(
+        &self,
+        leader_endpoint: Option<PeerEndpoint>,
+        leader_epoch: Option<Epoch>,
+    ) {
         self.allocator.lock().on_leadership_lost();
         self.state_tx.send_replace(ServingState::NotServing {
             leader_endpoint,
@@ -278,14 +282,15 @@ mod tests {
         let core = ServingCore::new(Duration::from_secs(3));
         assert_eq!(core.state_tx.receiver_count(), 0);
 
-        core.step_down(Some("http://new-leader:9000".into()), Some(Epoch(7)));
+        let hint = PeerEndpoint::try_from("new-leader:9000").unwrap();
+        core.step_down(Some(hint.clone()), Some(Epoch(7)));
 
         match core.serving_state() {
             ServingState::NotServing {
                 leader_endpoint,
                 leader_epoch,
             } => {
-                assert_eq!(leader_endpoint.as_deref(), Some("http://new-leader:9000"));
+                assert_eq!(leader_endpoint, Some(hint));
                 assert_eq!(leader_epoch, Some(Epoch(7)));
             }
             ServingState::Serving => panic!("expected NotServing after step_down"),
@@ -367,7 +372,10 @@ mod tests {
         );
         assert!(matches!(core.serving_state(), ServingState::Serving));
 
-        core.step_down(Some("http://leader:9000".into()), Some(Epoch(1)));
+        core.step_down(
+            Some(PeerEndpoint::try_from("leader:9000").unwrap()),
+            Some(Epoch(1)),
+        );
         assert!(!core.is_serving(), "step_down must flip is_serving false");
     }
 

--- a/crates/tsoracle-server/src/test_fakes.rs
+++ b/crates/tsoracle-server/src/test_fakes.rs
@@ -32,7 +32,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::{Notify, watch};
 use tokio_stream::wrappers::WatchStream;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, PeerEndpoint};
 
 #[derive(Clone)]
 pub struct InMemoryDriver {
@@ -61,7 +61,7 @@ impl InMemoryDriver {
         let _ = self.tx.send(LeaderState::Leader { epoch });
     }
 
-    pub fn become_follower(&self, hint: Option<String>) {
+    pub fn become_follower(&self, hint: Option<PeerEndpoint>) {
         let _ = self.tx.send(LeaderState::Follower {
             leader_endpoint: hint,
             leader_epoch: None,
@@ -70,7 +70,7 @@ impl InMemoryDriver {
 
     /// Emit a `Follower` transition carrying both the leader endpoint hint and
     /// the leader's epoch, so tests can exercise epoch propagation.
-    pub fn become_follower_with_epoch(&self, hint: Option<String>, epoch: Option<Epoch>) {
+    pub fn become_follower_with_epoch(&self, hint: Option<PeerEndpoint>, epoch: Option<Epoch>) {
         let _ = self.tx.send(LeaderState::Follower {
             leader_endpoint: hint,
             leader_epoch: epoch,
@@ -280,7 +280,7 @@ impl FaultyDriver {
         self.inner.become_leader(epoch);
     }
 
-    pub fn become_follower(&self, hint: Option<String>) {
+    pub fn become_follower(&self, hint: Option<PeerEndpoint>) {
         self.inner.become_follower(hint);
     }
 

--- a/crates/tsoracle-server/tests/e2e.rs
+++ b/crates/tsoracle-server/tests/e2e.rs
@@ -22,7 +22,7 @@
 //
 
 use std::{sync::Arc, time::Duration};
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
 use tsoracle_server::test_fakes::InMemoryDriver;
 use tsoracle_server::test_support::{
@@ -79,7 +79,7 @@ async fn returns_not_leader_with_hint() {
 
     let mut booted = boot_server(server).await;
 
-    driver.become_follower(Some("10.9.8.7:50551".into()));
+    driver.become_follower(Some(PeerEndpoint::try_from("10.9.8.7:50551").unwrap()));
     // Wait for the follower hint to actually be visible in state — distinct
     // from the initial NotServing { leader_endpoint: None }.
     wait_until(&mut booted.state_rx, |s| {

--- a/crates/tsoracle-server/tests/get_current_max_safe.rs
+++ b/crates/tsoracle-server/tests/get_current_max_safe.rs
@@ -22,7 +22,7 @@
 //
 
 use std::{sync::Arc, time::Duration};
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{
     GetCurrentMaxSafeRequest, GetTsRequest, tso_service_client::TsoServiceClient,
 };
@@ -45,7 +45,7 @@ async fn get_current_max_safe_returns_zero_on_follower() {
 
     let booted = boot_server(server).await;
 
-    driver.become_follower(Some("10.9.8.7:50551".into()));
+    driver.become_follower(Some(PeerEndpoint::try_from("10.9.8.7:50551").unwrap()));
     wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
         .await
         .expect("tonic never accepted gRPC handshake");

--- a/crates/tsoracle-server/tests/leader_watch.rs
+++ b/crates/tsoracle-server/tests/leader_watch.rs
@@ -24,7 +24,7 @@
 use std::{sync::Arc, time::Duration};
 use tokio::time::timeout;
 use tsoracle_consensus::ConsensusDriver;
-use tsoracle_core::{Epoch, testing::MockClock};
+use tsoracle_core::{Epoch, PeerEndpoint, testing::MockClock};
 use tsoracle_server::{
     Server, ServerError, ServingState,
     test_fakes::{FaultKind, FaultyDriver, InMemoryDriver},
@@ -336,7 +336,10 @@ async fn leader_watch_propagates_follower_epoch_into_serving_state() {
     let watch_server = server.clone();
     let watch_handle = tokio::spawn(async move { watch_server.run_leader_watch_for_tests().await });
 
-    driver.become_follower_with_epoch(Some("leader:9000".into()), Some(Epoch(7)));
+    driver.become_follower_with_epoch(
+        Some(PeerEndpoint::try_from("leader:9000").unwrap()),
+        Some(Epoch(7)),
+    );
 
     let mut state_rx = server.subscribe();
     let snapshot = timeout(Duration::from_secs(1), async {
@@ -360,7 +363,10 @@ async fn leader_watch_propagates_follower_epoch_into_serving_state() {
             leader_endpoint,
             leader_epoch,
         } => {
-            assert_eq!(leader_endpoint.as_deref(), Some("leader:9000"));
+            assert_eq!(
+                leader_endpoint,
+                Some(PeerEndpoint::try_from("leader:9000").unwrap())
+            );
             assert_eq!(leader_epoch, Some(Epoch(7)));
         }
         other => panic!("expected NotServing, got {other:?}"),

--- a/crates/tsoracle-server/tests/metrics.rs
+++ b/crates/tsoracle-server/tests/metrics.rs
@@ -36,7 +36,7 @@ use metrics_util::{
     debugging::{DebugValue, DebuggingRecorder, Snapshotter},
 };
 use tokio::time::sleep;
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{GetTsRequest, tso_service_client::TsoServiceClient};
 use tsoracle_server::test_fakes::{FaultKind, FaultyDriver};
 use tsoracle_server::test_support::{
@@ -135,7 +135,7 @@ async fn emits_documented_signals_end_to_end() {
 
     // Drop leadership, then issue one more GetTs to drive a NOT_LEADER
     // rejection through `not_leader_status`.
-    driver.become_follower(Some("10.9.8.7:50551".into()));
+    driver.become_follower(Some(PeerEndpoint::try_from("10.9.8.7:50551").unwrap()));
     wait_until(&mut booted.state_rx, |s| {
         matches!(
             s,

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -32,7 +32,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
 use tsoracle_consensus::ConsensusDriver;
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
-use tsoracle_paxos_toolkit::lifecycle::TsoPeer;
+use tsoracle_paxos_toolkit::lifecycle::{PeerEndpoint, TsoPeer};
 use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 
 use crate::config::PaxosConfig;
@@ -198,11 +198,15 @@ async fn build_paxos_inner(
         .tso_peers
         .iter()
         .filter(|(id, _)| **id != cfg.node_id)
-        .map(|(id, endpoint)| TsoPeer {
-            node_id: *id,
-            endpoint: endpoint.clone(),
+        .map(|(id, endpoint)| {
+            PeerEndpoint::try_from(endpoint.clone())
+                .map(|endpoint| TsoPeer {
+                    node_id: *id,
+                    endpoint,
+                })
+                .map_err(|e| StandaloneError::Config(format!("peer {id}: {e}")))
         })
-        .collect();
+        .collect::<Result<_, _>>()?;
     let mut host = StandaloneHost::builder()
         .omnipaxos(omnipaxos)
         .my_node_id(cfg.node_id)

--- a/crates/tsoracle-tests/tests/client_e2e_dst.rs
+++ b/crates/tsoracle-tests/tests/client_e2e_dst.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tsoracle_client::{Client, ClientBuilder, ClientError};
-use tsoracle_core::{Clock, Epoch};
+use tsoracle_core::{Clock, Epoch, PeerEndpoint};
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::InMemoryDriver;
 use tsoracle_server_testkit::{into_sim_parts, serve, sim_channel};
@@ -140,7 +140,9 @@ fn client_follows_leader_hint_on_first_call() {
                     .build()
                     .unwrap();
                 let parts = into_sim_parts(server)?;
-                driver_a.become_follower(Some(format!("server-b:{PORT}")));
+                driver_a.become_follower(Some(
+                    PeerEndpoint::try_from(format!("server-b:{PORT}")).unwrap(),
+                ));
                 serve(parts.routes, PORT).await?;
                 Ok(())
             }

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -49,7 +49,7 @@ use tonic::{
     transport::Server as TonicServer,
 };
 use tsoracle_client::Client;
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{
     GetTsRequest, GetTsResponse, LEADER_HINT_TRAILER_KEY,
     tso_service_server::{TsoService, TsoServiceServer},
@@ -214,7 +214,9 @@ async fn emits_documented_client_signals_end_to_end() {
     let mut booted_a = boot_server(server_a).await;
     let mut booted_b = boot_server(server_b).await;
     driver_b.become_leader(Epoch(1));
-    driver_a.become_follower(Some(booted_b.addr.to_string()));
+    driver_a.become_follower(Some(
+        PeerEndpoint::try_from(booted_b.addr.to_string()).unwrap(),
+    ));
     wait_until_serving(&mut booted_b.state_rx).await;
     wait_until(&mut booted_a.state_rx, |s| {
         matches!(

--- a/crates/tsoracle-tests/tests/client_tls.rs
+++ b/crates/tsoracle-tests/tests/client_tls.rs
@@ -31,7 +31,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 use tonic::transport::{Certificate, ClientTlsConfig, Identity, ServerTlsConfig};
-use tsoracle_core::Epoch;
+use tsoracle_core::{Epoch, PeerEndpoint};
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::InMemoryDriver;
 use tsoracle_server::test_support::{
@@ -307,7 +307,9 @@ async fn leader_hint_redirect_under_tls() {
 
     let leader_endpoint = format!("127.0.0.1:{}", booted_leader.addr.port());
     let follower_driver = Arc::new(InMemoryDriver::new());
-    follower_driver.become_follower(Some(leader_endpoint.clone()));
+    follower_driver.become_follower(Some(
+        PeerEndpoint::try_from(leader_endpoint.clone()).unwrap(),
+    ));
     let follower = Server::builder()
         .consensus_driver(follower_driver.clone())
         .tls_config(server_tls_config(&bundle))

--- a/crates/tsoracle-tests/tests/leadership_churn_dst.rs
+++ b/crates/tsoracle-tests/tests/leadership_churn_dst.rs
@@ -45,7 +45,7 @@ use std::time::Duration;
 
 use futures::Stream;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
-use tsoracle_core::{Epoch, testing::MockClock};
+use tsoracle_core::{Epoch, PeerEndpoint, testing::MockClock};
 use tsoracle_proto::v1::GetTsRequest;
 use tsoracle_server::test_fakes::{FaultKind, FaultyDriver, InMemoryDriver};
 use tsoracle_server::test_support::{wait_until, wait_until_not_serving, wait_until_serving};
@@ -126,7 +126,7 @@ fn fence_observes_follower_transition_during_unbounded_transient_retry() {
         // Follower handler publishes NotServing carrying the hint; the fence's
         // own NotServing uses leader_endpoint: None, so observing Some(hint)
         // proves the event was dispatched rather than spun past.
-        inner_in_host.become_follower(Some("10.1.2.3:50551".into()));
+        inner_in_host.become_follower(Some(PeerEndpoint::try_from("10.1.2.3:50551").unwrap()));
 
         wait_until(&mut parts.state_rx, |s| {
             matches!(

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -90,9 +90,12 @@ pub struct HostPeer {
 }
 
 impl tsoracle_driver_openraft::ServiceEndpoint for HostPeer {
-    // The piggyback KV demo never redirects tsoracle clients, so it carries no
-    // client endpoint.
-    fn service_endpoint(&self) -> Option<&str> {
+    // The piggyback KV demo never redirects tsoracle clients, so it carries
+    // no client endpoint and no admin endpoint.
+    fn service_endpoint(&self) -> Option<tsoracle_core::PeerEndpoint> {
+        None
+    }
+    fn admin_endpoint(&self) -> Option<tsoracle_core::PeerEndpoint> {
         None
     }
 }

--- a/examples/paxos-embedded/src/main.rs
+++ b/examples/paxos-embedded/src/main.rs
@@ -43,7 +43,7 @@ use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
 use parking_lot::Mutex;
 use tokio::sync::{mpsc, oneshot};
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
-use tsoracle_paxos_toolkit::lifecycle::{MessageSink, TsoPeer};
+use tsoracle_paxos_toolkit::lifecycle::{MessageSink, PeerEndpoint, TsoPeer};
 use tsoracle_paxos_toolkit::test_fakes::mem_network::MemNetwork;
 use tsoracle_paxos_toolkit::test_fakes::mem_storage::MemStorage;
 use tsoracle_server::Server as TsoServer;
@@ -126,11 +126,14 @@ async fn main() -> anyhow::Result<()> {
         let toolkit_peers: Vec<TsoPeer> = tso_endpoints
             .iter()
             .filter(|(peer_id, _)| *peer_id != id)
-            .map(|(peer_id, addr)| TsoPeer {
-                node_id: *peer_id,
-                endpoint: format!("http://{addr}"),
+            .map(|(peer_id, addr)| -> anyhow::Result<TsoPeer> {
+                Ok(TsoPeer {
+                    node_id: *peer_id,
+                    endpoint: PeerEndpoint::try_from(addr.to_string())
+                        .context("invalid peer endpoint")?,
+                })
             })
-            .collect();
+            .collect::<anyhow::Result<_>>()?;
         let mut host = StandaloneHost::builder()
             .omnipaxos(omnipaxos)
             .my_node_id(id)


### PR DESCRIPTION
## Summary

- Introduces `tsoracle_core::PeerEndpoint(String)`, a newtype enforcing the scheme-less `host:port` contract at construction (`try_from`) and on serde-deserialize. Rejects `http(s)://` prefixes, empty strings, missing ports, and ports outside `1..=65535`; bracketed IPv6 supported.
- Migrates `TsoPeer.endpoint`, `LeaderState::Follower::leader_endpoint`, and `ServingState::NotServing::leader_endpoint` to flow `PeerEndpoint` end-to-end in process. `OpenraftPeer.{service,admin}_endpoint` stay `String` on the type to preserve the postcard wire format used by openraft membership log entries; the `ServiceEndpoint` trait validates at the read boundary instead, returning `Option<PeerEndpoint>` and silently mapping malformed/empty to `None`.
- Deletes `tsoracle-server::fence::endpoint_is_scheme_less` and the scheme-bearing branch of the `debug_assert` driver-contract guard — both are subsumed by the type system. The epoch-monotonicity branch is retained.

## Motivation

The scheme-less host:port invariant for follower-redirect leader hints has lived as runtime guards (`endpoint_is_scheme_less` debug_assert, fired only when a follower observes a *stable* leader long enough to surface its hint) and prose contracts (`LeaderState::Follower` doc-comment at `tsoracle-consensus/src/leadership.rs:46-54`). Both have leaked: a TLS-configured client silently drops `http(s)://` hints (`rejects_plaintext_hint`) to refuse a transport downgrade, so a contract-violating endpoint makes its leader unreachable via redirect with only a log line as evidence. A scheme-bearing fixture has slipped through twice (`examples/paxos-embedded/src/main.rs` and the paxos stress topology, the latter caused PR #446's flake cascade). Type-level enforcement closes the gap.

## Surface-area changes

| Boundary | Wire-format change | New shape |
|---|---|---|
| In-process `TsoPeer`, `LeaderState`, `ServingState` | None | `PeerEndpoint` |
| `tsoracle-proto` `LeaderHint.leader_endpoint` | None (stays `String`) | Server converts via `into_inner` on publish; client parses via `try_from` on receive (existing behavior) |
| `OpenraftPeer.{service,admin}_endpoint` postcard format | None (stays `String` on the struct) | `ServiceEndpoint` trait parses on read; malformed → `None` |

The `ServiceEndpoint` trait gains an `admin_endpoint()` method for symmetry. Two impls updated (`OpenraftPeer`, `HostPeer` in `examples/openraft-piggyback`).

## Notable cleanups

- `examples/paxos-embedded/src/main.rs:131` was constructing `endpoint: format!(\"http://{addr}\")` — a latent contract violation in the example. Now uses `addr.to_string()` (`SocketAddr::Display` is scheme-less).
- `crates/tsoracle-paxos-toolkit/tests/lifecycle.rs:72` was using `format!(\"mem://{}\", ...)` — also a latent violation. Replaced with `mem-peer-{n}:1` (contract-conforming).
- `benchmarks/stress/.../topology/paxos.rs` test `build_toolkit_peers_yields_scheme_less_endpoints` was a defense-in-depth runtime check from PR #446. It's now tautological (the type system enforces what it checked), so the assertion was trimmed to a smoke-check; the protective comment updated to explain the type-level enforcement.
- `benchmarks/stress` enforces `clippy::expect_used`; one local `#[allow]` added on `build_toolkit_peers` since `SocketAddr::Display` is provably scheme-less.

## Test plan

- [x] `cargo test --workspace --all-features` — 133 test groups, 0 failed (workspace + 5 integration suites + 22 new `PeerEndpoint` unit tests)
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean (pre-commit hook)
- [x] Serde round-trip + serde-rejects-malformed-input tests for `PeerEndpoint` (`crates/tsoracle-core/src/peer.rs::tests::serde_round_trip_preserves_value`, `serde_rejects_scheme_bearing_input`)
- [x] `OpenraftPeer` trait silently drops malformed (`type_config.rs::tests::service_endpoint_silently_drops_malformed`)
- [ ] Rebase before merge — branched from 4 commits behind current `main` (the worktree was created before `#530`, `#524`, `#547`, `#557` landed)