### PR TITLE
fix(core/allocator): try_prepare_window_extension +1 overflow guard reported wrong operand

### DIFF
--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -506,9 +506,12 @@ impl Allocator {
                 committed_high_water,
                 ..
             } => {
-                let floor = committed_high_water
-                    .checked_add(1)
-                    .ok_or(CoreError::PhysicalMsOutOfRange(*committed_high_water))?;
+                debug_assert!(
+                    *committed_high_water <= PHYSICAL_MS_MAX,
+                    "committed_high_water > PHYSICAL_MS_MAX: \
+                     try_on_leadership_gained / try_commit_window_extension invariant",
+                );
+                let floor = *committed_high_water + 1;
                 let now_ms = now_ms.get();
                 let requested = core::cmp::max(floor, now_ms).checked_add(ahead_ms).ok_or(
                     CoreError::WindowExtensionOverflow {


### PR DESCRIPTION
## Summary

- `Allocator::try_prepare_window_extension` guarded `committed_high_water + 1` with `checked_add(1).ok_or(PhysicalMsOutOfRange(*committed_high_water))?`. The reported operand is in range — the value that overflowed is `committed_high_water + 1`. The error misnamed the offending value.
- That branch is also dead: every entry point that can seed `committed_high_water` validates against `PHYSICAL_MS_MAX` at the `PhysicalMs` type boundary (`try_on_leadership_gained`, `try_commit_window_extension`, and the construction-site `PhysicalMs::try_new` introduced in #562), so `committed_high_water` is bounded at `PHYSICAL_MS_MAX = (1 << 46) - 1`, many orders of magnitude below `u64::MAX`. The +1 cannot overflow without an upstream invariant violation.
- Replaced the dead `Result`-returning guard with a `debug_assert!` that documents the invariant and trips loudly in debug if it is ever broken. Release-mode safety is preserved by the existing downstream `PhysicalMs::try_new(requested)` check at allocator.rs:521 — a hypothetical wraparound to 0 would surface there once `now_ms + ahead_ms` exceeds `PHYSICAL_MS_MAX`.

Rebased onto main after #562 landed (which hoisted the per-method bound checks into the `PhysicalMs` newtype). The substantive fix is unchanged; the invariant the `debug_assert!` documents is now also enforced at the type boundary in more call sites, strengthening the argument that the removed branch is unreachable.

The original review note rated this **very low** severity (dead branch, misleading-only).

## Test plan

- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean (post-rebase)
- [x] `cargo test --workspace --all-features` — 1141 passed / 0 failed / 21 ignored (post-rebase)
- [x] Existing tests at allocator.rs:799-808 (`prepare_window_extension_rejects_out_of_range_target`, downstream `PhysicalMs::try_new(requested)`) and allocator.rs:811-835 (`prepare_window_extension_overflow_names_all_operands`, `WindowExtensionOverflow` from `floor + ahead_ms`) still cover the live overflow paths. The removed branch is unreachable so cannot be unit-tested.