### PR TITLE
refactor(core)!: clearer leadership naming + Applied { high_water }

### DIFF
--- a/crates/tsoracle-consensus/src/advance.rs
+++ b/crates/tsoracle-consensus/src/advance.rs
@@ -73,8 +73,8 @@ pub struct AdvanceOutOfRange(pub u64);
 /// fit the 46-bit timestamp layout. A value above the cap is a *poison*: once
 /// durably committed it can never be served — every subsequent leadership gain
 /// reloads it and the boundary `PhysicalMs::try_new` wrap (which feeds
-/// `try_on_leadership_gained`) rejects it (`CoreError::PhysicalMsOutOfRange`),
-/// so the new leader can never serve. The
+/// `become_leader`) rejects it (`CoreError::PhysicalMsOutOfRange`), so the new
+/// leader can never serve. The
 /// high-water only ratchets up, so it cannot self-heal.
 ///
 /// Every `ConsensusDriver::persist_high_water` MUST call this before appending

--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -215,8 +215,8 @@ pub enum CoreError {
 /// a leading indicator of epoch churn or persist reordering.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CommitOutcome {
-    /// The durable bound advanced to this value.
-    Applied(u64),
+    /// The durable bound advanced to `high_water`.
+    Applied { high_water: u64 },
     /// The bound did not move; see [`IgnoreReason`] for why.
     Ignored(IgnoreReason),
 }
@@ -280,7 +280,7 @@ impl Allocator {
     /// already persisted (typically `fence_floor + window_ms`). It must
     /// satisfy `committed_ceiling >= fence_floor` so the allocator can serve
     /// `try_grant` immediately without an additional extension round-trip.
-    pub fn try_on_leadership_gained(
+    pub fn become_leader(
         &mut self,
         fence_floor: PhysicalMs,
         committed_ceiling: PhysicalMs,
@@ -301,7 +301,7 @@ impl Allocator {
         Ok(())
     }
 
-    pub fn on_leadership_lost(&mut self) {
+    pub fn step_down(&mut self) {
         self.state = State::NotLeader;
     }
 
@@ -544,7 +544,7 @@ impl Allocator {
     /// physical-ceiling invariant on `persisted_high_water` is now enforced by
     /// the [`PhysicalMs`] parameter type itself ([`PhysicalMs::try_new`]);
     /// the `Result<_, CoreError>` shape is retained for source compatibility
-    /// with [`try_on_leadership_gained`] / [`try_prepare_window_extension`],
+    /// with [`become_leader`] / [`try_prepare_window_extension`],
     /// so callers can stay uniform under `?`, but no current code path here
     /// produces `Err`.
     pub fn try_commit_window_extension(
@@ -577,7 +577,9 @@ impl Allocator {
             }));
         }
         *committed_high_water = persisted_high_water;
-        Ok(CommitOutcome::Applied(persisted_high_water))
+        Ok(CommitOutcome::Applied {
+            high_water: persisted_high_water,
+        })
     }
 }
 
@@ -592,7 +594,7 @@ mod tests {
     use super::*;
 
     // Tiny helper to keep the bound-validated literals readable. Every
-    // pre-newtype `try_on_leadership_gained(1_000, 5_000, …)` call carried an
+    // pre-newtype `become_leader(1_000, 5_000, …)` call carried an
     // implicit "these literals are within the 46-bit field" precondition;
     // wrapping each in `PhysicalMs::try_new(_).unwrap()` would have buried
     // every test in unwrap noise without adding coverage (the literals are
@@ -610,24 +612,24 @@ mod tests {
     }
 
     #[test]
-    fn on_leadership_gained_sets_epoch() {
+    fn become_leader_sets_epoch() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(5000), Epoch(5))
+            .become_leader(pms(1000), pms(5000), Epoch(5))
             .unwrap();
         assert!(allocator.is_leader());
         assert_eq!(allocator.epoch(), Some(Epoch(5)));
     }
 
     #[test]
-    fn try_on_leadership_gained_rejects_inverted_window() {
+    fn become_leader_rejects_inverted_window() {
         // The per-argument PHYSICAL_MS_MAX checks are now enforced one layer
         // out at `PhysicalMs::try_new` (see the `physical_ms` test block below),
         // so this method's only remaining error is the cross-argument
         // `committed_ceiling < fence_floor` invariant.
         let mut allocator = Allocator::new();
         assert_eq!(
-            allocator.try_on_leadership_gained(pms(5000), pms(4000), Epoch(5)),
+            allocator.become_leader(pms(5000), pms(4000), Epoch(5)),
             Err(CoreError::InvalidLeadershipWindow {
                 fence_floor: 5000,
                 committed_ceiling: 4000
@@ -636,12 +638,12 @@ mod tests {
     }
 
     #[test]
-    fn on_leadership_lost_clears_state() {
+    fn step_down_clears_state() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(5000), Epoch(5))
+            .become_leader(pms(1000), pms(5000), Epoch(5))
             .unwrap();
-        allocator.on_leadership_lost();
+        allocator.step_down();
         assert!(!allocator.is_leader());
         assert_eq!(allocator.epoch(), None);
     }
@@ -652,7 +654,7 @@ mod tests {
         assert_eq!(allocator.committed_high_water(), None);
 
         allocator
-            .try_on_leadership_gained(pms(1_000), pms(5_000), Epoch(1))
+            .become_leader(pms(1_000), pms(5_000), Epoch(1))
             .unwrap();
         assert_eq!(allocator.committed_high_water(), Some(5_000));
 
@@ -664,7 +666,7 @@ mod tests {
             .unwrap();
         assert_eq!(allocator.committed_high_water(), Some(target.get()));
 
-        allocator.on_leadership_lost();
+        allocator.step_down();
         assert_eq!(allocator.committed_high_water(), None);
     }
 
@@ -678,7 +680,7 @@ mod tests {
     fn try_grant_zero_count() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(5000), Epoch(1))
+            .become_leader(pms(1000), pms(5000), Epoch(1))
             .unwrap();
         assert_eq!(
             allocator.try_grant(1000, 0),
@@ -690,7 +692,7 @@ mod tests {
     fn try_grant_oversized_count() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(5000), Epoch(1))
+            .become_leader(pms(1000), pms(5000), Epoch(1))
             .unwrap();
         let oversized = LOGICAL_MAX + 2;
         assert_eq!(
@@ -706,7 +708,7 @@ mod tests {
         let mut allocator = Allocator::new();
         // fence_floor=5_000, ceiling=5_000 (tight window, no pre-extended gap).
         allocator
-            .try_on_leadership_gained(pms(5_000), pms(5_000), Epoch(1))
+            .become_leader(pms(5_000), pms(5_000), Epoch(1))
             .unwrap();
         // now_ms below floor: clamps to floor=5_000, which equals the ceiling → succeeds.
         allocator.try_grant(4_999, 1).unwrap();
@@ -725,7 +727,7 @@ mod tests {
         let mut allocator = Allocator::new();
         // Tight initial window: fence_floor == ceiling == 1_000.
         allocator
-            .try_on_leadership_gained(pms(1_000), pms(1_000), Epoch(1))
+            .become_leader(pms(1_000), pms(1_000), Epoch(1))
             .unwrap();
         // now_ms far past the ceiling exhausts the window.
         assert_eq!(
@@ -755,7 +757,7 @@ mod tests {
         // can serve immediately. Grants start at fence_floor regardless of now_ms.
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(5_000), pms(10_000), Epoch(1))
+            .become_leader(pms(5_000), pms(10_000), Epoch(1))
             .unwrap();
         let grant = allocator.try_grant(1_000, 1).unwrap();
         // now_ms=1_000 < fence_floor=5_000, so next_physical_ms stays at 5_000.
@@ -779,7 +781,7 @@ mod tests {
     fn prepare_window_extension_uses_now_ms_when_ahead_of_high_water() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(1000), Epoch(1))
+            .become_leader(pms(1000), pms(1000), Epoch(1))
             .unwrap();
         let target = allocator
             .try_prepare_window_extension(pms(2000), 3000)
@@ -791,7 +793,7 @@ mod tests {
     fn prepare_window_extension_uses_high_water_floor_when_clock_behind() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(10_000), pms(10_000), Epoch(1))
+            .become_leader(pms(10_000), pms(10_000), Epoch(1))
             .unwrap();
         let target = allocator
             .try_prepare_window_extension(pms(500), 3000)
@@ -804,7 +806,7 @@ mod tests {
     fn prepare_window_extension_rejects_out_of_range_target() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(PhysicalMs::MAX, PhysicalMs::MAX, Epoch(1))
+            .become_leader(PhysicalMs::MAX, PhysicalMs::MAX, Epoch(1))
             .unwrap();
         assert_eq!(
             allocator.try_prepare_window_extension(PhysicalMs::MAX, 1),
@@ -827,7 +829,7 @@ mod tests {
         // phantom "someone passed an absurd physical_ms".
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1_000), pms(1_000), Epoch(1))
+            .become_leader(pms(1_000), pms(1_000), Epoch(1))
             .unwrap();
         assert_eq!(
             allocator.try_prepare_window_extension(pms(1_000), u64::MAX),
@@ -843,14 +845,16 @@ mod tests {
     fn commit_then_try_grant_succeeds() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(1000), Epoch(7))
+            .become_leader(pms(1000), pms(1000), Epoch(7))
             .unwrap();
         let target = allocator
             .try_prepare_window_extension(pms(1000), 3000)
             .unwrap();
         assert_eq!(
             allocator.try_commit_window_extension(target, Epoch(7)),
-            Ok(CommitOutcome::Applied(target.get()))
+            Ok(CommitOutcome::Applied {
+                high_water: target.get()
+            })
         );
         let grant = allocator.try_grant(1000, 5).unwrap();
         assert_eq!(grant.count, 5);
@@ -864,11 +868,11 @@ mod tests {
     fn commit_with_lower_value_is_ignored() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(1000), Epoch(1))
+            .become_leader(pms(1000), pms(1000), Epoch(1))
             .unwrap();
         assert_eq!(
             allocator.try_commit_window_extension(pms(5000), Epoch(1)),
-            Ok(CommitOutcome::Applied(5000))
+            Ok(CommitOutcome::Applied { high_water: 5000 })
         );
         // A non-advancing commit reports the values so the caller can tell a
         // monotonic-bound regression (persist reordering) from epoch churn.
@@ -890,7 +894,7 @@ mod tests {
         // equal value moves nothing, so it is Ignored(NotAdvanced), not Applied.
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(5000), Epoch(1))
+            .become_leader(pms(1000), pms(5000), Epoch(1))
             .unwrap();
         assert_eq!(
             allocator.try_commit_window_extension(pms(5000), Epoch(1)),
@@ -909,7 +913,7 @@ mod tests {
     fn try_grant_rejects_out_of_range_clock() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), PhysicalMs::MAX, Epoch(1))
+            .become_leader(pms(1000), PhysicalMs::MAX, Epoch(1))
             .unwrap();
         assert_eq!(
             allocator.try_grant(PHYSICAL_MS_MAX + 1, 1),
@@ -922,7 +926,7 @@ mod tests {
         let mut allocator = Allocator::new();
         // fence_floor=1000, ceiling=1000: tight initial window.
         allocator
-            .try_on_leadership_gained(pms(1000), pms(1000), Epoch(5))
+            .become_leader(pms(1000), pms(1000), Epoch(5))
             .unwrap();
         // A late persist from epoch 4 (the prior leader) — fenced out. The
         // outcome names both epochs so the caller can metric epoch churn.
@@ -946,9 +950,9 @@ mod tests {
     fn commit_after_leadership_lost_is_ignored() {
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1000), pms(5000), Epoch(1))
+            .become_leader(pms(1000), pms(5000), Epoch(1))
             .unwrap();
-        allocator.on_leadership_lost();
+        allocator.step_down();
         assert_eq!(
             allocator.try_commit_window_extension(pms(9_999), Epoch(1)),
             Ok(CommitOutcome::Ignored(IgnoreReason::NotLeader))
@@ -963,7 +967,7 @@ mod tests {
         assert!(!allocator.would_grant(1_000, 1));
         // Invalid counts: never grants.
         allocator
-            .try_on_leadership_gained(pms(1_000), pms(5_000), Epoch(1))
+            .become_leader(pms(1_000), pms(5_000), Epoch(1))
             .unwrap();
         assert!(!allocator.would_grant(1_000, 0));
         assert!(!allocator.would_grant(1_000, LOGICAL_MAX + 2));
@@ -983,7 +987,7 @@ mod tests {
         // advance leaves the window, would_grant must return false.
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(pms(1_000), pms(1_000), Epoch(1))
+            .become_leader(pms(1_000), pms(1_000), Epoch(1))
             .unwrap();
         // count >= LOGICAL_MAX + 1 forces the advance branch on a fresh
         // window: logical(0) + count(LOGICAL_MAX+1) doesn't overflow on its
@@ -1001,7 +1005,7 @@ mod tests {
         // crosses the 46-bit ceiling and the predicate refuses.
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(PhysicalMs::MAX, PhysicalMs::MAX, Epoch(1))
+            .become_leader(PhysicalMs::MAX, PhysicalMs::MAX, Epoch(1))
             .unwrap();
         // Fill the logical range so the next would_grant call has to
         // advance physical_ms.
@@ -1023,7 +1027,7 @@ mod tests {
         let mut allocator = Allocator::new();
         // fence_floor=0, ceiling=0; extend to 10 before granting.
         allocator
-            .try_on_leadership_gained(PhysicalMs::ZERO, PhysicalMs::ZERO, Epoch(1))
+            .become_leader(PhysicalMs::ZERO, PhysicalMs::ZERO, Epoch(1))
             .unwrap();
         allocator
             .try_commit_window_extension(pms(10), Epoch(1))
@@ -1048,7 +1052,7 @@ mod tests {
         // (physical_ms + 1, 0), so stored state is always directly packable.
         let mut allocator = Allocator::new();
         allocator
-            .try_on_leadership_gained(PhysicalMs::ZERO, PhysicalMs::ZERO, Epoch(1))
+            .become_leader(PhysicalMs::ZERO, PhysicalMs::ZERO, Epoch(1))
             .unwrap();
         allocator
             .try_commit_window_extension(pms(10), Epoch(1))
@@ -1139,7 +1143,7 @@ mod tests {
     // PhysicalMs newtype: the construction-site bound check that the
     // three Allocator entry points used to re-implement inline. Every
     // assertion below was previously expressed as a runtime check
-    // *inside* try_on_leadership_gained, try_prepare_window_extension,
+    // *inside* become_leader, try_prepare_window_extension,
     // or try_commit_window_extension; they now belong to the type.
     // ----------------------------------------------------------------
 
@@ -1158,7 +1162,7 @@ mod tests {
 
     #[test]
     fn physical_ms_rejects_one_past_max() {
-        // The previously-inline checks in try_on_leadership_gained and
+        // The previously-inline checks in become_leader and
         // try_commit_window_extension lived at this exact boundary;
         // they now live here.
         assert_eq!(

--- a/crates/tsoracle-core/tests/monotonicity.rs
+++ b/crates/tsoracle-core/tests/monotonicity.rs
@@ -98,7 +98,7 @@ proptest! {
                     // committed_ceiling must be >= fence_floor for immediate serving.
                     let committed_ceiling = fence_floor.saturating_add(30_000);
                     allocator
-                        .try_on_leadership_gained(
+                        .become_leader(
                             PhysicalMs::try_new(fence_floor).unwrap(),
                             PhysicalMs::try_new(committed_ceiling).unwrap(),
                             Epoch(u128::from(epoch_counter)),
@@ -106,7 +106,7 @@ proptest! {
                         .unwrap();
                 }
                 Op::Lose => {
-                    allocator.on_leadership_lost();
+                    allocator.step_down();
                 }
             }
         }

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -27,7 +27,7 @@
 //!   serving_floor = max(prior_max + 1, now)
 //!   requested     = serving_floor + failover_advance
 //!   actual        = consensus.persist_high_water(requested, epoch)
-//!   allocator.try_on_leadership_gained(serving_floor, actual, epoch)
+//!   allocator.become_leader(serving_floor, actual, epoch)
 //!
 //! The `+1` is load-bearing: a prior leader at physical_ms = prior_max could
 //! have served logical = LOGICAL_MAX, so the new leader MUST start strictly

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -160,7 +160,7 @@ impl ServingCore {
         leader_endpoint: Option<PeerEndpoint>,
         leader_epoch: Option<Epoch>,
     ) {
-        self.allocator.lock().on_leadership_lost();
+        self.allocator.lock().step_down();
         self.state_tx.send_replace(ServingState::NotServing {
             leader_endpoint,
             leader_epoch,
@@ -198,7 +198,7 @@ impl ServingCore {
         let committed_ceiling = PhysicalMs::try_new(committed_ceiling)?;
         self.allocator
             .lock()
-            .try_on_leadership_gained(serving_floor, committed_ceiling, epoch)
+            .become_leader(serving_floor, committed_ceiling, epoch)
     }
 
     pub(crate) fn commit_extension(
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn seed_then_try_grant_succeeds_at_seeded_epoch() {
-        // try_on_leadership_gained(floor, ceiling, epoch) seeds a serveable
+        // become_leader(floor, ceiling, epoch) seeds a serveable
         // window; a grant at the floor returns timestamps stamped with the
         // seeded epoch.
         let core = ServingCore::new(Duration::from_secs(3));

--- a/crates/tsoracle-tests/tests/server_failpoints.rs
+++ b/crates/tsoracle-tests/tests/server_failpoints.rs
@@ -87,7 +87,7 @@ async fn fence_recovers_after_transient_load_error() {
 }
 
 /// `server::fence::after_persist_before_publish` fires after
-/// `persist_high_water` returns, before `try_on_leadership_gained` and
+/// `persist_high_water` returns, before `become_leader` and
 /// the `state_tx.send(Serving)`. A `panic` action terminates the
 /// leader-watch task. The durable high-water has already advanced
 /// (verifiable via `driver.current_high_water()`), but serving state
@@ -198,7 +198,7 @@ async fn panic_after_serving_published_poisons_state_when_guard_unobserved() {
     // After the panic, the catch_unwind branch calls step_down, which
     // publishes NotServing. Without the fix, state would stay Serving and
     // GetTs would succeed against the allocator (seeded by
-    // try_on_leadership_gained before the failpoint fires). Polling rather
+    // become_leader before the failpoint fires). Polling rather
     // than observing watch::Receiver transitions because rapid Serving →
     // NotServing transitions can collapse on a slow receiver — see
     // tokio::sync::watch's "only latest value retained" semantics.

--- a/docs/failpoint-testing.md
+++ b/docs/failpoint-testing.md
@@ -64,7 +64,7 @@ With `feature = "failpoints"` off, both forms expand to `()` — zero code, no d
 | Site name | Position | Useful actions | Test |
 |---|---|---|---|
 | `server::fence::after_load_before_persist` | In `run_leader_watch`, between `consensus.load_high_water()` and `consensus.persist_high_water()`. | `panic`, `sleep(ms)`, `return(transient)` via the closure form (closure produces `Err(ServerError::Consensus(ConsensusError::TransientDriver(_)))`). A single `1*return(transient)` is recovered by the fence's bounded retry; a `panic` still terminates the watch task. | `fence_recovers_after_transient_load_error` |
-| `server::fence::after_persist_before_publish` | In `run_leader_watch`, after `persist_high_water` returns, before `try_on_leadership_gained` and the `state_tx.send(Serving)`. | `panic`. | `fence_panic_after_persist_advances_durable_but_not_serving` |
+| `server::fence::after_persist_before_publish` | In `run_leader_watch`, after `persist_high_water` returns, before `become_leader` and the `state_tx.send(Serving)`. | `panic`. | `fence_panic_after_persist_advances_durable_but_not_serving` |
 | `server::service::before_allocate` | In `Service::get_ts`, before the allocator lock is taken. | `sleep(ms)`, `pause`. Used for timing-shape tests only — closure-form `return` would produce a `Status` directly and bypass the production `ConsensusError → Status` classification path. | `before_allocate_sleep_delays_get_ts` |
 | `server::service::extension_gate_held` | In `Service::extend_window`, immediately after the `extension_gate.read().await` guard is bound. | `pause`, `sleep(ms)`. | `extension_gate_held_sleep_delays_get_ts` |
 

--- a/docs/key-subsystems.md
+++ b/docs/key-subsystems.md
@@ -9,7 +9,7 @@ The server runs one long-lived task per process — `run_leader_watch` — that 
 The driver reports three variants:
 
 - **`Leader { epoch }`** — this node is the elected leader at `epoch`. The pipeline runs the [failover fence](#the-failover-fence): clear serving, drain in-flight extensions, load the durable high-water, persist the requested advance, seed the allocator, then publish `Serving`. Until the fence completes, `GetTs` returns `NOT_LEADER`.
-- **`Follower { leader_endpoint }`** — this node is not the leader. The pipeline calls `allocator.on_leadership_lost()` (which forgets any cached window so the next `try_grant` returns `NotLeader`) and publishes `ServingState::NotServing { leader_endpoint }` so the service handler can include the endpoint in the `tsoracle-leader-hint-bin` trailer. Followers reject `GetTs` immediately, with no I/O.
+- **`Follower { leader_endpoint }`** — this node is not the leader. The pipeline calls `allocator.step_down()` (which forgets any cached window so the next `try_grant` returns `NotLeader`) and publishes `ServingState::NotServing { leader_endpoint }` so the service handler can include the endpoint in the `tsoracle-leader-hint-bin` trailer. Followers reject `GetTs` immediately, with no I/O.
 - **`Unknown`** — election in progress, partition, or driver-internal transient. Treated as a follower with no known leader: the allocator loses its window, `ServingState::NotServing { leader_endpoint: None }` is published. Clients seeing this trailer fall back to round-robin across configured endpoints.
 
 The drain step on entering `Leader` is the part most worth understanding. The server holds a single `tokio::sync::RwLock` (`extension_gate`): the steady-state window-extension code path in `service.rs` acquires a *read* lock for the entire `prepare → persist_high_water → commit` sequence, and the leader-watch task acquires a *write* lock immediately after clearing `ServingState`. Acquiring the write lock blocks until every read lock from the prior epoch has been dropped, so the new fence's `load_high_water` cannot race a stale `persist_high_water` still in flight from the previous leader. This is what makes the [monotonicity proof](the-allocator.md#monotonicity-proof) hold under realistic concurrency: any stale persist call either committed before the fence load (and is visible to it) or was dropped by the allocator's epoch check on return.
@@ -50,7 +50,7 @@ sequenceDiagram
     Note over LW: floor = max(prior_max + 1, now_ms)<br/>requested = floor + failover_advance
     LW->>Driver: persist_high_water(requested, epoch)
     Driver-->>LW: actual
-    LW->>Alloc: on_leadership_gained(floor, actual, epoch)
+    LW->>Alloc: become_leader(floor, actual, epoch)
     LW->>Svc: ServingState::Serving
     LW->>Gate: drop write-lock
     Note over Svc: GetTs → Ok

--- a/docs/the-allocator.md
+++ b/docs/the-allocator.md
@@ -11,13 +11,13 @@ The allocator tracks a *committed high-water* `H` — the persisted upper bound 
 ```mermaid
 stateDiagram-v2
     [*] --> NoEpoch
-    NoEpoch --> Serving: on_leadership_gained(floor, H, epoch)
+    NoEpoch --> Serving: become_leader(floor, H, epoch)
     Serving --> Exhausted: try_grant reaches H
     Exhausted --> Extending: prepare_window_extension
     Extending --> Serving: commit_window_extension(actual, epoch)
-    Serving --> NoEpoch: on_leadership_lost
-    Exhausted --> NoEpoch: on_leadership_lost
-    Extending --> NoEpoch: on_leadership_lost
+    Serving --> NoEpoch: step_down
+    Exhausted --> NoEpoch: step_down
+    Extending --> NoEpoch: step_down
 ```
 
 ## Prepare-commit split


### PR DESCRIPTION
## Summary

Surface clean-up in `tsoracle-core`'s `Allocator` and `CommitOutcome` types — no behavior change.

- `Allocator::try_on_leadership_gained` → `become_leader` (same `Result<(), CoreError>` signature). The `try_` prefix was redundant against the return type; reserve it for the "fallible peer of an infallible sibling" idiom we already use (`try_grant` vs `would_grant`).
- `Allocator::on_leadership_lost` → `step_down`. The `on_` prefix read like an event handler more than a state transition.
- `CommitOutcome::Applied(u64)` → `Applied { high_water: u64 }`. Every construction site now reads as a self-describing literal, and future fields (e.g., a `prior_high_water` for tracing) become additive instead of breaking tuple arity.

`ServingCore::seed_on_leadership_gained` is intentionally **not** renamed: its "seed in-memory state from the durably-fenced floor/ceiling" semantic is layer-specific and distinct from the inner state-machine transition, and renaming would erase that boundary. `ServingCore::step_down` already used that name at the wrapper layer; the inner rename simply makes the two read the same way.

## Breaking change

`tsoracle_core::Allocator` and `tsoracle_core::CommitOutcome` are part of the crate's `pub` surface (re-exported from `lib.rs`). Downstream consumers must update method names and the `Applied` destructuring pattern. The `!` in the commit type signals this per project convention.

## Test plan

- [x] `cargo check --workspace --all-features` — exit 0
- [x] `cargo test --workspace --all-features` — 1132 passed / 0 failed / 21 ignored across 133 binaries
- [x] `cargo clippy --workspace --all-features --tests -- -D warnings` — exit 0
- [x] `cargo fmt --check` — clean (pre-commit hook)