### PR TITLE
feat(server): periodic heartbeat log + typed Reporter metric facade

### DIFF
--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -162,6 +162,10 @@ pub struct CommonServeArgs {
     /// Advance on leadership gain.
     #[arg(long, value_parser = parse_duration, default_value = "1s")]
     pub failover_advance: Duration,
+    /// Interval between proof-of-life heartbeat log lines. Default 10s.
+    /// Pass `0s` to disable.
+    #[arg(long, value_parser = parse_duration, default_value = "10s")]
+    pub heartbeat_interval: Duration,
     /// Log level.
     #[arg(long, default_value = "info")]
     pub log: String,

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -330,7 +330,8 @@ async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
     let mut builder = Server::builder()
         .consensus_driver(node.driver.clone())
         .window_ahead(common.window_ahead)
-        .failover_advance(common.failover_advance);
+        .failover_advance(common.failover_advance)
+        .heartbeat_interval(common.heartbeat_interval);
     if let Some(tls) = tls {
         builder = builder.tls_config(tls);
     }

--- a/crates/tsoracle-bin/tests/heartbeat_subprocess.rs
+++ b/crates/tsoracle-bin/tests/heartbeat_subprocess.rs
@@ -1,0 +1,323 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::process::{ExitStatus, Stdio};
+use std::sync::{Arc, Mutex};
+use std::{io, net::SocketAddr, time::Duration};
+use tempfile::tempdir;
+use tokio::io::AsyncReadExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout};
+
+/// Allocate `n` unused 127.0.0.1 ports by binding `n` listeners at once and
+/// dropping them together, which keeps the probe window per-port as short as
+/// possible. The kernel can still hand any one of these ports to another
+/// process between `drop` and the subprocess's `.bind()` — that residual
+/// race is handled by [`retry_spawn_with_stderr`].
+async fn bind_unused_set(n: usize) -> Vec<SocketAddr> {
+    let mut listeners = Vec::with_capacity(n);
+    for _ in 0..n {
+        listeners.push(TcpListener::bind("127.0.0.1:0").await.unwrap());
+    }
+    let addrs: Vec<SocketAddr> = listeners.iter().map(|l| l.local_addr().unwrap()).collect();
+    drop(listeners);
+    addrs
+}
+
+/// Replaces the brittle `sleep(...)` startup wait with a real condition
+/// signal: poll TCP connectability until the subprocess's listener accepts.
+async fn wait_until_accepting(addr: SocketAddr, budget: Duration) -> io::Result<()> {
+    timeout(budget, async move {
+        loop {
+            if TcpStream::connect(addr).await.is_ok() {
+                return;
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("server at {addr} did not accept within {budget:?}"),
+        )
+    })
+}
+
+enum AwaitOutcome {
+    Ready,
+    ChildExited(ExitStatus),
+    Timeout(SocketAddr),
+}
+
+/// Wait for each address in `ready_idx` to start accepting connections,
+/// racing every wait against the child exiting early.
+async fn await_listening(
+    child: &mut Child,
+    ready_idx: &[usize],
+    addrs: &[SocketAddr],
+    per_addr_budget: Duration,
+) -> AwaitOutcome {
+    for &i in ready_idx {
+        let addr = addrs[i];
+        let waiter = wait_until_accepting(addr, per_addr_budget);
+        tokio::pin!(waiter);
+        tokio::select! {
+            res = &mut waiter => match res {
+                Ok(()) => continue,
+                Err(_) => return AwaitOutcome::Timeout(addr),
+            },
+            res = child.wait() => {
+                let status = res.expect("wait on child failed");
+                return AwaitOutcome::ChildExited(status);
+            }
+        }
+    }
+    AwaitOutcome::Ready
+}
+
+/// Same as smoke::retry_spawn but ALSO returns the stdout-buffer Arc<Mutex<Vec<u8>>>
+/// and the background drain `JoinHandle` so the test can `await` the drain after
+/// killing the child (ensuring all buffered output is flushed before asserting).
+///
+/// NOTE: `tracing_subscriber::fmt()` (the default, used by the tsoracle binary) writes
+/// tracing logs to **stdout**. This helper therefore pipes and drains **stdout**; stderr
+/// is inherited so EADDRINUSE diagnostics still reach the test runner for debugging.
+///
+/// Pattern:
+/// ```ignore
+/// let (mut child, addrs, drain, stdout_buf) = retry_spawn_with_stderr(...).await;
+/// // ... run the child ...
+/// child.start_kill().unwrap();
+/// let _ = child.wait().await;          // child exit closes its pipe end
+/// let stdout = collect_stderr(drain, stdout_buf).await;   // drain sees EOF, exits cleanly
+/// ```
+///
+/// - `n_ports` reserves that many `127.0.0.1:0` ports per attempt.
+/// - `ready_idx` lists the addrs whose subprocess listener we wait for via
+///   [`wait_until_accepting`].
+/// - `build` constructs the `Command` for each attempt and is called once per retry.
+async fn retry_spawn_with_stderr<F>(
+    n_ports: usize,
+    ready_idx: &[usize],
+    per_addr_budget: Duration,
+    mut build: F,
+) -> (Child, Vec<SocketAddr>, JoinHandle<()>, Arc<Mutex<Vec<u8>>>)
+where
+    F: FnMut(&[SocketAddr]) -> Command,
+{
+    const MAX_ATTEMPTS: usize = 3;
+    let mut last_eaddrinuse: Option<String> = None;
+
+    for attempt in 0..MAX_ATTEMPTS {
+        let addrs = bind_unused_set(n_ports).await;
+        let mut cmd = build(&addrs);
+        // tracing_subscriber::fmt() (the binary's default) writes to STDOUT, so
+        // pipe stdout to capture heartbeat log lines. Also pipe stderr to detect
+        // EADDRINUSE on early-exit retry logic.
+        cmd.stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().expect("spawn tsoracle (heartbeat_subprocess)");
+
+        // Drain stdout concurrently so a chatty child can't fill the pipe buffer
+        // and back-pressure itself into a hang. The buffer is kept alive and
+        // returned to the caller so it can read accumulated log output after
+        // killing the child.
+        let stdout_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut stdout_pipe = child.stdout.take().expect("stdout piped");
+        let drain_buf = Arc::clone(&stdout_buf);
+        let drain = tokio::spawn(async move {
+            let mut chunk = [0u8; 4096];
+            loop {
+                match stdout_pipe.read(&mut chunk).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => drain_buf.lock().unwrap().extend_from_slice(&chunk[..n]),
+                }
+            }
+        });
+
+        // Also drain stderr into a separate buffer used only for EADDRINUSE
+        // classification on early exit. It is not returned to the caller.
+        let stderr_diag_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut stderr_pipe = child.stderr.take().expect("stderr piped");
+        let stderr_drain_buf = Arc::clone(&stderr_diag_buf);
+        let stderr_drain = tokio::spawn(async move {
+            let mut chunk = [0u8; 4096];
+            loop {
+                match stderr_pipe.read(&mut chunk).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => stderr_drain_buf
+                        .lock()
+                        .unwrap()
+                        .extend_from_slice(&chunk[..n]),
+                }
+            }
+        });
+
+        match await_listening(&mut child, ready_idx, &addrs, per_addr_budget).await {
+            AwaitOutcome::Ready => {
+                // Return the stdout drain handle so the caller can await it after
+                // killing the child. The child's exit closes its pipe end, which
+                // makes the drain task see EOF and exit promptly.
+                // The stderr drain is detached; it exits when the child closes.
+                drop(stderr_drain);
+                return (child, addrs, drain, stdout_buf);
+            }
+            AwaitOutcome::ChildExited(status) => {
+                let _ = drain.await;
+                let _ = stderr_drain.await;
+                let stdout = String::from_utf8_lossy(&stdout_buf.lock().unwrap()).into_owned();
+                let stderr = String::from_utf8_lossy(&stderr_diag_buf.lock().unwrap()).into_owned();
+                // EADDRINUSE may surface on either stdout (tracing) or stderr.
+                if stdout.contains("Address already in use")
+                    || stderr.contains("Address already in use")
+                {
+                    last_eaddrinuse = Some(format!(
+                        "attempt {}/{MAX_ATTEMPTS}: EADDRINUSE (status={status})\
+                         \nstdout:\n{stdout}\nstderr:\n{stderr}",
+                        attempt + 1,
+                    ));
+                    continue;
+                }
+                panic!(
+                    "heartbeat_subprocess: binary exited before accepting connections: \
+                     status={status}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                );
+            }
+            AwaitOutcome::Timeout(addr) => {
+                let _ = child.kill().await;
+                let _ = drain.await;
+                let _ = stderr_drain.await;
+                let stdout = String::from_utf8_lossy(&stdout_buf.lock().unwrap()).into_owned();
+                let stderr = String::from_utf8_lossy(&stderr_diag_buf.lock().unwrap()).into_owned();
+                panic!(
+                    "heartbeat_subprocess: binary did not start accepting on {addr} \
+                     within {per_addr_budget:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                );
+            }
+        }
+    }
+
+    panic!(
+        "heartbeat_subprocess: EADDRINUSE on all {MAX_ATTEMPTS} port-allocation attempts; \
+         last error:\n{}",
+        last_eaddrinuse.unwrap_or_else(|| "<none>".into())
+    );
+}
+
+/// Await the stdout drain task and return the accumulated output as a `String`.
+///
+/// Call this after `child.start_kill() + child.wait()`: the child's exit closes
+/// its stdout pipe, which causes the drain task to see EOF and exit cleanly.
+async fn collect_log_output(drain: JoinHandle<()>, stdout_buf: Arc<Mutex<Vec<u8>>>) -> String {
+    let _ = drain.await;
+    String::from_utf8_lossy(&stdout_buf.lock().unwrap()).into_owned()
+}
+
+/// The binary emits heartbeat log lines at (approximately) the configured interval.
+///
+/// We run the file driver with `--heartbeat-interval 100ms` for ~400 ms and
+/// assert that at least 2 lines containing `tsoracle::heartbeat` appear on
+/// stderr, which proves the background heartbeat task is firing.
+#[tokio::test]
+async fn binary_emits_heartbeat_lines_at_configured_interval() {
+    let binary_path = env!("CARGO_BIN_EXE_tsoracle");
+    let state_dir = tempdir().unwrap();
+
+    let (mut child, _addrs, drain, stdout_buf) =
+        retry_spawn_with_stderr(1, &[0], Duration::from_secs(10), |addrs| {
+            let mut cmd = Command::new(binary_path);
+            cmd.arg("serve")
+                .arg("file")
+                .arg("--listen")
+                .arg(addrs[0].to_string())
+                .arg("--state-dir")
+                .arg(state_dir.path())
+                .arg("--log")
+                .arg("info")
+                .arg("--heartbeat-interval")
+                .arg("100ms");
+            cmd
+        })
+        .await;
+
+    // ~400 ms gives 3-4 heartbeat ticks at 100 ms interval.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    child.start_kill().unwrap();
+    let _ = child.wait().await;
+
+    // Await the drain task: child exit closes its stdout pipe, so the drain
+    // sees EOF and exits promptly. This guarantees all buffered log output is
+    // flushed before we assert.
+    let stdout = collect_log_output(drain, stdout_buf).await;
+    let count = stdout
+        .lines()
+        .filter(|l| l.contains("tsoracle::heartbeat"))
+        .count();
+    assert!(
+        count >= 2,
+        "expected >= 2 heartbeat lines, got {count}.\nstdout:\n{stdout}"
+    );
+}
+
+/// With `--heartbeat-interval 0s` the heartbeat task is disabled and the binary
+/// must emit zero `tsoracle::heartbeat` lines during normal operation.
+#[tokio::test]
+async fn binary_with_zero_heartbeat_interval_emits_no_heartbeat_lines() {
+    let binary_path = env!("CARGO_BIN_EXE_tsoracle");
+    let state_dir = tempdir().unwrap();
+
+    let (mut child, _addrs, drain, stdout_buf) =
+        retry_spawn_with_stderr(1, &[0], Duration::from_secs(10), |addrs| {
+            let mut cmd = Command::new(binary_path);
+            cmd.arg("serve")
+                .arg("file")
+                .arg("--listen")
+                .arg(addrs[0].to_string())
+                .arg("--state-dir")
+                .arg(state_dir.path())
+                .arg("--log")
+                .arg("info")
+                .arg("--heartbeat-interval")
+                .arg("0s");
+            cmd
+        })
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    child.start_kill().unwrap();
+    let _ = child.wait().await;
+    let stdout = collect_log_output(drain, stdout_buf).await;
+
+    let count = stdout
+        .lines()
+        .filter(|l| l.contains("tsoracle::heartbeat"))
+        .count();
+    assert_eq!(
+        count, 0,
+        "expected zero heartbeat lines, got {count}.\nstdout:\n{stdout}"
+    );
+}

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -91,3 +91,7 @@ required-features = ["test-support", "metrics"]
 [[test]]
 name = "fence_yieldpoint"
 required-features = ["yieldpoints", "test-fakes"]
+
+[[test]]
+name = "heartbeat_into_router"
+required-features = ["test-support", "tracing"]

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -171,7 +171,6 @@ pub(crate) async fn run_leader_watch(
                 // Time the full fence: drain-barrier wait, durable persist, and
                 // allocator seed are all included. Recorded only when the fence
                 // reaches Serving.
-                #[cfg(feature = "metrics")]
                 let fence_started_at = std::time::Instant::now();
 
                 // Enter the fence: clear the allocator and publish NotServing so
@@ -186,8 +185,8 @@ pub(crate) async fn run_leader_watch(
                 // then steps down (NotLeader/Fenced) or faults — matching the
                 // prior pre-`match` placement exactly. Emitting after the clear
                 // (not before) keeps a blocking recorder from delaying it.
-                #[cfg(feature = "metrics")]
-                metrics::counter!("tsoracle.leader_transition.total").increment(1);
+                server.reporter.leader_transitions.increment(1);
+                server.reporter.last_leader_transition.touch_now();
 
                 // Fence with retry. A consensus error here is not automatically
                 // fatal: the post-election window is volatile and `ConsensusError`
@@ -288,8 +287,9 @@ pub(crate) async fn run_leader_watch(
 
                     match attempt {
                         Ok(()) => {
-                            #[cfg(feature = "metrics")]
-                            metrics::histogram!("tsoracle.leader_transition.fence_latency")
+                            server
+                                .reporter
+                                .fence_latency
                                 .record(fence_started_at.elapsed().as_secs_f64());
                             break;
                         }
@@ -318,11 +318,7 @@ pub(crate) async fn run_leader_watch(
                                 // transition is observed instead of spun past.
                                 PersistDisposition::Transient(_source) => {
                                     transient_retries += 1;
-                                    #[cfg(feature = "metrics")]
-                                    metrics::counter!(
-                                        "tsoracle.leader_transition.fence_transient_retries.total"
-                                    )
-                                    .increment(1);
+                                    server.reporter.fence_transient_retries.increment(1);
                                     #[cfg(feature = "tracing")]
                                     if warn_on_stuck_fence(transient_retries) {
                                         tracing::warn!(
@@ -382,15 +378,15 @@ pub(crate) async fn run_leader_watch(
                 server.core.step_down(leader_endpoint, leader_epoch);
                 // Emit after the NotServing publish so a blocking recorder
                 // cannot delay the safety state change.
-                #[cfg(feature = "metrics")]
-                metrics::counter!("tsoracle.leader_transition.total").increment(1);
+                server.reporter.leader_transitions.increment(1);
+                server.reporter.last_leader_transition.touch_now();
             }
             LeaderState::Unknown => {
                 server.core.step_down(None, None);
                 // Emit after the NotServing publish so a blocking recorder
                 // cannot delay the safety state change.
-                #[cfg(feature = "metrics")]
-                metrics::counter!("tsoracle.leader_transition.total").increment(1);
+                server.reporter.leader_transitions.increment(1);
+                server.reporter.last_leader_transition.touch_now();
             }
         }
     }

--- a/crates/tsoracle-server/src/heartbeat.rs
+++ b/crates/tsoracle-server/src/heartbeat.rs
@@ -1,0 +1,93 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Periodic heartbeat task: emits one structured `tracing::info!` line per
+//! `interval` summarising activity since the prior tick. Lives next to the
+//! leader-watch task in the `Server::into_router_parts()` spawn site so both
+//! the embedder path (`into_router()`) and the daemon path (`serve*`) get it.
+
+#![allow(dead_code)]
+
+use crate::reporter::Reporter;
+
+/// Subset of Reporter counters/timestamps the heartbeat line carries. Adding a
+/// new Reporter field does NOT automatically appear here — `sample()` must be
+/// updated explicitly. That's the gate: forgetting to add a metric to the
+/// heartbeat is the safe default.
+pub(crate) struct HeartbeatSnapshot {
+    pub requests: u64,
+    pub ts_issued: u64,
+    pub not_leader: u64,
+    pub transitions: u64,
+    pub fence_retries: u64,
+    pub last_transition_unix_ms: Option<u64>,
+}
+
+impl HeartbeatSnapshot {
+    pub(crate) fn sample(r: &Reporter) -> Self {
+        Self {
+            requests: r.get_ts_requests.snapshot(),
+            ts_issued: r.timestamps_issued.snapshot(),
+            not_leader: r.not_leader.snapshot(),
+            transitions: r.leader_transitions.snapshot(),
+            fence_retries: r.fence_transient_retries.snapshot(),
+            last_transition_unix_ms: r.last_leader_transition.snapshot(),
+        }
+    }
+}
+
+/// Saturating wall-clock age in seconds since `then_unix_ms`. Returns 0 if the
+/// stored timestamp is ahead of now (wall-clock skew tolerance).
+pub(crate) fn age_secs_from(then_unix_ms: u64) -> u64 {
+    let now_ms = crate::reporter::now_unix_ms();
+    now_ms.saturating_sub(then_unix_ms) / 1000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_reflects_current_counter_values() {
+        let r = Reporter::new();
+        r.get_ts_requests.increment(3);
+        r.timestamps_issued.increment(8);
+        r.leader_transitions.increment(1);
+        r.last_leader_transition.touch_now();
+
+        let s = HeartbeatSnapshot::sample(&r);
+        assert_eq!(s.requests, 3);
+        assert_eq!(s.ts_issued, 8);
+        assert_eq!(s.transitions, 1);
+        assert_eq!(s.not_leader, 0);
+        assert!(s.last_transition_unix_ms.is_some());
+    }
+
+    #[test]
+    fn age_zero_on_future_timestamp() {
+        let now = crate::reporter::now_unix_ms();
+        // Pretend last transition is one full second in the future.
+        let future = now + 1000;
+        assert_eq!(age_secs_from(future), 0);
+    }
+}

--- a/crates/tsoracle-server/src/heartbeat.rs
+++ b/crates/tsoracle-server/src/heartbeat.rs
@@ -28,7 +28,12 @@
 
 #![allow(dead_code)]
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use crate::reporter::Reporter;
+use crate::server::ServingState;
+use crate::serving_core::ServingCore;
 
 /// Subset of Reporter counters/timestamps the heartbeat line carries. Adding a
 /// new Reporter field does NOT automatically appear here — `sample()` must be
@@ -63,9 +68,127 @@ pub(crate) fn age_secs_from(then_unix_ms: u64) -> u64 {
     now_ms.saturating_sub(then_unix_ms) / 1000
 }
 
+/// Heartbeat loop: every `interval`, snapshot the Reporter, sample the
+/// serving state, and emit one structured `tracing::info!` line.
+///
+/// Returns when `cancel` resolves (explicit send OR sender drop). The cancel
+/// branch is `biased` first in the `select!`, so shutdown is always preferred
+/// over an in-flight tick.
+pub(crate) async fn run_heartbeat(
+    interval: Duration,
+    core: Arc<ServingCore>,
+    reporter: Arc<Reporter>,
+    cancel: tokio::sync::oneshot::Receiver<()>,
+) {
+    let mut prev = HeartbeatSnapshot::sample(&reporter);
+    let started = reporter.started_at;
+    let mut cancel = cancel;
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut cancel => break,
+            _ = tokio::time::sleep(interval) => {
+                let curr  = HeartbeatSnapshot::sample(&reporter);
+                let state = core.serving_state();
+                let epoch = core.current_epoch();
+                let last_age = curr.last_transition_unix_ms.map(age_secs_from);
+
+                tracing::info!(
+                    target: "tsoracle::heartbeat",
+                    uptime_secs              = started.elapsed().as_secs(),
+                    serving                  = matches!(state, ServingState::Serving),
+                    epoch                    = ?epoch.map(|e| e.0),
+                    requests                 = curr.requests.wrapping_sub(prev.requests),
+                    requests_total           = curr.requests,
+                    ts_issued                = curr.ts_issued.wrapping_sub(prev.ts_issued),
+                    not_leader               = curr.not_leader.wrapping_sub(prev.not_leader),
+                    transitions              = curr.transitions.wrapping_sub(prev.transitions),
+                    fence_retries            = curr.fence_retries.wrapping_sub(prev.fence_retries),
+                    last_transition_age_secs = ?last_age,
+                    "heartbeat"
+                );
+                prev = curr;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::sync::Mutex as StdMutex;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone, Default)]
+    struct BufWriter(std::sync::Arc<StdMutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for BufWriter {
+        type Writer = BufWriterHandle;
+        fn make_writer(&'a self) -> Self::Writer {
+            BufWriterHandle(self.0.clone())
+        }
+    }
+
+    struct BufWriterHandle(std::sync::Arc<StdMutex<Vec<u8>>>);
+    impl std::io::Write for BufWriterHandle {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn emits_after_each_interval() {
+        let buf = BufWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_max_level(tracing::Level::INFO)
+            .with_target(true)
+            .with_ansi(false)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let reporter = std::sync::Arc::new(Reporter::new());
+        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+        // Drive heartbeat and test control in the same async context so the
+        // thread-local subscriber set above is active during every poll.
+        let hb_fut = run_heartbeat(
+            Duration::from_millis(50),
+            core.clone(),
+            reporter.clone(),
+            rx,
+        );
+
+        // Control future: advance time one tick at a time so the heartbeat
+        // future gets woken and polled between advances.
+        let ctrl_fut = async move {
+            for _ in 0..3 {
+                tokio::time::advance(Duration::from_millis(55)).await;
+                tokio::task::yield_now().await;
+            }
+            drop(tx);
+        };
+
+        // join! drives both concurrently in the same async context (no spawn),
+        // so the thread-local subscriber is active during run_heartbeat polls.
+        tokio::join!(hb_fut, ctrl_fut);
+
+        let output = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        let lines = output
+            .lines()
+            .filter(|l| l.contains("tsoracle::heartbeat"))
+            .count();
+        assert!(
+            lines >= 3,
+            "expected >= 3 heartbeat lines, got {lines}.\nFull output:\n{output}"
+        );
+    }
 
     #[test]
     fn snapshot_reflects_current_counter_values() {
@@ -89,5 +212,113 @@ mod tests {
         // Pretend last transition is one full second in the future.
         let future = now + 1000;
         assert_eq!(age_secs_from(future), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn idle_tick_still_emits_with_zero_deltas() {
+        let buf = BufWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_max_level(tracing::Level::INFO)
+            .with_target(true)
+            .with_ansi(false)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let reporter = std::sync::Arc::new(Reporter::new());
+        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+        let hb_fut = run_heartbeat(
+            Duration::from_millis(50),
+            core.clone(),
+            reporter.clone(),
+            rx,
+        );
+        let ctrl_fut = async move {
+            tokio::time::advance(Duration::from_millis(55)).await;
+            tokio::task::yield_now().await;
+            drop(tx);
+        };
+        tokio::join!(hb_fut, ctrl_fut);
+
+        let output = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            output.contains("requests=0"),
+            "idle tick should report requests=0: {output}"
+        );
+        assert!(
+            output.contains("requests_total=0"),
+            "expected requests_total=0: {output}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn deltas_reset_each_tick() {
+        let buf = BufWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_max_level(tracing::Level::INFO)
+            .with_target(true)
+            .with_ansi(false)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let reporter = std::sync::Arc::new(Reporter::new());
+        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+        let reporter2 = reporter.clone();
+        let hb_fut = run_heartbeat(
+            Duration::from_millis(50),
+            core.clone(),
+            reporter.clone(),
+            rx,
+        );
+        let ctrl_fut = async move {
+            // Tick 1: 3 requests
+            reporter2.get_ts_requests.increment(3);
+            tokio::time::advance(Duration::from_millis(55)).await;
+            tokio::task::yield_now().await;
+
+            // Tick 2: 5 more requests (8 total). Delta should be 5, not 8.
+            reporter2.get_ts_requests.increment(5);
+            tokio::time::advance(Duration::from_millis(55)).await;
+            tokio::task::yield_now().await;
+
+            drop(tx);
+        };
+        tokio::join!(hb_fut, ctrl_fut);
+
+        let output = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            output.contains("requests=3"),
+            "tick 1 should report requests=3: {output}"
+        );
+        assert!(
+            output.contains("requests=5"),
+            "tick 2 should report requests=5: {output}"
+        );
+        assert!(
+            !output.contains("requests=8"),
+            "delta should reset; got cumulative: {output}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn cancel_terminates_promptly_on_sender_drop() {
+        let reporter = std::sync::Arc::new(Reporter::new());
+        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+        // Drop tx immediately — the biased cancel branch should win without
+        // waiting for the 60s sleep in the other arm.
+        drop(tx);
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            run_heartbeat(Duration::from_secs(60), core.clone(), reporter.clone(), rx),
+        )
+        .await
+        .expect("heartbeat did not terminate after cancel sender dropped");
     }
 }

--- a/crates/tsoracle-server/src/leader_hint.rs
+++ b/crates/tsoracle-server/src/leader_hint.rs
@@ -28,12 +28,11 @@ use tonic::Status;
 use tonic::metadata::{BinaryMetadataKey, BinaryMetadataValue};
 use tsoracle_proto::v1::{LEADER_HINT_TRAILER_KEY, LeaderHint, LeaderHintLookup};
 
-pub fn not_leader_status(hint: LeaderHint) -> Status {
+pub fn not_leader_status(reporter: &crate::reporter::Reporter, hint: LeaderHint) -> Status {
     // Single chokepoint: every NOT_LEADER rejection in the service layer
     // routes through this constructor, so the counter increments exactly
     // once per rejection regardless of which call site detected it.
-    #[cfg(feature = "metrics")]
-    metrics::counter!("tsoracle.not_leader.total").increment(1);
+    reporter.not_leader.increment(1);
     with_leader_hint(
         Status::failed_precondition("not leader"),
         hint,
@@ -93,7 +92,7 @@ mod tests {
             leader_endpoint: Some("10.0.0.7:50551".into()),
             leader_epoch: Some(EpochWire { hi: 0, lo: 42 }),
         };
-        let status = not_leader_status(hint.clone());
+        let status = not_leader_status(&crate::reporter::Reporter::for_tests(), hint.clone());
         let decoded = decode_leader_hint(&status).expect("present");
         assert_eq!(decoded.leader_endpoint, hint.leader_endpoint);
         assert_eq!(decoded.leader_epoch, hint.leader_epoch);

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -31,6 +31,7 @@ mod clock;
 mod fence;
 mod leader_hint;
 mod persist_disposition;
+pub(crate) mod reporter;
 mod server;
 mod service;
 mod serving_core;

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -39,6 +39,7 @@ mod signal;
 
 pub mod docs;
 
+pub use crate::reporter::Reporter;
 pub use bt::Bt;
 pub use clock::{Clock, SystemClock};
 pub use server::{BuildError, Server, ServerBuilder, ServerError, ServingState, WatchGuard};

--- a/crates/tsoracle-server/src/lib.rs
+++ b/crates/tsoracle-server/src/lib.rs
@@ -29,6 +29,8 @@
 mod bt;
 mod clock;
 mod fence;
+#[cfg(feature = "tracing")]
+pub(crate) mod heartbeat;
 mod leader_hint;
 mod persist_disposition;
 pub(crate) mod reporter;

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -62,6 +62,21 @@ impl ReporterCounter {
     }
 }
 
+pub struct ReporterHistogram {
+    name: &'static str,
+}
+
+impl ReporterHistogram {
+    pub(crate) fn new(name: &'static str) -> Self {
+        Self { name }
+    }
+
+    pub(crate) fn record(&self, _v: f64) {
+        #[cfg(feature = "metrics")]
+        metrics::histogram!(self.name).record(_v);
+    }
+}
+
 pub(crate) fn now_unix_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -112,6 +127,32 @@ mod tests {
             format!("{value:?}"),
             "Counter(7)",
             "expected the recorder to observe Counter(7), got {value:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "metrics")]
+    fn histogram_record_forwards_to_metrics_recorder() {
+        use metrics::Key;
+        use metrics_util::CompositeKey;
+        use metrics_util::MetricKind;
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            let h = ReporterHistogram::new("tsoracle.test.hist");
+            h.record(1.0);
+            h.record(2.0);
+            h.record(3.0);
+        });
+
+        let snap = snapshotter.snapshot().into_vec();
+        let key = CompositeKey::new(MetricKind::Histogram, Key::from_name("tsoracle.test.hist"));
+        assert!(
+            snap.iter().any(|(k, ..)| *k == key),
+            "histogram key not recorded"
         );
     }
 }

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -28,8 +28,10 @@
 //! both the global `metrics::` recorder (Prometheus path, unchanged) and a
 //! local `Arc<AtomicU64>` that the heartbeat task can read without depending
 //! on any installed recorder.
-
-// Items are scaffolded here and wired up in later tasks (T3–T11).
+//!
+//! **Scaffold note**: items are introduced here and wired up in later plan
+//! tasks (T3–T11). `#![allow(dead_code)]` is present for that reason and
+//! will become unnecessary once the call sites land in Task 7.
 #![allow(dead_code)]
 
 use std::sync::Arc;
@@ -49,13 +51,13 @@ impl ReporterCounter {
         }
     }
 
-    pub fn increment(&self, n: u64) {
+    pub(crate) fn increment(&self, n: u64) {
         #[cfg(feature = "metrics")]
         metrics::counter!(self.name).increment(n);
         self.local.fetch_add(n, Ordering::Relaxed);
     }
 
-    pub fn snapshot(&self) -> u64 {
+    pub(crate) fn snapshot(&self) -> u64 {
         self.local.load(Ordering::Relaxed)
     }
 }

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -81,4 +81,37 @@ mod tests {
         c.increment(4);
         assert_eq!(c.snapshot(), 5);
     }
+
+    #[test]
+    #[cfg(feature = "metrics")]
+    fn counter_increment_forwards_to_metrics_recorder() {
+        use metrics::Key;
+        use metrics_util::CompositeKey;
+        use metrics_util::MetricKind;
+        use metrics_util::debugging::{DebuggingRecorder, Snapshotter};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter: Snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            let c = ReporterCounter::new("tsoracle.test.forwarded");
+            c.increment(7);
+        });
+
+        let snap = snapshotter.snapshot().into_vec();
+        let key = CompositeKey::new(
+            MetricKind::Counter,
+            Key::from_name("tsoracle.test.forwarded"),
+        );
+        let entry = snap
+            .iter()
+            .find(|(k, ..)| *k == key)
+            .expect("counter not recorded by DebuggingRecorder");
+        let (_, _, _, value) = entry;
+        assert_eq!(
+            format!("{value:?}"),
+            "Counter(7)",
+            "expected the recorder to observe Counter(7), got {value:?}"
+        );
+    }
 }

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -36,7 +36,9 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use tsoracle_core::IgnoreReason;
 
 pub struct ReporterCounter {
     name: &'static str,
@@ -99,6 +101,95 @@ impl ReporterTimestamp {
     pub(crate) fn snapshot(&self) -> Option<u64> {
         let v = self.local.load(Ordering::Relaxed);
         (v != 0).then_some(v)
+    }
+}
+
+pub struct IgnoredCommitsByReason {
+    pub not_leader: ReporterCounter,
+    pub epoch_mismatch: ReporterCounter,
+    pub not_advanced: ReporterCounter,
+}
+
+impl IgnoredCommitsByReason {
+    fn new() -> Self {
+        Self {
+            not_leader: ReporterCounter::new("tsoracle.window.extensions.ignored.not_leader.total"),
+            epoch_mismatch: ReporterCounter::new(
+                "tsoracle.window.extensions.ignored.epoch_mismatch.total",
+            ),
+            not_advanced: ReporterCounter::new(
+                "tsoracle.window.extensions.ignored.not_advanced.total",
+            ),
+        }
+    }
+
+    pub(crate) fn for_reason(&self, reason: IgnoreReason) -> &ReporterCounter {
+        match reason {
+            IgnoreReason::NotLeader => &self.not_leader,
+            IgnoreReason::EpochMismatch { .. } => &self.epoch_mismatch,
+            IgnoreReason::NotAdvanced { .. } => &self.not_advanced,
+        }
+    }
+}
+
+pub struct Reporter {
+    // get_ts hot path
+    pub get_ts_requests: ReporterCounter,
+    pub get_ts_success: ReporterCounter,
+    pub timestamps_issued: ReporterCounter,
+
+    // leader / fence
+    pub not_leader: ReporterCounter,
+    pub leader_transitions: ReporterCounter,
+    pub fence_transient_retries: ReporterCounter,
+    pub fence_latency: ReporterHistogram,
+
+    // window
+    pub window_extensions: ReporterCounter,
+    pub window_extension_latency: ReporterHistogram,
+    pub ignored_commits: IgnoredCommitsByReason,
+
+    // lifecycle
+    pub shutdown_watch_aborted: ReporterCounter,
+    pub heartbeat_task_panicked: ReporterCounter,
+    pub last_leader_transition: ReporterTimestamp,
+    pub started_at: Instant,
+}
+
+impl Reporter {
+    pub fn new() -> Self {
+        Self {
+            get_ts_requests: ReporterCounter::new("tsoracle.get_ts.requests.total"),
+            get_ts_success: ReporterCounter::new("tsoracle.get_ts.success.total"),
+            timestamps_issued: ReporterCounter::new("tsoracle.get_ts.timestamps_issued"),
+            not_leader: ReporterCounter::new("tsoracle.not_leader.total"),
+            leader_transitions: ReporterCounter::new("tsoracle.leader_transition.total"),
+            fence_transient_retries: ReporterCounter::new(
+                "tsoracle.leader_transition.fence_transient_retries.total",
+            ),
+            fence_latency: ReporterHistogram::new("tsoracle.leader_transition.fence_latency"),
+            window_extensions: ReporterCounter::new("tsoracle.window.extensions.total"),
+            window_extension_latency: ReporterHistogram::new("tsoracle.window.extension_latency"),
+            ignored_commits: IgnoredCommitsByReason::new(),
+            shutdown_watch_aborted: ReporterCounter::new("tsoracle.shutdown.watch_aborted.total"),
+            heartbeat_task_panicked: ReporterCounter::new("tsoracle.heartbeat.task_panicked.total"),
+            last_leader_transition: ReporterTimestamp::new(),
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Convenience constructor for unit tests. Same as `Reporter::new()`; the
+    /// dedicated name documents intent at call sites (tests that just need a
+    /// Reporter to satisfy a struct field).
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn for_tests() -> Self {
+        Self::new()
+    }
+}
+
+impl Default for Reporter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -198,5 +289,50 @@ mod tests {
             observed >= before && observed <= after,
             "timestamp {observed} not within [{before}, {after}]"
         );
+    }
+
+    #[test]
+    #[cfg(feature = "metrics")]
+    fn reporter_new_resolves_distinct_metric_names() {
+        use metrics::Key;
+        use metrics_util::CompositeKey;
+        use metrics_util::MetricKind;
+        use metrics_util::debugging::DebuggingRecorder;
+        use tsoracle_core::{Epoch, IgnoreReason};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            let r = Reporter::new();
+            r.ignored_commits
+                .for_reason(IgnoreReason::NotLeader)
+                .increment(1);
+            r.ignored_commits
+                .for_reason(IgnoreReason::EpochMismatch {
+                    expected: Epoch(1),
+                    current: Epoch(2),
+                })
+                .increment(1);
+            r.ignored_commits
+                .for_reason(IgnoreReason::NotAdvanced {
+                    persisted: 1,
+                    committed: 2,
+                })
+                .increment(1);
+        });
+
+        let snap = snapshotter.snapshot().into_vec();
+        for name in [
+            "tsoracle.window.extensions.ignored.not_leader.total",
+            "tsoracle.window.extensions.ignored.epoch_mismatch.total",
+            "tsoracle.window.extensions.ignored.not_advanced.total",
+        ] {
+            let key = CompositeKey::new(MetricKind::Counter, Key::from_name(name));
+            assert!(
+                snap.iter().any(|(k, ..)| *k == key),
+                "expected metric {name} to be recorded distinctly"
+            );
+        }
     }
 }

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -77,6 +77,31 @@ impl ReporterHistogram {
     }
 }
 
+pub struct ReporterTimestamp {
+    local: Arc<AtomicU64>,
+}
+
+impl ReporterTimestamp {
+    pub(crate) fn new() -> Self {
+        Self {
+            local: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Record `SystemTime::now()` as unix-ms. Idempotent under concurrent
+    /// callers — the last writer wins under `Relaxed`, which matches the
+    /// "approximate last transition time" semantics the heartbeat needs.
+    pub(crate) fn touch_now(&self) {
+        self.local.store(now_unix_ms(), Ordering::Relaxed);
+    }
+
+    /// `None` if never touched, else the most recent unix-ms.
+    pub(crate) fn snapshot(&self) -> Option<u64> {
+        let v = self.local.load(Ordering::Relaxed);
+        (v != 0).then_some(v)
+    }
+}
+
 pub(crate) fn now_unix_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -153,6 +178,25 @@ mod tests {
         assert!(
             snap.iter().any(|(k, ..)| *k == key),
             "histogram key not recorded"
+        );
+    }
+
+    #[test]
+    fn timestamp_zero_is_none() {
+        let t = ReporterTimestamp::new();
+        assert_eq!(t.snapshot(), None);
+    }
+
+    #[test]
+    fn timestamp_touch_records_now() {
+        let before = now_unix_ms();
+        let t = ReporterTimestamp::new();
+        t.touch_now();
+        let after = now_unix_ms();
+        let observed = t.snapshot().expect("touch_now should produce Some");
+        assert!(
+            observed >= before && observed <= after,
+            "timestamp {observed} not within [{before}, {after}]"
         );
     }
 }

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -1,0 +1,82 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Typed metric facade for `tsoracle-server`.
+//!
+//! `Reporter` is the single place metric-name string literals live in this
+//! crate. Each typed counter/histogram field forwards an increment/record to
+//! both the global `metrics::` recorder (Prometheus path, unchanged) and a
+//! local `Arc<AtomicU64>` that the heartbeat task can read without depending
+//! on any installed recorder.
+
+// Items are scaffolded here and wired up in later tasks (T3–T11).
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct ReporterCounter {
+    name: &'static str,
+    local: Arc<AtomicU64>,
+}
+
+impl ReporterCounter {
+    pub(crate) fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            local: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn increment(&self, n: u64) {
+        #[cfg(feature = "metrics")]
+        metrics::counter!(self.name).increment(n);
+        self.local.fetch_add(n, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> u64 {
+        self.local.load(Ordering::Relaxed)
+    }
+}
+
+pub(crate) fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter_increment_bumps_local_snapshot() {
+        let c = ReporterCounter::new("tsoracle.test.local");
+        assert_eq!(c.snapshot(), 0);
+        c.increment(1);
+        c.increment(4);
+        assert_eq!(c.snapshot(), 5);
+    }
+}

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -292,6 +292,18 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "metrics"))]
+    fn counter_works_without_metrics_feature() {
+        // With the `metrics` feature off, the increment body skips the
+        // recorder forward but the local atomic still bumps — the heartbeat
+        // path stays functional in default tsoracle-bin builds (which do not
+        // enable the `metrics` feature on tsoracle-server).
+        let c = ReporterCounter::new("tsoracle.test.no_metrics");
+        c.increment(3);
+        assert_eq!(c.snapshot(), 3);
+    }
+
+    #[test]
     #[cfg(feature = "metrics")]
     fn reporter_new_resolves_distinct_metric_names() {
         use metrics::Key;

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -201,7 +201,6 @@ pub struct Server {
     /// gate *synchronously* at shutdown, leaving the watch task's later
     /// `step_down` a harmless idempotent repeat.
     pub(crate) core: Arc<ServingCore>,
-    #[allow(dead_code)]
     pub(crate) reporter: Arc<crate::reporter::Reporter>,
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     pub(crate) tls_config: Option<tonic::transport::ServerTlsConfig>,
@@ -273,10 +272,12 @@ impl Server {
         // the returned guard can bound its own shutdown wait identically to the
         // `serve_*` paths.
         let shutdown_grace = self.shutdown_grace;
-        // Clone the shared core before `into_router_parts` consumes `self`, so
-        // the guard can close the serving gate synchronously on drop / shutdown
-        // rather than relying on the watch task's later publish.
+        // Clone the shared core and reporter before `into_router_parts` consumes
+        // `self`, so the guard can close the serving gate synchronously on drop /
+        // shutdown rather than relying on the watch task's later publish, and can
+        // record the shutdown_watch_aborted counter if the grace-bounded reap fires.
         let core = self.core.clone();
+        let reporter = self.reporter.clone();
         let (routes, cancel_tx, handle) = self.into_router_parts()?;
         Ok((
             routes,
@@ -285,6 +286,7 @@ impl Server {
                 handle: Some(handle),
                 shutdown_grace,
                 core,
+                reporter,
             },
         ))
     }
@@ -393,10 +395,11 @@ impl Server {
         #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
         let tls_config = self.tls_config.clone();
 
-        // Read the `Copy` grace and clone the shared core before
+        // Read the `Copy` grace and clone the shared core and reporter before
         // `into_router_parts` consumes `self`.
         let shutdown_grace = self.shutdown_grace;
         let core = self.core.clone();
+        let reporter = self.reporter.clone();
         let (routes, watch_cancel_tx, watch_handle) = self.into_router_parts()?;
         let (combined_shutdown, cancel_tx) = combined_shutdown_with_cancel(shutdown);
 
@@ -416,6 +419,7 @@ impl Server {
             cancel_tx,
             shutdown_grace,
             core,
+            reporter,
         )
         .await
     }
@@ -450,10 +454,11 @@ impl Server {
         #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
         let tls_config = self.tls_config.clone();
 
-        // Read the `Copy` grace and clone the shared core before
+        // Read the `Copy` grace and clone the shared core and reporter before
         // `into_router_parts` consumes `self`.
         let shutdown_grace = self.shutdown_grace;
         let core = self.core.clone();
+        let reporter = self.reporter.clone();
         let (routes, watch_cancel_tx, watch_handle) = self.into_router_parts()?;
         let (combined_shutdown, cancel_tx) = combined_shutdown_with_cancel(shutdown);
 
@@ -475,6 +480,7 @@ impl Server {
             cancel_tx,
             shutdown_grace,
             core,
+            reporter,
         )
         .await
     }
@@ -507,6 +513,9 @@ pub struct WatchGuard {
     /// watch task to observe cancellation and publish `NotServing` on its own
     /// timeline — a window during which the fast gate would still admit RPCs.
     core: Arc<ServingCore>,
+    /// Metrics reporter, cloned from the `Server`. Used to record the
+    /// `shutdown_watch_aborted` counter if the grace-bounded reap fires.
+    reporter: Arc<crate::reporter::Reporter>,
 }
 
 impl WatchGuard {
@@ -529,7 +538,7 @@ impl WatchGuard {
         self.cancel_tx.take();
         match self.handle.take() {
             Some(mut handle) => join_to_server_result(
-                await_watch_within_grace(&mut handle, self.shutdown_grace).await,
+                await_watch_within_grace(&mut handle, self.shutdown_grace, &self.reporter).await,
             ),
             None => Ok(()),
         }
@@ -626,12 +635,12 @@ fn combined_shutdown_with_cancel(
 async fn await_watch_within_grace(
     watch_handle: &mut tokio::task::JoinHandle<Result<(), ServerError>>,
     grace: Duration,
+    reporter: &Arc<crate::reporter::Reporter>,
 ) -> Result<Result<(), ServerError>, tokio::task::JoinError> {
     match tokio::time::timeout(grace, &mut *watch_handle).await {
         Ok(join_result) => join_result,
         Err(_elapsed) => {
-            #[cfg(feature = "metrics")]
-            metrics::counter!("tsoracle.shutdown.watch_aborted.total").increment(1);
+            reporter.shutdown_watch_aborted.increment(1);
             #[cfg(feature = "tracing")]
             tracing::warn!(
                 grace_ms = grace.as_millis() as u64,
@@ -674,6 +683,7 @@ async fn serve_inner<S>(
     tonic_cancel_tx: tokio::sync::oneshot::Sender<()>,
     shutdown_grace: Duration,
     core: Arc<ServingCore>,
+    reporter: Arc<crate::reporter::Reporter>,
 ) -> Result<(), ServerError>
 where
     S: Future<Output = Result<(), tonic::transport::Error>>,
@@ -722,7 +732,7 @@ where
             // task's own cooperative-cancel publish.
             core.step_down(None, None);
             drop(watch_cancel_tx);
-            let _ = await_watch_within_grace(&mut watch_handle, shutdown_grace).await;
+            let _ = await_watch_within_grace(&mut watch_handle, shutdown_grace, &reporter).await;
             serve_result?;
             Ok(())
         }
@@ -1040,6 +1050,7 @@ mod tests {
             handle: Some(handle),
             shutdown_grace: Duration::from_secs(10),
             core: core.clone(),
+            reporter: Arc::new(crate::reporter::Reporter::new()),
         };
 
         drop(guard);
@@ -1080,6 +1091,7 @@ mod tests {
             tonic_cancel_tx,
             Duration::from_millis(0),
             core.clone(),
+            Arc::new(crate::reporter::Reporter::new()),
         )
         .await;
 

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -101,6 +101,7 @@ pub struct ServerBuilder {
     window_ahead: Duration,
     failover_advance: Duration,
     shutdown_grace: Duration,
+    heartbeat_interval: Duration,
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
@@ -113,6 +114,7 @@ impl Default for ServerBuilder {
             window_ahead: Duration::from_secs(3),
             failover_advance: Duration::from_secs(1),
             shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
+            heartbeat_interval: Duration::from_secs(10),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: None,
         }
@@ -156,6 +158,20 @@ impl ServerBuilder {
         self
     }
 
+    /// Interval between heartbeat log lines emitted at `target = "tsoracle::heartbeat"`.
+    /// Defaults to 10 seconds. Pass `Duration::ZERO` to disable the heartbeat task entirely.
+    ///
+    /// The heartbeat surfaces serving role, current epoch, requests served,
+    /// timestamps issued, and key error counters every interval — proof-of-life
+    /// for production deployments that may not have a metrics exporter installed.
+    ///
+    /// Requires `feature = "tracing"` to emit output; with `tracing` off the
+    /// setter is accepted but no task is spawned (no subscriber to log to).
+    pub fn heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.heartbeat_interval = interval;
+        self
+    }
+
     /// Configure TLS termination for this server. Applied inside
     /// [`Server::serve`], [`Server::serve_with_shutdown`], and
     /// [`Server::serve_with_listener`]. Not applied to [`Server::into_router`] —
@@ -176,6 +192,7 @@ impl ServerBuilder {
             window_ahead: self.window_ahead,
             failover_advance: self.failover_advance,
             shutdown_grace: self.shutdown_grace,
+            heartbeat_interval: self.heartbeat_interval,
             core: Arc::new(ServingCore::new(self.window_ahead)),
             reporter: Arc::new(crate::reporter::Reporter::new()),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
@@ -192,6 +209,9 @@ pub struct Server {
     /// Bound on the graceful-shutdown wait for the leader-watch task before a
     /// forced abort. See [`ServerBuilder::shutdown_grace`].
     pub(crate) shutdown_grace: Duration,
+    /// Interval between periodic heartbeat log lines. See [`ServerBuilder::heartbeat_interval`].
+    #[allow(dead_code)]
+    pub(crate) heartbeat_interval: Duration,
     /// Owns the allocator, serving-state channel, and both extension locks, with
     /// the lock-ordering and step-down invariants private behind its methods.
     ///

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -210,7 +210,11 @@ pub struct Server {
     /// forced abort. See [`ServerBuilder::shutdown_grace`].
     pub(crate) shutdown_grace: Duration,
     /// Interval between periodic heartbeat log lines. See [`ServerBuilder::heartbeat_interval`].
-    #[allow(dead_code)]
+    ///
+    /// The only reader is the `cfg(feature = "tracing")` spawn block in
+    /// `into_router_parts`; without `tracing` there is no subscriber to log to
+    /// and the spawn arm is compiled out, so the field is genuinely unread.
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     pub(crate) heartbeat_interval: Duration,
     /// Owns the allocator, serving-state channel, and both extension locks, with
     /// the lock-ordering and step-down invariants private behind its methods.
@@ -228,14 +232,20 @@ pub struct Server {
 
 /// Raw parts produced by [`Server::into_router_parts`]: the gRPC `Routes`, the
 /// leader-watch task's cooperative-cancel sender (dropping it stops the task),
-/// and the task's join handle. [`Server::into_router`] wraps these into a
-/// [`WatchGuard`]; the `serve_*` methods consume them directly via
-/// [`serve_inner`].
-type RouterParts = (
-    Routes,
-    tokio::sync::oneshot::Sender<()>,
-    tokio::task::JoinHandle<Result<(), ServerError>>,
-);
+/// the task's join handle, and the optional heartbeat task's cancel sender /
+/// join handle. [`Server::into_router`] wraps these into a [`WatchGuard`]; the
+/// `serve_*` methods consume them directly via [`serve_inner`].
+///
+/// The heartbeat fields are `None` when the heartbeat is disabled — either by
+/// `ServerBuilder::heartbeat_interval(Duration::ZERO)` or by building without
+/// the `tracing` feature (there is no subscriber to log to).
+pub(crate) struct RouterParts {
+    pub routes: Routes,
+    pub cancel_tx: tokio::sync::oneshot::Sender<()>,
+    pub watch_handle: tokio::task::JoinHandle<Result<(), ServerError>>,
+    pub heartbeat_cancel_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    pub heartbeat_handle: Option<tokio::task::JoinHandle<()>>,
+}
 
 impl Server {
     pub fn builder() -> ServerBuilder {
@@ -298,15 +308,17 @@ impl Server {
         // record the shutdown_watch_aborted counter if the grace-bounded reap fires.
         let core = self.core.clone();
         let reporter = self.reporter.clone();
-        let (routes, cancel_tx, handle) = self.into_router_parts()?;
+        let parts = self.into_router_parts()?;
         Ok((
-            routes,
+            parts.routes,
             WatchGuard {
-                cancel_tx: Some(cancel_tx),
-                handle: Some(handle),
+                cancel_tx: Some(parts.cancel_tx),
+                handle: Some(parts.watch_handle),
                 shutdown_grace,
                 core,
                 reporter,
+                heartbeat_cancel_tx: parts.heartbeat_cancel_tx,
+                heartbeat_handle: parts.heartbeat_handle,
             },
         ))
     }
@@ -374,6 +386,54 @@ impl Server {
             }
         });
 
+        // Spawn the heartbeat task, if enabled. Gated on `feature = "tracing"`
+        // because the heartbeat module is only compiled with `tracing`
+        // (no subscriber to emit to without it) — and on a non-zero interval,
+        // since `Duration::ZERO` is the documented opt-out.
+        //
+        // The task body is wrapped in `AssertUnwindSafe(...).catch_unwind()`
+        // mirroring the leader-watch spawn above: on panic we bump the
+        // `heartbeat_task_panicked` counter and log at error level, then let
+        // the task end (no restart — the heartbeat is observability, not
+        // correctness, so a panicked task must not be allowed to thrash).
+        let (heartbeat_cancel_tx, heartbeat_handle) = {
+            #[cfg(feature = "tracing")]
+            {
+                if server.heartbeat_interval.is_zero() {
+                    (None, None)
+                } else {
+                    use futures::FutureExt;
+                    let (htx, hrx) = tokio::sync::oneshot::channel::<()>();
+                    let hb_reporter = server.reporter.clone();
+                    let hb_core = server.core.clone();
+                    let hb_interval = server.heartbeat_interval;
+                    let handle = tokio::spawn(async move {
+                        let outcome =
+                            std::panic::AssertUnwindSafe(crate::heartbeat::run_heartbeat(
+                                hb_interval,
+                                hb_core,
+                                hb_reporter.clone(),
+                                hrx,
+                            ))
+                            .catch_unwind()
+                            .await;
+                        if outcome.is_err() {
+                            hb_reporter.heartbeat_task_panicked.increment(1);
+                            tracing::error!(
+                                target: "tsoracle::heartbeat",
+                                "heartbeat task panicked; liveness logs disabled until restart"
+                            );
+                        }
+                    });
+                    (Some(htx), Some(handle))
+                }
+            }
+            #[cfg(not(feature = "tracing"))]
+            {
+                (None, None)
+            }
+        };
+
         let service = TsoServiceImpl { server };
         #[allow(unused_mut)]
         let mut routes = Routes::new(TsoServiceServer::new(service));
@@ -381,7 +441,13 @@ impl Server {
         {
             routes = routes.add_service(reflection);
         }
-        Ok((routes, cancel_tx, watch_handle))
+        Ok(RouterParts {
+            routes,
+            cancel_tx,
+            watch_handle,
+            heartbeat_cancel_tx,
+            heartbeat_handle,
+        })
     }
 
     pub async fn serve(self, addr: SocketAddr) -> Result<(), ServerError> {
@@ -420,7 +486,7 @@ impl Server {
         let shutdown_grace = self.shutdown_grace;
         let core = self.core.clone();
         let reporter = self.reporter.clone();
-        let (routes, watch_cancel_tx, watch_handle) = self.into_router_parts()?;
+        let parts = self.into_router_parts()?;
         let (combined_shutdown, cancel_tx) = combined_shutdown_with_cancel(shutdown);
 
         let mut tonic = TonicServer::builder();
@@ -429,12 +495,14 @@ impl Server {
             tonic = tonic.tls_config(cfg).map_err(ServerError::Transport)?;
         }
         let serve = tonic
-            .add_routes(routes)
+            .add_routes(parts.routes)
             .serve_with_shutdown(addr, combined_shutdown);
 
         serve_inner(
-            watch_cancel_tx,
-            watch_handle,
+            parts.cancel_tx,
+            parts.watch_handle,
+            parts.heartbeat_cancel_tx,
+            parts.heartbeat_handle,
             serve,
             cancel_tx,
             shutdown_grace,
@@ -479,7 +547,7 @@ impl Server {
         let shutdown_grace = self.shutdown_grace;
         let core = self.core.clone();
         let reporter = self.reporter.clone();
-        let (routes, watch_cancel_tx, watch_handle) = self.into_router_parts()?;
+        let parts = self.into_router_parts()?;
         let (combined_shutdown, cancel_tx) = combined_shutdown_with_cancel(shutdown);
 
         let incoming = tonic::transport::server::TcpIncoming::from(listener);
@@ -490,12 +558,14 @@ impl Server {
             tonic = tonic.tls_config(cfg).map_err(ServerError::Transport)?;
         }
         let serve = tonic
-            .add_routes(routes)
+            .add_routes(parts.routes)
             .serve_with_incoming_shutdown(incoming, combined_shutdown);
 
         serve_inner(
-            watch_cancel_tx,
-            watch_handle,
+            parts.cancel_tx,
+            parts.watch_handle,
+            parts.heartbeat_cancel_tx,
+            parts.heartbeat_handle,
             serve,
             cancel_tx,
             shutdown_grace,
@@ -536,6 +606,15 @@ pub struct WatchGuard {
     /// Metrics reporter, cloned from the `Server`. Used to record the
     /// `shutdown_watch_aborted` counter if the grace-bounded reap fires.
     reporter: Arc<crate::reporter::Reporter>,
+    /// Cooperative-cancel sender for the heartbeat task. `None` when the
+    /// heartbeat is disabled (interval == 0 or built without `tracing`).
+    /// Dropping the sender resolves the task's cancel future.
+    heartbeat_cancel_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    /// Join handle for the heartbeat task. `None` when the heartbeat is
+    /// disabled. Output is `()` because the task never returns an error —
+    /// panics are caught inside the task body and recorded via the
+    /// `heartbeat_task_panicked` counter.
+    heartbeat_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl WatchGuard {
@@ -554,8 +633,29 @@ impl WatchGuard {
     /// elapses (still reported as `Ok(())`), so an embedder's shutdown can never
     /// wedge behind a hung driver.
     pub async fn shutdown(mut self) -> Result<(), ServerError> {
-        // Dropping the sender fires the task's cancel future.
+        // Dropping the senders fires each task's cancel future. The heartbeat
+        // task is reaped first because it is bounded by `tokio::time::sleep`
+        // (cooperative stop is fast and never wedges on a driver call), so its
+        // reap returns quickly and leaves the grace budget for the watch task
+        // — which may be parked in a wedged consensus-driver call.
+        self.heartbeat_cancel_tx.take();
         self.cancel_tx.take();
+        if let Some(mut hb_handle) = self.heartbeat_handle.take() {
+            match tokio::time::timeout(self.shutdown_grace, &mut hb_handle).await {
+                Ok(Ok(())) => {}
+                // Task panicked — already counted + logged via catch_unwind in
+                // the task body. Nothing more to do here.
+                Ok(Err(_join_err)) => {}
+                // Grace overrun — sleep + select! should always observe a
+                // dropped cancel sender, so this is a backstop. Abort and
+                // reap; no separate metric (the heartbeat is observability
+                // only — its lateness is not a serving correctness signal).
+                Err(_elapsed) => {
+                    hb_handle.abort();
+                    let _ = (&mut hb_handle).await;
+                }
+            }
+        }
         match self.handle.take() {
             Some(mut handle) => join_to_server_result(
                 await_watch_within_grace(&mut handle, self.shutdown_grace, &self.reporter).await,
@@ -572,6 +672,12 @@ impl WatchGuard {
     pub fn abort(mut self) {
         if let Some(handle) = self.handle.take() {
             handle.abort();
+        }
+        // Hard-abort the heartbeat task too — leaving it running after the
+        // watch is torn down would publish heartbeats describing a stale
+        // (typically `NotServing`) view until the Arc<Reporter> is dropped.
+        if let Some(hb_handle) = self.heartbeat_handle.take() {
+            hb_handle.abort();
         }
     }
 
@@ -606,6 +712,15 @@ impl Drop for WatchGuard {
         // `NotServing` and returns. The `JoinHandle` is dropped here too,
         // detaching the task to finish its cooperative shutdown on its own.
         self.cancel_tx.take();
+        // Same treatment for the heartbeat task. `Drop` is sync so we cannot
+        // await the cooperative stop; instead we drop the cancel sender (the
+        // task will observe it at its next select! boundary) and hard-abort
+        // the handle so it cannot outlive the guard and publish heartbeats
+        // describing a stale view if the runtime keeps the Arc alive.
+        self.heartbeat_cancel_tx.take();
+        if let Some(hb_handle) = self.heartbeat_handle.take() {
+            hb_handle.abort();
+        }
     }
 }
 
@@ -696,9 +811,17 @@ async fn await_watch_within_grace(
 /// same one the watch task and the gRPC service hold): the user-shutdown arm
 /// closes the gate on it synchronously so no RPC is admitted in the window
 /// before the watch task observes cancellation and publishes `NotServing`.
+// Private serve helper. The wide signature is the cost of being the single
+// merge point for the two public `serve_*` paths and the leader-watch +
+// heartbeat task pair: bundling these into a struct just to placate clippy
+// would obscure the lifecycle (every parameter is consumed exactly once and
+// has no shared identity worth naming). Keep the arguments visible.
+#[allow(clippy::too_many_arguments)]
 async fn serve_inner<S>(
     watch_cancel_tx: tokio::sync::oneshot::Sender<()>,
     mut watch_handle: tokio::task::JoinHandle<Result<(), ServerError>>,
+    heartbeat_cancel_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    heartbeat_handle: Option<tokio::task::JoinHandle<()>>,
     serve_future: S,
     tonic_cancel_tx: tokio::sync::oneshot::Sender<()>,
     shutdown_grace: Duration,
@@ -710,7 +833,7 @@ where
 {
     tokio::pin!(serve_future);
 
-    tokio::select! {
+    let outcome = tokio::select! {
         // Bias toward the watch arm: if both are ready in the same poll
         // (rare but possible — graceful shutdown completed in the same
         // tick the watch returned), we want to surface the watch error
@@ -756,7 +879,28 @@ where
             serve_result?;
             Ok(())
         }
+    };
+
+    // Stop the heartbeat task on every exit path. Done after the watch reap so
+    // the watch-arm `combine_watch_and_drain` already saw the watch outcome,
+    // and the user-shutdown arm has finished its grace-bounded wait. Dropping
+    // the cancel sender breaks the task's `tokio::select! { biased; cancel,
+    // sleep }` loop on the next poll; if the task is wedged for any reason we
+    // hard-abort on grace overrun. The task's outcome is observability only
+    // and cannot influence serving correctness, so its join result is dropped.
+    drop(heartbeat_cancel_tx);
+    if let Some(mut hb_handle) = heartbeat_handle {
+        match tokio::time::timeout(shutdown_grace, &mut hb_handle).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_join_err)) => {} // panic — already counted via catch_unwind
+            Err(_elapsed) => {
+                hb_handle.abort();
+                let _ = (&mut hb_handle).await;
+            }
+        }
     }
+
+    outcome
 }
 
 /// Convert a `JoinHandle` result into a `ServerError`-typed result.
@@ -1071,6 +1215,8 @@ mod tests {
             shutdown_grace: Duration::from_secs(10),
             core: core.clone(),
             reporter: Arc::new(crate::reporter::Reporter::new()),
+            heartbeat_cancel_tx: None,
+            heartbeat_handle: None,
         };
 
         drop(guard);
@@ -1107,6 +1253,8 @@ mod tests {
         let result = serve_inner(
             watch_cancel_tx,
             watch_handle,
+            None, // heartbeat_cancel_tx — heartbeat disabled in this regression test
+            None, // heartbeat_handle
             serve_future,
             tonic_cancel_tx,
             Duration::from_millis(0),

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -177,6 +177,7 @@ impl ServerBuilder {
             failover_advance: self.failover_advance,
             shutdown_grace: self.shutdown_grace,
             core: Arc::new(ServingCore::new(self.window_ahead)),
+            reporter: Arc::new(crate::reporter::Reporter::new()),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: self.tls_config,
         })
@@ -200,6 +201,8 @@ pub struct Server {
     /// gate *synchronously* at shutdown, leaving the watch task's later
     /// `step_down` a harmless idempotent repeat.
     pub(crate) core: Arc<ServingCore>,
+    #[allow(dead_code)]
+    pub(crate) reporter: Arc<crate::reporter::Reporter>,
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     pub(crate) tls_config: Option<tonic::transport::ServerTlsConfig>,
 }

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -127,7 +127,10 @@ impl TsoService for TsoServiceImpl {
         // is best-effort either way — this mirrors the NotLeader arm below, which
         // also re-reads after `try_grant`.
         if !self.server.core.is_serving() {
-            return Err(not_leader_status(leader_hint_from(&self.server)));
+            return Err(not_leader_status(
+                &self.server.reporter,
+                leader_hint_from(&self.server),
+            ));
         }
 
         // At most two attempts: the first may return WindowExhausted, in which
@@ -172,7 +175,10 @@ impl TsoService for TsoServiceImpl {
                     }));
                 }
                 Err(CoreError::NotLeader) => {
-                    return Err(not_leader_status(leader_hint_from(&self.server)));
+                    return Err(not_leader_status(
+                        &self.server.reporter,
+                        leader_hint_from(&self.server),
+                    ));
                 }
                 Err(CoreError::WindowExhausted) if attempt == 0 => {
                     self.extend_window(now_ms, count).await?;
@@ -246,7 +252,10 @@ impl TsoServiceImpl {
                 // channel knows about), not a bare FAILED_PRECONDITION without
                 // metadata.
                 Err(CoreError::NotLeader) => {
-                    return Err(not_leader_status(leader_hint_from(&self.server)));
+                    return Err(not_leader_status(
+                        &self.server.reporter,
+                        leader_hint_from(&self.server),
+                    ));
                 }
                 Err(other) => return Err(core_status(other)),
             };
@@ -285,7 +294,10 @@ impl TsoServiceImpl {
                 // present for Fenced, absent for NotLeader.
                 PersistDisposition::SteppedDown { fenced_by } => {
                     self.server.core.step_down(None, fenced_by);
-                    return Err(not_leader_status(leader_hint_from(&self.server)));
+                    return Err(not_leader_status(
+                        &self.server.reporter,
+                        leader_hint_from(&self.server),
+                    ));
                 }
                 // Transient driver failure: storage hiccup, peer transport
                 // flap, quorum momentarily lost. Tell the client it MAY retry;

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -25,8 +25,6 @@
 
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
-#[cfg(feature = "metrics")]
-use tsoracle_core::IgnoreReason;
 use tsoracle_core::{CommitOutcome, CoreError, Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{
     EpochWire, GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetTsRequest, GetTsResponse,
@@ -101,21 +99,6 @@ fn core_status(error: CoreError) -> Status {
     }
 }
 
-/// The per-reason counter name for an ignored window-extension commit. Each
-/// reason gets its own flat counter (matching the rest of the catalog) so an
-/// operator can alert on epoch churn (`not_leader` / `epoch_mismatch`)
-/// separately from persist reordering (`not_advanced`).
-#[cfg(feature = "metrics")]
-fn ignored_commit_metric(reason: IgnoreReason) -> &'static str {
-    match reason {
-        IgnoreReason::NotLeader => "tsoracle.window.extensions.ignored.not_leader.total",
-        IgnoreReason::EpochMismatch { .. } => {
-            "tsoracle.window.extensions.ignored.epoch_mismatch.total"
-        }
-        IgnoreReason::NotAdvanced { .. } => "tsoracle.window.extensions.ignored.not_advanced.total",
-    }
-}
-
 pub struct TsoServiceImpl {
     pub(crate) server: Arc<Server>,
 }
@@ -136,8 +119,7 @@ impl TsoService for TsoServiceImpl {
         // total climbing while successes stay flat (vs. flat-at-zero, which is
         // indistinguishable from no traffic). Outside the retry loop, so a
         // single-extend-retry call still counts exactly once.
-        #[cfg(feature = "metrics")]
-        metrics::counter!("tsoracle.get_ts.requests.total").increment(1);
+        self.server.reporter.get_ts_requests.increment(1);
 
         // Fast NOT_LEADER gate. `is_serving` answers the gate without cloning a
         // `ServingState`; only the rejected path re-reads (via `leader_hint_from`)
@@ -175,12 +157,11 @@ impl TsoService for TsoServiceImpl {
             let outcome = self.server.core.try_grant(now_ms, count);
             match outcome {
                 Ok(grant) => {
-                    #[cfg(feature = "metrics")]
-                    {
-                        metrics::counter!("tsoracle.get_ts.success.total").increment(1);
-                        metrics::counter!("tsoracle.get_ts.timestamps_issued")
-                            .increment(u64::from(grant.count()));
-                    }
+                    self.server.reporter.get_ts_success.increment(1);
+                    self.server
+                        .reporter
+                        .timestamps_issued
+                        .increment(u64::from(grant.count()));
                     let (epoch_hi, epoch_lo) = grant.epoch().to_wire();
                     return Ok(Response::new(GetTsResponse {
                         physical_ms: grant.physical_ms(),
@@ -273,19 +254,17 @@ impl TsoServiceImpl {
         // recheck-after-acquire short-circuit above skips it, and operators
         // tuning `window_ahead` care about how often a stampede actually
         // reached persist + how long that took (success or failure).
-        #[cfg(feature = "metrics")]
         let extension_started_at = std::time::Instant::now();
         let persist_outcome = self
             .server
             .consensus
             .persist_high_water(requested, epoch)
             .await;
-        #[cfg(feature = "metrics")]
-        {
-            metrics::counter!("tsoracle.window.extensions.total").increment(1);
-            metrics::histogram!("tsoracle.window.extension_latency")
-                .record(extension_started_at.elapsed().as_secs_f64());
-        }
+        self.server.reporter.window_extensions.increment(1);
+        self.server
+            .reporter
+            .window_extension_latency
+            .record(extension_started_at.elapsed().as_secs_f64());
         let actual = match persist_outcome {
             Ok(v) => v,
             // Route the failure through the shared classifier and apply the
@@ -335,8 +314,11 @@ impl TsoServiceImpl {
         if let CommitOutcome::Ignored(_reason) = commit_outcome {
             #[cfg(feature = "tracing")]
             tracing::debug!(reason = ?_reason, "window extension commit ignored after persist");
-            #[cfg(feature = "metrics")]
-            metrics::counter!(ignored_commit_metric(_reason)).increment(1);
+            self.server
+                .reporter
+                .ignored_commits
+                .for_reason(_reason)
+                .increment(1);
         }
         Ok(())
     }
@@ -435,32 +417,5 @@ mod tests {
         assert_eq!(wire_epoch(Some(cross)), Some(EpochWire { hi, lo }));
 
         assert_eq!(wire_epoch(None), None);
-    }
-
-    #[cfg(feature = "metrics")]
-    #[test]
-    fn ignored_commit_metric_names_each_reason_distinctly() {
-        use tsoracle_core::IgnoreReason;
-        // Each ignore reason maps to its own counter so an operator can tell
-        // epoch churn (not_leader / epoch_mismatch) from persist reordering
-        // (not_advanced) at the metric layer, not just in the logs.
-        assert_eq!(
-            ignored_commit_metric(IgnoreReason::NotLeader),
-            "tsoracle.window.extensions.ignored.not_leader.total"
-        );
-        assert_eq!(
-            ignored_commit_metric(IgnoreReason::EpochMismatch {
-                expected: Epoch(4),
-                current: Epoch(5),
-            }),
-            "tsoracle.window.extensions.ignored.epoch_mismatch.total"
-        );
-        assert_eq!(
-            ignored_commit_metric(IgnoreReason::NotAdvanced {
-                persisted: 3_000,
-                committed: 5_000,
-            }),
-            "tsoracle.window.extensions.ignored.not_advanced.total"
-        );
     }
 }

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -298,10 +298,13 @@ impl TsoService for FixedHintService {
         &self,
         _request: tonic::Request<GetTsRequest>,
     ) -> Result<tonic::Response<GetTsResponse>, tonic::Status> {
-        Err(not_leader_status(LeaderHint {
-            leader_endpoint: Some(self.hint_endpoint.clone()),
-            leader_epoch: None,
-        }))
+        Err(not_leader_status(
+            &crate::reporter::Reporter::for_tests(),
+            LeaderHint {
+                leader_endpoint: Some(self.hint_endpoint.clone()),
+                leader_epoch: None,
+            },
+        ))
     }
 
     async fn get_current_max_safe(

--- a/crates/tsoracle-server/tests/heartbeat_into_router.rs
+++ b/crates/tsoracle-server/tests/heartbeat_into_router.rs
@@ -1,0 +1,229 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Embedder-path coverage: a heartbeat must appear when the caller mounts
+//! routes via `Server::into_router()` and never calls any `serve*` method.
+//! Also covers the zero-interval (no task spawned) and drop-stops-task paths.
+//!
+//! All tests use `flavor = "current_thread"` so that `tokio::spawn`-ed tasks
+//! poll on the same OS thread as the test driver. This is essential: the
+//! tracing subscriber is installed via `set_default` (thread-local), and with
+//! `current_thread` the spawned heartbeat task inherits that subscriber.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tracing_subscriber::fmt::MakeWriter;
+
+use tsoracle_server::Server;
+use tsoracle_server::test_fakes::InMemoryDriver;
+
+// ---------------------------------------------------------------------------
+// Shared buffer writer (copied from heartbeat.rs unit tests, placed here for
+// the integration test binary which cannot reach crate-private types).
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Default)]
+struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+impl<'a> MakeWriter<'a> for BufWriter {
+    type Writer = BufWriterHandle;
+    fn make_writer(&'a self) -> Self::Writer {
+        BufWriterHandle(self.0.clone())
+    }
+}
+
+struct BufWriterHandle(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for BufWriterHandle {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Install a `tracing_subscriber` that writes into `buf`, returning a
+/// `DefaultGuard` that unregisters it on drop. Uses `set_default` (thread-
+/// local), safe to call once per test because each integration-test binary
+/// runs in its own process.
+fn install_subscriber(buf: BufWriter) -> tracing::dispatcher::DefaultGuard {
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(buf)
+        .with_max_level(tracing::Level::INFO)
+        .with_target(true)
+        .with_ansi(false)
+        .finish();
+    tracing::subscriber::set_default(subscriber)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Heartbeat lines must appear when the server is mounted via `into_router()`
+/// and no `serve*` method is ever called. This is the embedder path: a larger
+/// application owns the listener and calls `axum::serve` (or equivalent) with
+/// the returned `Routes`. The heartbeat task is spawned inside
+/// `into_router_parts()`, so it runs regardless of how the routes are served.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn heartbeat_emits_from_into_router_embedder_path() {
+    let buf = BufWriter::default();
+    let _guard = install_subscriber(buf.clone());
+
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .heartbeat_interval(Duration::from_millis(50))
+        .build()
+        .expect("build");
+
+    // Embedder mounts routes directly — never calls serve_*.
+    let (_routes, watch_guard) = server
+        .into_router()
+        .expect("into_router is infallible without the reflection feature");
+
+    // Yield first so the spawned heartbeat task gets its initial poll and
+    // registers its `sleep(interval)` timer before we advance the clock.
+    tokio::task::yield_now().await;
+
+    // Advance several intervals, yielding multiple times per step so that the
+    // spawned heartbeat task has enough polls to wake from each sleep.
+    // With current_thread + start_paused, spawned tasks poll only when the
+    // test task yields, so we yield generously between advances.
+    for _ in 0..3 {
+        tokio::time::advance(Duration::from_millis(60)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+    }
+
+    // Drop the guard — cancels both the watch task and the heartbeat task.
+    drop(watch_guard);
+
+    let output = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+    let lines = output
+        .lines()
+        .filter(|l| l.contains("tsoracle::heartbeat"))
+        .count();
+    assert!(
+        lines >= 2,
+        "expected >= 2 heartbeat lines via into_router path, got {lines}.\n{output}"
+    );
+}
+
+/// When the server is configured with `heartbeat_interval(Duration::ZERO)`,
+/// no heartbeat task is spawned; advancing time must produce zero heartbeat
+/// log lines.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn heartbeat_interval_zero_spawns_no_task() {
+    let buf = BufWriter::default();
+    let _guard = install_subscriber(buf.clone());
+
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .heartbeat_interval(Duration::ZERO)
+        .build()
+        .expect("build");
+
+    let (_routes, watch_guard) = server
+        .into_router()
+        .expect("into_router is infallible without the reflection feature");
+
+    tokio::time::advance(Duration::from_millis(500)).await;
+    tokio::task::yield_now().await;
+    drop(watch_guard);
+
+    let output = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+    let lines = output
+        .lines()
+        .filter(|l| l.contains("tsoracle::heartbeat"))
+        .count();
+    assert_eq!(
+        lines, 0,
+        "no heartbeat lines expected with interval=0, got {lines}.\n{output}"
+    );
+}
+
+/// Dropping the `WatchGuard` must stop the heartbeat task: after the drop, no
+/// additional heartbeat lines must appear even if more time is advanced.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn dropping_watch_guard_stops_heartbeat() {
+    let buf = BufWriter::default();
+    let _guard = install_subscriber(buf.clone());
+
+    let driver = Arc::new(InMemoryDriver::new());
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .heartbeat_interval(Duration::from_millis(50))
+        .build()
+        .expect("build");
+
+    let (_routes, watch_guard) = server
+        .into_router()
+        .expect("into_router is infallible without the reflection feature");
+
+    // Yield first so the spawned heartbeat task gets its initial poll and
+    // registers its `sleep(interval)` timer before we advance the clock.
+    tokio::task::yield_now().await;
+
+    // One interval — at least one heartbeat line should appear. Yield
+    // multiple times after advancing so the woken task can emit its line.
+    tokio::time::advance(Duration::from_millis(60)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    let lines_before_drop = String::from_utf8(buf.0.lock().unwrap().clone())
+        .unwrap()
+        .lines()
+        .filter(|l| l.contains("tsoracle::heartbeat"))
+        .count();
+
+    // Cancel both the watch task and the heartbeat task.
+    drop(watch_guard);
+
+    // Yield once more to allow any in-flight polls to settle.
+    tokio::task::yield_now().await;
+
+    // Five more intervals worth of time; the cancelled task must not emit.
+    tokio::time::advance(Duration::from_millis(300)).await;
+    tokio::task::yield_now().await;
+
+    let lines_after_drop = String::from_utf8(buf.0.lock().unwrap().clone())
+        .unwrap()
+        .lines()
+        .filter(|l| l.contains("tsoracle::heartbeat"))
+        .count();
+
+    assert!(
+        lines_before_drop >= 1,
+        "expected at least one heartbeat before drop, got {lines_before_drop}"
+    );
+    assert_eq!(
+        lines_before_drop, lines_after_drop,
+        "heartbeat continued after WatchGuard drop \
+         ({lines_before_drop} lines before → {lines_after_drop} after)"
+    );
+}


### PR DESCRIPTION
## Summary

- **Heartbeat log:** `tsoracle-server` now emits one structured `tracing::info!` line every `heartbeat_interval` (default 10s, `Duration::ZERO` disables) at `target = "tsoracle::heartbeat"`. Carries serving role, current epoch, requests-in-interval, requests-total, timestamps-issued, not-leader rejections, leader transitions, fence retries, and age-since-last-leader-transition. Closes the operability gap where a healthy idle daemon was indistinguishable from a hung one in `kubectl logs` / `journalctl`. Exposed on `tsoracle-bin` via `--heartbeat-interval` (humantime).
- **Typed `Reporter` metric facade** (motivated by the heartbeat needing in-process readback): new `crates/tsoracle-server/src/reporter.rs` is the single place in the crate where metric-name string literals live. Each typed counter/histogram/timestamp field forwards an increment to both the `metrics::` recorder (Prometheus path, **unchanged** — names preserved exactly, install order still flexible) and a local `Arc<AtomicU64>` the heartbeat reads. All 13 existing metric call sites in `service.rs` / `fence.rs` / `leader_hint.rs` / `server.rs` migrated; the `ignored_commit_metric()` helper and its test are deleted. Reporter compiles + works with `feature = "metrics"` off (which is the default for `tsoracle-bin`).
- **Lifecycle:** the heartbeat task is spawned by `Server::into_router_parts()` alongside the existing leader-watch task, so both `Server::into_router()` embedders AND the `serve_*` daemon path get it on equal footing. Lifetime tied to `WatchGuard`: drop / `shutdown` / `abort` stop the heartbeat together with the watch task. `AssertUnwindSafe(...).catch_unwind()` wrapper with `tsoracle.heartbeat.task_panicked.total` counter; no restart on panic (loud surface, server keeps serving). Disabled mode (`Duration::ZERO`) spawns no task at all.

## Test plan

- [x] `cargo test --workspace --all-features` — 1157 passed, 0 failed
- [x] `cargo clippy --workspace --all-features -- -D warnings` — zero warnings
- [x] `cargo clippy -p tsoracle-server --no-default-features --features tls-rustls,tracing -- -D warnings` — zero warnings (no-metrics build path)
- [x] `cargo fmt --check` — clean
- [x] `python3 scripts/check-ts-header.py` — 269 files, all headers OK
- [x] `grep -rn 'metrics::\(counter\|gauge\|histogram\)' crates/tsoracle-server/src` — 2 hits, both inside `reporter.rs` (the macro call sites in `ReporterCounter::increment` and `ReporterHistogram::record`). Zero stragglers.
- [x] End-to-end daemon smoke (file driver, 25 s window, default 10 s interval): two heartbeat lines emit, second tick shows `transitions=0` confirming delta semantics (first tick's `transitions=1` was the initial leader-election capture).
- [x] Subprocess test (`heartbeat_subprocess.rs`): `--heartbeat-interval 100ms` produces ≥2 lines in 400 ms; `--heartbeat-interval 0s` produces zero.
- [x] Integration test (`heartbeat_into_router.rs`): heartbeat reaches the `Server::into_router()` embedder path; zero-interval spawns no task; dropping `WatchGuard` stops further emissions.
- [ ] Watch CI Coverage lane (`%LINE` should not regress more than 0.5%; new `reporter.rs` and `heartbeat.rs` are covered by 6 + 6 + 3 + 2 = 17 new tests).

## Notes for review

1. **Prometheus name preservation**: every existing `tsoracle.*` metric name is preserved verbatim (verified during T5 by cross-checking the existing `ignored_commit_metric` helper output). Dashboards continue to work.
2. **No pre-resolution of `metrics::Counter` handles** — the `Reporter` stores `&'static str` names and calls `metrics::counter!(self.name).increment(n)` per call. Pre-resolution would freeze handles to whichever recorder was installed at `Server::build()` time and silently break the install-recorder-after-build pattern in metrics 0.24.
3. **Recorder isolation in tests**: every test that observes `metrics::` output uses `metrics::with_local_recorder` (not `install()`); avoids the `OnceLock`-per-process race.
4. **`#[allow(dead_code)]` in `heartbeat.rs`** is intentional and in-source documented — `HeartbeatSnapshot` and `age_secs_from` are constructed by external code (the spawn site) but their `pub` fields are read only via struct destructuring.