### PR TITLE
docs(consensus): align README with current public surface

### DIFF
--- a/crates/tsoracle-consensus/README.md
+++ b/crates/tsoracle-consensus/README.md
@@ -7,8 +7,15 @@ Implement this trait against your preferred mechanism (openraft, raft-rs, etcd, 
 ## What's in the box
 
 - `ConsensusDriver` — the three-method trait the server calls into: `leadership_events`, `load_high_water`, `persist_high_water`. About fifty lines of trait surface.
-- `LeaderState` — the role-class enum the driver's `leadership_events` stream carries (Leader / Follower / Candidate / NoLeader).
+- `LeaderState` — the role-class enum the driver's `leadership_events` stream carries: `Leader { epoch }`, `Follower { leader_endpoint, leader_epoch }`, `Unknown`.
 - `ConsensusError` — the error type all three trait methods return.
+- `AdvancePayload` + `reject_out_of_range_advance` — the shared "advance the high-water to at least N" command payload and the range guard every driver MUST call before persisting it. See [Required pre-persist guard](#required-pre-persist-guard).
+
+## Required pre-persist guard
+
+Every `ConsensusDriver::persist_high_water` implementation MUST call `reject_out_of_range_advance(at_least)` before durably appending the advance. The check rejects any value above `tsoracle_core::PHYSICAL_MS_MAX` (the 46-bit physical-millisecond cap) as `ConsensusError::PermanentDriver`.
+
+This is a poison-write guard, not a styling preference. The high-water only ratchets up, so once an out-of-range value is durably committed every subsequent leadership gain reloads it, `PhysicalMs::try_new` rejects it (`CoreError::PhysicalMsOutOfRange`), and the new leader can never serve — there is no path to self-heal. The single-node `FileDriver` already guards at its persist site; consensus-backed drivers append through a replicated log and apply with an unchecked `max`, so this shared check is what keeps them aligned with the same contract.
 
 ## Documentation
 
@@ -25,4 +32,3 @@ If you want a ready-made driver rather than implementing one yourself:
 ## Feature flags
 
 - `serde` — derives `Serialize` / `Deserialize` on the public types so they cross wire and storage boundaries cleanly. Propagates to `tsoracle-core`.
-- `bt` — enables backtrace capture in error variants (propagates to `tsoracle-core`).


### PR DESCRIPTION
## Summary

- `crates/tsoracle-consensus/README.md` is ingested into the lib via `#![doc = include_str!(\"../README.md\")]` (at `src/lib.rs:24`) and ships as the docs.rs / crates.io integration surface for external `ConsensusDriver` implementers. Four facts on it had drifted from the code, three of them visibly wrong to anyone copy-pasting from the README.
- **`LeaderState` variants** — README listed `Leader / Follower / Candidate / NoLeader`; the actual enum at `src/leadership.rs:37-69` is `Leader { epoch }`, `Follower { leader_endpoint, leader_epoch }`, `Unknown`. Neither `Candidate` nor `NoLeader` exist, so a reader writing match arms against the README would mispattern every consumer.
- **`bt` feature flag** — documented in the README but does not exist in `Cargo.toml` (only `default` and `serde` are declared). Removed.
- **Missing public surface** — `AdvancePayload` and `reject_out_of_range_advance` are re-exported at `src/lib.rs:36` and consumed by every shipped driver but were absent from \"What's in the box\". Added.
- **No pre-persist guard callout** — added a new \"Required pre-persist guard\" H2 explaining the MUST-call contract on `persist_high_water` and the poison-write hazard from `advance.rs:69-91`: the high-water only ratchets, so an out-of-range commit is non-recoverable — every subsequent leader's load fails `PhysicalMs::try_new` and the column can never be served. `FileDriver` guards locally; the shared `reject_out_of_range_advance` is what keeps the replicated-log drivers aligned with the same contract.

Diff is README-only (+8 / -3). Trait, error, leadership, and advance source files are unchanged.

## Test plan

- [x] `cargo doc -p tsoracle-consensus --no-deps --all-features` exits 0 with no warnings (the `include_str!`-embedded README compiles cleanly into rustdoc).
- [x] Pre-commit gate (`cargo fmt --check` + `cargo clippy`) green on the rebase.
- [ ] Render README on github.com to confirm `[Required pre-persist guard](#required-pre-persist-guard)` anchor link resolves.
- [ ] Spot-check the rendered docs.rs page on next publish for heading-slug parity with the README anchor.