### PR TITLE
refactor(consensus)!: typed AdvanceOutOfRange variant end-to-end

### DIFF
--- a/crates/tsoracle-consensus/src/advance.rs
+++ b/crates/tsoracle-consensus/src/advance.rs
@@ -60,12 +60,6 @@ impl AdvancePayload {
     }
 }
 
-/// The error carried by a rejected out-of-range high-water advance. See
-/// [`reject_out_of_range_advance`].
-#[derive(Debug, thiserror::Error)]
-#[error("high-water advance {0} exceeds the 46-bit physical_ms maximum")]
-pub struct AdvanceOutOfRange(pub u64);
-
 /// Reject a high-water advance whose `physical_ms` value exceeds
 /// `tsoracle_core::PHYSICAL_MS_MAX`, before it is durably persisted.
 ///
@@ -85,15 +79,15 @@ pub struct AdvanceOutOfRange(pub u64);
 /// a replicated log and apply with an unchecked `max` — from drifting away from
 /// that contract.
 ///
-/// Classified [`ConsensusError::PermanentDriver`]: an out-of-range advance
+/// Classified [`ConsensusError::AdvanceOutOfRange`]: an out-of-range advance
 /// signals a saturated or misconfigured clock (`SystemClock::now_ms` saturates
 /// to `u64::MAX` to surface a far-future clock visibly), not a transient
 /// condition, so the server must surface `INTERNAL` rather than silently retry.
+/// The variant carries the offending value structurally, so the server can
+/// route and format it without downcasting.
 pub fn reject_out_of_range_advance(at_least: u64) -> Result<(), ConsensusError> {
     if at_least > tsoracle_core::PHYSICAL_MS_MAX {
-        return Err(ConsensusError::PermanentDriver(Box::new(
-            AdvanceOutOfRange(at_least),
-        )));
+        return Err(ConsensusError::AdvanceOutOfRange(at_least));
     }
     Ok(())
 }
@@ -170,18 +164,17 @@ mod tests {
     }
 
     #[test]
-    fn reject_out_of_range_advance_rejects_above_the_cap_as_permanent() {
+    fn reject_out_of_range_advance_rejects_above_the_cap_as_variant() {
+        // The rejected value is carried in a typed variant, not type-erased
+        // through `PermanentDriver(Box<dyn Error>)`. Server-side classification
+        // can route on the variant directly (see `PersistDisposition::OutOfRange`)
+        // and reconstruct the original error faithfully after the disposition.
         for at_least in [tsoracle_core::PHYSICAL_MS_MAX + 1, u64::MAX] {
             let err = reject_out_of_range_advance(at_least)
                 .expect_err("a value above the cap must be rejected");
             match err {
-                ConsensusError::PermanentDriver(source) => {
-                    let downcast = source
-                        .downcast_ref::<AdvanceOutOfRange>()
-                        .expect("permanent driver error must carry AdvanceOutOfRange");
-                    assert_eq!(downcast.0, at_least);
-                }
-                other => panic!("expected PermanentDriver, got {other:?}"),
+                ConsensusError::AdvanceOutOfRange(value) => assert_eq!(value, at_least),
+                other => panic!("expected AdvanceOutOfRange, got {other:?}"),
             }
         }
     }

--- a/crates/tsoracle-consensus/src/error.rs
+++ b/crates/tsoracle-consensus/src/error.rs
@@ -31,12 +31,13 @@ use tsoracle_core::Epoch;
 /// `TransientDriver` or `PermanentDriver`. The server uses that classification
 /// directly to pick a gRPC status code:
 ///
-/// | Variant            | gRPC code            | Client expectation         |
-/// |--------------------|----------------------|----------------------------|
-/// | `NotLeader`        | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
-/// | `Fenced`           | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
-/// | `TransientDriver`  | `UNAVAILABLE`        | Safe to retry              |
-/// | `PermanentDriver`  | `INTERNAL`           | Do NOT silently retry      |
+/// | Variant              | gRPC code            | Client expectation         |
+/// |----------------------|----------------------|----------------------------|
+/// | `NotLeader`          | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
+/// | `Fenced`             | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
+/// | `TransientDriver`    | `UNAVAILABLE`        | Safe to retry              |
+/// | `PermanentDriver`    | `INTERNAL`           | Do NOT silently retry      |
+/// | `AdvanceOutOfRange`  | `INTERNAL`           | Do NOT silently retry      |
 #[derive(Debug, thiserror::Error)]
 pub enum ConsensusError {
     #[error("not leader (current epoch: {observed:?})")]
@@ -53,6 +54,16 @@ pub enum ConsensusError {
     /// storage device, bad driver implementation, invariant violation.
     #[error("permanent driver error: {0}")]
     PermanentDriver(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// A high-water advance whose `physical_ms` value exceeds the 46-bit
+    /// timestamp layout's cap. Carries the offending value structurally so
+    /// the server can format and route it without downcasting through
+    /// `Box<dyn Error>`. Semantically permanent (a saturated or misconfigured
+    /// clock), so the server surfaces it as `INTERNAL` rather than retrying.
+    /// See [`reject_out_of_range_advance`] for the propose-time guard.
+    ///
+    /// [`reject_out_of_range_advance`]: crate::reject_out_of_range_advance
+    #[error("high-water advance {0} exceeds the 46-bit physical_ms maximum")]
+    AdvanceOutOfRange(u64),
 }
 
 #[cfg(test)]
@@ -82,5 +93,11 @@ mod tests {
         let permanent = ConsensusError::PermanentDriver(Box::new(std::io::Error::other("corrupt")));
         assert!(permanent.to_string().contains("permanent"));
         assert!(permanent.to_string().contains("corrupt"));
+
+        let out_of_range = ConsensusError::AdvanceOutOfRange(tsoracle_core::PHYSICAL_MS_MAX + 1);
+        let oor_text = out_of_range.to_string();
+        assert!(oor_text.contains("high-water advance"));
+        assert!(oor_text.contains("46-bit"));
+        assert!(oor_text.contains(&(tsoracle_core::PHYSICAL_MS_MAX + 1).to_string()));
     }
 }

--- a/crates/tsoracle-consensus/src/lib.rs
+++ b/crates/tsoracle-consensus/src/lib.rs
@@ -33,7 +33,7 @@ mod leadership;
 
 pub mod docs;
 
-pub use advance::{AdvanceOutOfRange, AdvancePayload, reject_out_of_range_advance};
+pub use advance::{AdvancePayload, reject_out_of_range_advance};
 pub use driver::ConsensusDriver;
 pub use error::ConsensusError;
 pub use leadership::LeaderState;

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -392,7 +392,10 @@ mod tests {
             .persist_high_water(PHYSICAL_MS_MAX + 1, Epoch::ZERO)
             .await
             .unwrap_err();
-        assert!(matches!(err, ConsensusError::PermanentDriver(_)));
+        assert!(
+            matches!(err, ConsensusError::AdvanceOutOfRange(at_least) if at_least == PHYSICAL_MS_MAX + 1),
+            "out-of-range advance must surface as AdvanceOutOfRange carrying the offending value, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -334,8 +334,8 @@ mod tests {
             .await
             .expect_err("an out-of-range advance must be rejected, not persisted");
         assert!(
-            matches!(err, tsoracle_consensus::ConsensusError::PermanentDriver(_)),
-            "out-of-range advance must classify as PermanentDriver, got {err:?}"
+            matches!(err, tsoracle_consensus::ConsensusError::AdvanceOutOfRange(at_least) if at_least == PHYSICAL_MS_MAX + 1),
+            "out-of-range advance must surface as AdvanceOutOfRange carrying the offending value, got {err:?}"
         );
 
         // The boundary value is in range and still delegates to the host,

--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -408,8 +408,8 @@ mod tests {
             .await
             .expect_err("an out-of-range advance must be rejected, not appended");
         assert!(
-            matches!(err, ConsensusError::PermanentDriver(_)),
-            "out-of-range advance must classify as PermanentDriver, got {err:?}"
+            matches!(err, ConsensusError::AdvanceOutOfRange(at_least) if at_least == PHYSICAL_MS_MAX + 1),
+            "out-of-range advance must surface as AdvanceOutOfRange carrying the offending value, got {err:?}"
         );
 
         // The boundary value is in range and still reaches the host.

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -362,6 +362,17 @@ pub(crate) async fn run_leader_watch(
                                         ConsensusError::PermanentDriver(source),
                                     ));
                                 }
+                                // Same surface policy as Permanent (fatal, poison
+                                // serving), but the variant carries the offending
+                                // u64 structurally, so we reconstruct the original
+                                // ConsensusError variant — not collapse it into
+                                // PermanentDriver — so propagated diagnostics keep
+                                // their typed identity.
+                                PersistDisposition::OutOfRange(at_least) => {
+                                    return Err(ServerError::Consensus(
+                                        ConsensusError::AdvanceOutOfRange(at_least),
+                                    ));
+                                }
                             }
                         }
                         // A non-consensus fault (e.g. a Core allocator invariant

--- a/crates/tsoracle-server/src/persist_disposition.rs
+++ b/crates/tsoracle-server/src/persist_disposition.rs
@@ -71,6 +71,15 @@ pub(crate) enum PersistDisposition {
     ///
     /// [`Transient`]: PersistDisposition::Transient
     Permanent(Box<dyn std::error::Error + Send + Sync>),
+    /// The proposed high-water advance exceeded the 46-bit `physical_ms` cap
+    /// (`ConsensusError::AdvanceOutOfRange`). Semantically permanent — same
+    /// surface policy as [`Permanent`] (`INTERNAL`, no step-down, propagate as
+    /// fatal in the fence path) — but kept as its own variant so the offending
+    /// `u64` is carried structurally end-to-end. The two call sites can format
+    /// or reconstruct it without downcasting through `Box<dyn Error>`.
+    ///
+    /// [`Permanent`]: PersistDisposition::Permanent
+    OutOfRange(u64),
 }
 
 /// Classify a consensus persist/load failure into its policy-neutral
@@ -88,6 +97,7 @@ pub(crate) fn classify(error: ConsensusError) -> PersistDisposition {
         ConsensusError::NotLeader { .. } => PersistDisposition::SteppedDown { fenced_by: None },
         ConsensusError::TransientDriver(source) => PersistDisposition::Transient(source),
         ConsensusError::PermanentDriver(source) => PersistDisposition::Permanent(source),
+        ConsensusError::AdvanceOutOfRange(at_least) => PersistDisposition::OutOfRange(at_least),
     }
 }
 
@@ -146,6 +156,22 @@ mod tests {
         match disposition {
             PersistDisposition::Permanent(source) => assert_eq!(source.to_string(), "corrupted"),
             other => panic!("expected Permanent, got a different disposition: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn advance_out_of_range_carries_the_offending_value_structurally() {
+        // The `u64` survives classification typed — no boxing, no downcast.
+        // The fence path reconstructs the original ConsensusError variant from
+        // this disposition, so identity must round-trip faithfully.
+        let disposition = classify(ConsensusError::AdvanceOutOfRange(
+            tsoracle_core::PHYSICAL_MS_MAX + 1,
+        ));
+        match disposition {
+            PersistDisposition::OutOfRange(at_least) => {
+                assert_eq!(at_least, tsoracle_core::PHYSICAL_MS_MAX + 1);
+            }
+            other => panic!("expected OutOfRange, got a different disposition: {other:?}"),
         }
     }
 }

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -25,6 +25,7 @@
 
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
+use tsoracle_consensus::ConsensusError;
 use tsoracle_core::{CommitOutcome, CoreError, Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{
     EpochWire, GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetTsRequest, GetTsResponse,
@@ -311,6 +312,17 @@ impl TsoServiceImpl {
                 // down — the driver is sick, not fenced.
                 PersistDisposition::Permanent(source) => {
                     return Err(Status::internal(format!("persist: {source}")));
+                }
+                // Proposed advance exceeded the 46-bit physical_ms cap. Same
+                // surface policy as Permanent (INTERNAL, no step-down), but the
+                // offending value is carried structurally. Reuse the variant's
+                // `Display` (a single source of truth in `ConsensusError`) so
+                // the message text stays pinned to the consensus crate.
+                PersistDisposition::OutOfRange(at_least) => {
+                    return Err(Status::internal(format!(
+                        "persist: {}",
+                        ConsensusError::AdvanceOutOfRange(at_least)
+                    )));
                 }
             },
         };


### PR DESCRIPTION
## Summary

Promote the out-of-range high-water advance from a `Box<dyn Error>`-erased `ConsensusError::PermanentDriver` source to a first-class `ConsensusError::AdvanceOutOfRange(u64)` variant. The offending value is carried structurally from the propose-time guard, through the server's disposition layer, into both consumers — no downcasting, no re-boxing in `classify`.

- **Breaking surface (the `!`)**: the public `AdvanceOutOfRange` struct and its `pub use` re-export are removed from `tsoracle-consensus`. The only downcaster in the tree was the crate's own test; no external consumer is affected.
- **Disposition layer carries the value structurally**: `PersistDisposition::OutOfRange(u64)` instead of `Permanent(Box::new(...))`. This follows the disposition module's stated design philosophy — *"a fifth `ConsensusError` variant becomes one edit here plus a compiler-forced arm at each site"* — and lets the fence path reconstruct `ConsensusError::AdvanceOutOfRange(n)` faithfully instead of laundering it back into `PermanentDriver`. `service.rs` reuses the variant's `Display` so the message text stays pinned to one source of truth.
- **Test strengthening**: three driver tests that previously asserted `matches!(_, PermanentDriver(_))` on the OOR path now assert the new variant *and* the carried `u64`. The unrelated `PermanentDriver(_)` assertions (storage I/O failpoints, Raft `Fatal`, paxos `PendingReconfig`, watch-task death) are untouched.

Blast radius (9 files, +92/−30): the new variant + simplified guard in `tsoracle-consensus`, the new disposition arm + two compiler-forced consumer arms in `tsoracle-server`, and three updated test assertions across the file/paxos/openraft drivers.

## Test plan

- [x] `cargo test --workspace --all-features` — 1158 passed, 0 failed, 21 ignored across 135 test result blocks
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `scripts/check-ts-header.py` — 270 files OK
- [x] Pre-commit `cargo fmt --check` + `cargo clippy` passed
- [x] New unit tests:
  - `consensus::advance::tests::reject_out_of_range_advance_rejects_above_the_cap_as_variant`
  - `consensus::error::tests::consensus_error_display_text` (now covers `AdvanceOutOfRange`)
  - `server::persist_disposition::tests::advance_out_of_range_carries_the_offending_value_structurally`