### PR TITLE
refactor(consensus)!: promote AdvanceOutOfRange to a typed variant

### DIFF
--- a/crates/tsoracle-consensus/src/advance.rs
+++ b/crates/tsoracle-consensus/src/advance.rs
@@ -60,12 +60,6 @@ impl AdvancePayload {
     }
 }
 
-/// The error carried by a rejected out-of-range high-water advance. See
-/// [`reject_out_of_range_advance`].
-#[derive(Debug, thiserror::Error)]
-#[error("high-water advance {0} exceeds the 46-bit physical_ms maximum")]
-pub struct AdvanceOutOfRange(pub u64);
-
 /// Reject a high-water advance whose `physical_ms` value exceeds
 /// `tsoracle_core::PHYSICAL_MS_MAX`, before it is durably persisted.
 ///
@@ -85,15 +79,16 @@ pub struct AdvanceOutOfRange(pub u64);
 /// a replicated log and apply with an unchecked `max` — from drifting away from
 /// that contract.
 ///
-/// Classified [`ConsensusError::PermanentDriver`]: an out-of-range advance
-/// signals a saturated or misconfigured clock (`SystemClock::now_ms` saturates
-/// to `u64::MAX` to surface a far-future clock visibly), not a transient
-/// condition, so the server must surface `INTERNAL` rather than silently retry.
+/// Returns the dedicated [`ConsensusError::AdvanceOutOfRange`] variant so the
+/// server can pattern-match this single well-known condition without a
+/// `Box<dyn Error>` downcast. The wire disposition is `INTERNAL`, matching what
+/// `PermanentDriver` would have produced: an out-of-range advance signals a
+/// saturated or misconfigured clock (`SystemClock::now_ms` saturates to
+/// `u64::MAX` to surface a far-future clock visibly), not a transient
+/// condition, so the server must not silently retry.
 pub fn reject_out_of_range_advance(at_least: u64) -> Result<(), ConsensusError> {
     if at_least > tsoracle_core::PHYSICAL_MS_MAX {
-        return Err(ConsensusError::PermanentDriver(Box::new(
-            AdvanceOutOfRange(at_least),
-        )));
+        return Err(ConsensusError::AdvanceOutOfRange { at_least });
     }
     Ok(())
 }
@@ -170,18 +165,15 @@ mod tests {
     }
 
     #[test]
-    fn reject_out_of_range_advance_rejects_above_the_cap_as_permanent() {
+    fn reject_out_of_range_advance_rejects_above_the_cap_as_typed_variant() {
         for at_least in [tsoracle_core::PHYSICAL_MS_MAX + 1, u64::MAX] {
             let err = reject_out_of_range_advance(at_least)
                 .expect_err("a value above the cap must be rejected");
             match err {
-                ConsensusError::PermanentDriver(source) => {
-                    let downcast = source
-                        .downcast_ref::<AdvanceOutOfRange>()
-                        .expect("permanent driver error must carry AdvanceOutOfRange");
-                    assert_eq!(downcast.0, at_least);
+                ConsensusError::AdvanceOutOfRange { at_least: surfaced } => {
+                    assert_eq!(surfaced, at_least);
                 }
-                other => panic!("expected PermanentDriver, got {other:?}"),
+                other => panic!("expected AdvanceOutOfRange, got {other:?}"),
             }
         }
     }

--- a/crates/tsoracle-consensus/src/error.rs
+++ b/crates/tsoracle-consensus/src/error.rs
@@ -31,12 +31,13 @@ use tsoracle_core::Epoch;
 /// `TransientDriver` or `PermanentDriver`. The server uses that classification
 /// directly to pick a gRPC status code:
 ///
-/// | Variant            | gRPC code            | Client expectation         |
-/// |--------------------|----------------------|----------------------------|
-/// | `NotLeader`        | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
-/// | `Fenced`           | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
-/// | `TransientDriver`  | `UNAVAILABLE`        | Safe to retry              |
-/// | `PermanentDriver`  | `INTERNAL`           | Do NOT silently retry      |
+/// | Variant              | gRPC code            | Client expectation         |
+/// |----------------------|----------------------|----------------------------|
+/// | `NotLeader`          | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
+/// | `Fenced`             | `FAILED_PRECONDITION` + `LeaderHint` | Retry against the new leader |
+/// | `TransientDriver`    | `UNAVAILABLE`        | Safe to retry              |
+/// | `PermanentDriver`    | `INTERNAL`           | Do NOT silently retry      |
+/// | `AdvanceOutOfRange`  | `INTERNAL`           | Do NOT silently retry — saturated/misconfigured clock |
 #[derive(Debug, thiserror::Error)]
 pub enum ConsensusError {
     #[error("not leader (current epoch: {observed:?})")]
@@ -53,6 +54,16 @@ pub enum ConsensusError {
     /// storage device, bad driver implementation, invariant violation.
     #[error("permanent driver error: {0}")]
     PermanentDriver(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// The shared pre-persist range guard rejected a high-water advance whose
+    /// `physical_ms` value exceeds [`tsoracle_core::PHYSICAL_MS_MAX`]. Promoted
+    /// out of `PermanentDriver` so callers (and the server's gRPC mapping) can
+    /// react to this one well-known shape without a `downcast_ref`. Classified
+    /// as `INTERNAL` at the wire — the same disposition `PermanentDriver` would
+    /// have produced — because an out-of-range advance signals a saturated or
+    /// misconfigured clock, not a transient condition. See
+    /// [`reject_out_of_range_advance`](crate::reject_out_of_range_advance).
+    #[error("high-water advance {at_least} exceeds the 46-bit physical_ms maximum")]
+    AdvanceOutOfRange { at_least: u64 },
 }
 
 #[cfg(test)]
@@ -82,5 +93,11 @@ mod tests {
         let permanent = ConsensusError::PermanentDriver(Box::new(std::io::Error::other("corrupt")));
         assert!(permanent.to_string().contains("permanent"));
         assert!(permanent.to_string().contains("corrupt"));
+
+        let advance_out_of_range = ConsensusError::AdvanceOutOfRange { at_least: u64::MAX };
+        let text = advance_out_of_range.to_string();
+        assert!(text.contains("high-water advance"));
+        assert!(text.contains(&u64::MAX.to_string()));
+        assert!(text.contains("46-bit"));
     }
 }

--- a/crates/tsoracle-consensus/src/lib.rs
+++ b/crates/tsoracle-consensus/src/lib.rs
@@ -33,7 +33,7 @@ mod leadership;
 
 pub mod docs;
 
-pub use advance::{AdvanceOutOfRange, AdvancePayload, reject_out_of_range_advance};
+pub use advance::{AdvancePayload, reject_out_of_range_advance};
 pub use driver::ConsensusDriver;
 pub use error::ConsensusError;
 pub use leadership::LeaderState;

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -392,7 +392,12 @@ mod tests {
             .persist_high_water(PHYSICAL_MS_MAX + 1, Epoch::ZERO)
             .await
             .unwrap_err();
-        assert!(matches!(err, ConsensusError::PermanentDriver(_)));
+        assert!(matches!(
+            err,
+            ConsensusError::AdvanceOutOfRange {
+                at_least: v,
+            } if v == PHYSICAL_MS_MAX + 1
+        ));
     }
 
     #[tokio::test]

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -334,8 +334,12 @@ mod tests {
             .await
             .expect_err("an out-of-range advance must be rejected, not persisted");
         assert!(
-            matches!(err, tsoracle_consensus::ConsensusError::PermanentDriver(_)),
-            "out-of-range advance must classify as PermanentDriver, got {err:?}"
+            matches!(
+                err,
+                tsoracle_consensus::ConsensusError::AdvanceOutOfRange { at_least }
+                    if at_least == PHYSICAL_MS_MAX + 1
+            ),
+            "out-of-range advance must classify as AdvanceOutOfRange, got {err:?}"
         );
 
         // The boundary value is in range and still delegates to the host,

--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -408,8 +408,11 @@ mod tests {
             .await
             .expect_err("an out-of-range advance must be rejected, not appended");
         assert!(
-            matches!(err, ConsensusError::PermanentDriver(_)),
-            "out-of-range advance must classify as PermanentDriver, got {err:?}"
+            matches!(
+                err,
+                ConsensusError::AdvanceOutOfRange { at_least } if at_least == PHYSICAL_MS_MAX + 1
+            ),
+            "out-of-range advance must classify as AdvanceOutOfRange, got {err:?}"
         );
 
         // The boundary value is in range and still reaches the host.

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -362,6 +362,16 @@ pub(crate) async fn run_leader_watch(
                                         ConsensusError::PermanentDriver(source),
                                     ));
                                 }
+                                // Range-guard rejection: fatal-and-poison like
+                                // Permanent (the high-water only ratchets up so
+                                // an out-of-range value can never self-heal),
+                                // but reconstituted as the typed variant so the
+                                // propagated error keeps its shape end-to-end.
+                                PersistDisposition::AdvanceOutOfRange { at_least } => {
+                                    return Err(ServerError::Consensus(
+                                        ConsensusError::AdvanceOutOfRange { at_least },
+                                    ));
+                                }
                             }
                         }
                         // A non-consensus fault (e.g. a Core allocator invariant

--- a/crates/tsoracle-server/src/persist_disposition.rs
+++ b/crates/tsoracle-server/src/persist_disposition.rs
@@ -71,6 +71,16 @@ pub(crate) enum PersistDisposition {
     ///
     /// [`Transient`]: PersistDisposition::Transient
     Permanent(Box<dyn std::error::Error + Send + Sync>),
+    /// The shared pre-persist range guard rejected a high-water advance whose
+    /// `physical_ms` value exceeds [`tsoracle_core::PHYSICAL_MS_MAX`]. Same wire
+    /// disposition as [`Permanent`] (the caller MUST NOT silently retry), but
+    /// kept as its own variant so the typed `at_least` value flows to the gRPC
+    /// mapping site without re-boxing into `Box<dyn Error>` — a saturated or
+    /// misconfigured clock has one well-known shape, and the type system can
+    /// carry it intact.
+    ///
+    /// [`Permanent`]: PersistDisposition::Permanent
+    AdvanceOutOfRange { at_least: u64 },
 }
 
 /// Classify a consensus persist/load failure into its policy-neutral
@@ -88,6 +98,9 @@ pub(crate) fn classify(error: ConsensusError) -> PersistDisposition {
         ConsensusError::NotLeader { .. } => PersistDisposition::SteppedDown { fenced_by: None },
         ConsensusError::TransientDriver(source) => PersistDisposition::Transient(source),
         ConsensusError::PermanentDriver(source) => PersistDisposition::Permanent(source),
+        ConsensusError::AdvanceOutOfRange { at_least } => {
+            PersistDisposition::AdvanceOutOfRange { at_least }
+        }
     }
 }
 
@@ -146,6 +159,18 @@ mod tests {
         match disposition {
             PersistDisposition::Permanent(source) => assert_eq!(source.to_string(), "corrupted"),
             other => panic!("expected Permanent, got a different disposition: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn advance_out_of_range_threads_typed_value_through_classify() {
+        // The variant exists precisely so this path does NOT re-box into a
+        // Box<dyn Error>: the at_least value flows typed from the consensus
+        // guard all the way to the gRPC mapping site.
+        let disposition = classify(ConsensusError::AdvanceOutOfRange { at_least: u64::MAX });
+        match disposition {
+            PersistDisposition::AdvanceOutOfRange { at_least } => assert_eq!(at_least, u64::MAX),
+            other => panic!("expected AdvanceOutOfRange, got a different disposition: {other:?}"),
         }
     }
 }

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -312,6 +312,16 @@ impl TsoServiceImpl {
                 PersistDisposition::Permanent(source) => {
                     return Err(Status::internal(format!("persist: {source}")));
                 }
+                // Pre-persist range guard rejected the advance. Same wire
+                // contract as Permanent (INTERNAL, do NOT silently retry) but
+                // the typed at_least value reaches here without a Box<dyn
+                // Error> hop, so the message names the offending value
+                // directly instead of routing it through `source.to_string()`.
+                PersistDisposition::AdvanceOutOfRange { at_least } => {
+                    return Err(Status::internal(format!(
+                        "persist: high-water advance {at_least} exceeds the 46-bit physical_ms maximum"
+                    )));
+                }
             },
         };
         let commit_outcome = self


### PR DESCRIPTION
## Summary

- The shared pre-persist range guard was packing its rejection through `ConsensusError::PermanentDriver(Box::new(AdvanceOutOfRange(_)))`, forcing every consumer that wanted to identify this one well-known condition to `downcast_ref` (and a test to `expect()` that the downcast succeeded — a contract assertion the type system should enforce for free).
- Promotes the condition to its own variant `ConsensusError::AdvanceOutOfRange { at_least: u64 }` and threads the typed value end-to-end:
  - `reject_out_of_range_advance` returns the variant directly — no `Box::new`, no string formatting at the boundary.
  - `PersistDisposition` gains a matching `AdvanceOutOfRange { at_least }` variant so the server-side classifier does not re-box into `PersistDisposition::Permanent(Box<dyn Error>)`.
  - `service::extend_window` and `fence::run_leader_watch` get a new compiler-forced arm. Wire disposition is unchanged (INTERNAL, must-not-retry — exactly what `PermanentDriver` produced before); the gRPC status message now names the offending `at_least` value directly instead of routing it through `source.to_string()`.
- Removes the now-unused standalone `pub struct AdvanceOutOfRange(pub u64)` and its `pub use`. The three driver-level tests that previously matched `ConsensusError::PermanentDriver(_)` for the range-guard case now match the typed variant including the surfaced `at_least` value; the four `PermanentDriver(_)` matchers covering real driver faults (I/O failure, fsync panic, apply-task-gone) are left alone — they continue to test what they were meant to test.

After this change, every remaining `Box<dyn std::error::Error + Send + Sync>` carried by `ConsensusError` is genuinely-opaque driver internals (rocksdb errors, tonic errors, omnipaxos errors, file I/O) — the closed-shape `AdvanceOutOfRange` no longer hides in there.

## Breaking change

`ConsensusError` is not `#[non_exhaustive]`, so adding a variant is a SemVer break for external pattern matchers. The previously re-exported `tsoracle_consensus::AdvanceOutOfRange` struct is removed — match on `ConsensusError::AdvanceOutOfRange { at_least }` instead. No in-repo callers imported the struct directly, so the in-tree migration is mechanical.

## Test plan

- [x] `cargo build --workspace --all-features` — clean
- [x] `cargo test --workspace --all-features` — zero failures
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean (pre-commit hook enforced)
- [x] New unit test `reject_out_of_range_advance_rejects_above_the_cap_as_typed_variant` matches the variant with the exact `at_least` value (no `downcast_ref`)
- [x] New disposition test `advance_out_of_range_threads_typed_value_through_classify` proves the value flows typed across the consensus → server boundary without re-boxing
- [x] Driver-level guard tests in file/openraft/paxos now assert `ConsensusError::AdvanceOutOfRange { at_least } if at_least == PHYSICAL_MS_MAX + 1` (stronger than the previous `matches!(_, PermanentDriver(_))`)