### PR TITLE
ci(release): sign tags in gitsign offline Rekor mode so git verify-tag works

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -74,6 +74,18 @@ jobs:
           git config --global gpg.x509.program gitsign
           git config --global gpg.format x509
           git config --global tag.gpgSign true
+          # Use gitsign's offline Rekor mode: the inclusion proof is embedded
+          # in the tag signature itself (keyed to the CMS signed-attributes
+          # hash), rather than relying on the Rekor Search API at verify time.
+          # gitsign's default ("online") mode reconstructs the signed object
+          # with the signature as a `gpgsig` header (commit form) when logging
+          # to Rekor, but `git verify-tag` reconstructs annotated tags with the
+          # signature in-body (tag form) — the two hashes never match, so
+          # `git verify-tag --raw` always fails with "could not find matching
+          # tlog entry" for annotated tags. Offline mode is object-type-
+          # agnostic and round-trips for tags. (gitsign upstream is migrating
+          # its default to offline for this reason.)
+          git config --global gitsign.rekorMode offline
       - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db  # v0.5
         id: release-plz
         with:

--- a/docs/release-signatures.md
+++ b/docs/release-signatures.md
@@ -84,6 +84,8 @@ Together these prove the artifact you hold was built by *this* repository's CI f
 
 Release tags themselves are also signed (in addition to the release artifacts above). Signing uses [Sigstore gitsign](https://github.com/sigstore/gitsign) — the same keyless, transparency-log-anchored model as the SLSA provenance. The signing identity is the `release-plz` workflow's GitHub Actions OIDC token, attested by Fulcio and logged to Rekor; there is no long-lived key to rotate or revoke.
 
+Tags are signed in gitsign's *offline* Rekor mode (`gitsign.rekorMode offline`): the Rekor inclusion proof is embedded directly in the tag signature, keyed to the hash of the CMS signed attributes. Verification is therefore self-contained — it does not depend on the Rekor Search API and keeps working after the ephemeral signing certificate expires. (This is also what makes `git verify-tag` reliable for annotated tags; see [Tags from the first gitsign release](#tags-from-the-first-gitsign-release) for why the default *online* mode does not.)
+
 ### Quick verification
 
 For any release tag (e.g., `tsoracle-v1.0.0`):
@@ -115,3 +117,7 @@ Because the signature identity is the workflow, not a person, the verification t
 ### Pre-gitsign tags
 
 Releases tagged before the gitsign integration landed are annotated but unsigned. `git verify-tag` will report `no signature found` for those tags; their provenance is still verifiable via the `.intoto.jsonl` SLSA attestation as documented above.
+
+### Tags from the first gitsign release
+
+The first release signed by gitsign (the 2026-05-27 batch — `tsoracle-v2.0.0`, `tsoracle-core-v2.0.0`, and the sibling `*-v2.0.0` / `*-v1.0.1` tags) was produced in gitsign's *online* Rekor mode, before the switch to offline mode. Those tags carry a valid Fulcio-issued signature and a real Rekor entry (resolvable at <https://search.sigstore.dev/>), but `git verify-tag --raw` reports `could not find matching tlog entry` for them. The cause is a gitsign limitation for annotated tags: in online mode gitsign logs Rekor a hash of the tag *reconstructed with the signature as a `gpgsig` header* (commit form), whereas `git verify-tag` reconstructs an annotated tag with the signature *in-body* (tag form) — the two hashes never coincide, so the lookup misses. The signature itself is cryptographically valid and the Rekor entry is genuine; only the `git verify-tag` ↔ Rekor binding is broken. This is fixed forward by signing in offline mode; the affected tags cannot be re-signed retroactively (their ephemeral signing certificates have long since expired), but their provenance remains verifiable via the `.intoto.jsonl` SLSA attestation as documented above.


### PR DESCRIPTION
## Summary

Switches release-tag signing to gitsign's **offline** Rekor mode so that `git verify-tag --raw` actually verifies our annotated release tags. Closes the verification gap discovered while working #549 (the post-merge follow-up to #544).

- `.github/workflows/release-plz.yml`: add `git config --global gitsign.rekorMode offline` to the "configure git to sign tags via gitsign" step (with an explanatory comment).
- `docs/release-signatures.md`: document offline-mode verification and add a "Tags from the first gitsign release" section explaining why the 2026-05-27 batch doesn't verify.

## Root cause

gitsign's default **online** Rekor mode (`LegacySHASign`) logs the tag's signature to Rekor under the hash of the object *reconstructed with the signature as a `gpgsig` header* (commit form). But `git verify-tag` / `gitsign verify-tag` reconstruct an annotated tag with the signature **in-body** (tag form). The two reconstructions hash differently, so the Rekor lookup at verify time never matches — every release tag fails with `could not find matching tlog entry`.

Confirmed byte-for-byte against the shipped tag `tsoracle-v2.0.0`:

| Quantity | Value |
|---|---|
| CMS `messageDigest` (= SHA256 of tag payload) | `c270307288b3…e28e` ✅ valid |
| Rekor entry `data.hash` (what online mode logged) | `d86dc4f9…75f1` = `SHA256(gitSHA1(gpgsig-header reassembly))` |
| What `verify-tag` searches for | `9a404a7e…70ae` = `SHA256(`real in-body tag object `56a57b31…)` — **absent from Rekor** |

The signature is cryptographically valid and the Rekor entry is genuine (resolves at search.sigstore.dev); only the `git verify-tag` ↔ Rekor binding is broken. This is a gitsign limitation for annotated tags — gitsign upstream is migrating its default to offline for the same reason (`internal/config/config.go`: *"online verification will be deprecated in favor of offline… TODO: default to offline"*).

## Why offline mode fixes it

Offline `Sign` logs `SHA256(CMS signed-attributes)` — object-type-agnostic, no commit/tag reconstruction — and **embeds** the Rekor inclusion proof in the signature. `pkg/git.Verify` tries this embedded-proof path first, so verification is self-contained (no Rekor search, works after the ephemeral cert expires). The change is **sign-side only**; verifiers need no config.

## Test plan

- [x] `actionlint .github/workflows/release-plz.yml` passes.
- [x] Source-level confirmation that `git config gitsign.rekorMode offline` resolves to offline mode (`internal/config/config.go` `Get()` applies git-config before the env override, which preserves it when `GITSIGN_REKOR_MODE` is unset).
- [x] **Live keyless sign+verify (gitsign 0.16.0, real Sigstore):**

  | Mode | `git verify-tag --raw` | Exit |
  |---|---|---|
  | online (default) | `hashes don't match` | 1 (FAIL) |
  | offline (this PR) | `[GNUPG:] GOODSIG … TRUST_FULLY` | 0 (PASS) |

- [ ] After merge: the next release-plz run produces tags that pass `git verify-tag --raw` and resolve at search.sigstore.dev (the closing condition for #549).

## Note on existing tags

Tags already published in online mode (the 2026-05-27 batch) cannot be re-signed — their keyless signing certificates were valid for only ~10 minutes and have long expired. Per the workflow's own "fix forward, not retroactively" policy, this PR fixes future releases; the existing tags remain SLSA-attested via their `.intoto.jsonl` provenance, and the limitation is now documented.

Refs #549.
