### PR TITLE
fix(deploy): pre-create DATA_DIR owned by non-root user in image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -23,6 +23,16 @@ RUN apt-get update \
     && useradd --system --uid 10001 --create-home tsoracle
 COPY --from=build /src/target/release/tsoracle /usr/local/bin/tsoracle
 COPY deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+# Pre-create the default DATA_DIR (entrypoint.sh defaults to /data) owned by the
+# non-root runtime user. Without this the dir never exists in the image, so a
+# bare `docker run` (no volume) can't mkdir it at / as uid 10001, and a fresh
+# named volume mounted at /data is seeded root-owned -> "Permission denied". With
+# the dir present, Docker seeds a fresh named volume from it (carrying ownership),
+# and the no-volume case has a writable dir. Kubernetes is unaffected: the chart's
+# podSecurityContext.fsGroup still re-owns the PVC on top (OnRootMismatch skips the
+# re-chown since this already matches).
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && mkdir -p /data \
+    && chown tsoracle:tsoracle /data
 USER tsoracle
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Problem

The runtime image creates the `tsoracle` user (uid 10001) but never creates `/data` — the path `entrypoint.sh` defaults `DATA_DIR` to. As built, the **`file` driver cannot start under a plain `docker run`**:

- **No volume**: uid 10001 can't `mkdir /data` at the filesystem root.
- **Fresh named volume** (`-v vol:/data`): Docker seeds the mountpoint root-owned, so the server fails with:
  ```
  Error: driver bootstrap
  Caused by:
      0: failed to open storage at /data: io: Permission denied (os error 13)
  ```

Kubernetes hasn't hit this because the chart's `podSecurityContext.fsGroup` re-owns the PVC before the container starts. The bug only surfaces on the standalone Docker path (local dev, evals, ad-hoc runs).

## Fix

Pre-create `/data` in the image owned by `tsoracle`:

```dockerfile
RUN chmod +x /usr/local/bin/entrypoint.sh \
    && mkdir -p /data \
    && chown tsoracle:tsoracle /data
```

- A **fresh named volume** now inherits that ownership when Docker seeds it from the image directory.
- The **no-volume** case gets a writable dir.
- **Kubernetes is unaffected**: `fsGroup` still applies on top, and `fsGroupChangePolicy: OnRootMismatch` skips the now-redundant re-chown.

Chown is by name (not `10001:10001`) because `useradd --system` without `--gid` assigns the group gid 999, not 10001; owner-rwx is what the uid-10001 process needs.

## Verification

Reproduced the original failure and confirmed the fix with a minimal image mirroring the runtime stage (non-root uid 10001 + `mkdir`/`chown /data`):

- **With fix**: fresh named volume at `/data` comes up `tsoracle`-owned; write as uid 10001 succeeds.
- **Control (no fix)**: identical fresh volume is root-owned; write fails with `Permission denied` — matching the reported bug.