### PR TITLE
ci(coverage): exclude e2e crate from coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,13 +144,6 @@ COV_IGNORE_BENCHMARKS := benchmarks/.*
 # legitimate "rare race" retry paths that local CI never trips.
 COV_IGNORE_TEST_SUPPORT := crates/tsoracle-server/src/test_support
 
-# The kind-based e2e driver's binary entrypoint (`main`, `run_soak`,
-# `run_cold_start`, the `clap` CLI): it dials a live multi-node cluster and is
-# exercised only in the opt-in Kubernetes e2e lane, never under `cargo test`.
-# Its pure verdict logic lives in `tracker.rs`, which stays measured and carries
-# its own unit tests; only the unreachable I/O entrypoint is dropped here.
-COV_IGNORE_KUBE_E2E_MAIN := e2e/kube/driver/src/main
-
 # The standalone crate's node-to-node peer transports (`RaftNetworkV2` +
 # tonic client/server for openraft, the `MessageSink` + tonic client/server for
 # paxos). Like the openraft-toolkit lifecycle shims above, these are thin
@@ -163,17 +156,26 @@ COV_IGNORE_KUBE_E2E_MAIN := e2e/kube/driver/src/main
 # own in-module unit tests; only the live-RPC wrappers are dropped here.
 COV_IGNORE_STANDALONE_PEER_TRANSPORT := crates/tsoracle-standalone/src/drivers/(openraft|paxos)/network
 
-COV_IGNORE := ($(COV_IGNORE_OPENRAFT_LIFECYCLE)|$(COV_IGNORE_BENCHMARKS)|$(COV_IGNORE_TEST_SUPPORT)|$(COV_IGNORE_KUBE_E2E_MAIN)|$(COV_IGNORE_STANDALONE_PEER_TRANSPORT))\.rs
+COV_IGNORE := ($(COV_IGNORE_OPENRAFT_LIFECYCLE)|$(COV_IGNORE_BENCHMARKS)|$(COV_IGNORE_TEST_SUPPORT)|$(COV_IGNORE_STANDALONE_PEER_TRANSPORT))\.rs
 
 # Shared exclude flags so `coverage` (lcov for CI) and `coverage-html` (local
 # browsable report) cannot drift apart on which crates participate.
+#
+# `kube-e2e-driver` is the in-cluster assertion driver for the opt-in Kubernetes
+# e2e lane. Its `main`/`gen-certs` binaries dial a live multi-node cluster and
+# never run under `cargo test`; its pure verdict logic (`tracker.rs`) carries
+# its own unit tests, but those exercise only `Tracker` itself and so earn no
+# coverage for any shipped crate. The whole crate is therefore dropped from the
+# coverage build (it still compiles and tests in the `test` CI job) so that
+# nothing under `e2e/` lands in the report.
 COV_EXCLUDES := \
     --exclude tsoracle \
     --exclude example-embedded-server \
     --exclude example-failover-demo \
     --exclude example-openraft-piggyback \
     --exclude example-openraft-standalone \
-    --exclude bench-minimal
+    --exclude bench-minimal \
+    --exclude kube-e2e-driver
 
 # The process-topology smoke tests in `benchmarks/stress/tests/smoke.rs` shell
 # out to the `tsoracle` binary, but `--exclude tsoracle` above means


### PR DESCRIPTION
## Summary

The `e2e/` directory was showing up in the [Coveralls report](https://coveralls.io/github/prisma-risk/tsoracle). Its sole crate, `kube-e2e-driver`, was only *partially* excluded from coverage:

- `e2e/kube/driver/src/main.rs` was dropped via the `--ignore-filename-regex` (`COV_IGNORE_KUBE_E2E_MAIN`)
- `e2e/kube/driver/src/tracker.rs` stayed **measured**
- `e2e/kube/driver/src/bin/gen-certs.rs` was **never excluded at all**

This drops the whole `kube-e2e-driver` crate from the coverage build via `--exclude` (mirroring how `bench-minimal` is handled), so nothing under `e2e/` lands in `lcov.info`.

## Why exclude the whole crate

`kube-e2e-driver` is the in-cluster assertion driver for the opt-in Kubernetes e2e lane. Its `main`/`gen-certs` binaries dial a live multi-node cluster and never run under `cargo test`. Its pure verdict logic (`tracker.rs`) carries its own unit tests, but those exercise only `Tracker` itself, so they earn **no coverage for any shipped crate**. Keeping the crate in the coverage build therefore added nothing to the signal while diluting it with unreachable I/O code.

`tracker.rs` continues to compile and run its unit tests in the workspace `test` CI job (`cargo test --workspace --all-features`) — only the coverage build skips it.

## Changes

- Add `--exclude kube-e2e-driver` to `COV_EXCLUDES` (shared by `make coverage` and `make coverage-html`).
- Remove the now-redundant `COV_IGNORE_KUBE_E2E_MAIN` ignore-regex entry.

## Verification

- `cargo metadata` confirms `kube-e2e-driver` is a valid workspace member, so `--exclude` is accepted without error.
- `make -n coverage` expands to the expected command (the `--exclude` is present; the ignore-regex no longer references `e2e/`).
- The whole `e2e/` tree belongs solely to the `kube-e2e-driver` package, so excluding it removes every `e2e/` source file from the instrumented build.
- The coverage CI job on this PR will confirm `e2e/` no longer appears in `lcov.info` / Coveralls.