### PR TITLE
feat(server): configurable GetSeq max count via ServerBuilder::max_seq_count

### DIFF
--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -667,6 +667,71 @@ mod tests {
         assert_eq!(block.count, big);
     }
 
+    /// The rejection companion to `get_seq_forwards_large_count_to_server`: when
+    /// the server's configured `ServerBuilder::max_seq_count` is smaller than the
+    /// requested `count`, it rejects with `INVALID_ARGUMENT`
+    /// (`CoreError::SeqCountTooLarge`). Because the client no longer pre-checks the
+    /// upper bound, that rejection must surface through `Client::get_seq` as
+    /// `ClientError::Rpc` preserving the server's message — exactly as the `get_seq`
+    /// doc contract promises — and must NOT be mislabelled `InvalidSeqKey`: a valid
+    /// key was supplied; only the count was over-cap.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_seq_over_cap_count_surfaces_rpc_invalid_argument() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let calls = Arc::new(AtomicU64::new(0));
+        let server_calls = calls.clone();
+        // Mirrors the server's SeqCountTooLarge → INVALID_ARGUMENT mapping for a
+        // count above the configured max_seq_count. Counts calls to prove the
+        // definitive-error path stays bounded (no unbounded ride-out).
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq(move |_req| {
+                let calls = server_calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Err(tonic::Status::invalid_argument(
+                        "count must be between 1 and the maximum",
+                    ))
+                }
+            })
+            .spawn()
+            .await;
+
+        let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+            .retry_policy(RetryPolicy {
+                max_attempts: 3,
+                per_attempt_deadline: Duration::from_secs(2),
+                overall_deadline: Duration::from_secs(5),
+                base_backoff: Duration::ZERO,
+                leader_ttl: Duration::from_secs(30),
+            })
+            .build()
+            .await
+            .unwrap();
+
+        // A valid key with an over-cap count: the key is fine, so InvalidSeqKey
+        // would be the wrong label — the docs promise ClientError::Rpc.
+        let big = tsoracle_core::DEFAULT_MAX_SEQ_COUNT + 1;
+        match client.get_seq("orders", big).await {
+            Err(ClientError::Rpc(status)) => {
+                assert_eq!(status.code(), tonic::Code::InvalidArgument);
+                assert!(
+                    status.message().contains("maximum"),
+                    "must surface the server's over-cap message, not a synthetic \
+                     or mislabelled error; got {:?}",
+                    status.message()
+                );
+            }
+            other => panic!(
+                "an over-cap count with a valid key must surface as \
+                 ClientError::Rpc(InvalidArgument), not InvalidSeqKey; got {other:?}"
+            ),
+        }
+        // Definitive-error path: bounded attempts, never an unbounded ride-out.
+        let n = calls.load(Ordering::SeqCst);
+        assert!((1..=3).contains(&n), "expected bounded attempts, got {n}");
+    }
+
     /// Regression guard for the dense classification bug: a bare
     /// `FailedPrecondition` from the server (NO leader-hint trailer) — e.g.
     /// `SeqOverflow` — must surface immediately as that definitive error,

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -218,12 +218,21 @@ impl Client {
     ///
     /// All other errors are pre-commit-certain (the server rejected the request
     /// before any durable advance) and are safe to retry.
+    ///
+    /// The client only pre-rejects universally-invalid inputs — an empty/oversized
+    /// `key` and a zero `count` (a block always covers at least one ordinal).
+    /// The upper bound on `count` is the server's configured
+    /// `ServerBuilder::max_seq_count`, which is deployment-specific, so the client
+    /// does not second-guess it: an over-cap `count` is forwarded and the server
+    /// rejects it with `INVALID_ARGUMENT` (surfaced as `ClientError::Rpc`). This
+    /// keeps a client built against one cap correct against a server configured
+    /// with another.
     pub async fn get_seq(&self, key: &str, count: u32) -> Result<SeqBlock, ClientError> {
         if key.is_empty() || key.len() > tsoracle_core::MAX_SEQ_KEY_LEN {
             return Err(ClientError::InvalidSeqKey);
         }
-        if count == 0 || count > tsoracle_core::MAX_SEQ_COUNT {
-            return Err(ClientError::InvalidCount(count));
+        if count == 0 {
+            return Err(ClientError::InvalidCount(0));
         }
         retry::issue_seq_rpc(&self.pool, key, count).await
     }
@@ -614,6 +623,48 @@ mod tests {
             Err(ClientError::InvalidCount(0)) => {}
             other => panic!("count=0 must return InvalidCount, got {other:?}"),
         }
+    }
+
+    /// The upper bound on `count` is the server's configured `max_seq_count`, not
+    /// a fixed client-side constant, so the client must forward a large `count`
+    /// rather than short-circuit it with a local `InvalidCount`. Here a count far
+    /// above the old default reaches a cap-less echo server and is served —
+    /// proving the client dropped its hard-coded ceiling check.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_seq_forwards_large_count_to_server() {
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq(|req| async move {
+                let (hi, lo) = tsoracle_core::Epoch(1).to_wire();
+                Ok(tsoracle_proto::v1::GetSeqResponse {
+                    key: req.key,
+                    start: 0,
+                    count: req.count,
+                    epoch: Some(tsoracle_proto::v1::EpochWire { hi, lo }),
+                })
+            })
+            .spawn()
+            .await;
+
+        let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+            .retry_policy(RetryPolicy {
+                max_attempts: 3,
+                per_attempt_deadline: Duration::from_secs(2),
+                overall_deadline: Duration::from_secs(5),
+                base_backoff: Duration::ZERO,
+                leader_ttl: Duration::from_secs(30),
+            })
+            .build()
+            .await
+            .unwrap();
+
+        // Far above the old hard-coded default — would have been a local
+        // InvalidCount before; now it is forwarded and the echo server serves it.
+        let big = tsoracle_core::DEFAULT_MAX_SEQ_COUNT + 1;
+        let block = client
+            .get_seq("orders", big)
+            .await
+            .expect("a large count must be forwarded to the server, not locally rejected");
+        assert_eq!(block.count, big);
     }
 
     /// Regression guard for the dense classification bug: a bare

--- a/crates/tsoracle-client/src/seq_attempt.rs
+++ b/crates/tsoracle-client/src/seq_attempt.rs
@@ -64,8 +64,10 @@ pub(crate) enum SeqAttemptOutcome {
 /// post-rename directory-fsync failure to a permanent fault → `INTERNAL` — so
 /// the advance may already be committed; treating it as retry-safe would let
 /// the caller double-spend a block. Only these codes are pre-commit-certain by
-/// construction and stay definitive even post-send:
-///   * `InvalidArgument` — request validation, before any state is touched.
+/// construction and stay definitive even post-send (each is surfaced as
+/// [`ClientError::Rpc`], preserving the server's status and message):
+///   * `InvalidArgument` — request validation, before any state is touched
+///     (e.g. an over-cap `count` the server rejects as `SeqCountTooLarge`).
 ///   * `ResourceExhausted` — the per-key cardinality cap is checked before the
 ///     durable write.
 ///   * `Unimplemented` — the driver has no dense support and never advances.
@@ -78,9 +80,13 @@ pub(crate) enum SeqAttemptOutcome {
 pub(crate) fn classify_seq_status(status: tonic::Status, sent: bool) -> SeqAttemptOutcome {
     use tonic::Code;
     match status.code() {
-        // Pre-commit-certain regardless of send → definitive.
-        Code::InvalidArgument => SeqAttemptOutcome::Err(ClientError::InvalidSeqKey),
-        Code::ResourceExhausted | Code::Unimplemented => {
+        // Pre-commit-certain regardless of send → definitive. The server's
+        // status is preserved (surfaced as `ClientError::Rpc`) so the caller
+        // sees the real reason — e.g. an over-cap `count` rejected as
+        // INVALID_ARGUMENT (`SeqCountTooLarge`) — rather than a lossy
+        // reclassification. `InvalidSeqKey` stays reserved for the client-side
+        // pre-check in `Client::get_seq`, not server-reported validation.
+        Code::InvalidArgument | Code::ResourceExhausted | Code::Unimplemented => {
             SeqAttemptOutcome::Err(ClientError::from(status))
         }
         // Post-send and not provably pre-commit → ambiguous (incl. INTERNAL,

--- a/crates/tsoracle-core/src/lib.rs
+++ b/crates/tsoracle-core/src/lib.rs
@@ -37,5 +37,5 @@ pub mod docs;
 pub use allocator::{Allocator, CommitOutcome, CoreError, IgnoreReason, PhysicalMs, WindowGrant};
 pub use epoch::Epoch;
 pub use peer::{PeerEndpoint, PeerEndpointError, TsoPeer};
-pub use seq::{MAX_SEQ_COUNT, MAX_SEQ_KEY_LEN, SeqAllocator, SeqGrant, SeqKey};
+pub use seq::{DEFAULT_MAX_SEQ_COUNT, MAX_SEQ_KEY_LEN, SeqAllocator, SeqGrant, SeqKey};
 pub use timestamp::{LOGICAL_MAX, PHYSICAL_MS_MAX, Timestamp, TimestampError};

--- a/crates/tsoracle-core/src/seq.rs
+++ b/crates/tsoracle-core/src/seq.rs
@@ -31,8 +31,20 @@ use crate::{CoreError, Epoch};
 /// Maximum length, in bytes, of a sequence key's UTF-8 encoding.
 pub const MAX_SEQ_KEY_LEN: usize = 128;
 
-/// Maximum `count` a single `GetSeq` may reserve in one block.
-pub const MAX_SEQ_COUNT: u32 = 65_536;
+/// Default per-call ceiling on `GetSeq`'s `count` — the largest block a single
+/// request may reserve when the server has not overridden it.
+///
+/// Unlike the timestamp path's `MAX_TIMESTAMPS_PER_RPC` (forced by the 18-bit
+/// logical field in the packed wire format), nothing in the dense format
+/// requires a particular ceiling: `start` is `u64`, the wire `count` is `u32`,
+/// and the durable counter is `u64`. This cap is a soft anti-abuse guardrail —
+/// a dense block is permanently consumed (the gapless counter only moves
+/// forward), so an unbounded `count` would let one call irrevocably burn a huge
+/// span of a key's namespace. The value (`2^16`) is a deliberate round default;
+/// operators tune it via [`ServerBuilder::max_seq_count`].
+///
+/// [`ServerBuilder::max_seq_count`]: https://docs.rs/tsoracle-server
+pub const DEFAULT_MAX_SEQ_COUNT: u32 = 65_536;
 
 /// A validated sequence key: non-empty, valid UTF-8 (guaranteed by `String`),
 /// and at most [`MAX_SEQ_KEY_LEN`] bytes. `try_new` is the single validation
@@ -85,7 +97,7 @@ impl SeqGrant {
     /// least one ordinal, and `last`'s `start + count - 1` would underflow — and
     /// a block whose last ordinal `start + count - 1` exceeds `u64::MAX`
     /// ([`CoreError::SeqBlockOverflow`]). In the server's serving path neither
-    /// can occur (`count` is validated `1..=MAX_SEQ_COUNT` and the durable
+    /// can occur (`count` is validated `1..=max_seq_count` and the durable
     /// fetch-add already rejected an overflowing advance), but `SeqGrant` is
     /// public, so the constructor enforces the invariant for every caller.
     pub fn try_new(key: SeqKey, start: u64, count: u32, epoch: Epoch) -> Result<Self, CoreError> {
@@ -172,17 +184,30 @@ impl SeqAllocator {
     /// Validate a request without touching durable state. Leadership is checked
     /// first; then count bounds (zero, then oversized), then key validity.
     /// Returns the validated [`SeqKey`].
-    pub fn validate_request(&self, key: &str, count: u32) -> Result<SeqKey, CoreError> {
+    ///
+    /// `max_count` is the caller's per-call ceiling — the server's configured
+    /// [`ServerBuilder::max_seq_count`], which defaults to
+    /// [`DEFAULT_MAX_SEQ_COUNT`]. Injecting it (rather than reading the constant
+    /// here) keeps the cap a server-side policy the operator can tune, while the
+    /// `count >= 1` floor stays a hard invariant enforced unconditionally.
+    ///
+    /// [`ServerBuilder::max_seq_count`]: https://docs.rs/tsoracle-server
+    pub fn validate_request(
+        &self,
+        key: &str,
+        count: u32,
+        max_count: u32,
+    ) -> Result<SeqKey, CoreError> {
         if !self.is_leader() {
             return Err(CoreError::NotLeader);
         }
         if count == 0 {
             return Err(CoreError::SeqCountZero);
         }
-        if count > MAX_SEQ_COUNT {
+        if count > max_count {
             return Err(CoreError::SeqCountTooLarge {
                 count,
-                max: MAX_SEQ_COUNT,
+                max: max_count,
             });
         }
         SeqKey::try_new(key)
@@ -220,7 +245,10 @@ mod seqallocator_tests {
     #[test]
     fn validate_request_off_leader_is_not_leader() {
         let a = SeqAllocator::new();
-        assert_eq!(a.validate_request("orders", 1), Err(CoreError::NotLeader));
+        assert_eq!(
+            a.validate_request("orders", 1, DEFAULT_MAX_SEQ_COUNT),
+            Err(CoreError::NotLeader)
+        );
     }
 
     #[test]
@@ -228,7 +256,7 @@ mod seqallocator_tests {
         let mut a = SeqAllocator::new();
         a.become_leader(Epoch(1));
         assert_eq!(
-            a.validate_request("orders", 0),
+            a.validate_request("orders", 0, DEFAULT_MAX_SEQ_COUNT),
             Err(CoreError::SeqCountZero)
         );
     }
@@ -238,11 +266,38 @@ mod seqallocator_tests {
         let mut a = SeqAllocator::new();
         a.become_leader(Epoch(1));
         assert_eq!(
-            a.validate_request("orders", MAX_SEQ_COUNT + 1),
+            a.validate_request("orders", DEFAULT_MAX_SEQ_COUNT + 1, DEFAULT_MAX_SEQ_COUNT),
             Err(CoreError::SeqCountTooLarge {
-                count: MAX_SEQ_COUNT + 1,
-                max: MAX_SEQ_COUNT
+                count: DEFAULT_MAX_SEQ_COUNT + 1,
+                max: DEFAULT_MAX_SEQ_COUNT
             })
+        );
+    }
+
+    #[test]
+    fn validate_request_uses_caller_provided_max() {
+        // The ceiling is the `max_count` argument, not the default constant: a
+        // smaller cap rejects below the default, and a larger cap accepts above
+        // it — proving the cap is injected policy, not a hard-coded limit.
+        let mut a = SeqAllocator::new();
+        a.become_leader(Epoch(1));
+        assert_eq!(
+            a.validate_request("orders", 11, 10),
+            Err(CoreError::SeqCountTooLarge { count: 11, max: 10 }),
+            "count above a small configured cap must be rejected",
+        );
+        assert!(
+            a.validate_request("orders", 10, 10).is_ok(),
+            "count at the configured cap must be accepted",
+        );
+        assert!(
+            a.validate_request(
+                "orders",
+                DEFAULT_MAX_SEQ_COUNT + 1,
+                DEFAULT_MAX_SEQ_COUNT * 2
+            )
+            .is_ok(),
+            "a larger configured cap must accept counts above the default",
         );
     }
 
@@ -250,14 +305,19 @@ mod seqallocator_tests {
     fn validate_request_rejects_bad_key() {
         let mut a = SeqAllocator::new();
         a.become_leader(Epoch(1));
-        assert_eq!(a.validate_request("", 1), Err(CoreError::SeqKeyEmpty));
+        assert_eq!(
+            a.validate_request("", 1, DEFAULT_MAX_SEQ_COUNT),
+            Err(CoreError::SeqKeyEmpty)
+        );
     }
 
     #[test]
     fn validate_request_ok_returns_key() {
         let mut a = SeqAllocator::new();
         a.become_leader(Epoch(1));
-        let k = a.validate_request("orders", 10).unwrap();
+        let k = a
+            .validate_request("orders", 10, DEFAULT_MAX_SEQ_COUNT)
+            .unwrap();
         assert_eq!(k.as_str(), "orders");
     }
 
@@ -265,7 +325,10 @@ mod seqallocator_tests {
     fn validate_request_accepts_max_count_exactly() {
         let mut a = SeqAllocator::new();
         a.become_leader(Epoch(1));
-        assert!(a.validate_request("orders", MAX_SEQ_COUNT).is_ok());
+        assert!(
+            a.validate_request("orders", DEFAULT_MAX_SEQ_COUNT, DEFAULT_MAX_SEQ_COUNT)
+                .is_ok()
+        );
     }
 }
 

--- a/crates/tsoracle-server/src/heartbeat.rs
+++ b/crates/tsoracle-server/src/heartbeat.rs
@@ -153,7 +153,10 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let reporter = std::sync::Arc::new(Reporter::new());
-        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let core = std::sync::Arc::new(ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+        ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         // Drive heartbeat and test control in the same async context so the
@@ -226,7 +229,10 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let reporter = std::sync::Arc::new(Reporter::new());
-        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let core = std::sync::Arc::new(ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+        ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         let hb_fut = run_heartbeat(
@@ -265,7 +271,10 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let reporter = std::sync::Arc::new(Reporter::new());
-        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let core = std::sync::Arc::new(ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+        ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         let reporter2 = reporter.clone();
@@ -308,7 +317,10 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn cancel_terminates_promptly_on_sender_drop() {
         let reporter = std::sync::Arc::new(Reporter::new());
-        let core = std::sync::Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let core = std::sync::Arc::new(ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+        ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         // Drop tx immediately — the biased cancel branch should win without

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -43,6 +43,12 @@ use crate::serving_core::ServingCore;
 pub enum BuildError {
     #[error("consensus_driver is required")]
     MissingConsensusDriver,
+    /// `max_seq_count` was set to 0. Every positive `count` would then be
+    /// rejected as `SeqCountTooLarge` (the `count >= 1` floor leaves no valid
+    /// value), silently disabling `GetSeq`. Rejected at build time so the
+    /// misconfiguration surfaces immediately rather than at first request.
+    #[error("max_seq_count must be >= 1 (0 would reject every GetSeq request)")]
+    ZeroMaxSeqCount,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -197,6 +203,11 @@ impl ServerBuilder {
     /// `count` against a fixed constant, so changing this needs no client
     /// rebuild; an over-cap request is rejected with `INVALID_ARGUMENT`. The
     /// `count >= 1` floor is always enforced regardless of this value.
+    ///
+    /// A value of `0` is rejected by [`Self::build`] with
+    /// [`BuildError::ZeroMaxSeqCount`]: it would leave no valid `count` (the
+    /// floor is 1), silently disabling `GetSeq`, so the misconfiguration is
+    /// surfaced at build time rather than at first request.
     pub fn max_seq_count(mut self, max_seq_count: u32) -> Self {
         self.max_seq_count = max_seq_count;
         self
@@ -204,6 +215,9 @@ impl ServerBuilder {
 
     pub fn build(self) -> Result<Server, BuildError> {
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
+        if self.max_seq_count == 0 {
+            return Err(BuildError::ZeroMaxSeqCount);
+        }
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
         Ok(Server {
             consensus,
@@ -1102,6 +1116,35 @@ mod tests {
             .build()
             .expect("build with tls_config must succeed");
         assert!(server.tls_config.is_some());
+    }
+
+    #[test]
+    fn build_rejects_zero_max_seq_count() {
+        // max_seq_count(0) makes every positive `count` fail as
+        // SeqCountTooLarge{max:0} (the count>=1 floor leaves no valid value) —
+        // GetSeq is silently dead. build() must fail-fast rather than ship a
+        // server where GetSeq can never succeed.
+        // `Server` is not `Debug`, so match rather than `expect_err`.
+        match Server::builder()
+            .consensus_driver(Arc::new(crate::test_fakes::InMemoryDriver::new()))
+            .max_seq_count(0)
+            .build()
+        {
+            Err(BuildError::ZeroMaxSeqCount) => {}
+            Err(other) => panic!("expected ZeroMaxSeqCount, got {other:?}"),
+            Ok(_) => panic!("max_seq_count(0) must be rejected at build, but build succeeded"),
+        }
+    }
+
+    #[test]
+    fn build_accepts_max_seq_count_of_one() {
+        // 1 is the smallest usable cap: a single-ordinal block is valid, so the
+        // floor and the cap coincide and GetSeq still works. Must build.
+        Server::builder()
+            .consensus_driver(Arc::new(crate::test_fakes::InMemoryDriver::new()))
+            .max_seq_count(1)
+            .build()
+            .expect("max_seq_count(1) must build");
     }
 
     #[tokio::test]

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -102,6 +102,7 @@ pub struct ServerBuilder {
     failover_advance: Duration,
     shutdown_grace: Duration,
     heartbeat_interval: Duration,
+    max_seq_count: u32,
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
@@ -115,6 +116,7 @@ impl Default for ServerBuilder {
             failover_advance: Duration::from_secs(1),
             shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
             heartbeat_interval: Duration::from_secs(10),
+            max_seq_count: tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: None,
         }
@@ -183,6 +185,23 @@ impl ServerBuilder {
         self
     }
 
+    /// Per-call ceiling on `GetSeq`'s `count` — the largest contiguous block a
+    /// single dense-sequence request may reserve. Defaults to
+    /// [`tsoracle_core::DEFAULT_MAX_SEQ_COUNT`] (`65_536`).
+    ///
+    /// This is a soft anti-abuse guardrail, not a representational limit: a
+    /// dense block is permanently consumed (the gapless counter only moves
+    /// forward), so the cap bounds how much one call can irrevocably reserve.
+    /// Raise it for batch-allocation workloads or lower it to tighten abuse
+    /// control. The server is the sole authority — clients no longer pre-check
+    /// `count` against a fixed constant, so changing this needs no client
+    /// rebuild; an over-cap request is rejected with `INVALID_ARGUMENT`. The
+    /// `count >= 1` floor is always enforced regardless of this value.
+    pub fn max_seq_count(mut self, max_seq_count: u32) -> Self {
+        self.max_seq_count = max_seq_count;
+        self
+    }
+
     pub fn build(self) -> Result<Server, BuildError> {
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
@@ -193,7 +212,7 @@ impl ServerBuilder {
             failover_advance: self.failover_advance,
             shutdown_grace: self.shutdown_grace,
             heartbeat_interval: self.heartbeat_interval,
-            core: Arc::new(ServingCore::new(self.window_ahead)),
+            core: Arc::new(ServingCore::new(self.window_ahead, self.max_seq_count)),
             reporter: Arc::new(crate::reporter::Reporter::new()),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: self.tls_config,
@@ -1203,7 +1222,10 @@ mod tests {
         // test runtime no other task can run between the synchronous `drop` and
         // the synchronous `serving_state` read, so observing `NotServing` proves
         // `Drop` closed the gate synchronously rather than the watch task.
-        let core = Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let core = Arc::new(ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+        ));
         core.publish_serving();
 
         let handle: tokio::task::JoinHandle<Result<(), ServerError>> =
@@ -1237,7 +1259,10 @@ mod tests {
         // would stay open unless `serve_inner` closes it itself. Seed `Serving`,
         // run the user-shutdown arm with a zero grace (immediate abort), and
         // assert the gate is closed on return.
-        let core = Arc::new(ServingCore::new(Duration::from_secs(3)));
+        let core = Arc::new(ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+        ));
         core.publish_serving();
 
         let watch_handle: tokio::task::JoinHandle<Result<(), ServerError>> =

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -82,10 +82,16 @@ pub(crate) struct ServingCore {
     /// (`current_max_safe_physical_ms`) does not need a back-reference to
     /// `Server`.
     window_ahead: Duration,
+    /// Per-call ceiling on `GetSeq`'s `count`, from
+    /// [`ServerBuilder::max_seq_count`](crate::ServerBuilder::max_seq_count)
+    /// (default [`tsoracle_core::DEFAULT_MAX_SEQ_COUNT`]). Held here so
+    /// `seq_validate` enforces the operator-configured policy without a
+    /// back-reference to `Server`.
+    max_seq_count: u32,
 }
 
 impl ServingCore {
-    pub(crate) fn new(window_ahead: Duration) -> Self {
+    pub(crate) fn new(window_ahead: Duration, max_seq_count: u32) -> Self {
         let (state_tx, _) = watch::channel(ServingState::NotServing {
             leader_endpoint: None,
             leader_epoch: None,
@@ -97,6 +103,7 @@ impl ServingCore {
             extension_lock: AsyncMutex::new(()),
             extension_gate: RwLock::new(()),
             window_ahead,
+            max_seq_count,
         }
     }
 
@@ -216,7 +223,9 @@ impl ServingCore {
     /// Returns the validated [`SeqKey`] on success; maps gate errors to
     /// [`CoreError`] for the service layer to translate into gRPC statuses.
     pub(crate) fn seq_validate(&self, key: &str, count: u32) -> Result<SeqKey, CoreError> {
-        self.seq_allocator.lock().validate_request(key, count)
+        self.seq_allocator
+            .lock()
+            .validate_request(key, count, self.max_seq_count)
     }
 
     pub(crate) fn commit_extension(
@@ -308,7 +317,7 @@ mod tests {
         // lands even when no receiver is subscribed (`receiver_count == 0`). Were
         // a publish site to use `send`, this would be silently dropped and a
         // leaderless-then-leader core could stay NotServing forever.
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         assert_eq!(core.state_tx.receiver_count(), 0);
 
         let hint = PeerEndpoint::try_from("new-leader:9000").unwrap();
@@ -332,7 +341,7 @@ mod tests {
         // the read barrier on the current task; if step_down tried to take the
         // write lock it would deadlock here (single-threaded runtime, lock held
         // by us). Reaching the assertion proves it never touches the gate.
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         let slot = core.extension_slot().await;
         let _barrier = slot.drain_barrier().await;
 
@@ -350,7 +359,7 @@ mod tests {
         // extension readers to drain. `try_write` is a deterministic probe of
         // that exclusion (no timing): it fails while a read barrier is held and
         // succeeds once it is released.
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         let slot = core.extension_slot().await;
         let barrier = slot.drain_barrier().await;
 
@@ -372,7 +381,7 @@ mod tests {
         // A fresh core is NotLeader (no epoch). prepare_extension must surface
         // that as `NotLeader` so the caller emits a redirect, and would_grant is
         // false.
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         let slot = core.extension_slot().await;
         assert!(matches!(
             slot.prepare_extension(1, 1_000),
@@ -387,7 +396,7 @@ mod tests {
         // `ServingState`; it must agree with `serving_state`'s variant across
         // every transition. Fresh core is NotServing -> false; publish_serving
         // -> true; step_down -> false again.
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         assert!(!core.is_serving(), "fresh core is NotServing");
         assert!(matches!(
             core.serving_state(),
@@ -410,7 +419,7 @@ mod tests {
 
     #[test]
     fn try_grant_without_leadership_is_not_leader() {
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         assert!(matches!(core.try_grant(1, 1), Err(CoreError::NotLeader)));
     }
 
@@ -419,7 +428,7 @@ mod tests {
         // become_leader(floor, ceiling, epoch) seeds a serveable
         // window; a grant at the floor returns timestamps stamped with the
         // seeded epoch.
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
             .expect("seed must succeed (ceiling >= floor)");
         let grant = core.try_grant(1_000, 1).expect("grant must succeed");
@@ -433,7 +442,7 @@ mod tests {
         // the call site. Seed a serveable window first so the clear is
         // observable, then assert both effects: NotServing with no leader hint,
         // and a now-cleared allocator (try_grant -> NotLeader).
-        let core = ServingCore::new(Duration::from_secs(3));
+        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
         core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
             .expect("seed must succeed (ceiling >= floor)");
         assert!(core.try_grant(1_000, 1).is_ok(), "seeded core must grant");

--- a/crates/tsoracle-server/tests/get_seq.rs
+++ b/crates/tsoracle-server/tests/get_seq.rs
@@ -231,3 +231,57 @@ async fn get_seq_unsupported_driver_returns_unimplemented() {
 
     booted.shutdown().await.unwrap();
 }
+
+/// `ServerBuilder::max_seq_count` overrides the default per-call ceiling: a
+/// request above the configured cap is rejected with InvalidArgument, while one
+/// at the cap is served. Proves the cap is the server's configured value, not
+/// the `DEFAULT_MAX_SEQ_COUNT` constant.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_seq_honours_configured_max_seq_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let driver = FileDriver::open_or_init(dir.path()).unwrap();
+    let server = Server::builder()
+        .consensus_driver(driver)
+        .window_ahead(Duration::from_secs(1))
+        .failover_advance(Duration::from_millis(500))
+        .max_seq_count(2)
+        .build()
+        .unwrap();
+
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
+        .await
+        .unwrap();
+
+    // count = 3 exceeds the configured cap of 2 → InvalidArgument.
+    let err = client
+        .get_seq(GetSeqRequest {
+            key: "orders".to_string(),
+            count: 3,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.code(),
+        tonic::Code::InvalidArgument,
+        "count above the configured max_seq_count must be rejected, got: {err:?}"
+    );
+
+    // count = 2 is exactly at the cap → served.
+    let resp = client
+        .get_seq(GetSeqRequest {
+            key: "orders".to_string(),
+            count: 2,
+        })
+        .await
+        .expect("count at the configured cap must be served")
+        .into_inner();
+    assert_eq!(resp.count, 2);
+    assert_eq!(resp.start, 0);
+
+    booted.shutdown().await.unwrap();
+}


### PR DESCRIPTION
> **Stacked on #579** (base branch is `worktree-feat+keyed-dense-sequence`). Review/merge #579 first; this PR's diff shows only the configurable-cap layer. Retarget to `main` once #579 lands.

## Summary

The per-call ceiling on `GetSeq`'s `count` was a hard-coded core constant (`MAX_SEQ_COUNT = 65_536`). Unlike the timestamp path's cap — forced by the 18-bit logical field in the packed wire format — nothing in the dense format requires a particular ceiling (`start` is `u64`, the wire `count` is `u32`, the durable counter is `u64`). It's a **soft anti-abuse guardrail**: a dense block is permanently consumed (the gapless counter only moves forward), so the cap bounds how much one call can irrevocably reserve. That makes it a legitimately deployment-specific policy.

This makes it a server-side knob, with the server as the sole authority.

### Changes
- **core:** rename `MAX_SEQ_COUNT` → `DEFAULT_MAX_SEQ_COUNT` (it's now a *default*, not a hard limit) with a doc explaining the rationale; parameterize `SeqAllocator::validate_request(key, count, max_count)`. The `count >= 1` floor stays a hard invariant.
- **server:** `ServingCore` holds `max_seq_count` (mirroring `window_ahead`); `ServerBuilder::max_seq_count(u32)` configures it, defaulting to `DEFAULT_MAX_SEQ_COUNT`. An over-cap request → `INVALID_ARGUMENT`.
- **client:** drop the local `count > MAX_SEQ_COUNT` pre-check — the cap is deployment-specific, so the client forwards `count` and lets the server decide. A client built against one cap stays correct against a server configured with another. The universal `count == 0` floor is kept.

**Default deployments are unchanged** (cap still `65_536`); no client rebuild is needed when an operator retunes the server.

## Test Plan
- [x] `cargo test --workspace --all-features` (green, 138 result groups)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- [x] New tests: core `validate_request_uses_caller_provided_max`; server `get_seq_honours_configured_max_seq_count` (`.max_seq_count(2)` → count 3 rejected, count 2 served); client `get_seq_forwards_large_count_to_server`.