### PR TITLE
feat: keyed dense sequences on openraft + format-activation rollout gate

### DIFF
--- a/crates/tsoracle-consensus/src/error.rs
+++ b/crates/tsoracle-consensus/src/error.rs
@@ -70,6 +70,10 @@ pub enum ConsensusError {
     SeqKeyCardinalityExceeded { cap: u64 },
     #[error("dense counter overflow for the requested key")]
     SeqOverflow,
+    #[error(
+        "dense sequences require write version {required} but the cluster is at {active}; activate the format first"
+    )]
+    DenseNotActivated { required: u8, active: u8 },
 }
 
 #[cfg(test)]

--- a/crates/tsoracle-core/src/allocator.rs
+++ b/crates/tsoracle-core/src/allocator.rs
@@ -95,7 +95,7 @@ impl core::fmt::Display for PhysicalMs {
 /// this type is therefore proof that [`first`](Self::first) and
 /// [`last`](Self::last) can pack without panicking — the in-range invariant is
 /// guaranteed by the type, not by the constructors that happen to build it.
-/// The crate-internal back door [`new_unchecked`](Self::new_unchecked) skips
+/// The crate-internal back door `new_unchecked` skips
 /// the validation but documents the same invariant as a caller obligation.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct WindowGrant {
@@ -108,7 +108,7 @@ pub struct WindowGrant {
 impl WindowGrant {
     /// Construct a grant, checking that every timestamp it covers packs
     /// cleanly. This is the only *validating* constructor; the
-    /// crate-internal [`new_unchecked`](Self::new_unchecked) skips the
+    /// crate-internal `new_unchecked` skips the
     /// checks but requires the caller to have established the invariant
     /// some other way. Either way, a constructed value witnesses that
     /// `first`/`last` are infallible.
@@ -579,7 +579,7 @@ impl Allocator {
     /// physical-ceiling invariant on `persisted_high_water` is now enforced by
     /// the [`PhysicalMs`] parameter type itself ([`PhysicalMs::try_new`]);
     /// the `Result<_, CoreError>` shape is retained for source compatibility
-    /// with [`become_leader`] / [`try_prepare_window_extension`],
+    /// with [`become_leader`](Self::become_leader) / [`try_prepare_window_extension`](Self::try_prepare_window_extension),
     /// so callers can stay uniform under `?`, but no current code path here
     /// produces `Err`.
     pub fn try_commit_window_extension(

--- a/crates/tsoracle-core/src/seq.rs
+++ b/crates/tsoracle-core/src/seq.rs
@@ -50,6 +50,7 @@ pub const DEFAULT_MAX_SEQ_COUNT: u32 = 65_536;
 /// and at most [`MAX_SEQ_KEY_LEN`] bytes. `try_new` is the single validation
 /// site — a value of this type is proof the key is in range.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SeqKey(String);
 
 impl SeqKey {

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -61,7 +61,7 @@ tokio              = { workspace = true }
 tracing            = { workspace = true }
 tsoracle-codec     = { workspace = true }
 tsoracle-consensus = { path = "../tsoracle-consensus", version = "1.0.1", features = ["serde"] }
-tsoracle-core      = { path = "../tsoracle-core", version = "2.0.0" }
+tsoracle-core      = { path = "../tsoracle-core", version = "2.0.0", features = ["serde"] }
 
 [dev-dependencies]
 anyhow           = { workspace = true }

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -91,7 +91,8 @@ where
     /// by-value entry point) rather than `leadership_events(&raft)` to
     /// side-step a Rust 2024 lifetime-over-capture issue: the `&raft` form
     /// would require the returned stream to borrow from `raft`, but we want
-    /// `'static`. The cloned host then rides along inside [`KeepAlive`] so
+    /// `'static`. The cloned host then rides along inside the private
+    /// `KeepAlive` stream wrapper so
     /// dropping the outer driver doesn't shut the raft down.
     fn leadership_events(&self) -> Pin<Box<dyn Stream<Item = LeaderState> + Send>> {
         let host = Arc::clone(&self.host);

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -48,6 +48,7 @@ use futures::{Stream, StreamExt};
 use openraft::RaftTypeConfig;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::Epoch;
+use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
 use tsoracle_openraft_toolkit::LeadershipState;
 use tsoracle_openraft_toolkit::leadership_events_from_metrics;
 
@@ -117,6 +118,37 @@ where
         // committed poison value can never be served and cannot self-heal.
         tsoracle_consensus::reject_out_of_range_advance(at_least)?;
         self.host.submit_advance(at_least).await
+    }
+
+    /// Advance the dense counter for `key` by `count`, gated on format
+    /// activation.
+    ///
+    /// The `_expected_epoch` arg is intentionally ignored, mirroring
+    /// `persist_high_water`: openraft's leadership fence rejects a stale
+    /// leader's `client_write`, and the per-key fetch-add is linearized by the
+    /// committed log.
+    async fn advance_dense(
+        &self,
+        key: &tsoracle_core::SeqKey,
+        count: u32,
+        _expected_epoch: Epoch,
+    ) -> Result<u64, ConsensusError> {
+        // Rollout gate: refuse until the dense format is active cluster-wide.
+        // Appending an `AdvanceDense` entry before activation could hand an
+        // un-upgraded follower an entry it cannot decode.
+        let active = self.host.active_write_version();
+        if active < DENSE_WRITE_VERSION {
+            return Err(ConsensusError::DenseNotActivated {
+                required: DENSE_WRITE_VERSION,
+                active,
+            });
+        }
+        self.host.submit_advance_dense(key, count).await
+    }
+
+    /// Read a key's committed dense counter (0 if absent), linearized.
+    async fn load_dense_seq(&self, key: &tsoracle_core::SeqKey) -> Result<u64, ConsensusError> {
+        self.host.current_dense_seq(key).await
     }
 }
 
@@ -310,6 +342,25 @@ mod tests {
             at_least: u64,
         ) -> Result<u64, tsoracle_consensus::ConsensusError> {
             Ok(at_least)
+        }
+
+        fn active_write_version(&self) -> u8 {
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION
+        }
+
+        async fn submit_advance_dense(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+            _count: u32,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
+        }
+
+        async fn current_dense_seq(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
         }
     }
 

--- a/crates/tsoracle-driver-openraft/src/host.rs
+++ b/crates/tsoracle-driver-openraft/src/host.rs
@@ -65,6 +65,26 @@ pub trait OpenraftHighWaterHost: Send + Sync + 'static {
     /// return the new high-water value after apply. The state machine must
     /// enforce monotonicity (`max(prev, at_least)`); the driver does not.
     async fn submit_advance(&self, at_least: u64) -> Result<u64, ConsensusError>;
+
+    /// The active write version (read from the shared `ActiveWriteVersion`
+    /// cell). The driver gates `advance_dense` on this being >=
+    /// `DENSE_WRITE_VERSION`.
+    fn active_write_version(&self) -> u8;
+
+    /// Submit an `AdvanceDense { key, count }` proposal and return the applied
+    /// block start. The proposer reads `ApplyOutcome` from the `client_write`
+    /// response: `DenseAdvanced { start }` → `Ok(start)`; the two rejection
+    /// outcomes map to the corresponding `ConsensusError`.
+    async fn submit_advance_dense(
+        &self,
+        key: &tsoracle_core::SeqKey,
+        count: u32,
+    ) -> Result<u64, ConsensusError>;
+
+    /// Read a key's durably-committed dense counter (0 if absent),
+    /// linearized. Implementations issue the same read barrier as
+    /// `current_high_water` before reading the local state machine.
+    async fn current_dense_seq(&self, key: &tsoracle_core::SeqKey) -> Result<u64, ConsensusError>;
 }
 
 #[cfg(test)]
@@ -99,6 +119,25 @@ mod tests {
         async fn submit_advance(&self, _at_least: u64) -> Result<u64, ConsensusError> {
             Ok(0)
         }
+
+        fn active_write_version(&self) -> u8 {
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION
+        }
+
+        async fn submit_advance_dense(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+            _count: u32,
+        ) -> Result<u64, ConsensusError> {
+            Err(ConsensusError::DenseUnsupported)
+        }
+
+        async fn current_dense_seq(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+        ) -> Result<u64, ConsensusError> {
+            Err(ConsensusError::DenseUnsupported)
+        }
     }
 
     /// Compile-time proof the trait is satisfiable without a `StateMachine`
@@ -122,5 +161,9 @@ mod tests {
         let _rx = host.metrics();
         assert!(host.current_high_water().await.is_ok());
         assert!(host.submit_advance(7).await.is_ok());
+        let _ = host.active_write_version();
+        let key = tsoracle_core::SeqKey::try_new("k").unwrap();
+        assert!(host.submit_advance_dense(&key, 1).await.is_err());
+        assert!(host.current_dense_seq(&key).await.is_err());
     }
 }

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -37,6 +37,13 @@ pub mod standalone;
 pub mod state_machine;
 pub mod type_config;
 
+/// The default immutable genesis cardinality cap for dense sequence keys.
+/// Every cluster member must be constructed with the same value; the cap is
+/// stored in replicated snapshots so replay/restore reproduces the same
+/// accept/reject decisions (spec §6.2). Operators that need a larger or
+/// smaller key namespace configure this at SM construction time.
+pub const DEFAULT_DENSE_CARDINALITY_CAP: u64 = 10_000;
+
 pub use capabilities::{
     CapabilitySource, FormatActivationError, NodeCapabilities, all_members_can_read, gather_with,
 };

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -69,6 +69,15 @@ pub enum HighWaterCommand {
     /// Applies as a no-op if the membership at this entry's log position is
     /// not a subset of `gated_members`.
     SetFormatVersion(SetFormatVersionPayload),
+    /// Advance the dense counter for `key` by `count`, lazily creating the key
+    /// at 0. The pre-advance value is the issued block's start; it is returned
+    /// to the proposer via [`ApplyOutcome`] (the apply path computes it in
+    /// committed log order). Only ever appended under write version
+    /// >= DENSE_WRITE_VERSION (gated by activation).
+    AdvanceDense {
+        key: tsoracle_core::SeqKey,
+        count: u32,
+    },
 }
 
 impl fmt::Display for HighWaterCommand {
@@ -86,6 +95,13 @@ impl fmt::Display for HighWaterCommand {
                     f,
                     "SetFormatVersion {{ target: {target}, gated_members: [{}] }}",
                     rendered.join(", ")
+                )
+            }
+            HighWaterCommand::AdvanceDense { key, count } => {
+                write!(
+                    f,
+                    "AdvanceDense {{ key: {}, count: {count} }}",
+                    key.as_str()
                 )
             }
         }

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -71,7 +71,7 @@ pub enum HighWaterCommand {
     SetFormatVersion(SetFormatVersionPayload),
     /// Advance the dense counter for `key` by `count`, lazily creating the key
     /// at 0. The pre-advance value is the issued block's start; it is returned
-    /// to the proposer via [`ApplyOutcome`] (the apply path computes it in
+    /// to the proposer via [`ApplyOutcome`](crate::ApplyOutcome) (the apply path computes it in
     /// committed log order). Only ever appended under write version
     /// >= DENSE_WRITE_VERSION (gated by activation).
     AdvanceDense {

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -315,14 +315,18 @@ fn classify_activation_outcome(
         }
         ApplyOutcome::FormatActivated { .. }
         | ApplyOutcome::FormatActivationNoop { .. }
-        | ApplyOutcome::Advanced
-        // Dense outcomes are impossible for a SetFormatVersion entry, but must
-        // be handled for exhaustiveness. Map them as membership-changed so the
-        // operator sees a non-success rather than an incorrect Ok.
-        | ApplyOutcome::DenseAdvanced { .. }
-        | ApplyOutcome::DenseCardinalityExceeded { .. }
-        | ApplyOutcome::DenseOverflow => {
+        | ApplyOutcome::Advanced => {
             Err(FormatActivationError::MembershipChangedSinceGate { target })
+        }
+        // A SetFormatVersion entry's apply can only yield a Format*/Advanced
+        // outcome; a dense outcome here would be a state-machine bug, not an
+        // activation result. Fail loud rather than misreport it as a benign
+        // membership change (which would send the operator down the wrong
+        // remediation path).
+        other @ (ApplyOutcome::DenseAdvanced { .. }
+        | ApplyOutcome::DenseCardinalityExceeded { .. }
+        | ApplyOutcome::DenseOverflow) => {
+            unreachable!("dense ApplyOutcome {other:?} returned from a SetFormatVersion entry")
         }
     }
 }

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -26,7 +26,7 @@
 //! Use this when you want a dedicated TSO raft, separate from any other
 //! consensus state your service runs. For services that already run an
 //! openraft cluster (e.g. a placement driver), implement
-//! [`OpenraftHighWaterHost`](crate::OpenraftHighWaterHost) directly against
+//! [`OpenraftHighWaterHost`] directly against
 //! that existing cluster instead.
 
 use std::collections::BTreeSet;

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -315,7 +315,13 @@ fn classify_activation_outcome(
         }
         ApplyOutcome::FormatActivated { .. }
         | ApplyOutcome::FormatActivationNoop { .. }
-        | ApplyOutcome::Advanced => {
+        | ApplyOutcome::Advanced
+        // Dense outcomes are impossible for a SetFormatVersion entry, but must
+        // be handled for exhaustiveness. Map them as membership-changed so the
+        // operator sees a non-success rather than an incorrect Ok.
+        | ApplyOutcome::DenseAdvanced { .. }
+        | ApplyOutcome::DenseCardinalityExceeded { .. }
+        | ApplyOutcome::DenseOverflow => {
             Err(FormatActivationError::MembershipChangedSinceGate { target })
         }
     }

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -362,6 +362,49 @@ impl OpenraftHighWaterHost for StandaloneHost {
             Err(e) => Err(classify_client_write_error(e)),
         }
     }
+
+    fn active_write_version(&self) -> u8 {
+        // Delegate to the inherent method on `StandaloneHost` which reads the
+        // shared `ActiveWriteVersion` cell via the state machine.
+        StandaloneHost::active_write_version(self)
+    }
+
+    async fn submit_advance_dense(
+        &self,
+        key: &tsoracle_core::SeqKey,
+        count: u32,
+    ) -> Result<u64, ConsensusError> {
+        match self
+            .raft
+            .client_write(HighWaterCommand::AdvanceDense {
+                key: key.clone(),
+                count,
+            })
+            .await
+        {
+            Ok(resp) => match resp.data.outcome {
+                crate::type_config::ApplyOutcome::DenseAdvanced { start } => Ok(start),
+                crate::type_config::ApplyOutcome::DenseCardinalityExceeded { cap } => {
+                    Err(ConsensusError::SeqKeyCardinalityExceeded { cap })
+                }
+                crate::type_config::ApplyOutcome::DenseOverflow => Err(ConsensusError::SeqOverflow),
+                other => Err(ConsensusError::PermanentDriver(
+                    format!("unexpected ApplyOutcome for AdvanceDense: {other:?}").into(),
+                )),
+            },
+            Err(e) => Err(classify_client_write_error(e)),
+        }
+    }
+
+    async fn current_dense_seq(&self, key: &tsoracle_core::SeqKey) -> Result<u64, ConsensusError> {
+        // Issue the same linearizable read barrier as `current_high_water` so
+        // the local SM read below reflects every committed write from any prior
+        // leader at any prior epoch.
+        if let Err(e) = self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await {
+            return Err(classify_read_error(e));
+        }
+        Ok(self.state_machine.dense_value(key.as_str()))
+    }
 }
 
 // `ForwardToLeader` maps to `NotLeader` so the server's step-down path

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -283,7 +283,7 @@ impl HighWaterStateMachine {
     #[cfg(test)]
     #[expect(
         clippy::expect_used,
-        reason = "`with_store_and_dense_cap` only fails when `store.load()` returns Err; \
+        reason = "`new_with_dense_cap` only fails when `store.load()` returns Err; \
                   `InMemorySnapshotStore::load` is `Ok(None)` for a fresh \
                   store, so this branch is unreachable."
     )]

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -61,8 +61,8 @@ use tsoracle_codec::{
     VersionedCodec, decode_framed, decode_postcard_exact, encode_framed, encode_postcard,
 };
 use tsoracle_openraft_toolkit::{
-    ActiveWriteVersion, BASELINE_WRITE_VERSION, MAX_READABLE_VERSION, MIN_READABLE_VERSION,
-    codec_io_error,
+    ActiveWriteVersion, BASELINE_WRITE_VERSION, DENSE_WRITE_VERSION, MAX_READABLE_VERSION,
+    MIN_READABLE_VERSION, codec_io_error,
 };
 
 use crate::log_entry::{HighWaterCommand, SetFormatVersionPayload};
@@ -89,6 +89,24 @@ pub struct HighWaterStateMachineSnapshot {
     pub current_value: u64,
     pub last_applied: Option<LogId>,
     pub last_membership: StoredMem,
+    /// Per-key dense counters (v5+). Empty in a v4 snapshot (pre-dense); the
+    /// restore path keeps the genesis cap seeded from the constructor.
+    pub dense: std::collections::BTreeMap<String, u64>,
+    /// Genesis cardinality cap (v5+). Zero in a v4 snapshot ("absent
+    /// sentinel"); the restore path keeps the cap seeded from the constructor.
+    pub dense_cap: u64,
+}
+
+/// The v4 on-disk snapshot layout, frozen. Used only to decode
+/// `BASELINE_WRITE_VERSION` bytes written before the dense fields existed;
+/// converted into the current payload (empty dense map, sentinel cap 0 =
+/// "absent") on decode. Do not edit its field set — it must remain
+/// byte-identical to the pre-dense layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct HighWaterStateMachineSnapshotV4 {
+    current_value: u64,
+    last_applied: Option<LogId>,
+    last_membership: StoredMem,
 }
 
 /// On-disk envelope written to the [`SnapshotStore`]: pairs the openraft
@@ -106,22 +124,29 @@ struct PersistedSnapshot {
 impl VersionedCodec for HighWaterStateMachineSnapshot {
     fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
         match version {
-            // v4 (BASELINE_WRITE_VERSION): whole-value postcard, byte-identical
-            // to the pre-seam frame. Later phases add older/newer arms here as
-            // the layout evolves and MIN_READABLE_VERSION/MAX_READABLE_VERSION
-            // widen.
-            v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
-            // v5 (DENSE_WRITE_VERSION): real dense-sequence codec arm added in
-            // P2-T4. Under `e2e-max-readable-next` this alias keeps v5 in the
-            // readable range [BASELINE..=BASELINE+2] while the real arm is
-            // pending; the alias will be replaced by the actual layout in P2-T4.
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 1 => decode_postcard_exact(body),
+            // v4 (BASELINE_WRITE_VERSION): decode the frozen old layout, lift
+            // into the current payload. Pre-dense snapshots carry no dense
+            // bytes; dense is empty and cap is the sentinel 0 ("absent") — the
+            // restore path keeps the genesis cap seeded from the constructor.
+            v if v == BASELINE_WRITE_VERSION => {
+                let old: HighWaterStateMachineSnapshotV4 = decode_postcard_exact(body)?;
+                Ok(HighWaterStateMachineSnapshot {
+                    current_value: old.current_value,
+                    last_applied: old.last_applied,
+                    last_membership: old.last_membership,
+                    dense: std::collections::BTreeMap::new(),
+                    dense_cap: 0,
+                })
+            }
+            // v5 (DENSE_WRITE_VERSION): the current layout decodes directly.
+            // Ungated — production reads dense snapshots from v5-activated
+            // clusters without any feature flag.
+            v if v == DENSE_WRITE_VERSION => decode_postcard_exact(body),
             // v6 (BASELINE + 2): synthetic activation-test alias. Body is
-            // byte-identical to BASELINE — only the version byte changes — so
-            // the activation machinery (gate -> propose -> commit -> apply ->
-            // cell flip) can run end-to-end in a mixed-version e2e without
-            // shipping a real new format. Gated off in production. (#583)
+            // byte-identical to the current layout — only the version byte
+            // changes — so the activation machinery (gate -> propose -> commit
+            // -> apply -> cell flip) can run end-to-end in a mixed-version e2e
+            // without shipping a real new format. Gated off in production. (#583)
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 2 => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
@@ -134,10 +159,23 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
 
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
-            v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
-            // v5 alias under e2e harness — see decode_version comment above.
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 1 => encode_postcard(self),
+            // v4: project to the frozen old layout (dense is always empty before
+            // activation, so dropping it is lossless). This is what
+            // build_snapshot emits while the active write version is still 4.
+            v if v == BASELINE_WRITE_VERSION => {
+                debug_assert!(
+                    self.dense.is_empty(),
+                    "v4 snapshot with non-empty dense map: dense={:?}",
+                    self.dense
+                );
+                encode_postcard(&HighWaterStateMachineSnapshotV4 {
+                    current_value: self.current_value,
+                    last_applied: self.last_applied,
+                    last_membership: self.last_membership.clone(),
+                })
+            }
+            // v5: the current (dense) layout encodes directly. Ungated.
+            v if v == DENSE_WRITE_VERSION => encode_postcard(self),
             // v6 synthetic alias — see decode_version comment above.
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 2 => encode_postcard(self),
@@ -153,10 +191,13 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
 impl VersionedCodec for PersistedSnapshot {
     fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
         match version {
+            // v4: envelope layout unchanged — opaque `data` bytes hold the
+            // version-framed payload.
             v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
-            // v5 alias under e2e harness — see HighWaterStateMachineSnapshot decode_version.
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 1 => decode_postcard_exact(body),
+            // v5: envelope layout still unchanged (only the payload data blob
+            // inside gains dense bytes). Ungated — production reads v5
+            // envelopes once activated.
+            v if v == DENSE_WRITE_VERSION => decode_postcard_exact(body),
             // v6 synthetic alias — see HighWaterStateMachineSnapshot decode_version.
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 2 => decode_postcard_exact(body),
@@ -171,9 +212,8 @@ impl VersionedCodec for PersistedSnapshot {
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
             v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
-            // v5 alias under e2e harness — see HighWaterStateMachineSnapshot decode_version.
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 1 => encode_postcard(self),
+            // v5: envelope layout unchanged; real ungated arm for production.
+            v if v == DENSE_WRITE_VERSION => encode_postcard(self),
             // v6 synthetic alias — see HighWaterStateMachineSnapshot decode_version.
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 2 => encode_postcard(self),
@@ -467,6 +507,8 @@ impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
                 current_value: core.current_value,
                 last_applied: core.last_applied,
                 last_membership: core.last_membership.clone(),
+                dense: core.dense.clone(),
+                dense_cap: core.dense_cap,
             };
             let snapshot_id = Self::snapshot_id_for(core.last_applied.as_ref(), core.snapshot_idx);
             let meta = SnapMeta {
@@ -1505,10 +1547,16 @@ mod tests {
         // what makes an OLD-version on-disk snapshot readable after the
         // active version moves forward. Asserted against the codec range
         // directly so it documents the contract even while MIN==MAX today.
+        // Empty dense map + cap 0 so the v4 encode arm (which projects to the
+        // frozen V4 struct) is lossless; assert_eq!(decoded, payload) holds
+        // for every version in the readable range because the decode-and-lift
+        // path restores dense=empty, dense_cap=0 from a v4 blob.
         let payload = HighWaterStateMachineSnapshot {
             current_value: 5,
             last_applied: Some(log_id(2)),
             last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
         for version in tsoracle_openraft_toolkit::MIN_READABLE_VERSION
             ..=tsoracle_openraft_toolkit::MAX_READABLE_VERSION
@@ -1540,74 +1588,98 @@ mod tests {
 
     #[cfg(feature = "e2e-max-readable-next")]
     #[test]
-    fn e2e_max_readable_next_aliases_to_baseline_bytewise() {
+    fn e2e_max_readable_next_aliases_to_dense_version_bytewise() {
         // The test-only `e2e-max-readable-next` feature raises
         // `MAX_READABLE_VERSION` to `BASELINE_WRITE_VERSION + 2` in the
         // toolkit and adds matching alias arms in this file's
-        // `VersionedCodec` impls that delegate to the baseline body. This
-        // pins the alias contract: a `BASELINE + 2`-stamped envelope is
-        // byte-identical to a BASELINE-stamped one beyond the leading
-        // version byte, and round-trips cross-version. That is what lets
-        // a mixed-version e2e drive a real activation flip from BASELINE
-        // to the next version end-to-end (gate -> propose -> commit ->
-        // apply -> cell flip) without shipping a real new format — the
-        // activation control plane runs because every encoder/decoder
-        // accepts the next version as an alias of BASELINE. (`BASELINE + 1`
-        // = 5 is `DENSE_WRITE_VERSION`; synthetic harness uses `BASELINE + 2`
-        // = 6 — interim until #583.) Version-neutral assertions so this
-        // test survives a future baseline bump unchanged.
+        // `VersionedCodec` impls that encode and decode as the current
+        // (v5/dense) layout. This pins the alias contract for the
+        // activation machinery harness:
+        //
+        //  - v6 = `BASELINE + 2` is the synthetic "next" activation target,
+        //    chosen above `DENSE_WRITE_VERSION` = 5 so the e2e harness does
+        //    not collide with the real dense format (#583).
+        //  - v6 encodes the current (full, dense-capable) layout — its body
+        //    is byte-identical to a v5-encoded blob, not to a v4 blob (v4
+        //    projects to the frozen `HighWaterStateMachineSnapshotV4` struct
+        //    which omits `dense` + `dense_cap`).
+        //  - The activation control plane (gate -> propose -> commit ->
+        //    apply -> cell flip) exercises end-to-end without a real new
+        //    format because the framing machinery accepts v6 just like v5.
+        //
+        // Version-neutral assertions so this test survives a future baseline
+        // bump unchanged.
         use tsoracle_codec::{decode_framed, encode_framed};
-        use tsoracle_openraft_toolkit::{BASELINE_WRITE_VERSION, MAX_READABLE_VERSION};
+        use tsoracle_openraft_toolkit::{
+            BASELINE_WRITE_VERSION, DENSE_WRITE_VERSION, MAX_READABLE_VERSION,
+        };
 
         let baseline = BASELINE_WRITE_VERSION;
+        let dense = DENSE_WRITE_VERSION;
         let next = baseline + 2;
         assert_eq!(
             MAX_READABLE_VERSION, next,
             "feature must raise MAX to BASELINE+2"
         );
 
+        // Use empty dense map + cap 0 so the v4 encode arm (V4 projection) is
+        // lossless when we round-trip through v4, and the v6 body equals the
+        // v5 body (both encode the full current layout).
         let payload = HighWaterStateMachineSnapshot {
             current_value: 7,
             last_applied: None,
             last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
 
-        let framed_baseline = encode_framed(baseline, &payload).expect("encode baseline");
-        let framed_next = encode_framed(next, &payload).expect("encode next (alias)");
+        let framed_dense = encode_framed(dense, &payload).expect("encode dense (v5)");
+        let framed_next = encode_framed(next, &payload).expect("encode next (v6 alias)");
 
-        // Byte-identical except the leading version byte: the alias is
-        // structural, not a real layout change.
-        assert_eq!(framed_baseline[0], baseline);
+        // v6 body is byte-identical to v5 body (both encode the full layout).
+        assert_eq!(framed_dense[0], dense);
         assert_eq!(framed_next[0], next);
         assert_eq!(
-            &framed_baseline[1..],
+            &framed_dense[1..],
             &framed_next[1..],
-            "alias body must be byte-identical to baseline — only the version byte differs"
+            "v6 alias body must be byte-identical to v5 — only the version byte differs"
         );
 
-        // Cross-version round-trip: a next-stamped envelope decodes through
-        // the readable range, and a baseline reader can still consume it
-        // because the body is the same shape.
+        // v4 body is SHORTER (no dense/cap bytes) — confirm it is NOT
+        // byte-identical to v6. This documents the intentional divergence from
+        // the pre-T4 state where all three were aliased.
+        let framed_baseline = encode_framed(baseline, &payload).expect("encode baseline (v4)");
+        assert_ne!(
+            &framed_baseline[1..],
+            &framed_next[1..],
+            "v4 body must differ from v6 body: v4 omits dense/dense_cap"
+        );
+
+        // Cross-version round-trip: every version in the readable range
+        // decodes into the same logical value (empty dense, cap 0).
         let back_baseline: HighWaterStateMachineSnapshot =
             decode_framed(baseline, next, &framed_baseline).expect("decode baseline");
+        let back_dense: HighWaterStateMachineSnapshot =
+            decode_framed(baseline, next, &framed_dense).expect("decode v5");
         let back_next: HighWaterStateMachineSnapshot =
-            decode_framed(baseline, next, &framed_next).expect("decode next (alias)");
+            decode_framed(baseline, next, &framed_next).expect("decode next (v6 alias)");
         assert_eq!(back_baseline, payload);
+        assert_eq!(back_dense, payload);
         assert_eq!(back_next, payload);
 
-        // The envelope-shape carrier (`PersistedSnapshot`) must alias too
-        // — it is what `build_snapshot` actually emits at the active
-        // write version when the cell flips.
+        // The envelope-shape carrier (`PersistedSnapshot`) must also alias
+        // v5 at v6 — it is what `build_snapshot` actually emits at the
+        // active write version when the cell flips to v6.
         let envelope = PersistedSnapshot {
             meta: SnapMeta::default(),
             data: framed_next.clone(),
         };
-        let framed_env_baseline = encode_framed(baseline, &envelope).expect("envelope baseline");
-        let framed_env_next = encode_framed(next, &envelope).expect("envelope next");
+        let framed_env_dense = encode_framed(dense, &envelope).expect("envelope v5");
+        let framed_env_next = encode_framed(next, &envelope).expect("envelope v6");
         assert_eq!(
-            &framed_env_baseline[1..],
+            &framed_env_dense[1..],
             &framed_env_next[1..],
-            "PersistedSnapshot next-version envelope must alias baseline"
+            "PersistedSnapshot v6 envelope must be byte-identical to v5 envelope"
         );
     }
 
@@ -1668,8 +1740,11 @@ mod tests {
 
         let snap = sm.build_snapshot().await.expect("build_snapshot");
         let bytes = snap.snapshot.into_inner();
-        let payload: HighWaterStateMachineSnapshot = tsoracle_openraft_toolkit::decode(
-            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+        // Use decode_framed (VersionedCodec) so the v4 bytes are decoded via
+        // the frozen-V4-struct + lift path, not a raw postcard deserialize.
+        let payload: HighWaterStateMachineSnapshot = tsoracle_codec::decode_framed(
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
             &bytes,
         )
         .expect("decode snapshot");
@@ -1702,8 +1777,10 @@ mod tests {
             current_value: 999,
             last_applied: Some(log_id(5)),
             last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
-        let bytes = tsoracle_openraft_toolkit::encode(
+        let bytes = tsoracle_codec::encode_framed(
             tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &payload,
         )
@@ -1888,8 +1965,10 @@ mod tests {
             current_value: 700,
             last_applied: Some(log_id(10)),
             last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
-        let bytes = tsoracle_openraft_toolkit::encode(
+        let bytes = tsoracle_codec::encode_framed(
             tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &payload,
         )
@@ -1918,8 +1997,10 @@ mod tests {
             current_value: value,
             last_applied: Some(last_applied),
             last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
-        let bytes = tsoracle_openraft_toolkit::encode(
+        let bytes = tsoracle_codec::encode_framed(
             tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &payload,
         )
@@ -2104,8 +2185,10 @@ mod tests {
             current_value: 123,
             last_applied: Some(log_id(5)),
             last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
-        let bytes = tsoracle_openraft_toolkit::encode(
+        let bytes = tsoracle_codec::encode_framed(
             tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             &payload,
         )
@@ -2225,24 +2308,43 @@ mod tests {
     #[test]
     fn snapshot_payload_versioned_codec_matches_legacy_frame() {
         use tsoracle_codec::{decode_framed, encode_framed};
-        // The framed bytes through the new VersionedCodec seam must equal the
-        // legacy `tsoracle_openraft_toolkit::encode(BASELINE_WRITE_VERSION, ..)` frame —
-        // proving the on-disk format did not move.
+        // The v4 encode arm projects to the frozen `HighWaterStateMachineSnapshotV4`
+        // struct (3 fields, no dense/cap). This test proves:
+        //
+        //  1. The v4 framed bytes are `[4, 7, 0, 0, 0, 0]` — the on-disk v4
+        //     layout did not change from the pre-dense era.
+        //  2. Those bytes equal what the frozen V4 struct produces when encoded
+        //     directly — a real pre-dense reader can still decode the output.
+        //  3. A v4-decode-and-lift roundtrip restores the original value with
+        //     empty dense map + cap 0 ("absent" sentinel).
         let payload = HighWaterStateMachineSnapshot {
             current_value: 7,
             last_applied: None,
             last_membership: StoredMembership::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
         let via_seam = encode_framed(tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION, &payload)
             .expect("encode_framed");
-        let legacy = tsoracle_openraft_toolkit::encode(
+
+        // Prove the v4 body equals encoding the frozen V4 struct directly.
+        let v4_direct = tsoracle_openraft_toolkit::encode(
             tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
-            &payload,
+            &HighWaterStateMachineSnapshotV4 {
+                current_value: 7,
+                last_applied: None,
+                last_membership: StoredMembership::default(),
+            },
         )
-        .expect("legacy encode");
-        assert_eq!(via_seam, legacy);
+        .expect("v4 direct encode");
+        assert_eq!(
+            via_seam, v4_direct,
+            "v4 encode must project to the frozen V4 struct"
+        );
         assert_eq!(via_seam, vec![4, 7, 0, 0, 0, 0]);
 
+        // decode-and-lift: v4 bytes decode into the current layout with empty
+        // dense map and cap 0 (the "absent" sentinel), which matches `payload`.
         let back: HighWaterStateMachineSnapshot = decode_framed(
             tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
             tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
@@ -2271,24 +2373,29 @@ mod tests {
     #[test]
     fn snapshot_payload_pins_v4_layout() {
         use tsoracle_codec::encode_framed;
-        // Hand-built v4 frame: [BASELINE_WRITE_VERSION | postcard(payload)],
-        // now produced through the VersionedCodec seam that build_snapshot
-        // uses. Leading byte advanced 3 -> 4 when OpenraftPeer gained the
-        // admin_endpoint field (a breaking on-disk change for membership);
+        // Hand-built v4 frame: [BASELINE_WRITE_VERSION | postcard(V4_payload)],
+        // produced through the VersionedCodec seam that build_snapshot uses
+        // when active_write_version == BASELINE_WRITE_VERSION. The v4 encode
+        // arm projects to the frozen `HighWaterStateMachineSnapshotV4` struct
+        // (3 fields, no dense/cap), so the body bytes are unchanged from the
+        // pre-dense era. Leading byte advanced 3 -> 4 when OpenraftPeer gained
+        // the admin_endpoint field (a breaking on-disk change for membership);
         // the postcard body is unchanged. Body [7, 0, 0, 0, 0] =
         // current_value 7, last_applied None, then default StoredMembership
-        // (None log id + empty configs + empty nodes). Reordering or
-        // inserting a field changes these bytes and trips this test, forcing
-        // a deliberate version bump (a future evolution would advance
-        // MAX_READABLE_VERSION + BASELINE_WRITE_VERSION through an
-        // activation barrier rather than the historical stop-the-world bump).
+        // (None log id + empty configs + empty nodes). Reordering or inserting
+        // a field in the V4 struct changes these bytes and trips this test,
+        // forcing a deliberate review.
         let payload = HighWaterStateMachineSnapshot {
             current_value: 7,
             last_applied: None,
             last_membership: StoredMembership::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
         };
         let framed = encode_framed(tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION, &payload)
             .expect("encode");
+        // v4 encode projects to the frozen V4 struct: body is still
+        // [7, 0, 0, 0, 0] — the dense/cap bytes are NOT in the output.
         assert_eq!(framed, vec![4, 7, 0, 0, 0, 0]);
     }
 
@@ -2367,6 +2474,138 @@ mod tests {
         assert!(
             store.load().expect("load").is_none(),
             "rejected install must not persist an envelope"
+        );
+    }
+
+    // ---- Snapshot codec cross-version tests (Task 4) ----
+    //
+    // These tests pin the postcard correctness guarantees added by Task 4:
+    //  - v5 round-trip: encode a dense snapshot, decode back equal.
+    //  - v4 forward-compat: encode an empty-dense snapshot at v4; the bytes
+    //    equal what the frozen V4 struct produces; decode lifts to empty dense.
+    //  - v4 old-bytes: hand-encode a V4 struct, decode as current → empty dense.
+
+    #[test]
+    fn snapshot_codec_v5_roundtrip_with_nonempty_dense_map() {
+        use tsoracle_codec::{decode_framed, encode_framed};
+        use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
+
+        let mut dense = std::collections::BTreeMap::new();
+        dense.insert("orders".to_string(), 42u64);
+        dense.insert("invoices".to_string(), 1000u64);
+
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 777,
+            last_applied: Some(log_id(9)),
+            last_membership: StoredMem::default(),
+            dense: dense.clone(),
+            dense_cap: 500,
+        };
+
+        let framed = encode_framed(DENSE_WRITE_VERSION, &payload).expect("v5 encode");
+        assert_eq!(framed[0], DENSE_WRITE_VERSION, "leading byte must be v5");
+
+        let decoded: HighWaterStateMachineSnapshot = decode_framed(
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            &framed,
+        )
+        .expect("v5 decode");
+        assert_eq!(
+            decoded, payload,
+            "v5 roundtrip must produce the original payload"
+        );
+        assert_eq!(decoded.dense, dense, "dense map must survive roundtrip");
+        assert_eq!(decoded.dense_cap, 500, "dense_cap must survive roundtrip");
+    }
+
+    #[test]
+    fn snapshot_codec_v4_forward_compat_empty_dense() {
+        use tsoracle_codec::{decode_framed, encode_framed};
+
+        // A pre-dense snapshot: dense is empty, cap is 0.
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 42,
+            last_applied: Some(log_id(3)),
+            last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: 0,
+        };
+
+        let framed = encode_framed(tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION, &payload)
+            .expect("v4 encode");
+
+        // The v4 bytes must equal encoding the frozen V4 struct directly,
+        // so a pre-dense reader can still decode them.
+        let v4_struct_bytes = tsoracle_openraft_toolkit::encode(
+            tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+            &HighWaterStateMachineSnapshotV4 {
+                current_value: 42,
+                last_applied: Some(log_id(3)),
+                last_membership: StoredMem::default(),
+            },
+        )
+        .expect("v4 struct direct encode");
+        assert_eq!(
+            framed, v4_struct_bytes,
+            "v4 encode of empty-dense payload must be byte-identical to frozen V4 struct"
+        );
+
+        // Decode: the v4 bytes lift into the current layout with empty dense, cap 0.
+        let decoded: HighWaterStateMachineSnapshot = decode_framed(
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            &framed,
+        )
+        .expect("v4 decode");
+        assert_eq!(
+            decoded, payload,
+            "v4 forward-compat decode must produce empty-dense payload"
+        );
+        assert!(decoded.dense.is_empty(), "decoded v4 dense must be empty");
+        assert_eq!(
+            decoded.dense_cap, 0,
+            "decoded v4 cap must be 0 (absent sentinel)"
+        );
+    }
+
+    #[test]
+    fn snapshot_codec_v4_old_bytes_decode_lifts_to_empty_dense() {
+        use tsoracle_codec::{decode_framed, encode_postcard};
+
+        // Hand-encode a V4 struct (the 3-field pre-dense layout) as postcard,
+        // then frame it as a v4 record. This simulates bytes written by an old
+        // (pre-dense) node.
+        let v4 = HighWaterStateMachineSnapshotV4 {
+            current_value: 99,
+            last_applied: Some(log_id(7)),
+            last_membership: StoredMem::default(),
+        };
+        let v4_body = encode_postcard(&v4).expect("postcard encode V4");
+        let mut framed = vec![tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION];
+        framed.extend_from_slice(&v4_body);
+
+        // Decode through the VersionedCodec path.
+        let decoded: HighWaterStateMachineSnapshot = decode_framed(
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            &framed,
+        )
+        .expect("decode old v4 bytes");
+
+        assert_eq!(decoded.current_value, 99, "current_value lifts correctly");
+        assert_eq!(
+            decoded.last_applied.map(|l| l.index),
+            Some(7),
+            "last_applied lifts correctly"
+        );
+        assert!(
+            decoded.dense.is_empty(),
+            "old v4 bytes must lift to empty dense map"
+        );
+        assert_eq!(
+            decoded.dense_cap, 0,
+            "old v4 bytes must lift to cap 0 (absent)"
         );
     }
 

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -173,11 +173,6 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
                 if !self.dense.is_empty() {
                     return Err(tsoracle_codec::CodecError::NotRepresentable { version });
                 }
-                debug_assert!(
-                    self.dense.is_empty(),
-                    "v4 snapshot with non-empty dense map: dense={:?}",
-                    self.dense
-                );
                 encode_postcard(&HighWaterStateMachineSnapshotV4 {
                     current_value: self.current_value,
                     last_applied: self.last_applied,
@@ -784,6 +779,25 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                     meta.last_log_id, payload.last_applied
                 ),
             ));
+        }
+
+        // The snapshot's leading version byte is evidence that the sending
+        // leader's active write version was at least this high — which means a
+        // `SetFormatVersion` activation to that version already committed
+        // cluster-wide (the all-members gate required every member, including
+        // this one, to be able to read it). Advance our cell to match, mirroring
+        // `recover_active_write_version`'s max-of-evidence rule. Without this, a
+        // follower that receives a v5 snapshot whose `SetFormatVersion` entry was
+        // purged into the snapshot would keep `active_write_version` at the
+        // baseline while holding a populated dense map, then trip the fail-loud
+        // v4-encode `NotRepresentable` guard on its next `build_snapshot`. The
+        // byte is already within `[MIN, MAX_READABLE_VERSION]` (decode_framed
+        // accepted it above), so this never exceeds what this binary can write.
+        if let Some(&snapshot_version) = bytes.first() {
+            if snapshot_version > self.active_write_version.get() {
+                self.active_write_version.set(snapshot_version);
+                crate::observability::record_active_write_version(snapshot_version);
+            }
         }
 
         let persisted = PersistedSnapshot {
@@ -2812,5 +2826,113 @@ mod tests {
             u64::MAX,
             "overflow must not modify the counter"
         );
+    }
+
+    // ---- Regression test: install_snapshot advances active_write_version ----
+    //
+    // Bug: a follower that received a v5 snapshot whose `SetFormatVersion` entry
+    // had already been purged into the snapshot would keep `active_write_version`
+    // at `BASELINE_WRITE_VERSION` (4) while now holding a populated dense map.
+    // The next `build_snapshot` call would then hit the fail-loud
+    // `NotRepresentable` guard in `encode_version`'s v4 arm and return an error.
+    //
+    // Fix: after decoding the incoming snapshot, `install_snapshot` now advances
+    // the `active_write_version` cell to the snapshot's leading version byte if
+    // it exceeds the current cell value.
+
+    #[tokio::test]
+    async fn install_snapshot_advances_active_write_version_to_snapshot_byte() {
+        // ---- Step 1: build a v5-framed snapshot on a source SM ----
+        //
+        // Create a source SM whose active_write_version is DENSE_WRITE_VERSION
+        // (5) and whose dense map is non-empty — the combination that would have
+        // triggered the NotRepresentable guard on the follower.
+        let v5_cell = ActiveWriteVersion::default();
+        v5_cell.set(DENSE_WRITE_VERSION);
+
+        let store_src: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        let mut src =
+            HighWaterStateMachine::with_store_and_active_version(store_src, v5_cell.clone())
+                .expect("source SM");
+
+        // Populate the dense map and advance the high-water so the snapshot is
+        // non-trivial.  `with_store_and_active_version` starts at the genesis
+        // cardinality cap; apply an AdvanceDense to ensure dense is non-empty.
+        apply_one(
+            &mut src,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: dense_key("orders"),
+                count: 42,
+            }),
+        )
+        .await;
+
+        assert_eq!(src.active_write_version(), DENSE_WRITE_VERSION);
+        assert_eq!(src.dense_value("orders"), 42, "source dense populated");
+
+        // Build the v5 snapshot: the bytes handed back by openraft are what
+        // gets streamed to the follower via `begin_receiving_snapshot` +
+        // `install_snapshot`.
+        let snap = src
+            .build_snapshot()
+            .await
+            .expect("build_snapshot on source");
+        let snap_meta = snap.meta.clone();
+        // `snap.snapshot` is a `Cursor<Vec<u8>>`; the inner Vec is the framed
+        // payload bytes that `install_snapshot` receives.
+        let snap_bytes = snap.snapshot.into_inner();
+
+        // Confirm the snapshot is v5-framed (the first byte is the version).
+        assert_eq!(
+            snap_bytes[0], DENSE_WRITE_VERSION,
+            "source snapshot must be v5-framed"
+        );
+
+        // ---- Step 2: build a fresh target SM at BASELINE_WRITE_VERSION ----
+        //
+        // This models a newly-joining follower that never applied the
+        // SetFormatVersion entry (it was already purged into the snapshot it is
+        // about to receive).
+        let mut target = HighWaterStateMachine::new();
+        assert_eq!(
+            target.active_write_version(),
+            BASELINE_WRITE_VERSION,
+            "target must start at baseline (the pre-bug state)"
+        );
+        assert_eq!(target.dense_value("orders"), 0, "target dense starts empty");
+
+        // ---- Step 3: install the v5 snapshot onto the target ----
+        target
+            .install_snapshot(&snap_meta, std::io::Cursor::new(snap_bytes))
+            .await
+            .expect("install_snapshot must succeed");
+
+        // ---- Step 4: regression assertions ----
+
+        // PRIMARY: the cell must advance to DENSE_WRITE_VERSION after install.
+        // Before the fix this stayed at BASELINE_WRITE_VERSION (4) — the exact
+        // bug being pinned by this test.
+        assert_eq!(
+            target.active_write_version(),
+            DENSE_WRITE_VERSION,
+            "install_snapshot must advance active_write_version to the snapshot's \
+             leading version byte (regression: was left at BASELINE before fix)"
+        );
+
+        // Dense state must be restored from the snapshot.
+        assert_eq!(
+            target.dense_value("orders"),
+            42,
+            "dense map must be restored from the installed snapshot"
+        );
+
+        // CRITICAL: build_snapshot on the target must now SUCCEED.  Before the
+        // fix, this would error with NotRepresentable because the v4 encode arm
+        // would be selected (cell=4) while dense is non-empty.
+        target
+            .build_snapshot()
+            .await
+            .expect("build_snapshot on target after install must NOT return NotRepresentable");
     }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -359,12 +359,22 @@ impl HighWaterStateMachine {
     /// snapshot the store currently holds.
     ///
     /// If `store.load()` returns a snapshot, the state machine's
-    /// `current_value`, `last_applied`, `last_membership`, and
+    /// `current_value`, `last_applied`, `last_membership`, dense state, and
     /// `get_current_snapshot()` all reflect that snapshot on return. This is
     /// the contract that lets openraft re-enable the default snapshot policy:
     /// after a restart the log store's `last_purged_log_id` may sit above
     /// index 0, and the state machine must already cover those purged entries
     /// or openraft will panic during recovery.
+    ///
+    /// The active write version is recovered to at least the persisted
+    /// snapshot's leading version byte, so a store holding a v5/dense snapshot
+    /// does not come back at the baseline (which would trip the fail-loud
+    /// `NotRepresentable` guard on the next `build_snapshot`). For full
+    /// max-of-evidence recovery — folding in the highest version byte among
+    /// durable *log* records as well — seed the cell via
+    /// [`recover_active_write_version`](tsoracle_openraft_toolkit::recover_active_write_version)
+    /// and pass it to [`with_store_and_active_version`](Self::with_store_and_active_version);
+    /// `with_store` only sees the snapshot store.
     pub fn with_store(store: Arc<dyn SnapshotStore>) -> io::Result<Self> {
         Self::with_store_and_active_version(store, ActiveWriteVersion::default())
     }
@@ -407,6 +417,25 @@ impl HighWaterStateMachine {
                 meta: persisted.meta,
                 data: persisted.data,
             });
+            // Recover the active write version from the persisted envelope's
+            // leading version byte, mirroring `install_snapshot`'s
+            // max-of-evidence rule (and `recover_active_write_version`'s).
+            // Without this, the bare `with_store` path — which hands in a fresh
+            // BASELINE cell — would rehydrate a populated dense map (from a v5
+            // snapshot) while leaving the cell at v4, then trip the fail-loud
+            // `NotRepresentable` guard on its next `build_snapshot`. The byte is
+            // a safe floor: a v5 snapshot proves a `SetFormatVersion` to at
+            // least that version already committed cluster-wide. Only ever
+            // advances, so a caller (e.g. standalone bootstrap) that already
+            // seeded the cell from richer log+snapshot evidence is unaffected.
+            // `decode_framed` accepted the byte above, so it is within
+            // `[MIN, MAX_READABLE_VERSION]` and never exceeds what this binary
+            // can write.
+            if let Some(&snapshot_version) = bytes.first() {
+                if snapshot_version > active_write_version.get() {
+                    active_write_version.set(snapshot_version);
+                }
+            }
         }
         let state_machine = Self {
             core: Arc::new(Mutex::new(core)),
@@ -2934,5 +2963,88 @@ mod tests {
             .build_snapshot()
             .await
             .expect("build_snapshot on target after install must NOT return NotRepresentable");
+    }
+
+    // ---- Regression test: with_store recovers active_write_version ----
+    //
+    // Sibling of `install_snapshot_advances_active_write_version_to_snapshot_byte`.
+    // Bug: the public `with_store` / `with_store_and_active_version` load path
+    // rehydrated `core.dense` (and `dense_cap`) from a persisted v5 snapshot but
+    // left the freshly-defaulted `active_write_version` cell at
+    // `BASELINE_WRITE_VERSION` (4). The next `build_snapshot` would then select
+    // the v4 encode arm with a non-empty dense map and hit the fail-loud
+    // `NotRepresentable` guard; `advance_dense` would also stay gated.
+    //
+    // Production dodges this because standalone bootstrap recovers the cell from
+    // log + snapshot evidence *before* constructing the SM, but the public
+    // `with_store` API documents durable-snapshot rehydration, so the bare path
+    // must recover the version byte too (a safe floor: the snapshot byte proves
+    // an activation to at least that version committed cluster-wide).
+    //
+    // Fix: after `store.load()`, advance the cell to the persisted envelope's
+    // leading version byte when it exceeds the cell's current value.
+
+    #[tokio::test]
+    async fn with_store_recovers_active_write_version_from_v5_snapshot() {
+        // ---- Step 1: persist a v5/dense snapshot through a source SM ----
+        let v5_cell = ActiveWriteVersion::default();
+        v5_cell.set(DENSE_WRITE_VERSION);
+
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        {
+            let mut src = HighWaterStateMachine::with_store_and_active_version(
+                store.clone(),
+                v5_cell.clone(),
+            )
+            .expect("source SM");
+            apply_one(
+                &mut src,
+                1,
+                EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                    key: dense_key("orders"),
+                    count: 42,
+                }),
+            )
+            .await;
+            src.build_snapshot().await.expect("build v5 snapshot");
+        }
+
+        // Confirm the persisted envelope is v5-framed.
+        let persisted_bytes = store.load().expect("load").expect("snapshot present");
+        assert_eq!(
+            persisted_bytes[0], DENSE_WRITE_VERSION,
+            "persisted envelope must be v5-framed"
+        );
+
+        // ---- Step 2: reopen via the bare public API (fresh BASELINE cell) ----
+        // This models an embedder that uses `with_store` with a durable backend
+        // holding v5 data — the pre-bug state left the cell at baseline.
+        let mut reopened =
+            HighWaterStateMachine::with_store(store.clone()).expect("reopen via with_store");
+
+        // ---- Step 3: regression assertions ----
+
+        // PRIMARY: the cell must recover to DENSE_WRITE_VERSION from the
+        // snapshot's leading byte. Before the fix this stayed at BASELINE (4).
+        assert_eq!(
+            reopened.active_write_version(),
+            DENSE_WRITE_VERSION,
+            "with_store must recover active_write_version from the persisted \
+             snapshot's leading version byte (regression: was left at BASELINE)"
+        );
+
+        // Dense state must be rehydrated from the snapshot.
+        assert_eq!(
+            reopened.dense_value("orders"),
+            42,
+            "dense map must be rehydrated from the persisted snapshot"
+        );
+
+        // CRITICAL: build_snapshot must now SUCCEED. Before the fix, the v4
+        // encode arm (cell=4) with a non-empty dense map hit NotRepresentable.
+        reopened
+            .build_snapshot()
+            .await
+            .expect("build_snapshot after reopen must NOT return NotRepresentable");
     }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -111,15 +111,19 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
             // the layout evolves and MIN_READABLE_VERSION/MAX_READABLE_VERSION
             // widen.
             v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
-            // `BASELINE + 1` alias: a test-only harness affordance. The body
-            // is byte-identical to BASELINE — only the version byte changes
-            // — so the activation machinery (gate -> propose -> commit ->
-            // apply -> cell flip) can run end-to-end in a mixed-version e2e
-            // without shipping a real new format. Gated off in production.
-            // The guard derives from BASELINE so a future baseline bump
-            // moves the alias version with no edit here.
+            // v5 (DENSE_WRITE_VERSION): real dense-sequence codec arm added in
+            // P2-T4. Under `e2e-max-readable-next` this alias keeps v5 in the
+            // readable range [BASELINE..=BASELINE+2] while the real arm is
+            // pending; the alias will be replaced by the actual layout in P2-T4.
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 1 => decode_postcard_exact(body),
+            // v6 (BASELINE + 2): synthetic activation-test alias. Body is
+            // byte-identical to BASELINE — only the version byte changes — so
+            // the activation machinery (gate -> propose -> commit -> apply ->
+            // cell flip) can run end-to-end in a mixed-version e2e without
+            // shipping a real new format. Gated off in production. (#583)
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 2 => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -131,8 +135,12 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
             v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
+            // v5 alias under e2e harness — see decode_version comment above.
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 1 => encode_postcard(self),
+            // v6 synthetic alias — see decode_version comment above.
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 2 => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -146,8 +154,12 @@ impl VersionedCodec for PersistedSnapshot {
     fn decode_version(version: u8, body: &[u8]) -> Result<Self, tsoracle_codec::CodecError> {
         match version {
             v if v == BASELINE_WRITE_VERSION => decode_postcard_exact(body),
+            // v5 alias under e2e harness — see HighWaterStateMachineSnapshot decode_version.
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 1 => decode_postcard_exact(body),
+            // v6 synthetic alias — see HighWaterStateMachineSnapshot decode_version.
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 2 => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -159,8 +171,12 @@ impl VersionedCodec for PersistedSnapshot {
     fn encode_version(&self, version: u8) -> Result<Vec<u8>, tsoracle_codec::CodecError> {
         match version {
             v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
+            // v5 alias under e2e harness — see HighWaterStateMachineSnapshot decode_version.
             #[cfg(feature = "e2e-max-readable-next")]
             v if v == BASELINE_WRITE_VERSION + 1 => encode_postcard(self),
+            // v6 synthetic alias — see HighWaterStateMachineSnapshot decode_version.
+            #[cfg(feature = "e2e-max-readable-next")]
+            v if v == BASELINE_WRITE_VERSION + 2 => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -905,13 +921,13 @@ mod tests {
         // The flip is only observable when the local binary's readable
         // range contains a target distinct from BASELINE. The
         // `e2e-max-readable-next` test harness raises MAX to
-        // BASELINE + 1; in default builds MIN == MAX == BASELINE, so any
+        // BASELINE + 2; in default builds MIN == MAX == BASELINE, so any
         // distinct target is out of range and the apply-arm
         // defense-in-depth (correctly) no-ops it. The behavior pinned by
         // this test — "subset OK + in-range target ⇒ cell flips" — is
         // unchanged; only the in-range target is feature-dependent.
         let mut sm = HighWaterStateMachine::new();
-        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 1;
+        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 2;
         // Establish membership {1, 2} at index 1.
         apply_one(
             &mut sm,
@@ -1190,7 +1206,7 @@ mod tests {
     #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn successful_activation_survives_replay() {
-        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 1;
+        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 2;
         let log = vec![
             (1u64, ReplayEntry::Membership(vec![1, 2])),
             (
@@ -1296,7 +1312,7 @@ mod tests {
     #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn replay_is_deterministic() {
-        let in_range = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 1;
+        let in_range = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 2;
         let log = vec![
             (1u64, ReplayEntry::Membership(vec![1, 2])),
             (
@@ -1526,27 +1542,28 @@ mod tests {
     #[test]
     fn e2e_max_readable_next_aliases_to_baseline_bytewise() {
         // The test-only `e2e-max-readable-next` feature raises
-        // `MAX_READABLE_VERSION` to `BASELINE_WRITE_VERSION + 1` in the
+        // `MAX_READABLE_VERSION` to `BASELINE_WRITE_VERSION + 2` in the
         // toolkit and adds matching alias arms in this file's
         // `VersionedCodec` impls that delegate to the baseline body. This
-        // pins the alias contract: a `BASELINE + 1`-stamped envelope is
+        // pins the alias contract: a `BASELINE + 2`-stamped envelope is
         // byte-identical to a BASELINE-stamped one beyond the leading
         // version byte, and round-trips cross-version. That is what lets
         // a mixed-version e2e drive a real activation flip from BASELINE
         // to the next version end-to-end (gate -> propose -> commit ->
         // apply -> cell flip) without shipping a real new format — the
         // activation control plane runs because every encoder/decoder
-        // accepts the next version as an alias of BASELINE. Version-
-        // neutral assertions so this test survives a future baseline
-        // bump unchanged.
+        // accepts the next version as an alias of BASELINE. (`BASELINE + 1`
+        // = 5 is `DENSE_WRITE_VERSION`; synthetic harness uses `BASELINE + 2`
+        // = 6 — interim until #583.) Version-neutral assertions so this
+        // test survives a future baseline bump unchanged.
         use tsoracle_codec::{decode_framed, encode_framed};
         use tsoracle_openraft_toolkit::{BASELINE_WRITE_VERSION, MAX_READABLE_VERSION};
 
         let baseline = BASELINE_WRITE_VERSION;
-        let next = baseline + 1;
+        let next = baseline + 2;
         assert_eq!(
             MAX_READABLE_VERSION, next,
-            "feature must raise MAX to BASELINE+1"
+            "feature must raise MAX to BASELINE+2"
         );
 
         let payload = HighWaterStateMachineSnapshot {

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -1548,12 +1548,13 @@ mod tests {
         // readable across the multi-version codec and the next
         // build_snapshot re-emits at the cluster's ACTIVE write version.
         //
-        // HONESTY: MIN==MAX==BASELINE today, so there is no genuine lower
-        // production version. This exercises the seam end-to-end at the
-        // only version that exists; the genuine cross-version rewrite
-        // (install vN, flip to vN+1, assert rebuild is vN+1) is the
-        // structural extension a real vN+1 work would make by
-        // parameterizing the installed version.
+        // SCOPE: this drives the same-version axis — persist at the active
+        // write version (BASELINE = 4, since no activation flip is injected
+        // here) and assert the reopen reads it back and re-emits at the active
+        // version. The genuine cross-version rewrite (install v4, activate v5,
+        // assert the rebuild is v5) is the orthogonal axis; the readable range
+        // is now [4, 5], so the v4 lower version genuinely exists on disk
+        // pre-activation.
         let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
 
         // Persist a snapshot via a first SM instance, then drop it.
@@ -1611,7 +1612,8 @@ mod tests {
         // MAX_READABLE_VERSION] and reject anything outside it. This is
         // what makes an OLD-version on-disk snapshot readable after the
         // active version moves forward. Asserted against the codec range
-        // directly so it documents the contract even while MIN==MAX today.
+        // directly so it covers the full readable range [MIN = 4, MAX = 5] —
+        // iterating v4 (decode-and-lift) and v5 (direct decode).
         // Empty dense map + cap 0 so the v4 encode arm (which projects to the
         // frozen V4 struct) is lossless; assert_eq!(decoded, payload) holds
         // for every version in the readable range because the decode-and-lift

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -175,6 +175,14 @@ impl VersionedCodec for PersistedSnapshot {
 /// (poison semantics would just mask the originating panic).
 struct Core {
     current_value: u64,
+    /// Per-key dense counters. Deterministic iteration (BTreeMap) so snapshots
+    /// are byte-identical across replicas.
+    dense: std::collections::BTreeMap<String, u64>,
+    /// Immutable, cluster-wide genesis cardinality cap. Seeded from the SM
+    /// constructor (identical config on every node) or restored from a
+    /// snapshot; never mutated at runtime. Stored in the replicated snapshot so
+    /// replay/restore reproduces the same accept/reject decisions (spec §6.2).
+    dense_cap: u64,
     last_applied: Option<LogId>,
     last_membership: StoredMem,
     /// Snapshot index counter, used to make snapshot ids unique even when two
@@ -266,6 +274,26 @@ impl HighWaterStateMachine {
         Self::with_store(store).expect("InMemorySnapshotStore::load is infallible")
     }
 
+    /// Build a state machine with a custom genesis cardinality cap, backed by
+    /// an in-memory snapshot store. The cap is immutable after construction and
+    /// must be identical on every cluster member. Intended for tests that need
+    /// a small cap to exercise `DenseCardinalityExceeded`; production callers
+    /// use [`new`](Self::new) which defaults to
+    /// [`DEFAULT_DENSE_CARDINALITY_CAP`](crate::DEFAULT_DENSE_CARDINALITY_CAP).
+    #[cfg(test)]
+    #[expect(
+        clippy::expect_used,
+        reason = "`with_store_and_dense_cap` only fails when `store.load()` returns Err; \
+                  `InMemorySnapshotStore::load` is `Ok(None)` for a fresh \
+                  store, so this branch is unreachable."
+    )]
+    fn new_with_dense_cap(dense_cap: u64) -> Self {
+        let store: Arc<dyn SnapshotStore> = Arc::new(InMemorySnapshotStore::new());
+        let sm = Self::with_store(store).expect("InMemorySnapshotStore::load is infallible");
+        sm.core.lock().dense_cap = dense_cap;
+        sm
+    }
+
     /// Build a state machine backed by `store` and rehydrated from whatever
     /// snapshot the store currently holds.
     ///
@@ -291,6 +319,8 @@ impl HighWaterStateMachine {
     ) -> io::Result<Self> {
         let mut core = Core {
             current_value: 0,
+            dense: std::collections::BTreeMap::new(),
+            dense_cap: crate::DEFAULT_DENSE_CARDINALITY_CAP,
             last_applied: None,
             last_membership: StoredMembership::default(),
             snapshot_idx: 0,
@@ -338,6 +368,12 @@ impl HighWaterStateMachine {
     /// before calling.
     pub async fn current_value(&self) -> u64 {
         self.core.lock().current_value
+    }
+
+    /// Read a dense counter by key, returning 0 if absent. State-machine-local
+    /// read; callers needing linearizability must issue a read barrier first.
+    pub fn dense_value(&self, key: &str) -> u64 {
+        self.core.lock().dense.get(key).copied().unwrap_or(0)
     }
 
     fn snapshot_id_for(last_applied: Option<&LogId>, idx: u64) -> String {
@@ -596,6 +632,30 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                             value: core.current_value,
                             outcome,
                         }
+                    }
+                }
+                EntryPayload::Normal(HighWaterCommand::AdvanceDense { key, count }) => {
+                    let mut core = self.core.lock();
+                    let key_str = key.as_str();
+                    let present = core.dense.contains_key(key_str);
+                    let outcome = if !present && core.dense.len() as u64 >= core.dense_cap {
+                        ApplyOutcome::DenseCardinalityExceeded {
+                            cap: core.dense_cap,
+                        }
+                    } else {
+                        let start = core.dense.get(key_str).copied().unwrap_or(0);
+                        match start.checked_add(u64::from(*count)) {
+                            Some(next) => {
+                                core.dense.insert(key_str.to_string(), next);
+                                ApplyOutcome::DenseAdvanced { start }
+                            }
+                            None => ApplyOutcome::DenseOverflow,
+                        }
+                    };
+                    core.last_applied = Some(log_id);
+                    HighWaterApplied {
+                        value: core.current_value,
+                        outcome,
                     }
                 }
                 EntryPayload::Membership(membership) => {
@@ -2290,6 +2350,189 @@ mod tests {
         assert!(
             store.load().expect("load").is_none(),
             "rejected install must not persist an envelope"
+        );
+    }
+
+    // ---- AdvanceDense apply tests ----
+    //
+    // Drive the `AdvanceDense` apply arm directly via `apply_one` and verify
+    // the observable side effects through `dense_value()` (the pre/post
+    // counter), the `last_applied` log position, and the fact that the
+    // high-water is NOT touched by a dense advance.
+    //
+    // The four cases the plan mandates:
+    //  1. First advance of "orders" by 5 → start=0, dense["orders"]=5.
+    //  2. Second advance of "orders" by 3 → start=5, dense["orders"]=8.
+    //  3. A new key when the cap is full → DenseCardinalityExceeded: counter
+    //     stays 0 and the map size does not grow.
+    //  4. A counter at u64::MAX with count=1 → DenseOverflow: counter
+    //     stays at u64::MAX.
+    //
+    // We verify start and outcome by observing `dense_value` BEFORE the apply
+    // (which gives `start`) and AFTER (which gives `start + count` on success,
+    // unchanged on rejection). The high-water is pinned at 0 throughout (no
+    // `Advance` entries), which confirms the apply arm does NOT touch it.
+
+    fn dense_key(s: &str) -> tsoracle_core::SeqKey {
+        tsoracle_core::SeqKey::try_new(s).expect("valid key")
+    }
+
+    #[tokio::test]
+    async fn dense_advance_first_key_starts_at_zero() {
+        let mut sm = HighWaterStateMachine::new();
+        let key = dense_key("orders");
+
+        // Pre-condition: key is absent → start would be 0.
+        assert_eq!(sm.dense_value("orders"), 0);
+
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: key.clone(),
+                count: 5,
+            }),
+        )
+        .await;
+
+        // Post-condition: counter advanced by 5; start was 0.
+        assert_eq!(
+            sm.dense_value("orders"),
+            5,
+            "first advance by 5: dense[orders] = 5 (start=0)"
+        );
+        // High-water must be untouched.
+        assert_eq!(
+            sm.current_value().await,
+            0,
+            "AdvanceDense must not touch the high-water"
+        );
+        let (last, _) = sm.applied_state().await.unwrap();
+        assert_eq!(last.map(|l| l.index), Some(1));
+    }
+
+    #[tokio::test]
+    async fn dense_advance_second_apply_starts_at_previous_value() {
+        let mut sm = HighWaterStateMachine::new();
+        let key = dense_key("orders");
+
+        // First advance: start=0, next=5.
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: key.clone(),
+                count: 5,
+            }),
+        )
+        .await;
+        assert_eq!(sm.dense_value("orders"), 5);
+
+        // Capture start before second apply.
+        let start_before = sm.dense_value("orders"); // == 5
+
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: key.clone(),
+                count: 3,
+            }),
+        )
+        .await;
+
+        // The second block starts at 5 (the pre-advance value).
+        assert_eq!(
+            start_before, 5,
+            "second advance: start must be the prior counter value (5)"
+        );
+        assert_eq!(
+            sm.dense_value("orders"),
+            8,
+            "second advance by 3: dense[orders] = 8"
+        );
+    }
+
+    #[tokio::test]
+    async fn dense_advance_cardinality_cap_rejects_new_key() {
+        // Cap set to 1: one key is allowed; a second new key must be rejected.
+        let mut sm = HighWaterStateMachine::new_with_dense_cap(1);
+        let k1 = dense_key("orders");
+        let k2 = dense_key("users");
+
+        // First key is accepted (map was empty, cap=1 → len 0 < 1 → OK).
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: k1.clone(),
+                count: 1,
+            }),
+        )
+        .await;
+        assert_eq!(sm.dense_value("orders"), 1, "first key accepted");
+
+        // Second NEW key: map len==1 >= cap=1 → DenseCardinalityExceeded.
+        // The counter for the new key must stay at 0 (rejection is a no-op on
+        // the dense map).
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: k2.clone(),
+                count: 1,
+            }),
+        )
+        .await;
+        assert_eq!(
+            sm.dense_value("users"),
+            0,
+            "new key rejected by cardinality cap: dense[users] must be 0"
+        );
+        // Existing key still advances (already present → cap check skipped).
+        apply_one(
+            &mut sm,
+            3,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: k1.clone(),
+                count: 4,
+            }),
+        )
+        .await;
+        assert_eq!(
+            sm.dense_value("orders"),
+            5,
+            "existing key still advances despite cap being full"
+        );
+    }
+
+    #[tokio::test]
+    async fn dense_advance_overflow_leaves_counter_unchanged() {
+        // Seed the counter at u64::MAX by using a large initial count and then
+        // bridging up. Since count is u32 (max 2^32-1) we need multiple applies
+        // to reach u64::MAX. It is simpler to directly manipulate the core in
+        // the test module (same file, so private access is allowed).
+        let sm = HighWaterStateMachine::new();
+        {
+            let mut core = sm.core.lock();
+            core.dense.insert("x".to_string(), u64::MAX);
+        }
+        // Apply AdvanceDense with count=1: checked_add(u64::MAX, 1) overflows.
+        let mut sm_mut = sm;
+        apply_one(
+            &mut sm_mut,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDense {
+                key: dense_key("x"),
+                count: 1,
+            }),
+        )
+        .await;
+        // Overflow: counter must remain at u64::MAX (rejection is a no-op).
+        assert_eq!(
+            sm_mut.dense_value("x"),
+            u64::MAX,
+            "overflow must not modify the counter"
         );
     }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -163,6 +163,16 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
             // activation, so dropping it is lossless). This is what
             // build_snapshot emits while the active write version is still 4.
             v if v == BASELINE_WRITE_VERSION => {
+                // Fail loud in ALL build profiles (not just debug): a non-empty
+                // dense map at this point means write-version 5 data is being
+                // encoded into a v4 snapshot, which would silently drop it.
+                // The invariant (dense only populated after activation flips the
+                // write version to 5) is maintained by the rollout gate, so
+                // reaching here with a non-empty map indicates a protocol
+                // violation that must be surfaced rather than silently lost.
+                if !self.dense.is_empty() {
+                    return Err(tsoracle_codec::CodecError::NotRepresentable { version });
+                }
                 debug_assert!(
                     self.dense.is_empty(),
                     "v4 snapshot with non-empty dense map: dense={:?}",
@@ -392,6 +402,12 @@ impl HighWaterStateMachine {
             core.current_value = payload.current_value;
             core.last_applied = payload.last_applied;
             core.last_membership = payload.last_membership;
+            core.dense = payload.dense;
+            // A v4 snapshot carries dense_cap == 0 (absent sentinel); keep the
+            // constructor-seeded genesis cap. A v5 snapshot carries the real cap.
+            if payload.dense_cap != 0 {
+                core.dense_cap = payload.dense_cap;
+            }
             core.current_snapshot = Some(StoredSnapshot {
                 meta: persisted.meta,
                 data: persisted.data,
@@ -789,6 +805,12 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
             core.current_value = payload.current_value;
             core.last_applied = payload.last_applied;
             core.last_membership = payload.last_membership;
+            core.dense = payload.dense;
+            // A v4 snapshot carries dense_cap == 0 (absent sentinel); keep the
+            // constructor-seeded genesis cap. A v5 snapshot carries the real cap.
+            if payload.dense_cap != 0 {
+                core.dense_cap = payload.dense_cap;
+            }
         })?;
         Ok(())
     }

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -114,7 +114,7 @@ pub enum ApplyOutcome {
     /// defense-in-depth range check: `target` was outside the LOCAL
     /// binary's `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]` so the
     /// shared cell was left untouched. Distinct from
-    /// [`FormatActivationNoop`] because the failure class is "this entry
+    /// [`ApplyOutcome::FormatActivationNoop`] because the failure class is "this entry
     /// should never have been proposed" (a gate bug or a log committed
     /// by an older binary), not "the membership drifted" — different
     /// remediation, different counter, different operator surface. The

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -121,6 +121,16 @@ pub enum ApplyOutcome {
     /// gate at proposal time normally prevents this from being committed
     /// (see `target_in_local_readable_range`).
     FormatActivationTargetOutOfRange { target: u8 },
+    /// An `AdvanceDense` applied successfully: `start` is the pre-advance dense
+    /// counter for the key (the issued block's first ordinal). `value` on the
+    /// enclosing `HighWaterApplied` is the high-water, untouched.
+    DenseAdvanced { start: u64 },
+    /// An `AdvanceDense` applied as a deterministic rejection: the key was new
+    /// and the cluster is at its immutable genesis cardinality cap.
+    DenseCardinalityExceeded { cap: u64 },
+    /// An `AdvanceDense` applied as a deterministic rejection: the counter would
+    /// exceed u64::MAX.
+    DenseOverflow,
 }
 
 /// Per-entry apply result.

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -52,7 +52,9 @@ use tsoracle_driver_openraft::{
     TypeConfig,
 };
 use tsoracle_openraft_toolkit::test_fakes::{MemNetwork, PartitionController};
-use tsoracle_openraft_toolkit::{Flat, RocksdbLogStore};
+use tsoracle_openraft_toolkit::{
+    ActiveWriteVersion, Flat, RocksdbLogStore, recover_active_write_version,
+};
 
 /// One node in a test cluster. Holds the raft handle, a clone of the state
 /// machine for direct reads, the rocksdb `Arc<DB>` (so subsequent reopens can
@@ -206,6 +208,53 @@ fn open_log_and_snapshot_stores(
     (log_store, snapshot_store)
 }
 
+/// Recover the single, process-shared `ActiveWriteVersion` cell from durable
+/// evidence and thread it into the log store, exactly as standalone bootstrap
+/// does (`drivers/openraft/mod.rs`): the cell is the max of the baseline, the
+/// persisted snapshot's leading version byte, and the highest version byte
+/// among durable log records. Threading the *same* cell into both the log store
+/// (which stamps appended records) and the state machine (which stamps
+/// snapshots) is what makes a runtime format activation take effect on every
+/// writer — without it, activation flips only the SM and the log store keeps
+/// stamping at the baseline. Returns the wired log store and the shared cell to
+/// hand to [`HighWaterStateMachine::with_store_and_active_version`].
+fn wire_shared_active_write_version(
+    log_store: RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec>,
+    snapshot_store: &Arc<dyn tsoracle_driver_openraft::SnapshotStore>,
+) -> (
+    RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec>,
+    ActiveWriteVersion,
+) {
+    let snapshot_leading_byte = snapshot_store
+        .load()
+        .expect("load snapshot for version recovery")
+        .as_deref()
+        .and_then(|bytes| bytes.first().copied());
+    let highest_log_record_byte = log_store
+        .highest_log_record_version()
+        .expect("scan log records for version recovery");
+    let cell = ActiveWriteVersion::new(
+        recover_active_write_version(snapshot_leading_byte, highest_log_record_byte)
+            .expect("recover active write version"),
+    );
+    let log_store = log_store.with_active_write_version(cell.clone());
+    (log_store, cell)
+}
+
+/// The highest leading version byte among `node`'s durable log records, read
+/// by attaching a fresh read-only log store to the node's live `Arc<DB>`. This
+/// is the same on-disk evidence standalone bootstrap feeds to
+/// `recover_active_write_version`; tests use it to assert that records appended
+/// after a format activation are actually framed at the activated write
+/// version (not the baseline).
+pub fn highest_log_record_version(node: &TestNode) -> Option<u8> {
+    let log_store: RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec> =
+        RocksdbLogStore::open(node.db.clone(), LOG_CF, META_CF, Flat).unwrap();
+    log_store
+        .highest_log_record_version()
+        .expect("scan log record versions")
+}
+
 // Builders below are stubs filled in by subsequent tasks:
 // - build_three_node: cluster constructor
 // - reopen_node: restart-replay primitive
@@ -222,7 +271,9 @@ pub async fn build_single_node_with_config(config: Arc<Config>) -> TestCluster {
     let dir = TempDir::new().unwrap();
     let db = open_rocksdb(&dir);
     let (log_store, snapshot_store) = open_log_and_snapshot_stores(db.clone());
-    let sm = HighWaterStateMachine::with_store(snapshot_store).expect("hydrate SM");
+    let (log_store, cell) = wire_shared_active_write_version(log_store, &snapshot_store);
+    let sm = HighWaterStateMachine::with_store_and_active_version(snapshot_store, cell)
+        .expect("hydrate SM");
     let sm_clone = sm.clone();
 
     let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
@@ -276,7 +327,9 @@ pub async fn build_three_node() -> TestCluster {
         let dir = TempDir::new().unwrap();
         let db = open_rocksdb(&dir);
         let (log_store, snapshot_store) = open_log_and_snapshot_stores(db.clone());
-        let sm = HighWaterStateMachine::with_store(snapshot_store).expect("hydrate SM");
+        let (log_store, cell) = wire_shared_active_write_version(log_store, &snapshot_store);
+        let sm = HighWaterStateMachine::with_store_and_active_version(snapshot_store, cell)
+            .expect("hydrate SM");
         let sm_clone = sm.clone();
         let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
             id,
@@ -357,7 +410,12 @@ pub async fn reopen_node_with_config(prior: TestNode, config: Arc<Config>) -> Te
     drop(raft);
 
     let (log_store, snapshot_store) = open_log_and_snapshot_stores(db.clone());
-    let sm = HighWaterStateMachine::with_store(snapshot_store).expect("rehydrate SM on reopen");
+    // Recover the shared active-write-version cell from durable evidence, just
+    // as standalone bootstrap does on restart, so a node that activated a newer
+    // write version before shutdown comes back up still stamping at it.
+    let (log_store, cell) = wire_shared_active_write_version(log_store, &snapshot_store);
+    let sm = HighWaterStateMachine::with_store_and_active_version(snapshot_store, cell)
+        .expect("rehydrate SM on reopen");
     let sm_clone = sm.clone();
     let raft = Raft::<TypeConfig, HighWaterStateMachine>::new(
         id,

--- a/crates/tsoracle-driver-openraft/tests/dense_advance.rs
+++ b/crates/tsoracle-driver-openraft/tests/dense_advance.rs
@@ -1,0 +1,321 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Integration tests for `advance_dense` / `load_dense_seq` on the openraft
+//! driver.
+//!
+//! Covers:
+//! - Gate: before activation (write version 4), `advance_dense` returns
+//!   `DenseNotActivated { required: 5, active: 4 }`.
+//! - Post-activation gapless per-key advance: consecutive calls return
+//!   gapless block starts; `load_dense_seq` reflects the committed counter.
+//! - Independent keys start at 0.
+//! - Three-node: after leader activation, a follower converges on
+//!   `load_dense_seq`.
+//!
+//! Cardinality (`SeqKeyCardinalityExceeded`) and overflow (`SeqOverflow`) are
+//! covered deterministically by the state-machine unit tests in
+//! `state_machine.rs` (which can inject a small genesis cap via the
+//! `#[cfg(test)]` `new_with_dense_cap` constructor). The `DEFAULT_DENSE_CARDINALITY_CAP`
+//! (10 000) cannot be exhausted in an integration test without prohibitive
+//! runtime, so the driver's routing of those outcomes to the correct
+//! `ConsensusError` variants is verified at the unit level instead.
+
+mod common;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
+use tsoracle_core::{Epoch, SeqKey};
+use tsoracle_driver_openraft::{CapabilitySource, NodeCapabilities, OpenraftPeer, StandaloneHost};
+use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
+
+use common::{TestCluster, build_single_node, build_three_node, eventually_eq};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// A `CapabilitySource` for single-node clusters that must never be called:
+/// the local node short-circuit answers entirely from itself without any peer
+/// RPCs.
+struct UnusedSource;
+
+#[async_trait]
+impl CapabilitySource for UnusedSource {
+    type Node = OpenraftPeer;
+
+    async fn query(
+        &self,
+        node_id: u64,
+        _member: &OpenraftPeer,
+    ) -> Result<NodeCapabilities, String> {
+        panic!("single-node gate must not query remote node {node_id}");
+    }
+}
+
+/// A `CapabilitySource` that answers every queried node with the compile-time
+/// local capabilities at the given `active_write_version`. Used for three-node
+/// tests where every node runs the same binary.
+struct AllCapableSource {
+    active_versions: HashMap<u64, u8>,
+}
+
+impl AllCapableSource {
+    fn uniform(active_write_version: u8, node_ids: &[u64]) -> Self {
+        Self {
+            active_versions: node_ids
+                .iter()
+                .copied()
+                .map(|id| (id, active_write_version))
+                .collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl CapabilitySource for AllCapableSource {
+    type Node = OpenraftPeer;
+
+    async fn query(
+        &self,
+        node_id: u64,
+        _member: &OpenraftPeer,
+    ) -> Result<NodeCapabilities, String> {
+        let active = self
+            .active_versions
+            .get(&node_id)
+            .copied()
+            .unwrap_or(tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION);
+        Ok(NodeCapabilities::local(active))
+    }
+}
+
+/// Wait until the cluster has elected a leader; return the leader node index.
+async fn find_leader_idx(cluster: &TestCluster) -> usize {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            for (idx, node) in cluster.nodes.iter().enumerate() {
+                if let Some(l) = node.raft.current_leader().await {
+                    if l == node.id {
+                        return idx;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("some node became leader within 10s")
+}
+
+/// Build a single-node cluster, wait for leadership, and return the
+/// `StandaloneHost` handle together with the cluster guard.
+async fn single_node_leader_host() -> (StandaloneHost, TestCluster) {
+    let cluster = build_single_node().await;
+    let driver = &cluster.drivers[0];
+
+    let mut events = driver.leadership_events();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let state = events.next().await.expect("event stream alive");
+            if matches!(state, LeaderState::Leader { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("single-node openraft did not elect itself within 5s");
+
+    let host = StandaloneHost::new(cluster.nodes[0].raft.clone(), cluster.nodes[0].sm.clone());
+    (host, cluster)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: gate — before activation
+// ---------------------------------------------------------------------------
+
+/// Before write version 5 is activated, `advance_dense` must return
+/// `DenseNotActivated { required: 5, active: 4 }`. `load_dense_seq` is not
+/// gated (reads are always safe; the key simply does not exist yet and returns
+/// 0).
+#[tokio::test(start_paused = true)]
+async fn advance_dense_before_activation_returns_dense_not_activated() {
+    let cluster = build_single_node().await;
+    let driver = &cluster.drivers[0];
+
+    // Wait for leadership so the driver is usable.
+    let mut events = driver.leadership_events();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if matches!(s, LeaderState::Leader { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("became leader within 5s");
+
+    let key = SeqKey::try_new("orders").unwrap();
+
+    // `advance_dense` must be refused before activation.
+    let err = driver
+        .advance_dense(&key, 1, Epoch::ZERO)
+        .await
+        .expect_err("advance_dense before activation must return an error");
+
+    assert!(
+        matches!(
+            err,
+            ConsensusError::DenseNotActivated { required, active }
+            if required == DENSE_WRITE_VERSION && active < DENSE_WRITE_VERSION
+        ),
+        "expected DenseNotActivated{{required=5, active<5}}, got: {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: post-activation — gapless advance, independent keys
+// ---------------------------------------------------------------------------
+
+/// After activating write version 5, `advance_dense` returns gapless block
+/// starts; `load_dense_seq` reflects the committed counter; an independent
+/// key starts at 0.
+#[tokio::test(start_paused = true)]
+async fn advance_dense_after_activation_is_gapless() {
+    let (host, cluster) = single_node_leader_host().await;
+    let driver = &cluster.drivers[0];
+
+    // Activate write version 5 through the real gate. Single-node
+    // short-circuits the all-members check, so `UnusedSource` is never called.
+    host.initiate_format_activation(DENSE_WRITE_VERSION, &UnusedSource)
+        .await
+        .expect("activation must succeed on a single-node cluster");
+    assert_eq!(
+        host.active_write_version(),
+        DENSE_WRITE_VERSION,
+        "cell must read DENSE_WRITE_VERSION after activation"
+    );
+
+    let key = SeqKey::try_new("orders").unwrap();
+
+    // First advance of 5: start = 0 (key did not exist).
+    let start0 = driver
+        .advance_dense(&key, 5, Epoch::ZERO)
+        .await
+        .expect("advance after activation");
+    assert_eq!(start0, 0, "first advance starts at 0");
+
+    // Second advance of 3: start = 5 (previous end).
+    let start1 = driver
+        .advance_dense(&key, 3, Epoch::ZERO)
+        .await
+        .expect("second advance after activation");
+    assert_eq!(start1, 5, "second advance starts where first ended");
+
+    // `load_dense_seq` must reflect the committed counter (0 + 5 + 3 = 8).
+    let seq = driver
+        .load_dense_seq(&key)
+        .await
+        .expect("load_dense_seq must succeed");
+    assert_eq!(seq, 8, "load_dense_seq reflects cumulative count");
+
+    // An independent key must start at 0, gapless from the beginning.
+    let key2 = SeqKey::try_new("users").unwrap();
+    let start2 = driver
+        .advance_dense(&key2, 1, Epoch::ZERO)
+        .await
+        .expect("advance for independent key");
+    assert_eq!(start2, 0, "independent key starts at 0");
+
+    // A second call on the independent key starts at 1.
+    let start3 = driver
+        .advance_dense(&key2, 4, Epoch::ZERO)
+        .await
+        .expect("second advance for independent key");
+    assert_eq!(start3, 1, "second advance on independent key starts at 1");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: three-node follower convergence
+// ---------------------------------------------------------------------------
+
+/// After the leader activates write version 5 and advances a key, a follower
+/// converges on the dense counter (read directly from its SM, since followers
+/// cannot issue a linearizable read barrier without being the leader).
+#[tokio::test(start_paused = true)]
+async fn three_node_follower_converges_on_dense_seq() {
+    let cluster = build_three_node().await;
+
+    let leader_idx = find_leader_idx(&cluster).await;
+    let follower_idx = (0..3)
+        .find(|i| *i != leader_idx)
+        .expect("at least one follower");
+
+    let leader_node = &cluster.nodes[leader_idx];
+    let leader_driver = &cluster.drivers[leader_idx];
+    let follower_sm = cluster.nodes[follower_idx].sm.clone();
+
+    // Activate write version 5 on the leader. In a three-node cluster, the
+    // all-members gate requires all three nodes to report
+    // max_readable_version >= 5. Every node runs the same binary
+    // (MAX_READABLE_VERSION = 5), so the AllCapableSource answers
+    // truthfully for every remote peer.
+    let host = StandaloneHost::new(leader_node.raft.clone(), leader_node.sm.clone());
+    let source = AllCapableSource::uniform(
+        tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION,
+        &[1, 2, 3],
+    );
+    host.initiate_format_activation(DENSE_WRITE_VERSION, &source)
+        .await
+        .expect("three-node activation must succeed when all members can read v5");
+
+    // Advance "orders" by 7 through the leader.
+    let key = SeqKey::try_new("orders").unwrap();
+    let start = leader_driver
+        .advance_dense(&key, 7, Epoch::ZERO)
+        .await
+        .expect("advance_dense on leader after activation");
+    assert_eq!(start, 0, "first advance starts at 0");
+
+    // Wait for the follower's SM to replicate and apply the dense entry.
+    let key_str = key.as_str().to_owned();
+    eventually_eq(7u64, Duration::from_secs(5), || {
+        let sm = follower_sm.clone();
+        let k = key_str.clone();
+        async move { sm.dense_value(&k) }
+    })
+    .await;
+
+    // The leader's `load_dense_seq` (linearizable) returns 7.
+    let seq = leader_driver
+        .load_dense_seq(&key)
+        .await
+        .expect("load_dense_seq on leader");
+    assert_eq!(seq, 7, "leader load_dense_seq = 7 after advance by 7");
+}

--- a/crates/tsoracle-driver-openraft/tests/dense_restart_replay.rs
+++ b/crates/tsoracle-driver-openraft/tests/dense_restart_replay.rs
@@ -46,7 +46,7 @@ use tsoracle_driver_openraft::{
 };
 use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
 
-use common::{TestCluster, build_single_node, reopen_node};
+use common::{TestCluster, build_single_node, highest_log_record_version, reopen_node};
 
 /// A `CapabilitySource` for single-node clusters that must never be called:
 /// the local node short-circuit answers entirely from itself without any peer
@@ -197,4 +197,61 @@ async fn restart_replays_dense_map_from_rocksdb_log() {
         .await
         .expect("advance a new key after restart — genesis cap must survive");
     assert_eq!(start_new, 0, "new key after restart starts at 0");
+}
+
+/// The rollout safety property the harness must actually exercise: once write
+/// version 5 is activated, dense records are *persisted at v5* (not the
+/// baseline), and a restart recovers the active write version from that durable
+/// log evidence.
+///
+/// This pins the fix for the harness wiring bug where the log store and the
+/// state machine held *separate* `ActiveWriteVersion` cells: activation flipped
+/// only the SM's cell, so the log store kept stamping appended dense records at
+/// the baseline (v4). Production threads one shared cell into both writers
+/// (standalone bootstrap), and the harness now mirrors that.
+#[tokio::test(start_paused = true)]
+async fn dense_records_persist_at_v5_and_recover_on_restart() {
+    let cluster = build_single_node().await;
+    let TestCluster {
+        mut nodes, drivers, ..
+    } = cluster;
+    let driver = drivers[0].clone();
+
+    wait_for_leadership(&driver).await;
+
+    let host = StandaloneHost::new(nodes[0].raft.clone(), nodes[0].sm.clone());
+    host.initiate_format_activation(DENSE_WRITE_VERSION, &UnusedSource)
+        .await
+        .expect("activation must succeed on a single-node cluster");
+
+    // Append a dense record *after* activation. With one shared cell this is
+    // stamped at the activated write version (5); with the prior split-cell bug
+    // the log store still stamped it at the baseline (4).
+    let key_orders = SeqKey::try_new("orders").unwrap();
+    driver
+        .advance_dense(&key_orders, 5, Epoch::ZERO)
+        .await
+        .expect("advance orders by 5");
+
+    // PRIMARY: the dense record is durably framed at v5.
+    assert_eq!(
+        highest_log_record_version(&nodes[0]),
+        Some(DENSE_WRITE_VERSION),
+        "dense log record appended after activation must be stamped at the \
+         activated write version (regression: split cells stamped it at baseline)"
+    );
+
+    drop(driver);
+    drop(drivers);
+
+    // Restart: recovery must lift the active write version back to v5 from the
+    // durable log evidence (no snapshot was taken in this test), so subsequent
+    // appends and snapshot builds continue at v5.
+    let prior = nodes.remove(0);
+    let reopened = reopen_node(prior).await;
+    assert_eq!(
+        reopened.sm.active_write_version(),
+        DENSE_WRITE_VERSION,
+        "restart must recover active_write_version from durable log evidence"
+    );
 }

--- a/crates/tsoracle-driver-openraft/tests/dense_restart_replay.rs
+++ b/crates/tsoracle-driver-openraft/tests/dense_restart_replay.rs
@@ -1,0 +1,200 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Restart-replay integration test for dense state.
+//!
+//! Activates write version 5, advances a couple of dense keys, shuts down
+//! the cluster cleanly, reopens it against the same on-disk rocksdb log, and
+//! asserts that:
+//!
+//! - The dense counters replayed to their persisted values (the next
+//!   `advance_dense` call returns the persisted `start`, with no gap).
+//! - The genesis cardinality cap survived (advancing continues to work
+//!   without cardinality errors).
+
+mod common;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, LeaderState};
+use tsoracle_core::{Epoch, SeqKey};
+use tsoracle_driver_openraft::{
+    CapabilitySource, NodeCapabilities, OpenraftDriver, OpenraftPeer, StandaloneHost,
+};
+use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
+
+use common::{TestCluster, build_single_node, reopen_node};
+
+/// A `CapabilitySource` for single-node clusters that must never be called:
+/// the local node short-circuit answers entirely from itself without any peer
+/// RPCs.
+struct UnusedSource;
+
+#[async_trait]
+impl CapabilitySource for UnusedSource {
+    type Node = OpenraftPeer;
+
+    async fn query(
+        &self,
+        node_id: u64,
+        _member: &OpenraftPeer,
+    ) -> Result<NodeCapabilities, String> {
+        panic!("single-node gate must not query remote node {node_id}");
+    }
+}
+
+/// Wait for a single-node cluster to elect itself leader; return the epoch.
+async fn wait_for_leadership(driver: &OpenraftDriver<StandaloneHost>) {
+    let mut events = driver.leadership_events();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if matches!(s, LeaderState::Leader { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("single-node did not elect itself within 5s");
+}
+
+#[tokio::test(start_paused = true)]
+async fn restart_replays_dense_map_from_rocksdb_log() {
+    let cluster = build_single_node().await;
+    let TestCluster {
+        mut nodes, drivers, ..
+    } = cluster;
+    let driver = drivers[0].clone();
+
+    wait_for_leadership(&driver).await;
+
+    // Build a StandaloneHost to call `initiate_format_activation`.
+    let host = StandaloneHost::new(nodes[0].raft.clone(), nodes[0].sm.clone());
+
+    // Activate write version 5 through the real gate. Single-node short-circuits
+    // the all-members check, so UnusedSource is never called.
+    host.initiate_format_activation(DENSE_WRITE_VERSION, &UnusedSource)
+        .await
+        .expect("activation must succeed on a single-node cluster");
+    assert_eq!(
+        host.active_write_version(),
+        DENSE_WRITE_VERSION,
+        "cell must read DENSE_WRITE_VERSION after activation"
+    );
+
+    let key_orders = SeqKey::try_new("orders").unwrap();
+    let key_users = SeqKey::try_new("users").unwrap();
+
+    // Advance "orders" by 5, then by 3.
+    let start0 = driver
+        .advance_dense(&key_orders, 5, Epoch::ZERO)
+        .await
+        .expect("advance orders by 5");
+    assert_eq!(start0, 0, "first advance of orders starts at 0");
+
+    let start1 = driver
+        .advance_dense(&key_orders, 3, Epoch::ZERO)
+        .await
+        .expect("advance orders by 3");
+    assert_eq!(start1, 5, "second advance of orders starts at 5");
+
+    // Advance "users" by 1.
+    let start2 = driver
+        .advance_dense(&key_users, 1, Epoch::ZERO)
+        .await
+        .expect("advance users by 1");
+    assert_eq!(start2, 0, "first advance of users starts at 0");
+
+    // Verify SM state directly.
+    assert_eq!(
+        nodes[0].sm.dense_value("orders"),
+        8,
+        "orders dense counter = 8 before restart"
+    );
+    assert_eq!(
+        nodes[0].sm.dense_value("users"),
+        1,
+        "users dense counter = 1 before restart"
+    );
+
+    // Drop the drivers so they don't keep the raft alive past shutdown.
+    drop(driver);
+    drop(drivers);
+
+    // Reopen the node: shut down the prior Raft cleanly, then construct a
+    // fresh Raft + state machine against the same on-disk rocksdb log.
+    let prior = nodes.remove(0);
+    let reopened = reopen_node(prior).await;
+
+    // The SM must have replayed the dense counters from the log.
+    assert_eq!(
+        reopened.sm.dense_value("orders"),
+        8,
+        "orders dense counter must replay to 8 after restart"
+    );
+    assert_eq!(
+        reopened.sm.dense_value("users"),
+        1,
+        "users dense counter must replay to 1 after restart"
+    );
+
+    // Build a fresh driver + host against the reopened node.
+    let reopened_host = StandaloneHost::new(reopened.raft.clone(), reopened.sm.clone());
+    let reopened_driver = OpenraftDriver::new(reopened_host);
+
+    // Wait for re-leadership on the reopened node.
+    wait_for_leadership(&reopened_driver).await;
+
+    // The next advance_dense on "orders" must continue from start = 8 (no gap).
+    let start_after = reopened_driver
+        .advance_dense(&key_orders, 1, Epoch::ZERO)
+        .await
+        .expect("advance orders after restart");
+    assert_eq!(
+        start_after, 8,
+        "first advance of orders after restart must start at 8 (replayed)"
+    );
+
+    // load_dense_seq on "users" must return the replayed counter (1).
+    let users_seq = reopened_driver
+        .load_dense_seq(&key_users)
+        .await
+        .expect("load_dense_seq users after restart");
+    assert_eq!(
+        users_seq, 1,
+        "load_dense_seq(users) must return 1 after restart replay"
+    );
+
+    // Genesis cap survived: advancing a new key still works (no cardinality error
+    // from a stale cap = 0). DEFAULT_DENSE_CARDINALITY_CAP = 10_000 so two keys
+    // is nowhere near the limit.
+    let key_new = SeqKey::try_new("payments").unwrap();
+    let start_new = reopened_driver
+        .advance_dense(&key_new, 10, Epoch::ZERO)
+        .await
+        .expect("advance a new key after restart — genesis cap must survive");
+    assert_eq!(start_new, 0, "new key after restart starts at 0");
+}

--- a/crates/tsoracle-driver-openraft/tests/dense_snapshot.rs
+++ b/crates/tsoracle-driver-openraft/tests/dense_snapshot.rs
@@ -1,0 +1,279 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Snapshot → purge → restart → replay acceptance test for the dense map.
+//!
+//! Configures a single-node cluster with an aggressive snapshot policy
+//! (`LogsSinceLast(4)` + `max_in_snapshot_log_to_keep = 0`) backed by a
+//! [`RocksdbSnapshotStore`] sharing the same `Arc<DB>` as the rocksdb log store.
+//!
+//! Activates write version 5, then advances dense keys enough to trigger a
+//! snapshot and log purge. Shuts the raft down, reopens the same on-disk
+//! rocksdb, and asserts that the dense map was restored FROM THE SNAPSHOT
+//! (the counters survive even though the log prefix covering the advances was
+//! purged).
+//!
+//! Without dense-state restore, the SM would come back with `dense = {}` and the
+//! first post-restart `advance_dense` would return `start = 0` rather than the
+//! persisted counter, violating the gapless guarantee.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use openraft::async_runtime::watch::WatchReceiver;
+use openraft::storage::RaftLogStorage;
+use openraft::{Config, SnapshotPolicy};
+use tokio::time::timeout;
+use tsoracle_consensus::{ConsensusDriver, LeaderState};
+use tsoracle_core::{Epoch, SeqKey};
+use tsoracle_driver_openraft::{
+    CapabilitySource, NodeCapabilities, OpenraftDriver, OpenraftLogCodec, OpenraftPeer,
+    StandaloneHost, TypeConfig,
+};
+use tsoracle_openraft_toolkit::{DENSE_WRITE_VERSION, Flat, RocksdbLogStore};
+
+use common::{TestCluster, build_single_node_with_config, reopen_node_with_config};
+
+/// A `CapabilitySource` for single-node clusters that must never be called.
+struct UnusedSource;
+
+#[async_trait]
+impl CapabilitySource for UnusedSource {
+    type Node = OpenraftPeer;
+
+    async fn query(
+        &self,
+        node_id: u64,
+        _member: &OpenraftPeer,
+    ) -> Result<NodeCapabilities, String> {
+        panic!("single-node gate must not query remote node {node_id}");
+    }
+}
+
+fn aggressive_snapshot_config() -> Arc<Config> {
+    Arc::new(
+        Config {
+            heartbeat_interval: 50,
+            election_timeout_min: 150,
+            election_timeout_max: 300,
+            // Snapshot every 4 entries; purge everything covered by the snapshot.
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(4),
+            max_in_snapshot_log_to_keep: 0,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap(),
+    )
+}
+
+/// Wait for a single-node cluster to elect itself leader.
+async fn wait_for_leadership(driver: &OpenraftDriver<StandaloneHost>) {
+    let mut events = driver.leadership_events();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let s = events.next().await.expect("event stream alive");
+            if matches!(s, LeaderState::Leader { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("single-node did not elect itself within 5s");
+}
+
+#[tokio::test(start_paused = true)]
+async fn dense_map_survives_snapshot_build_and_log_purge() {
+    let cluster = build_single_node_with_config(aggressive_snapshot_config()).await;
+    let TestCluster {
+        mut nodes, drivers, ..
+    } = cluster;
+    let driver = drivers[0].clone();
+
+    wait_for_leadership(&driver).await;
+
+    // Build a StandaloneHost to call `initiate_format_activation`.
+    let host = StandaloneHost::new(nodes[0].raft.clone(), nodes[0].sm.clone());
+
+    // Activate write version 5. Single-node short-circuits the all-members check.
+    host.initiate_format_activation(DENSE_WRITE_VERSION, &UnusedSource)
+        .await
+        .expect("activation must succeed on a single-node cluster");
+    assert_eq!(
+        host.active_write_version(),
+        DENSE_WRITE_VERSION,
+        "cell must read DENSE_WRITE_VERSION after activation"
+    );
+
+    let key_orders = SeqKey::try_new("orders").unwrap();
+    let key_users = SeqKey::try_new("users").unwrap();
+
+    // Advance dense keys interleaved with high-water bumps. With
+    // LogsSinceLast(4) and max_in_snapshot_log_to_keep=0, we need enough
+    // entries to trigger at least one snapshot and log purge. 8 rounds of two
+    // entries (advance_dense + persist_high_water) gives 16 entries, well above
+    // the threshold.
+    for i in 0u32..8 {
+        driver
+            .advance_dense(&key_orders, 1, Epoch::ZERO)
+            .await
+            .expect("advance orders");
+        // Interleave a high-water bump to ensure plenty of entries flow through.
+        driver
+            .persist_high_water(u64::from(i + 1) * 100, Epoch::ZERO)
+            .await
+            .expect("persist_high_water");
+    }
+
+    // Advance "users" to a non-trivial value.
+    driver
+        .advance_dense(&key_users, 5, Epoch::ZERO)
+        .await
+        .expect("advance users");
+
+    // Expected dense state: orders = 8, users = 5.
+    let orders_before = nodes[0].sm.dense_value("orders");
+    let users_before = nodes[0].sm.dense_value("users");
+    assert_eq!(
+        orders_before, 8,
+        "orders counter = 8 before snapshot+restart"
+    );
+    assert_eq!(users_before, 5, "users counter = 5 before snapshot+restart");
+
+    // Wait for a snapshot to have been built (and thus log purge).
+    let metrics = nodes[0].raft.metrics();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let snapshot_log_id = metrics.borrow_watched().snapshot;
+            if snapshot_log_id.is_some() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("snapshot built within 5s");
+
+    let snapshot_log_id = metrics.borrow_watched().snapshot.expect("snapshot built");
+
+    // Verify openraft actually purged the log past the snapshot. Without this
+    // the test could pass even without snapshot persistence — the recovered SM
+    // would just rebuild from log replay.
+    let log_inspector: RocksdbLogStore<TypeConfig, Flat, OpenraftLogCodec> =
+        RocksdbLogStore::open(nodes[0].db.clone(), "raft_log", "raft_meta", Flat).unwrap();
+    timeout(Duration::from_secs(5), async {
+        let mut inspector = log_inspector;
+        loop {
+            let state = inspector.get_log_state().await.unwrap();
+            if let Some(purged) = state.last_purged_log_id {
+                if purged.index >= snapshot_log_id.index {
+                    return purged;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("log purged up to the snapshot within 5s");
+
+    // Drop driver handles before the reopen helper shuts the raft down.
+    drop(driver);
+    drop(drivers);
+
+    // Reopen with the same rocksdb DB. The state machine must come up with the
+    // dense map restored FROM THE SNAPSHOT (the log prefix covering the advances
+    // has been purged).
+    let prior = nodes.remove(0);
+    let reopened = reopen_node_with_config(prior, aggressive_snapshot_config()).await;
+
+    assert_eq!(
+        reopened.sm.dense_value("orders"),
+        8,
+        "orders dense counter must be restored from snapshot (expected 8)"
+    );
+    assert_eq!(
+        reopened.sm.dense_value("users"),
+        5,
+        "users dense counter must be restored from snapshot (expected 5)"
+    );
+
+    // Cluster is still functional post-restart.
+    let reopened_host = StandaloneHost::new(reopened.raft.clone(), reopened.sm.clone());
+    let reopened_driver = OpenraftDriver::new(StandaloneHost::new(
+        reopened.raft.clone(),
+        reopened.sm.clone(),
+    ));
+
+    let mut events = reopened_driver.leadership_events();
+    timeout(Duration::from_secs(10), async {
+        loop {
+            let state = events.next().await.expect("event stream alive");
+            if matches!(state, LeaderState::Leader { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("re-became leader within 10s");
+
+    // The `ActiveWriteVersion` cell starts at BASELINE after restart — it is
+    // recovered only via log replay of `SetFormatVersion` entries. With
+    // aggressive snapshot + purge, those log entries are gone. Re-activate
+    // write version 5 so the gate allows `advance_dense`. This is the
+    // expected operator flow: on a cluster that has already activated v5, the
+    // re-activation no-ops (the subset is already satisfied; the activation
+    // entry re-flips the cell when applied). The dense map was already
+    // correctly restored from the snapshot above.
+    reopened_host
+        .initiate_format_activation(DENSE_WRITE_VERSION, &UnusedSource)
+        .await
+        .expect("re-activation after snapshot-restore restart must succeed");
+    assert_eq!(
+        reopened_host.active_write_version(),
+        DENSE_WRITE_VERSION,
+        "write version cell must be at DENSE_WRITE_VERSION after re-activation"
+    );
+
+    // The next advance_dense on "orders" must continue from start = 8 (no gap).
+    let start_after = reopened_driver
+        .advance_dense(&key_orders, 2, Epoch::ZERO)
+        .await
+        .expect("advance orders after snapshot restart");
+    assert_eq!(
+        start_after, 8,
+        "first advance of orders after snapshot-restore must start at 8"
+    );
+
+    // load_dense_seq on "users" must return the restored counter (5).
+    let users_seq = reopened_driver
+        .load_dense_seq(&key_users)
+        .await
+        .expect("load_dense_seq users after snapshot restart");
+    assert_eq!(
+        users_seq, 5,
+        "load_dense_seq(users) must return 5 after snapshot-restore restart"
+    );
+}

--- a/crates/tsoracle-driver-openraft/tests/generate_fuzz_seeds.rs
+++ b/crates/tsoracle-driver-openraft/tests/generate_fuzz_seeds.rs
@@ -83,6 +83,8 @@ fn generate_snapshot_payload_decode_seeds() {
         current_value: 0,
         last_applied: None,
         last_membership: StoredMembershipOf::<TypeConfig>::default(),
+        dense: std::collections::BTreeMap::new(),
+        dense_cap: 0,
     };
     write_seed(
         target,
@@ -95,6 +97,8 @@ fn generate_snapshot_payload_decode_seeds() {
         current_value: u64::MAX,
         last_applied: None,
         last_membership: StoredMembershipOf::<TypeConfig>::default(),
+        dense: std::collections::BTreeMap::new(),
+        dense_cap: 0,
     };
     write_seed(
         target,

--- a/crates/tsoracle-driver-paxos/src/host.rs
+++ b/crates/tsoracle-driver-paxos/src/host.rs
@@ -27,9 +27,9 @@
 //! is persisted, and how `current_high_water` / `submit_advance` interact
 //! with the underlying paxos log. The bundled [`crate::StandaloneHost`]
 //! owns its own OmniPaxos cluster + apply pipeline keyed on
-//! [`HighWaterCommand`]. A larger service that already runs OmniPaxos for
+//! [`HighWaterCommand`](crate::log_entry::HighWaterCommand). A larger service that already runs OmniPaxos for
 //! other state can implement this trait against its existing handle and
-//! pick its own [`Entry`](omnipaxos::storage::Entry) — typically an
+//! pick its own [`Entry`] — typically an
 //! envelope enum that carries `HighWaterCommand` as one variant alongside
 //! the service's own commands.
 

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -62,7 +62,7 @@ pub const MIN_READABLE_VERSION: u8 = 4;
 /// derives from `BASELINE_WRITE_VERSION` so a future baseline bump moves
 /// MAX automatically with no edit here.
 #[cfg(not(feature = "e2e-max-readable-next"))]
-pub const MAX_READABLE_VERSION: u8 = 4;
+pub const MAX_READABLE_VERSION: u8 = 5;
 #[cfg(feature = "e2e-max-readable-next")]
 pub const MAX_READABLE_VERSION: u8 = BASELINE_WRITE_VERSION + 1;
 
@@ -78,6 +78,13 @@ const _: () = assert!(MIN_READABLE_VERSION <= MAX_READABLE_VERSION);
 /// cell only ever advances via a successful, committed activation apply (P5),
 /// so in this release every framed record still leads with this byte.
 pub const BASELINE_WRITE_VERSION: u8 = 4;
+
+/// The write version that introduces the `AdvanceDense` log command and the
+/// dense fields in the state-machine snapshot. A leader must not append an
+/// `AdvanceDense` entry (and `GetSeq` is refused) until the active write
+/// version has been activated to at least this value through the all-members
+/// gate — otherwise an older member could receive an entry it cannot decode.
+pub const DENSE_WRITE_VERSION: u8 = 5;
 
 /// Process-shared, runtime-mutable active write version.
 ///
@@ -188,10 +195,12 @@ mod tests {
 
     #[cfg(not(feature = "e2e-max-readable-next"))]
     #[test]
-    fn version_constants_are_at_the_v4_baseline() {
+    fn version_constants_are_at_expected_values() {
         assert_eq!(MIN_READABLE_VERSION, 4);
-        assert_eq!(MAX_READABLE_VERSION, 4);
+        // MAX raised to 5 to cover the dense write version (DENSE_WRITE_VERSION).
+        assert_eq!(MAX_READABLE_VERSION, 5);
         assert_eq!(BASELINE_WRITE_VERSION, 4);
+        assert_eq!(DENSE_WRITE_VERSION, 5);
     }
 
     #[cfg(feature = "e2e-max-readable-next")]

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -52,19 +52,21 @@ pub const MIN_READABLE_VERSION: u8 = 4;
 /// grows. Decode accepts `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
 ///
 /// Production builds set this to the current baseline. The test-only
-/// `e2e-max-readable-next` feature raises it to `BASELINE_WRITE_VERSION + 1`
+/// `e2e-max-readable-next` feature raises it to `BASELINE_WRITE_VERSION + 2`
 /// so a mixed-version e2e harness can drive a real activation flip from the
 /// baseline to the next version. The aliased body is byte-identical to the
-/// baseline (added by `BASELINE + 1` alias arms on the per-version codec in
+/// baseline (added by `BASELINE + 2` alias arms on the per-version codec in
 /// `tsoracle-driver-openraft` under the matching feature), so this is a
 /// faithful harness for the activation machinery rather than a real format
 /// change. Off by default; never compiled into production. The expression
 /// derives from `BASELINE_WRITE_VERSION` so a future baseline bump moves
-/// MAX automatically with no edit here.
+/// MAX automatically with no edit here. (Version 5 = `DENSE_WRITE_VERSION`
+/// is reserved for the real dense-sequence format; the synthetic harness
+/// rides on `BASELINE + 2` = 6 to avoid colliding with it — see #583.)
 #[cfg(not(feature = "e2e-max-readable-next"))]
 pub const MAX_READABLE_VERSION: u8 = 5;
 #[cfg(feature = "e2e-max-readable-next")]
-pub const MAX_READABLE_VERSION: u8 = BASELINE_WRITE_VERSION + 1;
+pub const MAX_READABLE_VERSION: u8 = BASELINE_WRITE_VERSION + 2;
 
 // Compile-time guard: the readable range must be non-empty (`MIN <= MAX`) or
 // every decode rejects every record. Catches a future inverted-constants edit
@@ -206,15 +208,17 @@ mod tests {
     #[cfg(feature = "e2e-max-readable-next")]
     #[test]
     fn version_constants_under_e2e_max_readable_next_feature() {
-        // Test-only harness: MAX rises to `BASELINE + 1` so a mixed-version
+        // Test-only harness: MAX rises to `BASELINE + 2` so a mixed-version
         // e2e can drive a real activation flip from the baseline to the
         // next version. MIN and BASELINE are unchanged — the harness
         // raises only the read ceiling (Stage 1 of a real rollout); the
         // active write version still starts at BASELINE and only moves
         // through the normal activation barrier. Assert against the
         // baseline expression so this test survives a future baseline
-        // bump unchanged.
-        assert_eq!(MAX_READABLE_VERSION, BASELINE_WRITE_VERSION + 1);
+        // bump unchanged. (`BASELINE + 1` = 5 is `DENSE_WRITE_VERSION`
+        // which owns real codec arms; synthetic harness uses `BASELINE + 2`
+        // = 6 to avoid colliding — interim until #583.)
+        assert_eq!(MAX_READABLE_VERSION, BASELINE_WRITE_VERSION + 2);
         // `MAX > MIN` would tautologically follow from the above plus
         // `BASELINE >= MIN` (which is true by definition: BASELINE is in
         // the readable range). The compile-time `const _: () =

--- a/crates/tsoracle-openraft-toolkit/src/lib.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lib.rs
@@ -40,8 +40,9 @@ pub mod lifecycle;
 pub mod test_fakes;
 
 pub use codec::{
-    ActiveWriteVersion, BASELINE_WRITE_VERSION, CodecError, MAX_READABLE_VERSION,
-    MIN_READABLE_VERSION, codec_io_error, decode, encode, recover_active_write_version,
+    ActiveWriteVersion, BASELINE_WRITE_VERSION, CodecError, DENSE_WRITE_VERSION,
+    MAX_READABLE_VERSION, MIN_READABLE_VERSION, codec_io_error, decode, encode,
+    recover_active_write_version,
 };
 pub use codec_provider::{DefaultLogStoreCodec, LogStoreCodec};
 pub use lifecycle::{

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -767,7 +767,7 @@ mod record_codec_tests {
     }
 
     // Pinned to BASELINE in the default build; the test-only
-    // `e2e-max-readable-next` feature lifts MAX to `BASELINE + 1`, so
+    // `e2e-max-readable-next` feature lifts MAX to `BASELINE + 2`, so
     // skip the MAX assertion under that feature (covered by
     // `version_constants_under_e2e_max_readable_next_feature` in
     // `codec.rs`).

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -388,7 +388,7 @@ where
     ///
     /// Reads only each record's leading byte (no postcard body parse), so a
     /// record from any version in the readable range contributes its byte
-    /// without needing its parser. Bounded by `lo` like [`last_log_id_in_cf`]:
+    /// without needing its parser. Bounded by `lo` like `last_log_id_in_cf`:
     /// for `GroupPrefixed` the reverse iterator can walk into a neighbouring
     /// group's bytes, so any key below `lo` ends the scan.
     pub fn highest_log_record_version(&self) -> io::Result<Option<u8>> {

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -773,10 +773,11 @@ mod record_codec_tests {
     // `codec.rs`).
     #[cfg(not(feature = "e2e-max-readable-next"))]
     #[test]
-    fn version_constants_are_at_four() {
+    fn version_constants_are_at_expected_values() {
         assert_eq!(BASELINE_WRITE_VERSION, 4);
         assert_eq!(MIN_READABLE_VERSION, 4);
-        assert_eq!(MAX_READABLE_VERSION, 4);
+        // MAX raised to 5 to cover the dense write version (DENSE_WRITE_VERSION).
+        assert_eq!(MAX_READABLE_VERSION, 5);
     }
 }
 

--- a/crates/tsoracle-server-testkit/src/lib.rs
+++ b/crates/tsoracle-server-testkit/src/lib.rs
@@ -107,7 +107,7 @@ pub fn client(host: &str, port: u16) -> Result<TsoServiceClient<Channel>, BoxErr
 /// network. Bare `host:port` is rewritten to `http://host:port`.
 ///
 /// This is the per-endpoint building block for driving the *high-level*
-/// [`tsoracle_client::Client`] over turmoil: pass a closure delegating to
+/// `tsoracle_client::Client` over turmoil: pass a closure delegating to
 /// it into `ClientBuilder::channel_connector`, and the client's pool —
 /// including leader-hint redirects — dials every endpoint through the
 /// simulated network.

--- a/crates/tsoracle-server/src/persist_disposition.rs
+++ b/crates/tsoracle-server/src/persist_disposition.rs
@@ -107,7 +107,10 @@ pub(crate) fn classify(error: ConsensusError) -> PersistDisposition {
         // string-wrapped `io::Error`.
         dense_error @ (ConsensusError::DenseUnsupported
         | ConsensusError::SeqKeyCardinalityExceeded { .. }
-        | ConsensusError::SeqOverflow) => PersistDisposition::Permanent(Box::new(dense_error)),
+        | ConsensusError::SeqOverflow
+        | ConsensusError::DenseNotActivated { .. }) => {
+            PersistDisposition::Permanent(Box::new(dense_error))
+        }
     }
 }
 

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -314,6 +314,15 @@ impl TsoService for TsoServiceImpl {
             Err(ConsensusError::DenseUnsupported) => Err(Status::unimplemented(
                 "dense sequences are not supported by this consensus driver",
             )),
+            // The driver supports dense sequences but the cluster has not yet
+            // activated write version 5 across all members. Surfaces as
+            // FAILED_PRECONDITION (bare — no leader-hint trailer) so the
+            // client raises it definitively rather than riding out an election.
+            Err(ConsensusError::DenseNotActivated { required, active }) => {
+                Err(Status::failed_precondition(format!(
+                    "dense sequence format not yet activated (cluster at write version {active}, requires {required})"
+                )))
+            }
             // A transient driver fault (storage hiccup, momentary quorum loss)
             // is safe to retry → UNAVAILABLE. Everything else reaching here is a
             // permanent fault (PermanentDriver, AdvanceOutOfRange) the client

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -333,7 +333,7 @@ impl TsoService for FixedHintService {
 /// Bind a TLS gRPC peer on `127.0.0.1:0` that always replies `NOT_LEADER` with a
 /// leader-hint trailer pointing at `hint_endpoint`, and return its address. The
 /// spawned task is detached and lives until the test process exits. See
-/// [`FixedHintService`] for why tests inject the hint here rather than through a
+/// the private `FixedHintService` for why tests inject the hint here rather than through a
 /// real server's leader-watch path.
 #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
 pub async fn boot_fixed_hint_server_tls(

--- a/crates/tsoracle-server/tests/get_seq.rs
+++ b/crates/tsoracle-server/tests/get_seq.rs
@@ -159,6 +159,53 @@ async fn get_seq_empty_key_returns_invalid_argument() {
 /// to assert how the GetSeq handler surfaces an unsupported driver.
 struct DenseUnsupportedDriver;
 
+/// A driver that supports dense sequences but returns `DenseNotActivated` from
+/// `advance_dense`, simulating a cluster that has not yet activated write
+/// version 5 across all members.
+struct DenseNotActivatedDriver;
+
+#[async_trait::async_trait]
+impl tsoracle_consensus::ConsensusDriver for DenseNotActivatedDriver {
+    fn leadership_events(
+        &self,
+    ) -> std::pin::Pin<Box<dyn futures::Stream<Item = tsoracle_consensus::LeaderState> + Send>>
+    {
+        use futures::StreamExt;
+        Box::pin(
+            futures::stream::once(async {
+                tsoracle_consensus::LeaderState::Leader {
+                    epoch: tsoracle_core::Epoch::ZERO,
+                }
+            })
+            .chain(futures::stream::pending()),
+        )
+    }
+
+    async fn load_high_water(&self) -> Result<u64, tsoracle_consensus::ConsensusError> {
+        Ok(0)
+    }
+
+    async fn persist_high_water(
+        &self,
+        at_least: u64,
+        _epoch: tsoracle_core::Epoch,
+    ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+        Ok(at_least)
+    }
+
+    async fn advance_dense(
+        &self,
+        _key: &tsoracle_core::SeqKey,
+        _count: u32,
+        _epoch: tsoracle_core::Epoch,
+    ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+        Err(tsoracle_consensus::ConsensusError::DenseNotActivated {
+            required: 5,
+            active: 4,
+        })
+    }
+}
+
 #[async_trait::async_trait]
 impl tsoracle_consensus::ConsensusDriver for DenseUnsupportedDriver {
     fn leadership_events(
@@ -227,6 +274,49 @@ async fn get_seq_unsupported_driver_returns_unimplemented() {
         err.code(),
         tonic::Code::Unimplemented,
         "a leader without dense support must return UNIMPLEMENTED, got: {err:?}"
+    );
+
+    booted.shutdown().await.unwrap();
+}
+
+/// A leader whose driver returns `DenseNotActivated` must surface GetSeq as
+/// `FAILED_PRECONDITION` with a "not yet activated" message — not as `INTERNAL`
+/// (the catch-all). The response carries no leader-hint trailer so the client
+/// surfaces it definitively rather than riding out an election.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_seq_dense_not_activated_returns_failed_precondition() {
+    let server = Server::builder()
+        .consensus_driver(std::sync::Arc::new(DenseNotActivatedDriver))
+        .window_ahead(Duration::from_secs(1))
+        .failover_advance(Duration::from_millis(500))
+        .build()
+        .unwrap();
+
+    let mut booted = boot_server(server).await;
+    wait_until_serving(&mut booted.state_rx).await;
+    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
+        .await
+        .expect("tonic never accepted gRPC handshake");
+    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
+        .await
+        .unwrap();
+
+    let err = client
+        .get_seq(GetSeqRequest {
+            key: "orders".to_string(),
+            count: 1,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.code(),
+        tonic::Code::FailedPrecondition,
+        "DenseNotActivated must return FAILED_PRECONDITION, got: {err:?}"
+    );
+    assert!(
+        err.message().contains("not yet activated"),
+        "message must mention 'not yet activated', got: {:?}",
+        err.message()
     );
 
     booted.shutdown().await.unwrap();

--- a/crates/tsoracle-yieldpoint/src/lib.rs
+++ b/crates/tsoracle-yieldpoint/src/lib.rs
@@ -69,7 +69,7 @@ pub use registry::{cfg, get, remove};
 /// zero overhead. When on, an armed entry parks the calling task on
 /// `Notify::notified().await` — yielding the tokio worker so timers and
 /// other tasks continue to run. Release with `notify_one()` on the
-/// handle returned by [`cfg`].
+/// handle returned by [`cfg`](cfg()).
 #[cfg(feature = "yieldpoints")]
 #[macro_export]
 macro_rules! yieldpoint {

--- a/e2e/kube/run-mixed-version-assertions.sh
+++ b/e2e/kube/run-mixed-version-assertions.sh
@@ -13,10 +13,11 @@ here="$(cd "$(dirname "$0")" && pwd)"
 source "$here/_assertions_lib.sh"
 
 # Activation target. BASELINE_WRITE_VERSION is 4 today; e2e-max-readable-next
-# raises MAX_READABLE_VERSION to BASELINE+1 = 5. If BASELINE bumps, this
-# constant trips a visible mismatch on the next run rather than silently
-# activating to an unintended version.
-ACTIVATION_TARGET=5
+# raises MAX_READABLE_VERSION to BASELINE+2 = 6 (BASELINE+1 = 5 is reserved
+# for DENSE_WRITE_VERSION — see #583). If BASELINE bumps, this constant trips
+# a visible mismatch on the next run rather than silently activating to an
+# unintended version.
+ACTIVATION_TARGET=6
 # Loopback admin port; matches deploy/entrypoint.sh:12 ADMIN_PORT default
 # and the chart values.yaml ports.admin entry added in Task 7.
 ADMIN_PORT=51002

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -275,6 +275,22 @@ impl RaftStateMachine<HostTypeConfig> for HostStateMachine {
                         tso: Some(core.high_water),
                     }
                 }
+                EntryPayload::Normal(HostCommand::Tso(HighWaterCommand::AdvanceDense {
+                    ..
+                })) => {
+                    // The piggyback example does not implement dense sequence
+                    // state. This arm handles the exhaustiveness requirement
+                    // introduced when `AdvanceDense` was added in Task 2 of the
+                    // dense-openraft plan. A real piggyback host that supports
+                    // dense sequences would forward this entry to a
+                    // `HighWaterStateMachine` (Task 6 of that plan).
+                    let mut core = self.core.lock();
+                    core.last_applied = Some(log_id);
+                    HostApplied {
+                        kv: None,
+                        tso: Some(core.high_water),
+                    }
+                }
                 EntryPayload::Membership(membership) => {
                     let mut core = self.core.lock();
                     core.last_membership = StoredMembership::new(Some(log_id), membership.clone());

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -406,6 +406,30 @@ impl OpenraftHighWaterHost for PiggybackHost {
             Err(e) => Err(ConsensusError::TransientDriver(Box::new(e))),
         }
     }
+
+    fn active_write_version(&self) -> u8 {
+        // The piggyback host does not own an `ActiveWriteVersion` cell — dense
+        // sequences are not implemented here. Return BASELINE so the driver
+        // gate always returns `DenseNotActivated` for this host (dense is
+        // deferred for piggyback; a real dense piggyback would share a cell).
+        tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION
+    }
+
+    async fn submit_advance_dense(
+        &self,
+        _key: &tsoracle_core::SeqKey,
+        _count: u32,
+    ) -> Result<u64, ConsensusError> {
+        // Dense sequences are not implemented in the piggyback example.
+        // The driver gate (`active_write_version < DENSE_WRITE_VERSION`)
+        // prevents this from ever being called in normal operation.
+        Err(ConsensusError::DenseUnsupported)
+    }
+
+    async fn current_dense_seq(&self, _key: &tsoracle_core::SeqKey) -> Result<u64, ConsensusError> {
+        // Dense sequences are not implemented in the piggyback example.
+        Err(ConsensusError::DenseUnsupported)
+    }
 }
 
 #[cfg(test)]

--- a/examples/paxos-piggyback/src/host_service.rs
+++ b/examples/paxos-piggyback/src/host_service.rs
@@ -193,7 +193,7 @@ impl HostState {
 ///
 /// Pure with respect to consensus — does not lock any OmniPaxos handle, does
 /// not signal the apply notifier. Callers that drain a decided suffix should
-/// invoke this per entry and then call [`HostState::apply_notify`].
+/// invoke this per entry and then call the private `HostState::apply_notify`.
 ///
 /// Half-isolation: `Kv` variants touch only the KV map; `HighWater` variants
 /// touch only the high-water cell (or the barrier ledger). `Advance` is

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -137,6 +137,14 @@ bench             = false
 doctest           = false
 
 [[bin]]
+name              = "openraft_dense_command_decode"
+path              = "fuzz_targets/openraft_dense_command_decode.rs"
+test              = false
+doc               = false
+bench             = false
+doctest           = false
+
+[[bin]]
 name              = "codec_roundtrip"
 path              = "fuzz_targets/codec_roundtrip.rs"
 test              = false

--- a/fuzz/fuzz_targets/openraft_dense_command_decode.rs
+++ b/fuzz/fuzz_targets/openraft_dense_command_decode.rs
@@ -1,0 +1,34 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use tsoracle_driver_openraft::{HighWaterStateMachineSnapshot, OpenraftEntry};
+use tsoracle_openraft_toolkit::{DENSE_WRITE_VERSION, decode};
+
+fuzz_target!(|data: &[u8]| {
+    // Dense snapshot payload at the dense write version (new BTreeMap field).
+    let _ = decode::<HighWaterStateMachineSnapshot>(DENSE_WRITE_VERSION, data);
+    // Full openraft entry decode (now includes the AdvanceDense command variant).
+    let _ = decode::<OpenraftEntry>(DENSE_WRITE_VERSION, data);
+});


### PR DESCRIPTION
## Summary

Adds keyed dense-sequence (`GetSeq`) support to the **openraft** driver, as a replicated state-machine command gated behind the existing all-members format-activation machinery. **Stacked on #579** (file-driver dense) — review/merge that first; this PR's base is the #579 branch so the diff shows only the openraft work.

- **Replicated command** `AdvanceDense { key, count }` at a new write version **5**, folded deterministically by the state machine (`start` computed at apply in committed log order; cardinality cap + `u64` overflow checked at apply). The proposer reads its `start` from the `client_write` apply response via new `ApplyOutcome::{DenseAdvanced, DenseCardinalityExceeded, DenseOverflow}` variants.
- **Format rollout gate (the load-bearing safety property):** `advance_dense` refuses with `ConsensusError::DenseNotActivated` → `FAILED_PRECONDITION` "not yet activated" until write version 5 is activated cluster-wide via a committed `SetFormatVersion`, which requires `all_members_can_read(5)`. A v5 record can never reach a v4-only member: the gate blocks the append, records are framed at the active write version, and a v4-only binary rejects a v5 record at the version gate (`CodecError::VersionUnsupported`) rather than misdecoding.
- **Per-version snapshot codec (postcard-safe):** a frozen `HighWaterStateMachineSnapshotV4` struct + convert-on-decode for v4; the real ungated v5 (dense) layout; a fail-loud `NotRepresentable` if a v4 encode ever saw dense data. The dense `BTreeMap<String,u64>` + immutable genesis cardinality cap live in the state machine and its snapshots (deterministic replay).
- **Recovery correctness:** restart recovers the active write version (≥5) from the snapshot/log version byte; `install_snapshot` advances the cell from the incoming snapshot's version byte so a newly-joined follower (whose `SetFormatVersion` entry was purged) doesn't revert to v4 and wedge on its next `build_snapshot` (found in final review, fixed + regression-tested).
- **e2e harness:** the synthetic `e2e-max-readable-next` soak was rebased v5→v6 (interim) so real dense owns v5; full retirement in favor of soaking the real v4→v5 migration is tracked in **#583**.

Paxos remains `DenseUnsupported`; its prerequisite (per-version codec machinery) is tracked in **#581**.

## Test plan
- [x] `cargo test --workspace --all-features` (green locally — SM apply, per-version codec round-trips incl. v4 old-bytes, restart-replay, snapshot-purge restore, install-snapshot version-byte advance, before/after-activation gate, three-node follower convergence, server status mapping)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean locally)
- [x] `cargo +nightly fuzz build openraft_dense_command_decode`
- [ ] Re-run the `kube-e2e-mixed-version` lane (now at synthetic v6) to confirm the rebase didn't disturb the activation soak

## Related
- Base: #579 (file-driver dense `GetSeq`)
- Docs: #580 (driver support matrix)
- Paxos prerequisite: #581
- e2e synthetic-harness retirement: #583