### PR TITLE
test(e2e): retire synthetic e2e-max-readable-next; soak real dense v4→v5 activation

### DIFF
--- a/.github/workflows/kube-e2e-mixed-version.yml
+++ b/.github/workflows/kube-e2e-mixed-version.yml
@@ -10,6 +10,8 @@ jobs:
   kube-e2e-mixed-version:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      BASELINE_REF: 2760a8d5e47f4610eda7559a0420e97f537414a2  # tsoracle-v2.0.0
     steps:
       - name: free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
@@ -26,15 +28,21 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-      - name: build baseline image (openraft only, no e2e feature)
+      - name: checkout baseline release (v4-only)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ env.BASELINE_REF }}
+          path: baseline-src
+          fetch-depth: 0
+      - name: build baseline image (v4-only, tsoracle-v2.0.0)
+        run: |
+          docker build -f baseline-src/deploy/Dockerfile \
+            --build-arg FEATURES=openraft \
+            -t tsoracle:e2e-baseline baseline-src
+      - name: build next image (openraft, v5-capable PR head)
         run: |
           docker build -f deploy/Dockerfile \
             --build-arg FEATURES=openraft \
-            -t tsoracle:e2e-baseline .
-      - name: build next image (openraft + e2e-max-readable-next)
-        run: |
-          docker build -f deploy/Dockerfile \
-            --build-arg FEATURES=openraft,e2e-max-readable-next \
             -t tsoracle:e2e-next .
       - name: build driver image
         run: docker build -f e2e/kube/driver/Dockerfile -t tsoracle-e2e-driver:latest .

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -20,12 +20,6 @@ openraft   = ["tsoracle-standalone/openraft"]
 paxos      = ["tsoracle-standalone/paxos"]
 reflection = ["tsoracle-server/reflection"]
 bt         = ["tsoracle-server/bt"]
-# Pass through `e2e-max-readable-next` to the standalone crate so the
-# production image (`deploy/Dockerfile` passing `--build-arg FEATURES=...`)
-# can opt in for the mixed-version kube-e2e lane. NEVER set in production
-# builds — see `tsoracle-openraft-toolkit` Cargo.toml for the safety
-# contract.
-e2e-max-readable-next = ["tsoracle-standalone/e2e-max-readable-next"]
 
 [dependencies]
 anyhow                = "1"

--- a/crates/tsoracle-driver-openraft/Cargo.toml
+++ b/crates/tsoracle-driver-openraft/Cargo.toml
@@ -25,18 +25,6 @@ rocksdb-snapshot-store = ["dep:rocksdb"]
 # lifecycle). Off by default so embedders that do not want the `metrics`
 # dependency are unaffected, matching `tsoracle-server`'s `metrics` feature.
 metrics                = ["dep:metrics"]
-# Test-only harness affordance: adds `BASELINE_WRITE_VERSION + 1` alias
-# arms to the per-version codec dispatch (`HighWaterStateMachineSnapshot`
-# / `PersistedSnapshot`) that delegate to the baseline body, and
-# propagates the matching toolkit feature so `MAX_READABLE_VERSION` rises
-# to `BASELINE + 1`. The aliased body is byte-identical to baseline; the
-# only difference is the leading version byte. This lets a mixed-version
-# e2e harness drive a real activation flip from baseline to the next
-# version end-to-end (gate -> propose -> commit -> apply -> cell flip)
-# without shipping a real new format. Off by default; never compiled
-# into production. The arm guard derives from `BASELINE_WRITE_VERSION`
-# so a future baseline bump moves the alias version with no edit here.
-e2e-max-readable-next  = ["tsoracle-openraft-toolkit/e2e-max-readable-next"]
 
 [dependencies]
 async-trait        = { workspace = true }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -142,13 +142,6 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
             // Ungated — production reads dense snapshots from v5-activated
             // clusters without any feature flag.
             v if v == DENSE_WRITE_VERSION => decode_postcard_exact(body),
-            // v6 (BASELINE + 2): synthetic activation-test alias. Body is
-            // byte-identical to the current layout — only the version byte
-            // changes — so the activation machinery (gate -> propose -> commit
-            // -> apply -> cell flip) can run end-to-end in a mixed-version e2e
-            // without shipping a real new format. Gated off in production. (#583)
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 2 => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -181,9 +174,6 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
             }
             // v5: the current (dense) layout encodes directly. Ungated.
             v if v == DENSE_WRITE_VERSION => encode_postcard(self),
-            // v6 synthetic alias — see decode_version comment above.
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 2 => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -203,9 +193,6 @@ impl VersionedCodec for PersistedSnapshot {
             // inside gains dense bytes). Ungated — production reads v5
             // envelopes once activated.
             v if v == DENSE_WRITE_VERSION => decode_postcard_exact(body),
-            // v6 synthetic alias — see HighWaterStateMachineSnapshot decode_version.
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 2 => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -219,9 +206,6 @@ impl VersionedCodec for PersistedSnapshot {
             v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
             // v5: envelope layout unchanged; real ungated arm for production.
             v if v == DENSE_WRITE_VERSION => encode_postcard(self),
-            // v6 synthetic alias — see HighWaterStateMachineSnapshot decode_version.
-            #[cfg(feature = "e2e-max-readable-next")]
-            v if v == BASELINE_WRITE_VERSION + 2 => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -1022,19 +1006,14 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn set_format_version_subset_match_sets_cell() {
-        // The flip is only observable when the local binary's readable
-        // range contains a target distinct from BASELINE. The
-        // `e2e-max-readable-next` test harness raises MAX to
-        // BASELINE + 2; in default builds MIN == MAX == BASELINE, so any
-        // distinct target is out of range and the apply-arm
-        // defense-in-depth (correctly) no-ops it. The behavior pinned by
-        // this test — "subset OK + in-range target ⇒ cell flips" — is
-        // unchanged; only the in-range target is feature-dependent.
+        // The flip is observable because DENSE_WRITE_VERSION (5) is a real
+        // target distinct from BASELINE (4) and within the readable range
+        // [MIN, MAX] = [4, 5]. The behavior pinned by this test — "subset OK +
+        // in-range target ⇒ cell flips" — uses the real dense activation target.
         let mut sm = HighWaterStateMachine::new();
-        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 2;
+        let target = tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
         // Establish membership {1, 2} at index 1.
         apply_one(
             &mut sm,
@@ -1310,10 +1289,9 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn successful_activation_survives_replay() {
-        let target = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 2;
+        let target = tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
         let log = vec![
             (1u64, ReplayEntry::Membership(vec![1, 2])),
             (
@@ -1416,10 +1394,9 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "e2e-max-readable-next")]
     #[tokio::test]
     async fn replay_is_deterministic() {
-        let in_range = tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION + 2;
+        let in_range = tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
         let log = vec![
             (1u64, ReplayEntry::Membership(vec![1, 2])),
             (
@@ -1650,103 +1627,6 @@ mod tests {
             )
             .is_err(),
             "a version above the readable max must be rejected"
-        );
-    }
-
-    #[cfg(feature = "e2e-max-readable-next")]
-    #[test]
-    fn e2e_max_readable_next_aliases_to_dense_version_bytewise() {
-        // The test-only `e2e-max-readable-next` feature raises
-        // `MAX_READABLE_VERSION` to `BASELINE_WRITE_VERSION + 2` in the
-        // toolkit and adds matching alias arms in this file's
-        // `VersionedCodec` impls that encode and decode as the current
-        // (v5/dense) layout. This pins the alias contract for the
-        // activation machinery harness:
-        //
-        //  - v6 = `BASELINE + 2` is the synthetic "next" activation target,
-        //    chosen above `DENSE_WRITE_VERSION` = 5 so the e2e harness does
-        //    not collide with the real dense format (#583).
-        //  - v6 encodes the current (full, dense-capable) layout — its body
-        //    is byte-identical to a v5-encoded blob, not to a v4 blob (v4
-        //    projects to the frozen `HighWaterStateMachineSnapshotV4` struct
-        //    which omits `dense` + `dense_cap`).
-        //  - The activation control plane (gate -> propose -> commit ->
-        //    apply -> cell flip) exercises end-to-end without a real new
-        //    format because the framing machinery accepts v6 just like v5.
-        //
-        // Version-neutral assertions so this test survives a future baseline
-        // bump unchanged.
-        use tsoracle_codec::{decode_framed, encode_framed};
-        use tsoracle_openraft_toolkit::{
-            BASELINE_WRITE_VERSION, DENSE_WRITE_VERSION, MAX_READABLE_VERSION,
-        };
-
-        let baseline = BASELINE_WRITE_VERSION;
-        let dense = DENSE_WRITE_VERSION;
-        let next = baseline + 2;
-        assert_eq!(
-            MAX_READABLE_VERSION, next,
-            "feature must raise MAX to BASELINE+2"
-        );
-
-        // Use empty dense map + cap 0 so the v4 encode arm (V4 projection) is
-        // lossless when we round-trip through v4, and the v6 body equals the
-        // v5 body (both encode the full current layout).
-        let payload = HighWaterStateMachineSnapshot {
-            current_value: 7,
-            last_applied: None,
-            last_membership: StoredMem::default(),
-            dense: std::collections::BTreeMap::new(),
-            dense_cap: 0,
-        };
-
-        let framed_dense = encode_framed(dense, &payload).expect("encode dense (v5)");
-        let framed_next = encode_framed(next, &payload).expect("encode next (v6 alias)");
-
-        // v6 body is byte-identical to v5 body (both encode the full layout).
-        assert_eq!(framed_dense[0], dense);
-        assert_eq!(framed_next[0], next);
-        assert_eq!(
-            &framed_dense[1..],
-            &framed_next[1..],
-            "v6 alias body must be byte-identical to v5 — only the version byte differs"
-        );
-
-        // v4 body is SHORTER (no dense/cap bytes) — confirm it is NOT
-        // byte-identical to v6. This documents the intentional divergence from
-        // the pre-T4 state where all three were aliased.
-        let framed_baseline = encode_framed(baseline, &payload).expect("encode baseline (v4)");
-        assert_ne!(
-            &framed_baseline[1..],
-            &framed_next[1..],
-            "v4 body must differ from v6 body: v4 omits dense/dense_cap"
-        );
-
-        // Cross-version round-trip: every version in the readable range
-        // decodes into the same logical value (empty dense, cap 0).
-        let back_baseline: HighWaterStateMachineSnapshot =
-            decode_framed(baseline, next, &framed_baseline).expect("decode baseline");
-        let back_dense: HighWaterStateMachineSnapshot =
-            decode_framed(baseline, next, &framed_dense).expect("decode v5");
-        let back_next: HighWaterStateMachineSnapshot =
-            decode_framed(baseline, next, &framed_next).expect("decode next (v6 alias)");
-        assert_eq!(back_baseline, payload);
-        assert_eq!(back_dense, payload);
-        assert_eq!(back_next, payload);
-
-        // The envelope-shape carrier (`PersistedSnapshot`) must also alias
-        // v5 at v6 — it is what `build_snapshot` actually emits at the
-        // active write version when the cell flips to v6.
-        let envelope = PersistedSnapshot {
-            meta: SnapMeta::default(),
-            data: framed_next.clone(),
-        };
-        let framed_env_dense = encode_framed(dense, &envelope).expect("envelope v5");
-        let framed_env_next = encode_framed(next, &envelope).expect("envelope v6");
-        assert_eq!(
-            &framed_env_dense[1..],
-            &framed_env_next[1..],
-            "PersistedSnapshot v6 envelope must be byte-identical to v5 envelope"
         );
     }
 

--- a/crates/tsoracle-openraft-toolkit/Cargo.toml
+++ b/crates/tsoracle-openraft-toolkit/Cargo.toml
@@ -22,19 +22,6 @@ default            = ["rocksdb-log-store"]
 rocksdb-log-store  = ["dep:rocksdb"]
 test-fakes         = ["dep:parking_lot"]
 failpoints         = ["tsoracle-failpoint/failpoints"]
-# Test-only harness affordance: raises `MAX_READABLE_VERSION` to
-# `BASELINE_WRITE_VERSION + 1` (i.e. one above whatever the current
-# baseline is — today 4, so MAX rises to 5; when baseline bumps to 5,
-# MAX rises to 6 with no edits here). When combined with the matching
-# `e2e-max-readable-next` feature on `tsoracle-driver-openraft` (which
-# adds `BASELINE + 1` alias arms to the per-version codec dispatch),
-# this lets a mixed-version e2e drive a real activation flip from the
-# baseline to the next version end-to-end. The aliased body layout is
-# byte-identical to baseline — only the version byte changes — so the
-# activation control plane runs but no genuine format change happens;
-# this is a faithful HARNESS for the activation machinery, not a real
-# format bump. Off by default; never compiled into production.
-e2e-max-readable-next = []
 
 [dependencies]
 async-trait      = { workspace = true }

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -51,22 +51,11 @@ pub const MIN_READABLE_VERSION: u8 = 4;
 /// Newest on-disk/wire format version this binary has a parser for. Only ever
 /// grows. Decode accepts `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
 ///
-/// Production builds set this to the current baseline. The test-only
-/// `e2e-max-readable-next` feature raises it to `BASELINE_WRITE_VERSION + 2`
-/// so a mixed-version e2e harness can drive a real activation flip from the
-/// baseline to the next version. The aliased body is byte-identical to the
-/// baseline (added by `BASELINE + 2` alias arms on the per-version codec in
-/// `tsoracle-driver-openraft` under the matching feature), so this is a
-/// faithful harness for the activation machinery rather than a real format
-/// change. Off by default; never compiled into production. The expression
-/// derives from `BASELINE_WRITE_VERSION` so a future baseline bump moves
-/// MAX automatically with no edit here. (Version 5 = `DENSE_WRITE_VERSION`
-/// is reserved for the real dense-sequence format; the synthetic harness
-/// rides on `BASELINE + 2` = 6 to avoid colliding with it — see #583.)
-#[cfg(not(feature = "e2e-max-readable-next"))]
+/// Today this is 5 (`DENSE_WRITE_VERSION`): a v5-capable binary can read both
+/// the v4 baseline layout and the v5 dense layout. A node writes
+/// `BASELINE_WRITE_VERSION` (4) until a committed `SetFormatVersion` activation
+/// advances the active write version through the all-members gate.
 pub const MAX_READABLE_VERSION: u8 = 5;
-#[cfg(feature = "e2e-max-readable-next")]
-pub const MAX_READABLE_VERSION: u8 = BASELINE_WRITE_VERSION + 2;
 
 // Compile-time guard: the readable range must be non-empty (`MIN <= MAX`) or
 // every decode rejects every record. Catches a future inverted-constants edit
@@ -195,36 +184,13 @@ pub fn recover_active_write_version(
 mod tests {
     use super::*;
 
-    #[cfg(not(feature = "e2e-max-readable-next"))]
     #[test]
     fn version_constants_are_at_expected_values() {
         assert_eq!(MIN_READABLE_VERSION, 4);
-        // MAX raised to 5 to cover the dense write version (DENSE_WRITE_VERSION).
+        // MAX is 5 to cover the dense write version (DENSE_WRITE_VERSION).
         assert_eq!(MAX_READABLE_VERSION, 5);
         assert_eq!(BASELINE_WRITE_VERSION, 4);
         assert_eq!(DENSE_WRITE_VERSION, 5);
-    }
-
-    #[cfg(feature = "e2e-max-readable-next")]
-    #[test]
-    fn version_constants_under_e2e_max_readable_next_feature() {
-        // Test-only harness: MAX rises to `BASELINE + 2` so a mixed-version
-        // e2e can drive a real activation flip from the baseline to the
-        // next version. MIN and BASELINE are unchanged — the harness
-        // raises only the read ceiling (Stage 1 of a real rollout); the
-        // active write version still starts at BASELINE and only moves
-        // through the normal activation barrier. Assert against the
-        // baseline expression so this test survives a future baseline
-        // bump unchanged. (`BASELINE + 1` = 5 is `DENSE_WRITE_VERSION`
-        // which owns real codec arms; synthetic harness uses `BASELINE + 2`
-        // = 6 to avoid colliding — interim until #583.)
-        assert_eq!(MAX_READABLE_VERSION, BASELINE_WRITE_VERSION + 2);
-        // `MAX > MIN` would tautologically follow from the above plus
-        // `BASELINE >= MIN` (which is true by definition: BASELINE is in
-        // the readable range). The compile-time `const _: () =
-        // assert!(MIN <= MAX)` at the top of this module guarantees the
-        // range invariant whether the feature is on or off; the
-        // runtime assertion would be flagged by `clippy::assertions_on_constants`.
     }
 
     #[test]
@@ -258,10 +224,8 @@ mod tests {
 
     #[test]
     fn recover_takes_the_max_of_present_lower_bounds() {
-        // The "max" only differs from BASELINE when MAX_READABLE_VERSION >
-        // BASELINE_WRITE_VERSION — the e2e-max-readable-next harness. Under the
-        // production cfg the range is a single point so every assertion here
-        // collapses to BASELINE, but the test still exercises every input shape.
+        // MAX_READABLE_VERSION (5) > BASELINE_WRITE_VERSION (4), so these
+        // assertions exercise the genuine multi-version max (4 vs 5).
         assert_eq!(
             recover_active_write_version(Some(MAX_READABLE_VERSION), None).unwrap(),
             MAX_READABLE_VERSION

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -701,7 +701,6 @@ mod range_boundary_tests {
 mod record_codec_tests {
     use super::{decode_entry_record, encode_entry_record};
     use crate::codec::BASELINE_WRITE_VERSION;
-    #[cfg(not(feature = "e2e-max-readable-next"))]
     use crate::codec::{MAX_READABLE_VERSION, MIN_READABLE_VERSION};
     use crate::declare_raft_types_ext;
     use crate::log_store::DefaultLogStoreCodec;
@@ -766,17 +765,11 @@ mod record_codec_tests {
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
-    // Pinned to BASELINE in the default build; the test-only
-    // `e2e-max-readable-next` feature lifts MAX to `BASELINE + 2`, so
-    // skip the MAX assertion under that feature (covered by
-    // `version_constants_under_e2e_max_readable_next_feature` in
-    // `codec.rs`).
-    #[cfg(not(feature = "e2e-max-readable-next"))]
     #[test]
     fn version_constants_are_at_expected_values() {
         assert_eq!(BASELINE_WRITE_VERSION, 4);
         assert_eq!(MIN_READABLE_VERSION, 4);
-        // MAX raised to 5 to cover the dense write version (DENSE_WRITE_VERSION).
+        // MAX is 5 to cover the dense write version (DENSE_WRITE_VERSION).
         assert_eq!(MAX_READABLE_VERSION, 5);
     }
 }

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -24,14 +24,6 @@ paxos    = [
     "dep:prost", "dep:postcard", "dep:parking_lot", "dep:tokio-stream",
     "tonic/tls-aws-lc",
 ]
-# Pass through `e2e-max-readable-next` to the openraft driver crate (which
-# propagates it to the toolkit). The `?` makes this a no-op unless
-# `openraft` (or another feature) has already pulled in the optional
-# `tsoracle-driver-openraft` dep — without `?`, bare `crate/feature`
-# syntax on an optional dep would forcibly activate it, silently
-# enabling half of the openraft stack under `--features e2e-max-readable-next`
-# alone.
-e2e-max-readable-next = ["tsoracle-driver-openraft?/e2e-max-readable-next"]
 # Gates `admin::test_support`, a tiny public seam exposing the otherwise
 # `pub(crate)` `AdminServiceImpl` constructor so an integration test can
 # drive the gRPC handler with a fake `MembershipAdmin`. Off in production.

--- a/docs/driver-comparison.md
+++ b/docs/driver-comparison.md
@@ -123,7 +123,7 @@ Paxos has no equivalent. There is no `drivers/paxos/handoff.rs`, no `transfer_le
 Openraft only. The version contract is four constants in `crates/tsoracle-openraft-toolkit/src/codec.rs:41-80`:
 
 - `MIN_READABLE_VERSION` — read-floor (today: 4).
-- `MAX_READABLE_VERSION` — read-ceiling (today: 4; bumps to 5 under the `e2e-max-readable-next` feature for soak testing).
+- `MAX_READABLE_VERSION` — read-ceiling (today: 5; covers the v5 dense layout, `DENSE_WRITE_VERSION`).
 - `BASELINE_WRITE_VERSION` — fallback write version (today: 4).
 - `ActiveWriteVersion(Arc<AtomicU8>)` — the runtime-mutable active write version, seeded from the log at recovery and *only* mutated by a committed `SetFormatVersion` raft entry.
 

--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -61,6 +61,19 @@ helm install tsoracle-tls deploy/charts/tsoracle -n e2e-tls --set image.reposito
 RELEASE=tsoracle-tls JOB_DIR=$(pwd)/e2e/kube/driver/tls ./e2e/kube/run-assertions.sh
 ```
 
+## Mixed-version lane (`kube-e2e-mixed-version.yml`)
+
+The `workflow_dispatch`-only mixed-version lane runs a separate kind cluster with two image tags: `tsoracle:e2e-baseline` built from the pinned `tsoracle-v2.0.0` commit (v4-only, `MAX_READABLE_VERSION=4`, no GetSeq) and `tsoracle:e2e-next` built from the PR head (`FEATURES=openraft`, v5-capable). It soaks `GetTs` monotonicity and `GetSeq` gaplessness across a partition=1 rolling restart, asserts the all-members gate rejects activation while the v4 member is present, then activates `DENSE_WRITE_VERSION=5` once all members are v5-capable.
+
+### Old-reader-rejects-too-new (version gate)
+
+The "an old-only reader rejects a too-new record at the version gate rather than misdecoding" property is covered deterministically, not in this e2e lane:
+
+- Unit: `snapshot_codec_accepts_full_readable_range` in `crates/tsoracle-driver-openraft/src/state_machine.rs` and `decode_entry_record_rejects_out_of_range_version` in the openraft toolkit log store assert a version above `MAX_READABLE_VERSION` is rejected, not misdecoded.
+- Fuzz: `openraft_dense_command_decode` drives decode at a fuzzed version byte and asserts out-of-range versions are rejected.
+
+This lane covers the complementary system-level guarantee: the all-members gate ensures a v4-only member is never *exposed* to a v5 record (the `MEMBERS_BELOW_TARGET` rejection in step 3).
+
 ## Deploying to EKS (staging)
 
 The kind flow above is fully local. To deploy the same `openraft-standalone` cluster onto the real **staging** EKS cluster (arm64, real EBS) for a manual smoke test, the Kubernetes manifests live in the **infra** repo at `k8s/tsoracle-e2e/`; this repo only builds and pushes the images.

--- a/e2e/kube/driver/job-mixed-version-soak.yaml
+++ b/e2e/kube/driver/job-mixed-version-soak.yaml
@@ -24,10 +24,8 @@ spec:
             # tsoracle client is configured (leader-hint failover assumes the
             # client knows every replica).
             - --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051
-            # Longer than the plain soak: must cover the rolling restart of
-            # every replica (one at a time, with readiness wait between) AND
-            # the operator-initiated activation that follows. 180s leaves
-            # ample headroom on top of a typical ~90s rolling restart of a
-            # 3-replica StatefulSet plus the activation round-trip; tune
-            # alongside the workflow if its sequencing grows.
-            - --duration-secs=180
+            # Longer than the plain soak: must cover the partition=1 rollout of
+            # two ordinals (with readiness waits), a possible leadership-handoff
+            # restart to seat a v5 leader, two GetSeq probes, and the activation
+            # round-trip. 300s leaves ample headroom on top of that sequencing.
+            - --duration-secs=300

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -21,6 +21,7 @@
 //  limitations under the License.
 //
 
+mod seq_tracker;
 mod tracker;
 
 use std::path::PathBuf;
@@ -31,6 +32,7 @@ use clap::{Parser, ValueEnum};
 use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 use tsoracle_client::{ClientBuilder, RetryPolicy};
 
+use crate::seq_tracker::SeqTracker;
 use crate::tracker::Tracker;
 
 #[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
@@ -68,6 +70,19 @@ enum Mode {
     /// The driver remains a pure observer; the orchestrator drives every
     /// membership transition over the loopback admin port via `kubectl exec`.
     MembershipSoak,
+    /// One-shot GetSeq probe used by the mixed-version orchestrator to assert
+    /// the activation transition: before activation it must observe
+    /// `--seq-expect=failed-precondition`; after activation, `--seq-expect=served`.
+    /// Uses the client's leader-hint routing so it reaches the leader.
+    GetSeqProbe,
+}
+
+#[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
+enum SeqExpect {
+    /// GetSeq must be refused with gRPC FAILED_PRECONDITION (not activated).
+    FailedPrecondition,
+    /// GetSeq must return a served block.
+    Served,
 }
 
 #[derive(Parser, Debug)]
@@ -107,6 +122,14 @@ struct Cli {
     /// Client identity private key (PEM); paired with `--tls-cert`.
     #[arg(long, requires = "tls_cert")]
     tls_key: Option<PathBuf>,
+
+    /// get-seq-probe: the dense key to probe.
+    #[arg(long, default_value = "orders")]
+    seq_key: String,
+
+    /// get-seq-probe: the expected outcome.
+    #[arg(long, value_enum, default_value_t = SeqExpect::Served)]
+    seq_expect: SeqExpect,
 }
 
 /// Soak error budget: monotonicity is the hard invariant (zero tolerance), but
@@ -158,6 +181,9 @@ async fn main() -> Result<()> {
         }
         Mode::MembershipSoak => {
             run_membership_soak(&cli.endpoints, Duration::from_secs(cli.duration_secs), tls).await?
+        }
+        Mode::GetSeqProbe => {
+            run_get_seq_probe(&cli.endpoints, &cli.seq_key, &cli.seq_expect, tls).await?
         }
     };
     if !passed {
@@ -264,14 +290,7 @@ async fn run_mixed_version_soak(
     duration: Duration,
     tls: Option<ClientTlsConfig>,
 ) -> Result<bool> {
-    sustain_load(
-        endpoints,
-        duration,
-        "mixed-version-soak",
-        MAX_SOAK_ERROR_RATE,
-        tls,
-    )
-    .await
+    sustain_load_with_seq(endpoints, duration, tls).await
 }
 
 /// Sustain GetTs load while the orchestrator force-deletes the current leader
@@ -357,6 +376,107 @@ async fn sustain_load(
         }
     }
     Ok(tracker.report_within_error_tolerance(label, max_error_rate))
+}
+
+/// Mixed-version soak body: sustain GetTs load while also probing GetSeq
+/// gaplessness. GetSeq is isolated to this function (not in [`sustain_load`])
+/// so the other soak modes (Soak, SigkillSoak, MembershipSoak) are unaffected.
+/// The `SeqTracker` observes the FAILED_PRECONDITION→served transition: pre-
+/// activation calls record as `not_serving` (not errors); post-activation calls
+/// must be gapless.  Both the GetTs monotonicity verdict and the SeqTracker
+/// verdict must pass for the soak to pass.
+async fn sustain_load_with_seq(
+    endpoints: &[String],
+    duration: Duration,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
+    use tsoracle_client::ClientError;
+
+    let builder = ClientBuilder::endpoints(endpoints.to_vec()).retry_policy(generous_policy());
+    let client = apply_tls(builder, tls)
+        .build()
+        .await
+        .context("build mixed-version-soak client")?;
+    let mut tracker: Tracker<_> = Tracker::new();
+    let mut seq = SeqTracker::new();
+    let mut announced = false;
+    // The deadline is checked before each call, so the loop can overrun by up
+    // to one client `overall_deadline` (the in-flight get_ts) against a fully
+    // unreachable cluster; size any Job activeDeadlineSeconds with that slack.
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+        match client.get_ts().await {
+            Ok(ts) => {
+                if !announced {
+                    println!("mixed-version-soak: first GetTs ok");
+                    announced = true;
+                }
+                tracker.record_ok(ts);
+            }
+            Err(error) => {
+                eprintln!("mixed-version-soak: get_ts error: {error}");
+                tracker.record_err();
+            }
+        }
+        match client.get_seq("orders", 1).await {
+            Ok(block) => seq.record_block("orders", block.start, block.count),
+            // Pre-activation: not-activated (or routed to a v4-only leader that
+            // lacks the RPC) is an expected state, not an error.
+            Err(ClientError::Rpc(status))
+                if matches!(
+                    status.code(),
+                    tonic::Code::FailedPrecondition | tonic::Code::Unimplemented
+                ) =>
+            {
+                seq.record_not_serving()
+            }
+            // Non-idempotent ambiguity: contiguity barrier, counts to error budget.
+            Err(ClientError::SeqUncertain) => seq.record_uncertain("orders"),
+            Err(error) => {
+                eprintln!("mixed-version-soak: get_seq error: {error}");
+                seq.record_err();
+            }
+        }
+    }
+    let ts_ok = tracker.report_within_error_tolerance("mixed-version-soak", MAX_SOAK_ERROR_RATE);
+    let seq_ok = seq.report_within_error_tolerance("mixed-version-soak-seq", MAX_SOAK_ERROR_RATE);
+    Ok(ts_ok && seq_ok)
+}
+
+async fn run_get_seq_probe(
+    endpoints: &[String],
+    key: &str,
+    expect: &SeqExpect,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
+    use tsoracle_client::ClientError;
+
+    let builder = ClientBuilder::endpoints(endpoints.to_vec()).retry_policy(generous_policy());
+    let client = apply_tls(builder, tls)
+        .build()
+        .await
+        .context("build get-seq-probe client")?;
+
+    let result = client.get_seq(key, 1).await;
+    match (expect, &result) {
+        (SeqExpect::Served, Ok(block)) => {
+            println!(
+                "get-seq-probe: SERVED key={key} start={} count={} -> PASS",
+                block.start, block.count
+            );
+            Ok(true)
+        }
+        (SeqExpect::FailedPrecondition, Err(ClientError::Rpc(status)))
+            if status.code() == tonic::Code::FailedPrecondition =>
+        {
+            println!("get-seq-probe: FAILED_PRECONDITION (not activated) -> PASS");
+            Ok(true)
+        }
+        (expect, other) => {
+            eprintln!("get-seq-probe: expected {expect:?} but got {other:?} -> FAIL");
+            Ok(false)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -493,5 +613,19 @@ mod cli_tests {
             err.to_string().contains("--tls-ca"),
             "expected --tls-ca message, got: {err}"
         );
+    }
+
+    #[test]
+    fn get_seq_probe_mode_parses() {
+        let cli = Cli::parse_from([
+            "kube-e2e-driver",
+            "--mode=get-seq-probe",
+            "--endpoints=a:5051,b:5051,c:5051",
+            "--seq-key=orders",
+            "--seq-expect=failed-precondition",
+        ]);
+        assert_eq!(cli.mode, Mode::GetSeqProbe);
+        assert_eq!(cli.seq_key, "orders");
+        assert_eq!(cli.seq_expect, SeqExpect::FailedPrecondition);
     }
 }

--- a/e2e/kube/driver/src/seq_tracker.rs
+++ b/e2e/kube/driver/src/seq_tracker.rs
@@ -1,0 +1,154 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Per-key gaplessness tracker for the dense `GetSeq` soak. A served block
+//! `[start, start + count)` for a key must abut the previous block for that
+//! key. `SeqUncertain` is a contiguity barrier (the advance may or may not
+//! have committed, so the jump across it is not a server gap), never a hard
+//! violation; it counts against the error budget like a severed RPC.
+
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct SeqTracker {
+    pub calls: u64,
+    pub errors: u64,
+    pub gap_violations: u64,
+    pub serving: bool,
+    expected_next: HashMap<String, u64>,
+}
+
+impl SeqTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A served block `[start, start + count)` for `key`. Within an unbroken
+    /// run of successes for a key, the next block's start must equal the
+    /// previous block's end; otherwise it is a gap/overlap violation.
+    pub fn record_block(&mut self, key: &str, start: u64, count: u32) {
+        self.calls += 1;
+        self.serving = true;
+        if let Some(&expected) = self.expected_next.get(key) {
+            if start != expected {
+                self.gap_violations += 1;
+            }
+        }
+        self.expected_next
+            .insert(key.to_string(), start + u64::from(count));
+    }
+
+    /// Pre-activation expected state (UNIMPLEMENTED / FAILED_PRECONDITION):
+    /// counted as a call, not an error, not a block.
+    pub fn record_not_serving(&mut self) {
+        self.calls += 1;
+    }
+
+    /// Ambiguous post-send failure (`SeqUncertain`): error-budget hit AND a
+    /// contiguity barrier — drop the per-key baseline so the next success
+    /// re-bases without a false gap.
+    pub fn record_uncertain(&mut self, key: &str) {
+        self.calls += 1;
+        self.errors += 1;
+        self.expected_next.remove(key);
+    }
+
+    /// A definitive transport/RPC error: error-budget hit, contiguity baseline
+    /// untouched (no block was issued).
+    pub fn record_err(&mut self) {
+        self.calls += 1;
+        self.errors += 1;
+    }
+
+    pub fn report_within_error_tolerance(&self, label: &str, max_error_rate: f64) -> bool {
+        let error_rate = if self.calls == 0 {
+            1.0
+        } else {
+            self.errors as f64 / self.calls as f64
+        };
+        let passed = self.serving && self.gap_violations == 0 && error_rate < max_error_rate;
+        println!(
+            "{label}: seq_calls={} seq_errors={} seq_error_rate={:.4}% (max {:.4}%) \
+             gap_violations={} serving={} -> {}",
+            self.calls,
+            self.errors,
+            error_rate * 100.0,
+            max_error_rate * 100.0,
+            self.gap_violations,
+            self.serving,
+            if passed { "PASS" } else { "FAIL" }
+        );
+        passed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SeqTracker;
+
+    #[test]
+    fn contiguous_blocks_have_no_violation() {
+        let mut t = SeqTracker::new();
+        t.record_block("orders", 0, 5);
+        t.record_block("orders", 5, 3);
+        t.record_block("orders", 8, 1);
+        assert_eq!(t.gap_violations, 0);
+        assert!(t.serving);
+    }
+
+    #[test]
+    fn a_gap_is_a_violation() {
+        let mut t = SeqTracker::new();
+        t.record_block("orders", 0, 5);
+        t.record_block("orders", 6, 1); // expected 5, got 6
+        assert_eq!(t.gap_violations, 1);
+    }
+
+    #[test]
+    fn an_overlap_is_a_violation() {
+        let mut t = SeqTracker::new();
+        t.record_block("orders", 0, 5);
+        t.record_block("orders", 4, 1); // expected 5, got 4
+        assert_eq!(t.gap_violations, 1);
+    }
+
+    #[test]
+    fn seq_uncertain_rebaselines_without_a_false_gap() {
+        let mut t = SeqTracker::new();
+        t.record_block("orders", 0, 5); // expected_next = 5
+        t.record_uncertain("orders"); // committed-or-not: drop baseline
+        t.record_block("orders", 9, 2); // re-base: NOT a gap
+        assert_eq!(t.gap_violations, 0);
+        assert_eq!(t.errors, 1);
+    }
+
+    #[test]
+    fn keys_are_independent() {
+        let mut t = SeqTracker::new();
+        t.record_block("orders", 0, 5);
+        t.record_block("users", 0, 1); // different key, own baseline
+        t.record_block("orders", 5, 1);
+        t.record_block("users", 1, 1);
+        assert_eq!(t.gap_violations, 0);
+    }
+}

--- a/e2e/kube/run-mixed-version-assertions.sh
+++ b/e2e/kube/run-mixed-version-assertions.sh
@@ -12,12 +12,12 @@ here="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=./_assertions_lib.sh
 source "$here/_assertions_lib.sh"
 
-# Activation target. BASELINE_WRITE_VERSION is 4 today; e2e-max-readable-next
-# raises MAX_READABLE_VERSION to BASELINE+2 = 6 (BASELINE+1 = 5 is reserved
-# for DENSE_WRITE_VERSION — see #583). If BASELINE bumps, this constant trips
-# a visible mismatch on the next run rather than silently activating to an
-# unintended version.
-ACTIVATION_TARGET=6
+# Activation target. DENSE_WRITE_VERSION is 5 (the real dense layout); this
+# is the genuine target the all-members gate must accept once all pods are
+# v5-capable. If DENSE_WRITE_VERSION bumps, this constant trips a visible
+# mismatch on the next run rather than silently activating to an unintended
+# version.
+ACTIVATION_TARGET=5
 # Loopback admin port; matches deploy/entrypoint.sh:12 ADMIN_PORT default
 # and the chart values.yaml ports.admin entry added in Task 7.
 ADMIN_PORT=51002
@@ -106,29 +106,95 @@ try_activate_format() {
     return 1
 }
 
+# Assert activation to $1 is rejected by the ALL-MEMBERS GATE specifically
+# (rc=2 MEMBERS_BELOW_TARGET on a v5-capable leader), NOT by a v4 leader's
+# local-range check (rc=4). With partition=1 two of three pods are v5-capable
+# and exactly one (ordinal 0) is v4. If the current leader is the v4 pod it
+# answers rc=4; we gracefully restart it (default-grace SIGTERM fires the
+# leadership handoff onto a caught-up v5 voter) and retry. Bounded attempts.
+assert_gate_rejection() {
+    local target="$1"
+    local v4_leader
+    for _attempt in 1 2 3; do
+        v4_leader=""
+        local pods
+        pods=$(kubectl get pods -l app.kubernetes.io/name=tsoracle \
+            -o jsonpath='{.items[*].metadata.name}')
+        for pod in $pods; do
+            local rc=0
+            "$TIMEOUT_CMD" 30s kubectl exec "$pod" -c tsoracle -- \
+                tsoracle admin activate-format \
+                --endpoint "http://127.0.0.1:${ADMIN_PORT}" \
+                --target "$target" >&2 || rc=$?
+            case "$rc" in
+                2)
+                    echo "gate held: activate-format(target=$target) -> MEMBERS_BELOW_TARGET on v5 leader $pod"
+                    return 0
+                    ;;
+                3) continue ;;                 # follower; skip
+                4) v4_leader="$pod" ;;          # v4 leader; record, will hand off
+                0)
+                    echo "FAIL: activation unexpectedly SUCCEEDED in mixed state on $pod"
+                    return 1
+                    ;;
+                *)
+                    echo "FAIL: activate-format on $pod: rc=$rc"
+                    return 1
+                    ;;
+            esac
+        done
+        if [ -n "$v4_leader" ]; then
+            echo "leader is v4 ($v4_leader); gracefully restarting to hand off to a v5 voter"
+            kubectl delete pod "$v4_leader"     # default grace -> SIGTERM -> #423 handoff
+            kubectl rollout status sts/tsoracle --timeout=120s
+        fi
+    done
+    echo "FAIL: could not establish a v5 leader for the gate assertion"
+    return 1
+}
+
+# One-shot GetSeq probe via the already-loaded driver image. EXPECT in
+# {failed-precondition, served}. Runs to completion; non-zero exit = FAIL.
+get_seq_probe() {
+    local expect="$1"
+    "$TIMEOUT_CMD" 60s kubectl run "seq-probe-${expect}-$$" \
+        --image=tsoracle-e2e-driver:latest --image-pull-policy=IfNotPresent \
+        --restart=Never --rm -i --command -- \
+        kube-e2e-driver --mode=get-seq-probe \
+        --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051 \
+        --seq-key=orders --seq-expect="$expect"
+}
+
 echo "== step 1: start mixed-version soak (load is live before any perturbation) =="
 kubectl apply -f "$here/driver/job-mixed-version-soak.yaml"
 wait_soak_live tsoracle-e2e-mixed-version-soak \
     "mixed-version-soak: first GetTs ok" 60
 
-echo "== step 2: partition=2; roll only ordinal 2 to :e2e-next =="
+echo "== step 2: partition=1; roll ordinals 1 and 2 to :e2e-next (ordinal 0 stays v4) =="
 kubectl patch sts/tsoracle --type=strategic \
-    -p '{"spec":{"updateStrategy":{"rollingUpdate":{"partition":2}}}}'
+    -p '{"spec":{"updateStrategy":{"rollingUpdate":{"partition":1}}}}'
 kubectl set image sts/tsoracle "tsoracle=${NEXT_IMAGE}"
 wait_pod_image_and_ready tsoracle-2 "${NEXT_IMAGE}" 120
+wait_pod_image_and_ready tsoracle-1 "${NEXT_IMAGE}" 120
 
-echo "== step 3: activation MUST be safely rejected (mixed-version state) =="
-try_activate_format "$ACTIVATION_TARGET" REJECTED
+echo "== step 3: all-members gate MUST reject (v5 leader, v4 member present) =="
+assert_gate_rejection "$ACTIVATION_TARGET"
 
-echo "== step 4: partition=0; complete the rollout =="
+echo "== step 4: partition=0; complete the rollout (all v5-capable) =="
 kubectl patch sts/tsoracle --type=strategic \
     -p '{"spec":{"updateStrategy":{"rollingUpdate":{"partition":0}}}}'
 kubectl rollout status sts/tsoracle --timeout=180s
 
-echo "== step 5: activation MUST succeed (all members on :e2e-next) =="
+echo "== step 5: pre-activation GetSeq MUST be FAILED_PRECONDITION =="
+get_seq_probe failed-precondition
+
+echo "== step 6: activation MUST succeed (all members on :e2e-next) =="
 try_activate_format "$ACTIVATION_TARGET" OK
 
-echo "== step 6: drain the soak (zero monotonicity violations + <0.5% errors) =="
+echo "== step 7: post-activation GetSeq MUST serve a block =="
+get_seq_probe served
+
+echo "== step 8: drain the soak (GetTs monotone + GetSeq gapless + <error budget) =="
 wait_job tsoracle-e2e-mixed-version-soak 180
 
 echo "== all mixed-version assertions passed =="

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2099,6 +2099,7 @@ dependencies = [
  "libfuzzer-sys",
  "postcard",
  "prost",
+ "tsoracle-codec",
  "tsoracle-driver-file",
  "tsoracle-driver-openraft",
  "tsoracle-driver-paxos",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,6 +28,7 @@ prost                    = "0.14"
 # `tsoracle_openraft_toolkit::codec` (the only toolkit surface the harnesses touch)
 # is unconditional and lives outside the feature-gated `log_store` module.
 tsoracle-openraft-toolkit         = { path = "../crates/tsoracle-openraft-toolkit", default-features = false }
+tsoracle-codec           = { path = "../crates/tsoracle-codec" }
 tsoracle-driver-file     = { path = "../crates/tsoracle-driver-file" }
 tsoracle-driver-openraft = { path = "../crates/tsoracle-driver-openraft", default-features = false }
 # `default-features = false` drops the `rocksdb-storage` feature on both paxos

--- a/fuzz/fuzz_targets/openraft_dense_command_decode.rs
+++ b/fuzz/fuzz_targets/openraft_dense_command_decode.rs
@@ -23,12 +23,40 @@
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use tsoracle_codec::decode_framed;
 use tsoracle_driver_openraft::{HighWaterStateMachineSnapshot, OpenraftEntry};
-use tsoracle_openraft_toolkit::{DENSE_WRITE_VERSION, decode};
+use tsoracle_openraft_toolkit::{MAX_READABLE_VERSION, MIN_READABLE_VERSION, decode};
 
 fuzz_target!(|data: &[u8]| {
-    // Dense snapshot payload at the dense write version (new BTreeMap field).
-    let _ = decode::<HighWaterStateMachineSnapshot>(DENSE_WRITE_VERSION, data);
-    // Full openraft entry decode (now includes the AdvanceDense command variant).
-    let _ = decode::<OpenraftEntry>(DENSE_WRITE_VERSION, data);
+    // Treat `data` as a version-framed snapshot record `[version | body]` and
+    // decode it through the real multi-version reader. `decode_framed` reads
+    // the leading byte and rejects anything outside the readable range
+    // [MIN_READABLE_VERSION, MAX_READABLE_VERSION] with `VersionUnsupported`
+    // before touching the body — the "old reader rejects a too-new record at
+    // the version gate rather than misdecoding" property (#583). The leading
+    // byte must therefore never produce a misdecode or a panic when it is out
+    // of range. `HighWaterStateMachineSnapshot` is the `VersionedCodec` type
+    // that carries the dense v5 layout; `OpenraftEntry`'s range gate lives in
+    // the log store's `decode_entry_record` (covered by a unit test) and is
+    // exercised here only for no-panic coverage via the single-version reader.
+    let snap = decode_framed::<HighWaterStateMachineSnapshot>(
+        MIN_READABLE_VERSION,
+        MAX_READABLE_VERSION,
+        data,
+    );
+    if let Some(&leading) = data.first() {
+        if leading < MIN_READABLE_VERSION || leading > MAX_READABLE_VERSION {
+            assert!(
+                snap.is_err(),
+                "out-of-range framed version {leading} must be rejected, not misdecoded"
+            );
+        }
+    }
+
+    // No-panic coverage of the entry decoder (single-version exact-match path;
+    // no range assertion because `decode` matches an exact version rather than
+    // gating a range).
+    if let Some((&version, body)) = data.split_first() {
+        let _ = decode::<OpenraftEntry>(version, body);
+    }
 });


### PR DESCRIPTION
Stacked on #585 (openraft dense PR) — review/merge #585 first. Closes #583.

Retires the synthetic `e2e-max-readable-next` cargo feature and makes the `kube-e2e-mixed-version` lane soak the real v4→v5 dense (`GetSeq`) format activation instead of a byte-identical synthetic version bump.

## Why

The synthetic harness raised `MAX_READABLE_VERSION` above the baseline and added byte-identical codec alias arms purely to drive the all-members format-activation machinery end-to-end without shipping a real new format. The dense `GetSeq` work now ships a real write-version-5 format (the `AdvanceDense` command + a struct-layout-changing snapshot), so soaking that activation directly is a strictly stronger test, and the synthetic arms collided with the real v5. The feature is removed outright.

## What

- Remove the `e2e-max-readable-next` feature from all crates along with its synthetic codec alias arms and gated tests; `MAX_READABLE_VERSION` is now unconditionally 5. Three activation tests are retargeted onto the real `DENSE_WRITE_VERSION` rather than deleted (they exercise the genuine cell flip).
- Mixed-version lane: build a genuinely v4-only baseline image from the pinned `tsoracle-v2.0.0` release commit and the v5-capable image from this branch; drive a real `SetFormatVersion(5)` through the all-members gate. The lane asserts the gate rejects with `MEMBERS_BELOW_TARGET` while a v4 member is present (rolling to `partition=1` so two of three replicas are v5-capable, and moving leadership onto a v5 node via a graceful-handoff restart), then asserts `GetSeq` transitions from `FAILED_PRECONDITION` to serving gapless dense blocks once every member is v5 and activation succeeds.
- Driver: a `SeqTracker` enforces per-key dense gaplessness across the soak, treating the non-idempotent `SeqUncertain` outcome as a contiguity barrier (re-baseline) rather than a false gap; plus a one-shot `get-seq-probe` mode for the discrete pre/post-activation transition assertions.
- The "an old-only reader rejects a too-new record at the version gate rather than misdecoding" property is covered deterministically by the codec `VersionUnsupported` unit test and an extended `openraft_dense_command_decode` fuzz target (now drives an out-of-range framed version through `decode_framed`); the lane covers the complementary system-level guarantee that the gate never exposes a v4 member to a v5 record.

## Test plan

- `cargo build/test/clippy --workspace --all-features` green locally.
- The `kube-e2e-mixed-version` lane is `workflow_dispatch`-only and is the end-to-end proof. A live kind run additionally confirms two things that cannot be checked locally: that the chart renders cleanly against the older v2.0.0 baseline binary, and that leadership reliably lands on a v5-capable node for the gate-rejection assertion.
