### PR TITLE
fix(seq): re-validate SeqKey on serde deserialize and dense snapshot restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,7 @@ name = "tsoracle-core"
 version = "2.1.0"
 dependencies = [
  "husky-rs",
+ "postcard",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/tsoracle-core/Cargo.toml
+++ b/crates/tsoracle-core/Cargo.toml
@@ -27,5 +27,6 @@ serde     = { workspace = true, optional = true }
 
 [dev-dependencies]
 husky-rs   = { workspace = true }
+postcard   = { workspace = true }
 proptest   = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/tsoracle-core/src/seq.rs
+++ b/crates/tsoracle-core/src/seq.rs
@@ -49,8 +49,14 @@ pub const DEFAULT_MAX_SEQ_COUNT: u32 = 65_536;
 /// A validated sequence key: non-empty, valid UTF-8 (guaranteed by `String`),
 /// and at most [`MAX_SEQ_KEY_LEN`] bytes. `try_new` is the single validation
 /// site — a value of this type is proof the key is in range.
+///
+/// The `serde` impls are hand-written (not derived) so deserialization routes
+/// through `try_new`: a derived `Deserialize` for a newtype builds the inner
+/// `String` directly and would be a second construction site that bypasses the
+/// invariant. Mirrors [`crate::peer::PeerEndpoint`]'s validate-on-deserialize
+/// discipline. `Serialize` emits the bare string (newtype-transparent), so the
+/// on-disk and wire byte layout is unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SeqKey(String);
 
 impl SeqKey {
@@ -70,6 +76,25 @@ impl SeqKey {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SeqKey {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SeqKey {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Re-validate on the way in: `try_new` is the single validation site, so
+        // a crafted or corrupted key (empty, or longer than `MAX_SEQ_KEY_LEN`
+        // bytes) arriving in a replicated log entry or a persisted snapshot is
+        // rejected here rather than silently observed as an in-range `SeqKey`.
+        let s = String::deserialize(deserializer)?;
+        SeqKey::try_new(s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -429,5 +454,60 @@ mod seqkey_tests {
             SeqKey::try_new(&too_long),
             Err(CoreError::SeqKeyTooLong { .. })
         ));
+    }
+
+    // ---- SeqKey: serde re-validates on deserialize (try_new is the single
+    // validation site, including the postcard decode path the openraft log and
+    // dense snapshot travel through). A derived `Deserialize` would build the
+    // inner `String` directly and bypass `try_new`, so these pin that decode
+    // routes through the invariant.
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_deserialize_rejects_empty_key() {
+        // `postcard::to_stdvec(&String::new())` is a structurally valid postcard
+        // String (a single zero length-prefix byte). Decoding it as a `SeqKey`
+        // must re-run `try_new` and reject the empty key, not return `SeqKey("")`.
+        let bytes = postcard::to_stdvec(&String::new()).expect("encode empty string");
+        let decoded = postcard::from_bytes::<SeqKey>(&bytes);
+        assert!(
+            decoded.is_err(),
+            "empty-key postcard payload must fail to decode, got {decoded:?}",
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_deserialize_rejects_oversized_key() {
+        let oversized = "a".repeat(MAX_SEQ_KEY_LEN + 1);
+        let bytes = postcard::to_stdvec(&oversized).expect("encode oversized string");
+        let decoded = postcard::from_bytes::<SeqKey>(&bytes);
+        assert!(
+            decoded.is_err(),
+            "oversized-key postcard payload must fail to decode, got {decoded:?}",
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trip_preserves_valid_key() {
+        let key = SeqKey::try_new("orders").unwrap();
+        let bytes = postcard::to_stdvec(&key).expect("encode key");
+        // Serialize is newtype-transparent: the bytes are exactly a postcard
+        // `String`, so the on-disk/wire format is unchanged by routing decode
+        // through `try_new`.
+        assert_eq!(bytes, postcard::to_stdvec(&"orders".to_string()).unwrap());
+        let back: SeqKey = postcard::from_bytes(&bytes).expect("decode key");
+        assert_eq!(back, key);
+        assert_eq!(back.as_str(), "orders");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_deserialize_accepts_max_length_key() {
+        let max = "a".repeat(MAX_SEQ_KEY_LEN);
+        let bytes = postcard::to_stdvec(&max).expect("encode max-length string");
+        let back: SeqKey = postcard::from_bytes(&bytes).expect("max-length key must decode");
+        assert_eq!(back.as_str(), max);
     }
 }

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -186,4 +186,60 @@ mod tests {
         let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
         assert_eq!(back, cmd);
     }
+
+    #[test]
+    fn postcard_round_trip_advance_dense() {
+        // A valid `AdvanceDense` round-trips unchanged: routing the embedded
+        // `SeqKey` decode through `try_new` must not perturb the honest path.
+        let cmd = HighWaterCommand::AdvanceDense {
+            key: tsoracle_core::SeqKey::try_new("orders").unwrap(),
+            count: 7,
+        };
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn advance_dense_postcard_layout_is_pinned() {
+        // Pin the byte layout the hand-crafted invalid-key payloads below rely
+        // on: `AdvanceDense` is the 3rd `HighWaterCommand` variant (index 2),
+        // followed by the newtype-transparent `SeqKey` (a postcard `String`:
+        // varint length prefix + UTF-8 bytes) then the `count` varint. A
+        // 1-byte key "a" with count 1 is therefore [2, 1, b'a', 1].
+        let cmd = HighWaterCommand::AdvanceDense {
+            key: tsoracle_core::SeqKey::try_new("a").unwrap(),
+            count: 1,
+        };
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        assert_eq!(bytes, vec![2u8, 1, b'a', 1]);
+    }
+
+    #[test]
+    fn decode_rejects_advance_dense_empty_key() {
+        // Variant 2 (AdvanceDense), empty-string key (length prefix 0), count 1.
+        // The bytes are structurally valid postcard, but the embedded `SeqKey`
+        // violates the non-empty invariant, so the decode must fail loud rather
+        // than land `SeqKey("")` in a replicated command.
+        let bytes = vec![2u8, 0, 1];
+        let decoded = postcard::from_bytes::<HighWaterCommand>(&bytes);
+        assert!(
+            decoded.is_err(),
+            "AdvanceDense with empty key must fail to decode, got {decoded:?}",
+        );
+    }
+
+    #[test]
+    fn decode_rejects_advance_dense_oversized_key() {
+        // Variant 2, a 129-byte key (one past MAX_SEQ_KEY_LEN), count 1. 129 as
+        // a postcard varint is [0x81, 0x01].
+        let mut bytes = vec![2u8, 0x81, 0x01];
+        bytes.extend(std::iter::repeat_n(b'a', 129));
+        bytes.push(1);
+        let decoded = postcard::from_bytes::<HighWaterCommand>(&bytes);
+        assert!(
+            decoded.is_err(),
+            "AdvanceDense with oversized key must fail to decode, got {decoded:?}",
+        );
+    }
 }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -794,6 +794,24 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
             ));
         }
 
+        // Re-validate every dense key before adopting the snapshot. The dense
+        // map is persisted as raw `String` keys, so — unlike the replicated
+        // `AdvanceDense` log command, whose `SeqKey` re-validates on decode — a
+        // crafted or corrupted snapshot can carry an empty or oversized key that
+        // `decode_framed` above accepts. Enforce `SeqKey`'s invariant here, fail
+        // loud, and do it before the `active_write_version` bump and the persist
+        // below so a rejected install leaves the store and in-memory state
+        // untouched for openraft to retry — exactly like the meta/payload check
+        // above.
+        for key in payload.dense.keys() {
+            if let Err(e) = tsoracle_core::SeqKey::try_new(key.as_str()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("snapshot dense key fails the SeqKey invariant: {e}"),
+                ));
+            }
+        }
+
         // The snapshot's leading version byte is evidence that the sending
         // leader's active write version was at least this high — which means a
         // `SetFormatVersion` activation to that version already committed
@@ -1752,6 +1770,81 @@ mod tests {
             .expect("get_current_snapshot")
             .expect("snapshot present");
         assert_eq!(current.meta.snapshot_id, "test-install-1");
+    }
+
+    /// Build a v5 (dense) snapshot whose `dense` map carries one raw-`String`
+    /// key, paired with a meta whose `last_log_id` agrees with the payload so
+    /// the install reaches the dense-key validation guard (not the earlier
+    /// meta/payload-disagreement check). Returns `(meta, framed bytes)`.
+    fn dense_snapshot_with_key(key: &str) -> (SnapMeta, Vec<u8>) {
+        let last_applied = Some(log_id(9));
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 999,
+            last_applied,
+            last_membership: StoredMem::default(),
+            dense: std::collections::BTreeMap::from([(key.to_string(), 7u64)]),
+            dense_cap: 64,
+        };
+        let bytes =
+            tsoracle_codec::encode_framed(tsoracle_openraft_toolkit::DENSE_WRITE_VERSION, &payload)
+                .expect("serialize v5 dense payload");
+        let meta = SnapMeta {
+            last_log_id: last_applied,
+            last_membership: StoredMem::default(),
+            snapshot_id: "test-invalid-dense-key".to_string(),
+        };
+        (meta, bytes)
+    }
+
+    #[tokio::test]
+    async fn install_snapshot_rejects_empty_dense_key() {
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.current_value().await;
+        let (meta, bytes) = dense_snapshot_with_key("");
+
+        let err = sm
+            .install_snapshot(&meta, std::io::Cursor::new(bytes))
+            .await
+            .expect_err("install of a snapshot with an empty dense key must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+        // Rejected before any mutation: the wholesale state replacement (which
+        // would have set current_value to 999) did not happen, and the invalid
+        // key is absent from the dense map.
+        assert_eq!(sm.current_value().await, before);
+        assert_eq!(sm.dense_value(""), 0);
+    }
+
+    #[tokio::test]
+    async fn install_snapshot_rejects_oversized_dense_key() {
+        let mut sm = HighWaterStateMachine::new();
+        let before = sm.current_value().await;
+        let oversized = "a".repeat(tsoracle_core::MAX_SEQ_KEY_LEN + 1);
+        let (meta, bytes) = dense_snapshot_with_key(&oversized);
+
+        let err = sm
+            .install_snapshot(&meta, std::io::Cursor::new(bytes))
+            .await
+            .expect_err("install of a snapshot with an oversized dense key must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+        assert_eq!(sm.current_value().await, before);
+        assert_eq!(sm.dense_value(&oversized), 0);
+    }
+
+    #[tokio::test]
+    async fn install_snapshot_accepts_valid_dense_key() {
+        // The guard must not reject an honest v5 snapshot: a valid dense key
+        // installs and is observable afterwards.
+        let mut sm = HighWaterStateMachine::new();
+        let (meta, bytes) = dense_snapshot_with_key("orders");
+
+        sm.install_snapshot(&meta, std::io::Cursor::new(bytes))
+            .await
+            .expect("install of a snapshot with a valid dense key must succeed");
+
+        assert_eq!(sm.current_value().await, 999);
+        assert_eq!(sm.dense_value("orders"), 7);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #593.

## Problem

`SeqKey` (`crates/tsoracle-core/src/seq.rs`) documents `try_new` as the single validation site — "a value of this type is proof the key is in range" (non-empty, ≤ `MAX_SEQ_KEY_LEN` = 128 bytes). But the derived `Deserialize` constructed the inner `String` directly and never called `try_new`, making the type's guarantee false. A structurally-valid-but-invariant-violating postcard payload could land an empty or oversized key in the openraft `AdvanceDense` log command or the dense snapshot map.

Severity is low / defense-in-depth: the honest serving path always validates via `SeqAllocator::validate_request → SeqKey::try_new` before the leader proposes `AdvanceDense`. The only injection vectors are an authenticated (mTLS) raft peer — who can already propose arbitrary commands — or on-disk byte corruption.

## Fix

Restore the invariant **fail-loud** (matching the codebase's framed-codec discipline) at both construction sites:

- **`tsoracle-core`**: replace `SeqKey`'s derived serde with hand-written impls that route `Deserialize` through `try_new`, mirroring `PeerEndpoint`'s existing validate-on-deserialize pattern. `Serialize` emits the bare string (newtype-transparent), so the wire/on-disk byte layout is **unchanged for valid keys**. This covers the log path automatically: `AdvanceDense`'s embedded `SeqKey` now fails loud at `decode_entry`, no driver change needed.
- **`tsoracle-driver-openraft`**: the dense snapshot stores raw `String` keys, which bypass `SeqKey`'s validating `Deserialize`. `install_snapshot` now validates every dense key via `SeqKey::try_new` **before** the active-write-version bump and persist, so a rejected install leaves store and in-memory state untouched (mirroring the meta/payload-disagreement check directly above it).

No `ApplyOutcome::DenseKeyInvalid` apply-time arm: with fail-loud decode, the apply path can never receive an invalid key, so it would be unreachable. (The issue's "decode-guard + apply-skip" pairing is mutually exclusive — fail-loud-at-decode means apply never sees the invalid key.)

## Tests

Each test was written first and watched to fail for the right reason (TDD):

- `seq.rs`: postcard decode of empty / 129-byte keys → `Err`; valid key round-trips with byte-equality to a plain `String`; max-length key accepted.
- `log_entry.rs`: hand-crafted `AdvanceDense` postcard with empty / oversized key fails to decode; layout pinned; valid round-trips.
- `state_machine.rs`: `install_snapshot` of a v5 snapshot whose dense map carries an empty / oversized key returns `InvalidData` and leaves state untouched; a valid key still installs.

## Verification

- `cargo test --workspace --all-features` → 1257 passed, 0 failed
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` → clean
- `cargo fmt --all --check` → clean
- `tsoracle-core` builds with default features and `--no-default-features` (impls correctly `serde`-gated)