### PR TITLE
build(release): drop registry version from dev-only workspace deps

### DIFF
--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -34,9 +34,9 @@ tsoracle-server       = { path = "../tsoracle-server", version = "3.0.1" }
 tsoracle-standalone   = { path = "../tsoracle-standalone", version = "1.1.2", default-features = false }
 
 [dev-dependencies]
-tsoracle-client    = { path = "../tsoracle-client", version = "1.1.1" }
-tsoracle-consensus = { path = "../tsoracle-consensus", version = "2.0.1" }
-tsoracle-driver-file = { path = "../tsoracle-driver-file", version = "2.0.1" }
+tsoracle-client    = { path = "../tsoracle-client" }
+tsoracle-consensus = { path = "../tsoracle-consensus" }
+tsoracle-driver-file = { path = "../tsoracle-driver-file" }
 async-trait        = { workspace = true }
 futures            = { workspace = true }
 parking_lot        = { workspace = true }

--- a/crates/tsoracle-server/Cargo.toml
+++ b/crates/tsoracle-server/Cargo.toml
@@ -55,7 +55,7 @@ tsoracle-failpoint = { workspace = true }
 tokio        = { workspace = true, features = ["test-util"] }
 metrics-util = { workspace = true }
 tsoracle-core = { path = "../tsoracle-core", version = "2.1.1" }
-tsoracle-driver-file = { path = "../tsoracle-driver-file", version = "2.0.1" }
+tsoracle-driver-file = { path = "../tsoracle-driver-file" }
 tracing-subscriber = { workspace = true }
 tempfile = { workspace = true }
 


### PR DESCRIPTION
## Problem

`release-plz release` stranded releases **#595** and **#597** mid-publish:

```
failed to publish tsoracle-server:
  Packaging tsoracle-server v3.0.1
  error: failed to prepare local package for uploading
  Caused by:
    failed to select a version for the requirement `tsoracle-driver-file = "^2.0.1"`
    candidate versions found which didn't match: 2.0.0, 1.0.1, ...
```

## Root cause

`release-plz` computes publish order from the **normal** dependency graph. But `cargo package` resolves **every versioned dependency — including dev-dependencies — against the registry**.

`tsoracle-server` had a *dev-dependency* on `tsoracle-driver-file` carrying `version = "2.0.1"`. That edge is invisible to the ordering planner (it's not a normal dep), so release-plz scheduled `server` right after the leaf crates — **before** `driver-file` — yet `cargo package` still demanded `driver-file 2.0.1` from crates.io before it was published. Fail-fast aborted the release, stranding every crate after the failure. It recurred on every release that bumped `driver-file`.

## Fix

Drop the `version` key from workspace dev-deps that are **not also normal deps**. cargo omits path-only dev-deps from the published manifest entirely, removing both the registry requirement and the false ordering independence — no change to the published artifact (dev-deps are never part of it):

- `tsoracle-server`: `tsoracle-driver-file`
- `tsoracle` (bin): `tsoracle-client`, `tsoracle-consensus`, `tsoracle-driver-file`

Versioned dev-deps that *are* also normal deps (e.g. `driver-openraft` → `openraft-toolkit`) are left untouched — release-plz already orders those correctly.

## Verification

`cargo publish -p tsoracle-server --dry-run` (includes `--verify`, which compiles the packaged tarball) now exits 0, and the packaged manifests no longer reference the stripped dev-deps.

On merge, the `release-plz release` job will publish the still-stranded #597 versions in one clean pass.