### PR TITLE
build(images): describe GHCR images via OCI label + manifest annotation

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -83,12 +83,15 @@ jobs:
           - variant: file
             image: tsoracle-file
             features: file
+            description: 'tsoracle with the file driver — single-node timestamp & sequence oracle'
           - variant: openraft
             image: tsoracle-openraft
             features: openraft
+            description: 'tsoracle with the openraft driver — distributed, fault-tolerant timestamp & sequence oracle'
           - variant: umbrella
             image: tsoracle
             features: ''
+            description: 'tsoracle with all drivers bundled (file, openraft & OmniPaxos) — distributed timestamp & sequence oracle'
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
@@ -105,12 +108,16 @@ jobs:
       - name: Build and push per-arch image
         env:
           V: ${{ needs.version.outputs.v }}
+          IMAGE: ${{ matrix.image }}
+          DESC: ${{ matrix.description }}
         run: |
           docker buildx build \
             --platform linux/${{ matrix.arch }} \
             -f deploy/Dockerfile \
             --build-arg FEATURES=${{ matrix.features }} \
-            -t "ghcr.io/prisma-risk/${{ matrix.image }}:${V}-${{ matrix.arch }}" \
+            --build-arg IMAGE_TITLE="$IMAGE" \
+            --build-arg IMAGE_DESCRIPTION="$DESC" \
+            -t "ghcr.io/prisma-risk/$IMAGE:${V}-${{ matrix.arch }}" \
             --push .
 
   manifest:
@@ -125,10 +132,13 @@ jobs:
         include:
           - variant: file
             image: tsoracle-file
+            description: 'tsoracle with the file driver — single-node timestamp & sequence oracle'
           - variant: openraft
             image: tsoracle-openraft
+            description: 'tsoracle with the openraft driver — distributed, fault-tolerant timestamp & sequence oracle'
           - variant: umbrella
             image: tsoracle
+            description: 'tsoracle with all drivers bundled (file, openraft & OmniPaxos) — distributed timestamp & sequence oracle'
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
@@ -140,14 +150,26 @@ jobs:
       - name: Create multi-arch manifest list
         env:
           V: ${{ needs.version.outputs.v }}
+          IMAGE: ${{ matrix.image }}
+          DESC: ${{ matrix.description }}
         run: |
-          IMG=ghcr.io/prisma-risk/${{ matrix.image }}
+          IMG=ghcr.io/prisma-risk/$IMAGE
+          # `index:`-scoped annotations land on the manifest list itself. GHCR reads
+          # the package-page description from the index annotation, NOT from the
+          # per-arch config LABEL baked by the Dockerfile (imagetools create does not
+          # copy child labels up), so this is the half that actually fixes the page.
+          ANNOTATIONS=(
+            --annotation "index:org.opencontainers.image.title=$IMAGE"
+            --annotation "index:org.opencontainers.image.description=$DESC"
+            --annotation "index:org.opencontainers.image.source=https://github.com/prisma-risk/tsoracle"
+            --annotation "index:org.opencontainers.image.licenses=Apache-2.0"
+          )
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            docker buildx imagetools create \
+            docker buildx imagetools create "${ANNOTATIONS[@]}" \
               -t "$IMG:$V" -t "$IMG:latest" \
               "$IMG:$V-amd64" "$IMG:$V-arm64"
           else
-            docker buildx imagetools create \
+            docker buildx imagetools create "${ANNOTATIONS[@]}" \
               -t "$IMG:$V" \
               "$IMG:$V-amd64" "$IMG:$V-arm64"
           fi

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,6 +17,18 @@ COPY . .
 RUN cargo build --release -p tsoracle --bin tsoracle ${FEATURES:+--no-default-features --features $FEATURES}
 
 FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS runtime
+# OCI image metadata. IMAGE_TITLE/IMAGE_DESCRIPTION are passed per-variant by the
+# release-images workflow so each driver image (tsoracle-file, tsoracle-openraft,
+# tsoracle) carries its own description; defaults cover a bare `docker build`. This
+# description LABEL is the per-arch-config copy that `docker inspect` reads; the
+# release workflow ALSO re-emits the same value as an index-level annotation on the
+# multi-arch manifest, which is the layer GHCR's package page actually surfaces.
+ARG IMAGE_TITLE="tsoracle"
+ARG IMAGE_DESCRIPTION="A distributed timestamp and sequence oracle"
+LABEL org.opencontainers.image.title="${IMAGE_TITLE}" \
+      org.opencontainers.image.description="${IMAGE_DESCRIPTION}" \
+      org.opencontainers.image.source="https://github.com/prisma-risk/tsoracle" \
+      org.opencontainers.image.licenses="Apache-2.0"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Why

GHCR shows **"No description provided"** on the published container packages (e.g. `tsoracle-openraft`) because the images carry no `org.opencontainers.image.description`. The Dockerfile set no OCI labels and the release workflow added no annotations.

## What

Belt-and-suspenders metadata so both the registry UI and image inspection are covered:

- **`deploy/Dockerfile`** — an `ARG`-driven `LABEL` block (`title` / `description` / `source` / `licenses`) on the runtime stage. This is the per-arch image-config copy that `docker inspect` reads; the defaults give a sensible description on a bare `docker build`.
- **`.github/workflows/release-images.yml`** — re-emit the same values as `index:`-scoped annotations on `docker buildx imagetools create`. The manifest-list **index** is the layer GHCR's package page actually reads, and `imagetools create` does **not** copy child-image labels up onto the index — so the `LABEL` alone would not fix the page. The annotation is the half that does.

Each variant gets its own description, threaded per-variant through the `build-image` and `manifest` matrices (a new `description:` column) and passed via build-args / `env` rather than inline shell interpolation:

| Image | Description |
|---|---|
| `tsoracle-file` | tsoracle with the file driver — single-node timestamp & sequence oracle |
| `tsoracle-openraft` | tsoracle with the openraft driver — distributed, fault-tolerant timestamp & sequence oracle |
| `tsoracle` | tsoracle with all drivers bundled (file, openraft & OmniPaxos) — distributed timestamp & sequence oracle |

## Verification

- `actionlint` passes (runs shellcheck over the `run:` blocks, validating the new `bash` annotation array).
- The `ARG`→`LABEL` interpolation was smoke-tested in isolation: defaults apply on a bare build, and the per-variant override (with `&` and the em-dash intact) flows correctly into `org.opencontainers.image.description`.

## Notes

- Takes effect on the **next** publish (next `tsoracle-v*` tag or a `workflow_dispatch` run); already-published versions won't retroactively gain a description.
- The description strings are duplicated across the two jobs' matrices — inherent to GitHub Actions, since `include:` blocks can't be shared between jobs without a reusable/composite workflow. They must be kept in sync.