### PR TITLE
feat: atomic multi-key GetSeqBatch RPC

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -52,6 +52,7 @@ jobs:
           - toolkit_codec_decode
           - openraft_entry_decode
           - openraft_meta_decode
+          - openraft_advance_dense_batch_decode
           - codec_roundtrip
           - paxos_log_entry_decode
           - paxos_snapshot_decode

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -37,6 +37,7 @@ jobs:
           - toolkit_codec_decode
           - openraft_entry_decode
           - openraft_meta_decode
+          - openraft_advance_dense_batch_decode
           - codec_roundtrip
           - paxos_log_entry_decode
           - paxos_snapshot_decode

--- a/.github/workflows/kube-e2e-mixed-version.yml
+++ b/.github/workflows/kube-e2e-mixed-version.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      BASELINE_REF: 2760a8d5e47f4610eda7559a0420e97f537414a2  # tsoracle-v2.0.0
+      # Latest v5-capable release (MAX_READABLE_VERSION=5, dense but not batch):
+      # the realistic "previous release" a v6 (batch) cluster upgrades FROM. The
+      # lane therefore exercises the genuine v5->v6 transition and the v6
+      # all-members gate against a v5-only peer.
+      BASELINE_REF: 2d7ba937b98fdfdc4edc4d3c90e6a8e2f7ddd60a  # tsoracle-v2.0.2
     steps:
       - name: free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
@@ -28,18 +32,18 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-      - name: checkout baseline release (v4-only)
+      - name: checkout baseline release (v5-capable)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.BASELINE_REF }}
           path: baseline-src
           fetch-depth: 0
-      - name: build baseline image (v4-only, tsoracle-v2.0.0)
+      - name: build baseline image (v5-capable, tsoracle-v2.0.2)
         run: |
           docker build -f baseline-src/deploy/Dockerfile \
             --build-arg FEATURES=openraft \
             -t tsoracle:e2e-baseline baseline-src
-      - name: build next image (openraft, v5-capable PR head)
+      - name: build next image (openraft, v6-capable PR head)
         run: |
           docker build -f deploy/Dockerfile \
             --build-arg FEATURES=openraft \

--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -237,6 +237,42 @@ impl Client {
         retry::issue_seq_rpc(&self.pool, key, count).await
     }
 
+    /// Atomically request contiguous dense blocks for several DISTINCT keys in
+    /// one round-trip. Returns one [`SeqBlock`] per entry, in request order.
+    ///
+    /// **Non-idempotent (whole batch):** on `ClientError::SeqUncertain` the
+    /// entire batch may or may not have committed — do NOT retry; reconcile
+    /// first (the atomic server contract means it is all-or-nothing, so there is
+    /// never a partial mix to untangle). All other errors are pre-commit-certain.
+    ///
+    /// Client-side pre-checks reject only universally-invalid input: an empty
+    /// batch, a duplicate key, an empty/oversized key, or a zero count. The
+    /// per-entry count cap and the batch-size cap are server-side and are
+    /// forwarded for the server to reject, so a client built against one
+    /// configuration stays correct against a server with another.
+    pub async fn get_seq_batch(
+        &self,
+        entries: &[(&str, u32)],
+    ) -> Result<Vec<SeqBlock>, ClientError> {
+        if entries.is_empty() {
+            return Err(ClientError::InvalidCount(0));
+        }
+        let mut seen = std::collections::HashSet::with_capacity(entries.len());
+        for (key, count) in entries {
+            if key.is_empty() || key.len() > tsoracle_core::MAX_SEQ_KEY_LEN {
+                return Err(ClientError::InvalidSeqKey);
+            }
+            if *count == 0 {
+                return Err(ClientError::InvalidCount(0));
+            }
+            if !seen.insert(*key) {
+                // Distinct-key contract — mirror the server's pre-commit reject.
+                return Err(ClientError::InvalidSeqKey);
+            }
+        }
+        retry::issue_seq_batch_rpc(&self.pool, entries).await
+    }
+
     /// Read the leader's current safe-point in physical-millisecond units.
     ///
     /// Targets the cached leader if known, otherwise the first configured
@@ -980,6 +1016,391 @@ mod tests {
             calls.load(Ordering::SeqCst),
             1,
             "malformed success: one call"
+        );
+    }
+
+    /// `get_seq_batch` returns one [`SeqBlock`] per entry, in request order,
+    /// with each block's start/count/epoch matching the server's echoed grant.
+    /// Uses a fake server that echoes grants positionally from a shared counter.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_seq_batch_returns_blocks_in_request_order() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        const EPOCH: u128 = 77;
+
+        // Simple echo server: for each entry, allocate `count` ordinals from a
+        // shared counter and echo them back in request order.
+        let counter = Arc::new(AtomicU64::new(0));
+        let server_counter = counter.clone();
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(move |req| {
+                let counter = server_counter.clone();
+                async move {
+                    let mut grants = Vec::with_capacity(req.entries.len());
+                    for entry in &req.entries {
+                        let start = counter.fetch_add(u64::from(entry.count), Ordering::SeqCst);
+                        grants.push(tsoracle_proto::v1::SeqGrantEntry {
+                            key: entry.key.clone(),
+                            start,
+                            count: entry.count,
+                        });
+                    }
+                    let (hi, lo) = tsoracle_core::Epoch(EPOCH).to_wire();
+                    Ok(tsoracle_proto::v1::GetSeqBatchResponse {
+                        grants,
+                        epoch: Some(tsoracle_proto::v1::EpochWire { hi, lo }),
+                    })
+                }
+            })
+            .spawn()
+            .await;
+
+        let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+            .retry_policy(RetryPolicy {
+                max_attempts: 3,
+                per_attempt_deadline: Duration::from_secs(2),
+                overall_deadline: Duration::from_secs(5),
+                base_backoff: Duration::ZERO,
+                leader_ttl: Duration::from_secs(30),
+            })
+            .build()
+            .await
+            .expect("client must build");
+
+        let blocks = client
+            .get_seq_batch(&[("orders", 5), ("invoices", 3)])
+            .await
+            .expect("get_seq_batch must succeed");
+
+        assert_eq!(blocks.len(), 2, "one block per entry");
+        // First entry: "orders" with count 5, starting at 0.
+        assert_eq!(blocks[0].start, 0);
+        assert_eq!(blocks[0].count, 5);
+        assert_eq!(blocks[0].epoch, EPOCH);
+        // Second entry: "invoices" with count 3, gapless after orders.
+        assert_eq!(blocks[1].start, 5);
+        assert_eq!(blocks[1].count, 3);
+        assert_eq!(blocks[1].epoch, EPOCH);
+    }
+
+    /// Duplicate keys are rejected client-side without hitting the server.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_seq_batch_rejects_duplicate_keys_without_hitting_server() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let calls = Arc::new(AtomicU64::new(0));
+        let server_calls = calls.clone();
+        // Server should never be reached; count calls to prove it.
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(move |_req| {
+                let calls = server_calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Err(tonic::Status::internal("should not be called"))
+                }
+            })
+            .spawn()
+            .await;
+
+        let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+            .retry_policy(RetryPolicy {
+                max_attempts: 3,
+                per_attempt_deadline: Duration::from_secs(2),
+                overall_deadline: Duration::from_secs(5),
+                base_backoff: Duration::ZERO,
+                leader_ttl: Duration::from_secs(30),
+            })
+            .build()
+            .await
+            .expect("client must build");
+
+        // Duplicate key "orders" — must be caught client-side.
+        match client.get_seq_batch(&[("orders", 1), ("orders", 2)]).await {
+            Err(ClientError::InvalidSeqKey) => {}
+            other => panic!("duplicate key must return InvalidSeqKey, got {other:?}"),
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "duplicate-key rejection must not reach the server"
+        );
+    }
+
+    /// A malformed success response (wrong grants length, mismatched key/count,
+    /// or missing epoch) surfaces as `SeqUncertain`. The server is called
+    /// exactly once — the ambiguity is not retried.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_seq_batch_malformed_success_is_uncertain() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        // Case 1: grants.len() != entries.len() (one fewer grant than requested).
+        {
+            let calls = Arc::new(AtomicU64::new(0));
+            let server_calls = calls.clone();
+            let addr = crate::test_support::FakeTso::new()
+                .on_get_seq_batch(move |_req| {
+                    let calls = server_calls.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let (hi, lo) = tsoracle_core::Epoch(1).to_wire();
+                        // Return only one grant for a two-entry request.
+                        Ok(tsoracle_proto::v1::GetSeqBatchResponse {
+                            grants: vec![tsoracle_proto::v1::SeqGrantEntry {
+                                key: "orders".into(),
+                                start: 0,
+                                count: 5,
+                            }],
+                            epoch: Some(tsoracle_proto::v1::EpochWire { hi, lo }),
+                        })
+                    }
+                })
+                .spawn()
+                .await;
+
+            let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+                .retry_policy(RetryPolicy {
+                    max_attempts: 3,
+                    per_attempt_deadline: Duration::from_secs(2),
+                    overall_deadline: Duration::from_secs(5),
+                    base_backoff: Duration::ZERO,
+                    leader_ttl: Duration::from_secs(30),
+                })
+                .build()
+                .await
+                .expect("client must build");
+
+            match client
+                .get_seq_batch(&[("orders", 5), ("invoices", 3)])
+                .await
+            {
+                Err(ClientError::SeqUncertain) => {}
+                other => panic!("wrong grants.len must surface as SeqUncertain, got {other:?}"),
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "malformed success must not trigger a retry"
+            );
+        }
+
+        // Case 2: grant.count mismatches the requested count.
+        {
+            let calls = Arc::new(AtomicU64::new(0));
+            let server_calls = calls.clone();
+            let addr = crate::test_support::FakeTso::new()
+                .on_get_seq_batch(move |req| {
+                    let calls = server_calls.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let (hi, lo) = tsoracle_core::Epoch(1).to_wire();
+                        // Echo the right key but wrong count for the first entry.
+                        let grants = req
+                            .entries
+                            .iter()
+                            .enumerate()
+                            .map(|(i, e)| tsoracle_proto::v1::SeqGrantEntry {
+                                key: e.key.clone(),
+                                start: 0,
+                                // Tamper: inflate count for the first entry.
+                                count: if i == 0 { e.count + 1 } else { e.count },
+                            })
+                            .collect();
+                        Ok(tsoracle_proto::v1::GetSeqBatchResponse {
+                            grants,
+                            epoch: Some(tsoracle_proto::v1::EpochWire { hi, lo }),
+                        })
+                    }
+                })
+                .spawn()
+                .await;
+
+            let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+                .retry_policy(RetryPolicy {
+                    max_attempts: 3,
+                    per_attempt_deadline: Duration::from_secs(2),
+                    overall_deadline: Duration::from_secs(5),
+                    base_backoff: Duration::ZERO,
+                    leader_ttl: Duration::from_secs(30),
+                })
+                .build()
+                .await
+                .expect("client must build");
+
+            match client
+                .get_seq_batch(&[("orders", 5), ("invoices", 3)])
+                .await
+            {
+                Err(ClientError::SeqUncertain) => {}
+                other => panic!("count-mismatch grant must surface as SeqUncertain, got {other:?}"),
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "malformed success must not trigger a retry"
+            );
+        }
+
+        // Case 3: missing epoch on an otherwise-valid response.
+        {
+            let calls = Arc::new(AtomicU64::new(0));
+            let server_calls = calls.clone();
+            let addr = crate::test_support::FakeTso::new()
+                .on_get_seq_batch(move |req| {
+                    let calls = server_calls.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let grants = req
+                            .entries
+                            .iter()
+                            .map(|e| tsoracle_proto::v1::SeqGrantEntry {
+                                key: e.key.clone(),
+                                start: 0,
+                                count: e.count,
+                            })
+                            .collect();
+                        // No epoch — protocol violation.
+                        Ok(tsoracle_proto::v1::GetSeqBatchResponse {
+                            grants,
+                            epoch: None,
+                        })
+                    }
+                })
+                .spawn()
+                .await;
+
+            let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+                .retry_policy(RetryPolicy {
+                    max_attempts: 3,
+                    per_attempt_deadline: Duration::from_secs(2),
+                    overall_deadline: Duration::from_secs(5),
+                    base_backoff: Duration::ZERO,
+                    leader_ttl: Duration::from_secs(30),
+                })
+                .build()
+                .await
+                .expect("client must build");
+
+            match client
+                .get_seq_batch(&[("orders", 5), ("invoices", 3)])
+                .await
+            {
+                Err(ClientError::SeqUncertain) => {}
+                other => panic!("missing epoch must surface as SeqUncertain, got {other:?}"),
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "malformed success must not trigger a retry"
+            );
+        }
+
+        // Case 4: grant.key mismatches the requested key (the other branch of
+        // the per-entry `||` guard, distinct from the count-mismatch Case 2).
+        {
+            let calls = Arc::new(AtomicU64::new(0));
+            let server_calls = calls.clone();
+            let addr = crate::test_support::FakeTso::new()
+                .on_get_seq_batch(move |req| {
+                    let calls = server_calls.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let (hi, lo) = tsoracle_core::Epoch(1).to_wire();
+                        // Echo the right count but tamper the first grant's key.
+                        let grants = req
+                            .entries
+                            .iter()
+                            .enumerate()
+                            .map(|(i, e)| tsoracle_proto::v1::SeqGrantEntry {
+                                key: if i == 0 {
+                                    format!("{}-tampered", e.key)
+                                } else {
+                                    e.key.clone()
+                                },
+                                start: 0,
+                                count: e.count,
+                            })
+                            .collect();
+                        Ok(tsoracle_proto::v1::GetSeqBatchResponse {
+                            grants,
+                            epoch: Some(tsoracle_proto::v1::EpochWire { hi, lo }),
+                        })
+                    }
+                })
+                .spawn()
+                .await;
+
+            let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+                .retry_policy(RetryPolicy {
+                    max_attempts: 3,
+                    per_attempt_deadline: Duration::from_secs(2),
+                    overall_deadline: Duration::from_secs(5),
+                    base_backoff: Duration::ZERO,
+                    leader_ttl: Duration::from_secs(30),
+                })
+                .build()
+                .await
+                .expect("client must build");
+
+            match client
+                .get_seq_batch(&[("orders", 5), ("invoices", 3)])
+                .await
+            {
+                Err(ClientError::SeqUncertain) => {}
+                other => panic!("key-mismatch grant must surface as SeqUncertain, got {other:?}"),
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "malformed success must not trigger a retry"
+            );
+        }
+    }
+
+    /// A post-send server error (e.g. `INTERNAL`) from `GetSeqBatch` surfaces as
+    /// `SeqUncertain` and the server is invoked exactly once — never retried.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_seq_batch_post_send_error_is_uncertain_without_retry() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let calls = Arc::new(AtomicU64::new(0));
+        let server_calls = calls.clone();
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(move |_req| {
+                let calls = server_calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Err(tonic::Status::internal("permanent dense driver fault"))
+                }
+            })
+            .spawn()
+            .await;
+
+        let client = ClientBuilder::endpoints(vec![format!("http://{addr}")])
+            .retry_policy(RetryPolicy {
+                max_attempts: 3,
+                per_attempt_deadline: Duration::from_secs(2),
+                overall_deadline: Duration::from_secs(5),
+                base_backoff: Duration::ZERO,
+                leader_ttl: Duration::from_secs(30),
+            })
+            .build()
+            .await
+            .expect("client must build");
+
+        match client
+            .get_seq_batch(&[("orders", 1), ("invoices", 2)])
+            .await
+        {
+            Err(ClientError::SeqUncertain) => {}
+            other => panic!("post-send INTERNAL must be SeqUncertain, got {other:?}"),
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "post-send INTERNAL must NOT be retried (possible committed advance)"
         );
     }
 }

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -716,6 +716,273 @@ pub(crate) async fn issue_seq_rpc(
     Err(surface_error(election_signal, last_err))
 }
 
+/// Issue one `GetSeqBatch(entries)` with the dense retry policy.
+///
+/// Structurally identical to [`issue_seq_rpc`] — per-attempt budget, overall
+/// deadline, redirect bounds, squeezed-budget guard, election ride-out — but
+/// dispatches `GetSeqBatch` and validates the *whole batch* on success.
+///
+/// **Non-idempotent (whole batch):** on any ambiguous post-send failure the
+/// function returns [`ClientError::SeqUncertain`] immediately and does NOT retry.
+/// The server contract is all-or-nothing (one atomic apply for the entire batch),
+/// so `SeqUncertain` means the batch may or may not have committed; the caller
+/// must reconcile before re-issuing. There is never a partial mix to untangle.
+///
+/// A malformed success response (wrong grants length, mismatched key or count,
+/// missing epoch) is likewise treated as a protocol violation and surfaces
+/// `SeqUncertain` — a commit occurred, the block descriptions are untrustworthy.
+pub(crate) async fn issue_seq_batch_rpc(
+    pool: &ChannelPool,
+    entries: &[(&str, u32)],
+) -> Result<Vec<SeqBlock>, ClientError> {
+    let policy = pool.retry_policy().clone();
+    let budget = Budget::start(&policy);
+    let mut last_err: Option<ClientError> = None;
+    let mut election_signal: Option<tonic::Status> = None;
+    let mut failed_attempts: u32 = 0;
+    let mut total_redirects: u32 = 0;
+    let mut attempt_cap: usize = 0;
+    let mut pass: u32 = 0;
+    let mut issued_one = false;
+
+    'passes: loop {
+        let initial_endpoints = pool.iter_round_robin();
+        if pass == 0 {
+            attempt_cap = policy.max_attempts.max(initial_endpoints.len());
+        }
+        let mut worklist = Worklist::new(initial_endpoints);
+        let mut redirects: u32 = 0;
+        let mut saw_election_signal = false;
+
+        while let Some(endpoint) = worklist.next() {
+            if failed_attempts as usize >= attempt_cap {
+                break;
+            }
+            let Some(attempt_budget) = budget.next_attempt() else {
+                break;
+            };
+            // Non-idempotent ride-out guard: once at least one attempt has been
+            // issued, refuse to issue a sub-viable attempt whose budget the
+            // overall deadline has squeezed below a full per-attempt window.
+            if issued_one && attempt_budget < policy.per_attempt_deadline {
+                break 'passes;
+            }
+            issued_one = true;
+
+            #[cfg(feature = "tracing")]
+            tracing::debug!(
+                endpoint = %endpoint,
+                keys = entries.len(),
+                failed_attempts,
+                pass,
+                budget_ms = attempt_budget.as_millis() as u64,
+                "tsoracle-client: dispatching GetSeqBatch to endpoint",
+            );
+
+            let pair = PairBudget::start(attempt_budget);
+
+            let (mut client, cell) = match tokio::time::timeout(
+                attempt_budget,
+                pool.client_with_cell(&endpoint),
+            )
+            .await
+            {
+                Ok(Ok(leased)) => leased,
+                Ok(Err(err)) => {
+                    // Connect failed before any bytes were sent — pre-commit-certain.
+                    let do_backoff = should_backoff(&err);
+                    last_err = Some(err);
+                    failed_attempts = failed_attempts.saturating_add(1);
+                    if do_backoff {
+                        let backoff = jittered_backoff(policy.base_backoff, failed_attempts - 1);
+                        let sleep_for = budget.clamp_backoff(backoff);
+                        if sleep_for > Duration::ZERO {
+                            tokio::time::sleep(sleep_for).await;
+                        }
+                    }
+                    continue;
+                }
+                Err(_) => {
+                    // Connect timed out — pre-commit-certain (no bytes sent).
+                    let err = ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
+                        "connect exceeded per_attempt_deadline of {attempt_budget:?}"
+                    )));
+                    last_err = Some(err);
+                    failed_attempts = failed_attempts.saturating_add(1);
+                    continue;
+                }
+            };
+
+            // Channel acquired: from this point a commit may occur on the
+            // server. Any transport-class failure from here on is ambiguous.
+            let rpc_budget = pair.remaining();
+            let request_entries: Vec<tsoracle_proto::v1::SeqRequestEntry> = entries
+                .iter()
+                .map(|(key, count)| tsoracle_proto::v1::SeqRequestEntry {
+                    key: key.to_string(),
+                    count: *count,
+                })
+                .collect();
+            let rpc = client.get_seq_batch(tsoracle_proto::v1::GetSeqBatchRequest {
+                entries: request_entries,
+            });
+
+            let outcome = match tokio::time::timeout(rpc_budget, rpc).await {
+                Ok(Ok(response)) => {
+                    let inner = response.into_inner();
+                    // Validate the WHOLE batch before trusting it. Positional
+                    // mapping makes a malformed response silently wrong, so any
+                    // shape mismatch is a protocol violation we cannot resolve
+                    // into safe blocks: surface SeqUncertain (a commit may have
+                    // occurred; the caller reconciles) rather than return
+                    // mis-mapped blocks or silently retry into a double-spend.
+                    if inner.grants.len() != entries.len() {
+                        return Err(ClientError::SeqUncertain);
+                    }
+                    let epoch = match inner.epoch {
+                        Some(ew) => tsoracle_core::Epoch::from_wire(ew.hi, ew.lo).0,
+                        None => return Err(ClientError::SeqUncertain),
+                    };
+                    let mut blocks = Vec::with_capacity(inner.grants.len());
+                    for ((req_key, req_count), grant) in entries.iter().zip(inner.grants.iter()) {
+                        if grant.key != *req_key || grant.count != *req_count {
+                            return Err(ClientError::SeqUncertain);
+                        }
+                        blocks.push(SeqBlock {
+                            start: grant.start,
+                            count: grant.count,
+                            epoch,
+                        });
+                    }
+                    pool.record_success(&endpoint, epoch);
+                    return Ok(blocks);
+                }
+                Ok(Err(status)) if status.code() == tonic::Code::FailedPrecondition => {
+                    use crate::attempt::{AttemptOutcome as AO, HintUnusableReason};
+                    use crate::channel_pool::{LeaderHintLookup, decode_leader_hint};
+                    if matches!(decode_leader_hint(&status), LeaderHintLookup::Absent) {
+                        classify_seq_status(status, false)
+                    } else {
+                        match classify_not_leader_hint(pool, &endpoint, status) {
+                            AO::LeaderHint {
+                                endpoint: hinted,
+                                epoch,
+                            } => SeqAttemptOutcome::LeaderHint {
+                                endpoint: hinted,
+                                epoch,
+                            },
+                            AO::NoLeaderYet(status)
+                            | AO::HintUnusable {
+                                status,
+                                reason: HintUnusableReason::StaleEpoch,
+                            } => {
+                                #[cfg(feature = "metrics")]
+                                metrics::counter!("tsoracle.client.leader_hint.stale.total")
+                                    .increment(1);
+                                saw_election_signal = true;
+                                election_signal = Some(status.clone());
+                                last_err = Some(ClientError::Rpc(status));
+                                continue;
+                            }
+                            AO::HintUnusable {
+                                status,
+                                reason: HintUnusableReason::Rejected,
+                            } => SeqAttemptOutcome::Err(ClientError::Rpc(status)),
+                            AO::Ok { .. } | AO::Err(_) => {
+                                unreachable!(
+                                    "classify_not_leader_hint on FailedPrecondition \
+                                     cannot produce Ok/Err"
+                                )
+                            }
+                        }
+                    }
+                }
+                Ok(Err(status)) => {
+                    // Post-connect RPC failure — always post-send.
+                    if is_transport_failure(&ClientError::Rpc(status.clone())) {
+                        pool.evict_if_current(&endpoint, &cell);
+                    }
+                    classify_seq_status(status, true)
+                }
+                Err(_) => {
+                    // RPC timed out post-connect — ambiguous.
+                    pool.evict_if_current(&endpoint, &cell);
+                    SeqAttemptOutcome::Uncertain
+                }
+            };
+
+            match outcome {
+                SeqAttemptOutcome::Uncertain => {
+                    // Ambiguous post-send failure: surface immediately, never retry.
+                    return Err(ClientError::SeqUncertain);
+                }
+                SeqAttemptOutcome::LeaderHint {
+                    endpoint: hinted,
+                    epoch: _hint_epoch,
+                } => {
+                    // Absolute total-redirect cap.
+                    if total_redirects >= MAX_TOTAL_LEADER_REDIRECTS {
+                        #[cfg(feature = "metrics")]
+                        metrics::counter!("tsoracle.client.leader_redirect_total_cap.total")
+                            .increment(1);
+                        last_err = Some(ClientError::Rpc(tonic::Status::failed_precondition(
+                            format!(
+                                "absolute leader-hint redirect cap ({MAX_TOTAL_LEADER_REDIRECTS}) \
+                                 reached across passes before finding the live leader"
+                            ),
+                        )));
+                        break 'passes;
+                    }
+                    if redirects >= MAX_LEADER_REDIRECTS {
+                        #[cfg(feature = "metrics")]
+                        metrics::counter!("tsoracle.client.leader_redirect_cap.total").increment(1);
+                        let status = tonic::Status::failed_precondition(format!(
+                            "leader-hint redirect cap ({MAX_LEADER_REDIRECTS}) reached \
+                             before finding the live leader"
+                        ));
+                        election_signal = Some(status.clone());
+                        last_err = Some(ClientError::Rpc(status));
+                        saw_election_signal = true;
+                        break;
+                    }
+                    redirects += 1;
+                    total_redirects = total_redirects.saturating_add(1);
+                    #[cfg(feature = "metrics")]
+                    metrics::counter!("tsoracle.client.leader_pivots.total").increment(1);
+                    worklist.redirect_to(hinted);
+                    continue;
+                }
+                SeqAttemptOutcome::Err(err) => {
+                    let should_sleep = should_backoff(&err);
+                    last_err = Some(err);
+                    failed_attempts = failed_attempts.saturating_add(1);
+                    if should_sleep {
+                        let backoff = jittered_backoff(policy.base_backoff, failed_attempts - 1);
+                        let sleep_for = budget.clamp_backoff(backoff);
+                        if sleep_for > Duration::ZERO {
+                            tokio::time::sleep(sleep_for).await;
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
+
+        // End of pass.
+        if saw_election_signal && budget.next_attempt().is_some() {
+            let backoff = jittered_backoff(policy.base_backoff, pass);
+            let sleep_for = budget.clamp_backoff(backoff);
+            if sleep_for > Duration::ZERO {
+                tokio::time::sleep(sleep_for).await;
+            }
+            pass = pass.saturating_add(1);
+            continue;
+        }
+        break;
+    }
+    Err(surface_error(election_signal, last_err))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tsoracle-client/src/retry.rs
+++ b/crates/tsoracle-client/src/retry.rs
@@ -2429,4 +2429,382 @@ mod tests {
             ),
         }
     }
+
+    // ------------------------------------------------------------------
+    // seq_batch_* tests: analogues of the seq_* tests above for the
+    // GetSeqBatch (multi-key) path. Each mirrors the structural intent of
+    // its single-key sibling; only the RPC call and fake handler differ.
+    // ------------------------------------------------------------------
+
+    /// Helper: build a well-formed `GetSeqBatchResponse` that echoes the
+    /// first request entry back (key="orders", count=1, start=100) with a
+    /// fixed epoch. Used by tests whose batch handler succeeds.
+    fn batch_ok_response(
+        req: tsoracle_proto::v1::GetSeqBatchRequest,
+    ) -> tsoracle_proto::v1::GetSeqBatchResponse {
+        let (hi, lo) = tsoracle_core::Epoch(9).to_wire();
+        let grants = req
+            .entries
+            .iter()
+            .scan(100u64, |start, entry| {
+                let grant = tsoracle_proto::v1::SeqGrantEntry {
+                    key: entry.key.clone(),
+                    start: *start,
+                    count: entry.count,
+                };
+                *start += u64::from(entry.count);
+                Some(grant)
+            })
+            .collect();
+        tsoracle_proto::v1::GetSeqBatchResponse {
+            grants,
+            epoch: Some(tsoracle_proto::v1::EpochWire { hi, lo }),
+        }
+    }
+
+    /// Dense-batch analogue of `seq_follows_leader_hint_chain_to_leader`:
+    /// GetSeqBatch redirected by NOT_LEADER+hint several times must follow
+    /// the chain to the live leader and return blocks. Exercises
+    /// `issue_seq_batch_rpc`'s LeaderHint redirect arm.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seq_batch_follows_leader_hint_chain_to_leader() {
+        use std::future::Future;
+        use std::pin::Pin;
+        const REDIRECTS: usize = 3;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let server_calls = calls.clone();
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(move |req| {
+                let calls = server_calls.clone();
+                async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst);
+                    if n < REDIRECTS {
+                        Err(make_status_with_hint(tsoracle_proto::v1::LeaderHint {
+                            leader_endpoint: Some(format!("redirect-{}:1", n + 1)),
+                            leader_epoch: None,
+                        }))
+                    } else {
+                        Ok(batch_ok_response(req))
+                    }
+                }
+            })
+            .spawn()
+            .await;
+
+        let connector: Arc<crate::transport::ChannelConnector> =
+            Arc::new(move |_endpoint: &str| {
+                let target = format!("http://{addr}");
+                Box::pin(async move {
+                    tonic::transport::Endpoint::from_shared(target)
+                        .map_err(ClientError::from)?
+                        .connect()
+                        .await
+                        .map_err(ClientError::from)
+                }) as Pin<Box<dyn Future<Output = Result<_, _>> + Send>>
+            });
+
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            per_attempt_deadline: Duration::from_secs(2),
+            overall_deadline: Duration::from_secs(10),
+            base_backoff: Duration::ZERO,
+            leader_ttl: Duration::from_secs(30),
+        };
+        let pool = ChannelPool::new(vec!["redirect-0:1".into()], Some(connector), false, policy);
+
+        let blocks = issue_seq_batch_rpc(&pool, &[("orders", 1), ("invoices", 2)])
+            .await
+            .expect("a redirect chain ending at a live leader must yield blocks");
+        assert_eq!(blocks.len(), 2, "one block per batch entry");
+        assert_eq!(blocks[0].start, 100, "orders block start");
+        assert_eq!(blocks[0].count, 1);
+        assert_eq!(blocks[0].epoch, 9);
+        assert_eq!(blocks[1].start, 101, "invoices block start after orders");
+        assert_eq!(blocks[1].count, 2);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            REDIRECTS + 1,
+            "the loop must dial through all {REDIRECTS} redirects to the leader",
+        );
+    }
+
+    /// Batch analogue of `seq_endpointless_hint_fails_fast`: a NOT_LEADER
+    /// whose hint is present but carries no endpoint classifies as
+    /// `HintUnusable { Rejected }` and causes `issue_seq_batch_rpc` to fail
+    /// fast rather than ride out the deadline.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seq_batch_endpointless_hint_fails_fast() {
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(|_req| async {
+                Err(make_status_with_hint(tsoracle_proto::v1::LeaderHint {
+                    leader_endpoint: None,
+                    leader_epoch: None,
+                }))
+            })
+            .spawn()
+            .await;
+
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            per_attempt_deadline: Duration::from_secs(2),
+            overall_deadline: Duration::from_secs(10),
+            base_backoff: Duration::ZERO,
+            leader_ttl: Duration::from_secs(30),
+        };
+        let pool = ChannelPool::new(vec![format!("http://{addr}")], None, false, policy);
+
+        let start = Instant::now();
+        let result = issue_seq_batch_rpc(&pool, &[("orders", 1), ("invoices", 2)]).await;
+        let elapsed = start.elapsed();
+        assert!(
+            matches!(result, Err(ClientError::Rpc(_))),
+            "an unfollowable hint must surface a definitive Rpc error, got {result:?}",
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "an unfollowable hint must fail fast, not ride out the deadline; took {elapsed:?}",
+        );
+    }
+
+    /// Batch analogue of `seq_dead_pool_surfaces_error_fast`: a pool whose
+    /// endpoints all refuse to connect must surface an error fast (all
+    /// connect failures are pre-commit-certain; no `SeqUncertain` risk).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seq_batch_dead_pool_surfaces_error_fast() {
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            per_attempt_deadline: Duration::from_millis(100),
+            overall_deadline: Duration::from_secs(10),
+            base_backoff: Duration::ZERO,
+            leader_ttl: Duration::from_secs(30),
+        };
+        let pool = ChannelPool::new(
+            vec!["http://127.0.0.1:1".into(), "http://127.0.0.1:2".into()],
+            None,
+            false,
+            policy,
+        );
+        let start = Instant::now();
+        let result = issue_seq_batch_rpc(&pool, &[("orders", 1), ("invoices", 2)]).await;
+        let elapsed = start.elapsed();
+        assert!(result.is_err(), "all-dead pool must surface an error");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "a dead pool must fail fast, not ride out the full deadline; took {elapsed:?}",
+        );
+    }
+
+    /// Batch analogue of `seq_success_without_epoch_is_uncertain`: a batch
+    /// success response that omits the epoch is a protocol violation;
+    /// `issue_seq_batch_rpc` must surface `SeqUncertain`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seq_batch_success_without_epoch_is_uncertain() {
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(|req| async move {
+                let grants = req
+                    .entries
+                    .iter()
+                    .map(|e| tsoracle_proto::v1::SeqGrantEntry {
+                        key: e.key.clone(),
+                        start: 0,
+                        count: e.count,
+                    })
+                    .collect();
+                Ok(tsoracle_proto::v1::GetSeqBatchResponse {
+                    grants,
+                    epoch: None, // protocol violation
+                })
+            })
+            .spawn()
+            .await;
+
+        let pool = ChannelPool::new(vec![format!("http://{addr}")], None, false, short_policy());
+        match issue_seq_batch_rpc(&pool, &[("orders", 1), ("invoices", 2)]).await {
+            Err(ClientError::SeqUncertain) => {}
+            other => panic!("epoch-less batch success must be SeqUncertain, got {other:?}"),
+        }
+    }
+
+    /// Batch analogue of `seq_endless_redirect_is_bounded_by_cap`: a cluster
+    /// that hints an endless redirect chain must be bounded by the absolute
+    /// cross-pass redirect cap, not the overall deadline.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seq_batch_endless_redirect_is_bounded_by_cap() {
+        use std::future::Future;
+        use std::pin::Pin;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let server_calls = calls.clone();
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(move |_req| {
+                let calls = server_calls.clone();
+                async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst);
+                    Err(make_status_with_hint(tsoracle_proto::v1::LeaderHint {
+                        leader_endpoint: Some(format!("redirect-{}:1", n + 1)),
+                        leader_epoch: None,
+                    }))
+                }
+            })
+            .spawn()
+            .await;
+
+        let connector: Arc<crate::transport::ChannelConnector> =
+            Arc::new(move |_endpoint: &str| {
+                let target = format!("http://{addr}");
+                Box::pin(async move {
+                    tonic::transport::Endpoint::from_shared(target)
+                        .map_err(ClientError::from)?
+                        .connect()
+                        .await
+                        .map_err(ClientError::from)
+                }) as Pin<Box<dyn Future<Output = Result<_, _>> + Send>>
+            });
+
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            per_attempt_deadline: Duration::from_secs(2),
+            overall_deadline: Duration::from_secs(10),
+            base_backoff: Duration::ZERO,
+            leader_ttl: Duration::from_secs(30),
+        };
+        let pool = ChannelPool::new(vec!["redirect-0:1".into()], Some(connector), false, policy);
+
+        let start = Instant::now();
+        let err = issue_seq_batch_rpc(&pool, &[("orders", 1), ("invoices", 2)])
+            .await
+            .expect_err("an endless redirect chain must surface an error, not blocks");
+        let elapsed = start.elapsed();
+        let dials = calls.load(Ordering::SeqCst);
+
+        match err {
+            ClientError::Rpc(status) => {
+                assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+                assert!(
+                    status
+                        .message()
+                        .contains("absolute leader-hint redirect cap"),
+                    "must surface the absolute-cap rejection, got {:?}",
+                    status.message(),
+                );
+            }
+            other => panic!("expected a bounded ClientError::Rpc, got {other:?}"),
+        }
+        assert!(
+            dials >= MAX_TOTAL_LEADER_REDIRECTS as usize
+                && dials <= (MAX_TOTAL_LEADER_REDIRECTS + 2 * MAX_LEADER_REDIRECTS) as usize,
+            "dials must be bounded by the absolute cap, not the deadline; got {dials}",
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "the cap (not the 10s deadline) must terminate the churn; took {elapsed:?}",
+        );
+    }
+
+    /// Batch analogue of `seq_stale_epoch_hint_rides_out_then_surfaces_election`:
+    /// a follower that hints an older-epoch leader triggers the StaleEpoch
+    /// election signal and `issue_seq_batch_rpc` rides it out until the
+    /// overall deadline, surfacing `FAILED_PRECONDITION`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seq_batch_stale_epoch_hint_rides_out_then_surfaces_election() {
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(|_req| async {
+                Err(make_status_with_hint(tsoracle_proto::v1::LeaderHint {
+                    leader_endpoint: Some("b:1".into()),
+                    leader_epoch: Some(tsoracle_proto::v1::EpochWire { hi: 0, lo: 5 }),
+                }))
+            })
+            .spawn()
+            .await;
+
+        let endpoint = format!("http://{addr}");
+        let pool = ChannelPool::new(vec![endpoint.clone()], None, false, short_policy());
+
+        // Wait until the fake peer is accepting and replying FAILED_PRECONDITION.
+        let ready_deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(mut client) = pool.client(&endpoint).await {
+                let replied = client
+                    .get_seq_batch(tsoracle_proto::v1::GetSeqBatchRequest {
+                        entries: vec![tsoracle_proto::v1::SeqRequestEntry {
+                            key: "orders".into(),
+                            count: 1,
+                        }],
+                    })
+                    .await
+                    .err()
+                    .is_some_and(|s| s.code() == tonic::Code::FailedPrecondition);
+                if replied {
+                    break;
+                }
+            }
+            assert!(
+                Instant::now() < ready_deadline,
+                "fake follower never came up"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Cache the endpoint as leader at epoch 10 so the epoch-5 hint is stale.
+        pool.record_success(&endpoint, 10);
+
+        match issue_seq_batch_rpc(&pool, &[("orders", 1), ("invoices", 2)]).await {
+            Err(ClientError::Rpc(status)) => assert_eq!(
+                status.code(),
+                tonic::Code::FailedPrecondition,
+                "a stale-hint batch ride-out must surface the election FAILED_PRECONDITION",
+            ),
+            other => panic!("expected a ridden-out FAILED_PRECONDITION, got {other:?}"),
+        }
+    }
+
+    /// Batch analogue of `seq_ride_out_skips_squeezed_attempt_and_surfaces_election`:
+    /// a budget-squeezed final ride-out attempt must NOT be issued on the batch
+    /// path. Without the guard the second attempt would time out post-send
+    /// and surface `SeqUncertain`, masking the election signal.
+    ///
+    /// Construction: the server delays every reply by 300ms; the policy grants
+    /// a 500ms per-attempt / 500ms overall budget. The first attempt drains
+    /// ~300ms, leaving ~200ms overall — too little for a full per-attempt
+    /// window. The squeezed second attempt must be skipped.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seq_batch_ride_out_skips_squeezed_attempt_and_surfaces_election() {
+        let addr = crate::test_support::FakeTso::new()
+            .on_get_seq_batch(|_req| async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                Err(make_status_with_hint(tsoracle_proto::v1::LeaderHint {
+                    leader_endpoint: Some("b:1".into()),
+                    leader_epoch: Some(tsoracle_proto::v1::EpochWire { hi: 0, lo: 5 }),
+                }))
+            })
+            .spawn()
+            .await;
+
+        let endpoint = format!("http://{addr}");
+        let policy = RetryPolicy {
+            max_attempts: 5,
+            per_attempt_deadline: Duration::from_millis(500),
+            overall_deadline: Duration::from_millis(500),
+            base_backoff: Duration::ZERO,
+            leader_ttl: Duration::from_secs(30),
+        };
+        let pool = ChannelPool::new(vec![endpoint.clone()], None, false, policy);
+
+        // Cache the endpoint as epoch-10 leader so the epoch-5 hint is stale.
+        pool.record_success(&endpoint, 10);
+
+        match issue_seq_batch_rpc(&pool, &[("orders", 1), ("invoices", 2)]).await {
+            Err(ClientError::Rpc(status)) => assert_eq!(
+                status.code(),
+                tonic::Code::FailedPrecondition,
+                "a budget-squeezed batch ride-out must surface the election \
+                 FAILED_PRECONDITION, not a manufactured SeqUncertain",
+            ),
+            other => panic!(
+                "a squeezed batch ride-out attempt must not be issued and time out; \
+                 expected the election FAILED_PRECONDITION, got {other:?}"
+            ),
+        }
+    }
 }

--- a/crates/tsoracle-client/src/test_support.rs
+++ b/crates/tsoracle-client/src/test_support.rs
@@ -32,8 +32,8 @@ use std::time::Duration;
 
 use tsoracle_proto::v1::tso_service_server::{TsoService, TsoServiceServer};
 use tsoracle_proto::v1::{
-    GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetSeqRequest, GetSeqResponse,
-    GetTsRequest, GetTsResponse,
+    GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetSeqBatchRequest, GetSeqBatchResponse,
+    GetSeqRequest, GetSeqResponse, GetTsRequest, GetTsResponse,
 };
 
 use crate::RetryPolicy;
@@ -81,21 +81,24 @@ pub(crate) fn make_status_with_hint(hint: tsoracle_proto::v1::LeaderHint) -> ton
 type BoxFut<T> = Pin<Box<dyn Future<Output = Result<T, tonic::Status>> + Send>>;
 type TsHandler = Arc<dyn Fn(GetTsRequest) -> BoxFut<GetTsResponse> + Send + Sync>;
 type SeqHandler = Arc<dyn Fn(GetSeqRequest) -> BoxFut<GetSeqResponse> + Send + Sync>;
+type SeqBatchHandler = Arc<dyn Fn(GetSeqBatchRequest) -> BoxFut<GetSeqBatchResponse> + Send + Sync>;
 
 /// A configurable fake [`TsoService`] for client tests. Per-call behavior is
 /// injected as closures, so this single trait impl — one `get_ts`, one
-/// `get_seq` — replaces the many bespoke per-test server structs. The shared
-/// `get_seq` earns real coverage from the dense tests that configure it, instead
-/// of leaving an unreachable `unimplemented!()` stub in every timestamp-path
-/// test that never calls it.
+/// `get_seq`, one `get_seq_batch` — replaces the many bespoke per-test server
+/// structs. The shared handlers earn real coverage from the tests that configure
+/// them, instead of leaving unreachable `unimplemented!()` stubs in every test
+/// that never calls a given RPC.
 ///
-/// Both handlers default to returning `UNIMPLEMENTED`; a test overrides only the
+/// All handlers default to returning `UNIMPLEMENTED`; a test overrides only the
 /// RPC it exercises via [`on_get_ts`](Self::on_get_ts) /
-/// [`on_get_seq`](Self::on_get_seq). `get_current_max_safe` returns the default
-/// response (every test that touches it wants exactly that).
+/// [`on_get_seq`](Self::on_get_seq) / [`on_get_seq_batch`](Self::on_get_seq_batch).
+/// `get_current_max_safe` returns the default response (every test that touches
+/// it wants exactly that).
 pub(crate) struct FakeTso {
     get_ts: TsHandler,
     get_seq: SeqHandler,
+    get_seq_batch: SeqBatchHandler,
 }
 
 impl FakeTso {
@@ -106,6 +109,11 @@ impl FakeTso {
             }),
             get_seq: Arc::new(|_| {
                 Box::pin(async { Err(tonic::Status::unimplemented("get_seq not configured")) })
+            }),
+            get_seq_batch: Arc::new(|_| {
+                Box::pin(async {
+                    Err(tonic::Status::unimplemented("get_seq_batch not configured"))
+                })
             }),
         }
     }
@@ -127,6 +135,16 @@ impl FakeTso {
         Fut: Future<Output = Result<GetSeqResponse, tonic::Status>> + Send + 'static,
     {
         self.get_seq = Arc::new(move |req| Box::pin(f(req)));
+        self
+    }
+
+    /// Override the `get_seq_batch` behavior with an async closure of the request.
+    pub(crate) fn on_get_seq_batch<F, Fut>(mut self, f: F) -> Self
+    where
+        F: Fn(GetSeqBatchRequest) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<GetSeqBatchResponse, tonic::Status>> + Send + 'static,
+    {
+        self.get_seq_batch = Arc::new(move |req| Box::pin(f(req)));
         self
     }
 
@@ -173,6 +191,15 @@ impl TsoService for FakeTso {
         request: tonic::Request<GetSeqRequest>,
     ) -> Result<tonic::Response<GetSeqResponse>, tonic::Status> {
         (self.get_seq)(request.into_inner())
+            .await
+            .map(tonic::Response::new)
+    }
+
+    async fn get_seq_batch(
+        &self,
+        request: tonic::Request<GetSeqBatchRequest>,
+    ) -> Result<tonic::Response<GetSeqBatchResponse>, tonic::Status> {
+        (self.get_seq_batch)(request.into_inner())
             .await
             .map(tonic::Response::new)
     }

--- a/crates/tsoracle-consensus/src/driver.rs
+++ b/crates/tsoracle-consensus/src/driver.rs
@@ -148,6 +148,20 @@ pub trait ConsensusDriver: Send + Sync + 'static {
         let (_, _, _) = (key, count, expected_epoch);
         Err(ConsensusError::DenseUnsupported)
     }
+
+    /// Atomic, linearized multi-key fetch-add: advances each `(key, count)` and
+    /// returns the per-key pre-advance block starts in request order. All-or-
+    /// nothing — a cardinality or overflow rejection advances no key. Lazily
+    /// creates absent keys at 0. `expected_epoch` fences a stale proposer.
+    /// Default: unsupported.
+    async fn advance_dense_batch(
+        &self,
+        entries: &[(tsoracle_core::SeqKey, u32)],
+        expected_epoch: Epoch,
+    ) -> Result<Vec<u64>, ConsensusError> {
+        let (_, _) = (entries, expected_epoch);
+        Err(ConsensusError::DenseUnsupported)
+    }
 }
 
 #[cfg(test)]
@@ -222,6 +236,14 @@ mod tests {
                     Err(ConsensusError::DenseUnsupported)
                 ),
                 "default advance_dense is DenseUnsupported",
+            );
+            let entries = vec![(tsoracle_core::SeqKey::try_new("k").unwrap(), 1u32)];
+            assert!(
+                matches!(
+                    driver.advance_dense_batch(&entries, Epoch(1)).await,
+                    Err(ConsensusError::DenseUnsupported)
+                ),
+                "default advance_dense_batch is DenseUnsupported",
             );
         });
     }

--- a/crates/tsoracle-consensus/src/error.rs
+++ b/crates/tsoracle-consensus/src/error.rs
@@ -74,6 +74,10 @@ pub enum ConsensusError {
         "dense sequences require write version {required} but the cluster is at {active}; activate the format first"
     )]
     DenseNotActivated { required: u8, active: u8 },
+    #[error(
+        "dense batch sequences require write version {required} but the cluster is at {active}; activate the format first"
+    )]
+    DenseBatchNotActivated { required: u8, active: u8 },
 }
 
 #[cfg(test)]

--- a/crates/tsoracle-core/src/lib.rs
+++ b/crates/tsoracle-core/src/lib.rs
@@ -37,5 +37,8 @@ pub mod docs;
 pub use allocator::{Allocator, CommitOutcome, CoreError, IgnoreReason, PhysicalMs, WindowGrant};
 pub use epoch::Epoch;
 pub use peer::{PeerEndpoint, PeerEndpointError, TsoPeer};
-pub use seq::{DEFAULT_MAX_SEQ_COUNT, MAX_SEQ_KEY_LEN, SeqAllocator, SeqGrant, SeqKey};
+pub use seq::{
+    DEFAULT_MAX_SEQ_BATCH_KEYS, DEFAULT_MAX_SEQ_COUNT, MAX_SEQ_KEY_LEN, SeqAllocator, SeqGrant,
+    SeqKey,
+};
 pub use timestamp::{LOGICAL_MAX, PHYSICAL_MS_MAX, Timestamp, TimestampError};

--- a/crates/tsoracle-core/src/seq.rs
+++ b/crates/tsoracle-core/src/seq.rs
@@ -31,6 +31,14 @@ use crate::{CoreError, Epoch};
 /// Maximum length, in bytes, of a sequence key's UTF-8 encoding.
 pub const MAX_SEQ_KEY_LEN: usize = 128;
 
+/// Default cap on the number of `(key, count)` entries in one `GetSeqBatch`
+/// request. A soft anti-abuse guardrail bounding fan-out and the size of one
+/// atomic consensus entry; operators tune it via
+/// [`ServerBuilder::max_seq_batch_keys`].
+///
+/// [`ServerBuilder::max_seq_batch_keys`]: https://docs.rs/tsoracle-server
+pub const DEFAULT_MAX_SEQ_BATCH_KEYS: u32 = 128;
+
 /// Default per-call ceiling on `GetSeq`'s `count` — the largest block a single
 /// request may reserve when the server has not overridden it.
 ///

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -437,6 +437,68 @@ impl ConsensusDriver for FileDriver {
         dense.map = new_map;
         Ok(start)
     }
+
+    async fn advance_dense_batch(
+        &self,
+        entries: &[(tsoracle_core::SeqKey, u32)],
+        _expected_epoch: Epoch,
+    ) -> Result<Vec<u64>, ConsensusError> {
+        // An empty batch is a no-op: return before locking or touching disk so a
+        // degenerate call never triggers a gratuitous durable rewrite.
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut dense = self.dense.lock().await;
+
+        // Phase 1: cardinality. Count distinct keys not already present;
+        // duplicates within the batch count only once.
+        let new_keys: std::collections::BTreeSet<&str> = entries
+            .iter()
+            .map(|(key, _)| key.as_str())
+            .filter(|k| !dense.map.contains_key(*k))
+            .collect();
+        if dense.map.len() as u64 + new_keys.len() as u64 > dense.cap {
+            return Err(ConsensusError::SeqKeyCardinalityExceeded { cap: dense.cap });
+        }
+
+        // Phase 2: sequential fold into a scratch map seeded from current
+        // counters; each entry's start is the running value before the advance.
+        // Overflow against the accumulated value rejects the whole batch.
+        let mut scratch: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
+        let mut starts: Vec<u64> = Vec::with_capacity(entries.len());
+        for (key, count) in entries {
+            let key_str = key.as_str();
+            let running = scratch
+                .get(key_str)
+                .copied()
+                .or_else(|| dense.map.get(key_str).copied())
+                .unwrap_or(0);
+            starts.push(running);
+            let next = running
+                .checked_add(u64::from(*count))
+                .ok_or(ConsensusError::SeqOverflow)?;
+            scratch.insert(key_str.to_string(), next);
+        }
+
+        // Phase 3: build the would-be-new map, persist it durably ONCE, THEN
+        // publish. A crash before the publish leaves the prior map intact.
+        let mut new_map = dense.map.clone();
+        for (key_str, next) in &scratch {
+            new_map.insert(key_str.clone(), *next);
+        }
+        let cap = dense.cap;
+        let dir = self.dir.clone();
+        let to_write = new_map.clone();
+        tokio::task::spawn_blocking(move || write_dense_record(&dir, &to_write, cap))
+            .await
+            .map_err(|e| ConsensusError::PermanentDriver(Box::new(std::io::Error::other(e))))?
+            .map_err(|e| ConsensusError::PermanentDriver(Box::new(e)))?;
+
+        dense.map = new_map;
+        Ok(starts)
+    }
 }
 
 #[cfg(test)]
@@ -538,6 +600,90 @@ mod dense_tests {
             err,
             Err(tsoracle_consensus::ConsensusError::SeqKeyCardinalityExceeded { cap: 2 })
         ));
+    }
+
+    #[tokio::test]
+    async fn batch_advance_is_gapless_atomic_and_one_durable_write() {
+        let dir = tempfile::tempdir().unwrap();
+        // FileDriver holds an EXCLUSIVE directory lock for its lifetime, so the
+        // first driver must be dropped (scope) before reopening — mirroring the
+        // existing `counters_survive_reopen` test.
+        {
+            let d = FileDriver::open_or_init(dir.path()).unwrap();
+            let starts = d
+                .advance_dense_batch(&[(key("orders"), 5), (key("users"), 2)], Epoch(1))
+                .await
+                .unwrap();
+            assert_eq!(starts, vec![0, 0]);
+        }
+        // Reopen: the whole batch was one durable write.
+        let d2 = FileDriver::open_or_init(dir.path()).unwrap();
+        assert_eq!(d2.load_dense_seq(&key("orders")).await.unwrap(), 5);
+        assert_eq!(d2.load_dense_seq(&key("users")).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn batch_advance_duplicate_key_yields_adjacent_starts() {
+        // A duplicate key within one batch (rejected by the server pre-commit,
+        // but handled deterministically here so the driver is never the weak
+        // link) must produce ADJACENT, non-overlapping blocks: the second
+        // entry's start is the first entry's post-advance value. This pins the
+        // accumulation contract directly, since the file driver returns starts.
+        let dir = tempfile::tempdir().unwrap();
+        let d = FileDriver::open_or_init(dir.path()).unwrap();
+        let starts = d
+            .advance_dense_batch(&[(key("k"), 3), (key("k"), 5)], Epoch(1))
+            .await
+            .unwrap();
+        assert_eq!(starts, vec![0, 3]); // [0,3) then [3,8)
+        assert_eq!(d.load_dense_seq(&key("k")).await.unwrap(), 8);
+    }
+
+    #[tokio::test]
+    async fn batch_advance_empty_is_noop() {
+        // An empty batch returns an empty start list without touching disk.
+        let dir = tempfile::tempdir().unwrap();
+        let d = FileDriver::open_or_init(dir.path()).unwrap();
+        assert_eq!(d.advance_dense_batch(&[], Epoch(1)).await.unwrap(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn batch_cardinality_is_atomic() {
+        use std::collections::BTreeMap;
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = BTreeMap::new();
+        m.insert("a".to_string(), 1u64);
+        let bytes = crate::dense_record::encode(&m, 1); // cap 1, full
+        std::fs::write(dir.path().join("dense"), bytes).unwrap();
+        let d = FileDriver::open_or_init(dir.path()).unwrap();
+        let err = d
+            .advance_dense_batch(&[(key("a"), 1), (key("b"), 1)], Epoch(1))
+            .await;
+        assert!(matches!(
+            err,
+            Err(tsoracle_consensus::ConsensusError::SeqKeyCardinalityExceeded { cap: 1 })
+        ));
+        // "a" unchanged — nothing committed.
+        assert_eq!(d.load_dense_seq(&key("a")).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn batch_overflow_is_atomic_and_accumulates_duplicates() {
+        use std::collections::BTreeMap;
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = BTreeMap::new();
+        m.insert("k".to_string(), u64::MAX - 5);
+        let bytes = crate::dense_record::encode(&m, DEFAULT_DENSE_CARDINALITY_CAP);
+        std::fs::write(dir.path().join("dense"), bytes).unwrap();
+        let d = FileDriver::open_or_init(dir.path()).unwrap();
+        let err = d
+            .advance_dense_batch(&[(key("k"), 4), (key("k"), 4)], Epoch(1))
+            .await;
+        assert!(matches!(
+            err,
+            Err(tsoracle_consensus::ConsensusError::SeqOverflow)
+        ));
+        assert_eq!(d.load_dense_seq(&key("k")).await.unwrap(), u64::MAX - 5);
     }
 }
 

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -48,6 +48,7 @@ use futures::{Stream, StreamExt};
 use openraft::RaftTypeConfig;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::Epoch;
+use tsoracle_openraft_toolkit::BATCH_WRITE_VERSION;
 use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
 use tsoracle_openraft_toolkit::LeadershipState;
 use tsoracle_openraft_toolkit::leadership_events_from_metrics;
@@ -145,6 +146,27 @@ where
             });
         }
         self.host.submit_advance_dense(key, count).await
+    }
+
+    /// Atomic multi-key dense fetch-add, gated on batch-format activation.
+    /// `_expected_epoch` is ignored for the same reason as `advance_dense`
+    /// (openraft's leadership fence + committed-log linearization).
+    async fn advance_dense_batch(
+        &self,
+        entries: &[(tsoracle_core::SeqKey, u32)],
+        _expected_epoch: Epoch,
+    ) -> Result<Vec<u64>, ConsensusError> {
+        // Rollout gate: refuse until the batch format is active cluster-wide, so
+        // no un-upgraded follower is ever handed an AdvanceDenseBatch entry it
+        // cannot decode.
+        let active = self.host.active_write_version();
+        if active < BATCH_WRITE_VERSION {
+            return Err(ConsensusError::DenseBatchNotActivated {
+                required: BATCH_WRITE_VERSION,
+                active,
+            });
+        }
+        self.host.submit_advance_dense_batch(entries).await
     }
 
     /// Read a key's committed dense counter (0 if absent), linearized.
@@ -357,6 +379,13 @@ mod tests {
             Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
         }
 
+        async fn submit_advance_dense_batch(
+            &self,
+            _entries: &[(tsoracle_core::SeqKey, u32)],
+        ) -> Result<Vec<u64>, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
+        }
+
         async fn current_dense_seq(
             &self,
             _key: &tsoracle_core::SeqKey,
@@ -370,6 +399,121 @@ mod tests {
         let metrics = openraft::RaftMetrics::<TypeConfig>::new_initial(1u64);
         let (_tx, rx) = <TypeConfig as TypeConfigExt>::watch_channel(metrics);
         super::OpenraftDriver::new(EchoHost { rx })
+    }
+
+    /// A host whose `active_write_version` returns a caller-supplied value,
+    /// used to test the activation gate at an exact version boundary.
+    struct VersionedEchoHost {
+        version: u8,
+        rx: openraft::type_config::alias::WatchReceiverOf<
+            TypeConfig,
+            openraft::RaftMetrics<TypeConfig>,
+        >,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::host::OpenraftHighWaterHost for VersionedEchoHost {
+        type Config = TypeConfig;
+
+        fn metrics(
+            &self,
+        ) -> openraft::type_config::alias::WatchReceiverOf<
+            Self::Config,
+            openraft::RaftMetrics<Self::Config>,
+        > {
+            self.rx.clone()
+        }
+
+        async fn current_high_water(&self) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Ok(0)
+        }
+
+        async fn submit_advance(
+            &self,
+            at_least: u64,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Ok(at_least)
+        }
+
+        fn active_write_version(&self) -> u8 {
+            self.version
+        }
+
+        async fn submit_advance_dense(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+            _count: u32,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
+        }
+
+        async fn submit_advance_dense_batch(
+            &self,
+            _entries: &[(tsoracle_core::SeqKey, u32)],
+        ) -> Result<Vec<u64>, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
+        }
+
+        async fn current_dense_seq(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
+        }
+    }
+
+    fn versioned_echo_driver(
+        version: u8,
+    ) -> std::sync::Arc<super::OpenraftDriver<VersionedEchoHost>> {
+        use openraft::type_config::TypeConfigExt;
+        let metrics = openraft::RaftMetrics::<TypeConfig>::new_initial(1u64);
+        let (_tx, rx) = <TypeConfig as TypeConfigExt>::watch_channel(metrics);
+        super::OpenraftDriver::new(VersionedEchoHost { version, rx })
+    }
+
+    #[tokio::test]
+    async fn advance_dense_returns_dense_not_activated_below_dense_write_version() {
+        use tsoracle_consensus::ConsensusDriver;
+        use tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION;
+        use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
+
+        let driver = versioned_echo_driver(BASELINE_WRITE_VERSION);
+        let key = tsoracle_core::SeqKey::try_new("k").unwrap();
+        let err = driver
+            .advance_dense(&key, 1, Epoch::ZERO)
+            .await
+            .expect_err("advance_dense must be rejected when dense is not activated");
+        assert!(
+            matches!(
+                err,
+                tsoracle_consensus::ConsensusError::DenseNotActivated { required, active }
+                if required == DENSE_WRITE_VERSION && active == BASELINE_WRITE_VERSION
+            ),
+            "expected DenseNotActivated, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn advance_dense_batch_returns_dense_batch_not_activated_below_batch_write_version() {
+        use tsoracle_consensus::ConsensusDriver;
+        use tsoracle_openraft_toolkit::BATCH_WRITE_VERSION;
+        use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
+
+        // Dense is activated (version == DENSE_WRITE_VERSION) but batch is not yet.
+        let driver = versioned_echo_driver(DENSE_WRITE_VERSION);
+        let key = tsoracle_core::SeqKey::try_new("k").unwrap();
+        let err = driver
+            .advance_dense_batch(&[(key, 1)], Epoch::ZERO)
+            .await
+            .expect_err("advance_dense_batch must be rejected when batch format is not activated");
+        assert!(
+            matches!(
+                err,
+                tsoracle_consensus::ConsensusError::DenseBatchNotActivated { required, active }
+                if required == BATCH_WRITE_VERSION && active == DENSE_WRITE_VERSION
+            ),
+            "expected DenseBatchNotActivated, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/tsoracle-driver-openraft/src/driver.rs
+++ b/crates/tsoracle-driver-openraft/src/driver.rs
@@ -493,6 +493,102 @@ mod tests {
         );
     }
 
+    /// A host whose `submit_advance_dense_batch` echoes back fixed starts so the
+    /// driver's success-delegation path is exercised at BATCH_WRITE_VERSION.
+    struct BatchEchoHost {
+        version: u8,
+        rx: openraft::type_config::alias::WatchReceiverOf<
+            TypeConfig,
+            openraft::RaftMetrics<TypeConfig>,
+        >,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::host::OpenraftHighWaterHost for BatchEchoHost {
+        type Config = TypeConfig;
+
+        fn metrics(
+            &self,
+        ) -> openraft::type_config::alias::WatchReceiverOf<
+            Self::Config,
+            openraft::RaftMetrics<Self::Config>,
+        > {
+            self.rx.clone()
+        }
+
+        async fn current_high_water(&self) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Ok(0)
+        }
+
+        async fn submit_advance(
+            &self,
+            at_least: u64,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Ok(at_least)
+        }
+
+        fn active_write_version(&self) -> u8 {
+            self.version
+        }
+
+        async fn submit_advance_dense(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+            _count: u32,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
+        }
+
+        /// Echo fixed starts: entry i gets start = i * 100.
+        async fn submit_advance_dense_batch(
+            &self,
+            entries: &[(tsoracle_core::SeqKey, u32)],
+        ) -> Result<Vec<u64>, tsoracle_consensus::ConsensusError> {
+            Ok(entries
+                .iter()
+                .enumerate()
+                .map(|(i, _)| i as u64 * 100)
+                .collect())
+        }
+
+        async fn current_dense_seq(
+            &self,
+            _key: &tsoracle_core::SeqKey,
+        ) -> Result<u64, tsoracle_consensus::ConsensusError> {
+            Err(tsoracle_consensus::ConsensusError::DenseUnsupported)
+        }
+    }
+
+    fn batch_echo_driver(version: u8) -> std::sync::Arc<super::OpenraftDriver<BatchEchoHost>> {
+        use openraft::type_config::TypeConfigExt;
+        let metrics = openraft::RaftMetrics::<TypeConfig>::new_initial(1u64);
+        let (_tx, rx) = <TypeConfig as TypeConfigExt>::watch_channel(metrics);
+        super::OpenraftDriver::new(BatchEchoHost { version, rx })
+    }
+
+    /// When the active write version is >= BATCH_WRITE_VERSION, `advance_dense_batch`
+    /// must delegate to the host's `submit_advance_dense_batch` and return its
+    /// starts. Exercises the success-delegation path in the driver.
+    #[tokio::test]
+    async fn advance_dense_batch_delegates_to_host_when_batch_activated() {
+        use tsoracle_consensus::ConsensusDriver;
+        use tsoracle_openraft_toolkit::BATCH_WRITE_VERSION;
+
+        let driver = batch_echo_driver(BATCH_WRITE_VERSION);
+        let key_a = tsoracle_core::SeqKey::try_new("orders").unwrap();
+        let key_b = tsoracle_core::SeqKey::try_new("invoices").unwrap();
+
+        let starts = driver
+            .advance_dense_batch(&[(key_a, 5), (key_b, 3)], tsoracle_core::Epoch::ZERO)
+            .await
+            .expect("advance_dense_batch must succeed when batch format is activated");
+
+        assert_eq!(starts.len(), 2, "one start per entry");
+        // BatchEchoHost returns i * 100 for entry i.
+        assert_eq!(starts[0], 0, "first entry start = 0");
+        assert_eq!(starts[1], 100, "second entry start = 100");
+    }
+
     #[tokio::test]
     async fn advance_dense_batch_returns_dense_batch_not_activated_below_batch_write_version() {
         use tsoracle_consensus::ConsensusDriver;

--- a/crates/tsoracle-driver-openraft/src/host.rs
+++ b/crates/tsoracle-driver-openraft/src/host.rs
@@ -81,6 +81,16 @@ pub trait OpenraftHighWaterHost: Send + Sync + 'static {
         count: u32,
     ) -> Result<u64, ConsensusError>;
 
+    /// Submit an `AdvanceDenseBatch { entries }` proposal and return the applied
+    /// per-key block starts in request order. The proposer reads `ApplyOutcome`
+    /// from the `client_write` response: `DenseBatchAdvanced { starts }` →
+    /// `Ok(starts)`; the two rejection outcomes map to the corresponding
+    /// `ConsensusError`.
+    async fn submit_advance_dense_batch(
+        &self,
+        entries: &[(tsoracle_core::SeqKey, u32)],
+    ) -> Result<Vec<u64>, ConsensusError>;
+
     /// Read a key's durably-committed dense counter (0 if absent),
     /// linearized. Implementations issue the same read barrier as
     /// `current_high_water` before reading the local state machine.
@@ -132,6 +142,13 @@ mod tests {
             Err(ConsensusError::DenseUnsupported)
         }
 
+        async fn submit_advance_dense_batch(
+            &self,
+            _entries: &[(tsoracle_core::SeqKey, u32)],
+        ) -> Result<Vec<u64>, ConsensusError> {
+            Err(ConsensusError::DenseUnsupported)
+        }
+
         async fn current_dense_seq(
             &self,
             _key: &tsoracle_core::SeqKey,
@@ -164,6 +181,11 @@ mod tests {
         let _ = host.active_write_version();
         let key = tsoracle_core::SeqKey::try_new("k").unwrap();
         assert!(host.submit_advance_dense(&key, 1).await.is_err());
+        assert!(
+            host.submit_advance_dense_batch(&[(key.clone(), 1)])
+                .await
+                .is_err()
+        );
         assert!(host.current_dense_seq(&key).await.is_err());
     }
 }

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -50,7 +50,7 @@ pub use capabilities::{
 pub use driver::OpenraftDriver;
 pub use host::OpenraftHighWaterHost;
 pub use log_codec::OpenraftLogCodec;
-pub use log_entry::{HighWaterCommand, SetFormatVersionPayload};
+pub use log_entry::{DenseAdvance, HighWaterCommand, SetFormatVersionPayload};
 #[cfg(feature = "rocksdb-snapshot-store")]
 pub use snapshot_store::RocksdbSnapshotStore;
 pub use snapshot_store::{InMemorySnapshotStore, SnapshotStore};

--- a/crates/tsoracle-driver-openraft/src/log_codec.rs
+++ b/crates/tsoracle-driver-openraft/src/log_codec.rs
@@ -46,9 +46,22 @@ pub struct OpenraftLogCodec;
 
 impl LogStoreCodec<TypeConfig> for OpenraftLogCodec {
     fn encode_entry(
-        _version: u8,
+        version: u8,
         entry: &<TypeConfig as openraft::RaftTypeConfig>::Entry,
     ) -> Result<Vec<u8>, CodecError> {
+        // Defense-in-depth: never serialize an AdvanceDenseBatch under a write
+        // version that predates it. The driver's proposer gate already refuses
+        // to propose one before activation; this is the second line so a gate
+        // regression fails the write here at the leader rather than committing a
+        // poison entry a pre-v6 follower cannot decode.
+        if version < tsoracle_openraft_toolkit::BATCH_WRITE_VERSION {
+            if let openraft::EntryPayload::Normal(
+                crate::log_entry::HighWaterCommand::AdvanceDenseBatch { .. },
+            ) = &entry.payload
+            {
+                return Err(CodecError::NotRepresentable { version });
+            }
+        }
         encode_postcard(entry)
     }
 
@@ -116,5 +129,43 @@ mod tests {
         let via_provider =
             <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_log_id(4, &log_id).unwrap();
         assert_eq!(via_provider, postcard::to_stdvec(&log_id).unwrap());
+    }
+
+    #[test]
+    fn encode_entry_rejects_batch_below_batch_version() {
+        use crate::log_entry::{DenseAdvance, HighWaterCommand};
+        use tsoracle_openraft_toolkit::{BATCH_WRITE_VERSION, DENSE_WRITE_VERSION};
+        let lid = openraft::testing::log_id::<TypeConfig>(1, 1, 1);
+        let entry: <TypeConfig as openraft::RaftTypeConfig>::Entry =
+            openraft::entry::RaftEntry::new_normal(
+                lid,
+                HighWaterCommand::AdvanceDenseBatch {
+                    entries: vec![DenseAdvance {
+                        key: tsoracle_core::SeqKey::try_new("k").unwrap(),
+                        count: 1,
+                    }],
+                },
+            );
+        // Below BATCH_WRITE_VERSION: refused, no bytes produced. Tested at both
+        // the baseline and the just-below-threshold version to pin the whole
+        // pre-v6 range, not a single point.
+        use tsoracle_openraft_toolkit::BASELINE_WRITE_VERSION;
+        for below in [BASELINE_WRITE_VERSION, DENSE_WRITE_VERSION] {
+            assert!(
+                matches!(
+                    <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_entry(below, &entry),
+                    Err(CodecError::NotRepresentable { .. })
+                ),
+                "AdvanceDenseBatch must be refused at write version {below}",
+            );
+        }
+        // At BATCH_WRITE_VERSION: allowed.
+        assert!(
+            <OpenraftLogCodec as LogStoreCodec<TypeConfig>>::encode_entry(
+                BATCH_WRITE_VERSION,
+                &entry
+            )
+            .is_ok()
+        );
     }
 }

--- a/crates/tsoracle-driver-openraft/src/log_entry.rs
+++ b/crates/tsoracle-driver-openraft/src/log_entry.rs
@@ -57,6 +57,16 @@ pub struct SetFormatVersionPayload {
     pub gated_members: BTreeSet<u64>,
 }
 
+/// One `(key, count)` entry of an [`HighWaterCommand::AdvanceDenseBatch`]. A
+/// named struct (not a tuple) so the postcard layout is stable and pinnable and
+/// the embedded `SeqKey` revalidates on decode exactly like single-key
+/// `AdvanceDense`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DenseAdvance {
+    pub key: tsoracle_core::SeqKey,
+    pub count: u32,
+}
+
 /// Commands the state machine knows how to apply.
 ///
 /// `Display` is implemented because openraft's `AppData` blanket requires it
@@ -78,6 +88,13 @@ pub enum HighWaterCommand {
         key: tsoracle_core::SeqKey,
         count: u32,
     },
+    /// Atomically advance several distinct dense counters in one entry. Applied
+    /// all-or-nothing: a cardinality or overflow rejection moves no counter (see
+    /// the state-machine apply). Each entry's pre-advance value is the issued
+    /// block's start, returned in request order via
+    /// [`ApplyOutcome::DenseBatchAdvanced`](crate::ApplyOutcome). Only ever
+    /// appended under write version >= BATCH_WRITE_VERSION (gated by activation).
+    AdvanceDenseBatch { entries: Vec<DenseAdvance> },
 }
 
 impl fmt::Display for HighWaterCommand {
@@ -102,6 +119,17 @@ impl fmt::Display for HighWaterCommand {
                     f,
                     "AdvanceDense {{ key: {}, count: {count} }}",
                     key.as_str()
+                )
+            }
+            HighWaterCommand::AdvanceDenseBatch { entries } => {
+                let rendered: Vec<String> = entries
+                    .iter()
+                    .map(|e| format!("{} x{}", e.key.as_str(), e.count))
+                    .collect();
+                write!(
+                    f,
+                    "AdvanceDenseBatch {{ entries: [{}] }}",
+                    rendered.join(", ")
                 )
             }
         }
@@ -240,6 +268,69 @@ mod tests {
         assert!(
             decoded.is_err(),
             "AdvanceDense with oversized key must fail to decode, got {decoded:?}",
+        );
+    }
+
+    #[test]
+    fn display_renders_advance_dense_batch() {
+        let cmd = HighWaterCommand::AdvanceDenseBatch {
+            entries: vec![
+                DenseAdvance {
+                    key: tsoracle_core::SeqKey::try_new("orders").unwrap(),
+                    count: 3,
+                },
+                DenseAdvance {
+                    key: tsoracle_core::SeqKey::try_new("users").unwrap(),
+                    count: 5,
+                },
+            ],
+        };
+        assert_eq!(
+            format!("{cmd}"),
+            "AdvanceDenseBatch { entries: [orders x3, users x5] }"
+        );
+    }
+
+    #[test]
+    fn postcard_round_trip_advance_dense_batch() {
+        let cmd = HighWaterCommand::AdvanceDenseBatch {
+            entries: vec![DenseAdvance {
+                key: tsoracle_core::SeqKey::try_new("orders").unwrap(),
+                count: 7,
+            }],
+        };
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        let back: HighWaterCommand = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn advance_dense_batch_postcard_layout_is_pinned() {
+        // AdvanceDenseBatch is the 4th HighWaterCommand variant (index 3),
+        // followed by a postcard seq (varint len prefix) of DenseAdvance, each
+        // = SeqKey (String: varint len + bytes) then count varint. One entry
+        // {"a", 1} is therefore [3, 1, 1, b'a', 1]:
+        //   3 = variant index, 1 = vec len, 1 = key len, b'a' = key, 1 = count.
+        let cmd = HighWaterCommand::AdvanceDenseBatch {
+            entries: vec![DenseAdvance {
+                key: tsoracle_core::SeqKey::try_new("a").unwrap(),
+                count: 1,
+            }],
+        };
+        let bytes = postcard::to_stdvec(&cmd).expect("serialize");
+        assert_eq!(bytes, vec![3u8, 1, 1, b'a', 1]);
+    }
+
+    #[test]
+    fn decode_rejects_advance_dense_batch_empty_key() {
+        // Variant 3, vec len 1, key len 0 (empty), count 1. Structurally valid
+        // postcard, but the embedded SeqKey violates the non-empty invariant,
+        // so decode must fail loud rather than land SeqKey("") in a command.
+        let bytes = vec![3u8, 1, 0, 1];
+        let decoded = postcard::from_bytes::<HighWaterCommand>(&bytes);
+        assert!(
+            decoded.is_err(),
+            "AdvanceDenseBatch with empty key must fail to decode, got {decoded:?}",
         );
     }
 }

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -325,7 +325,10 @@ fn classify_activation_outcome(
         // remediation path).
         other @ (ApplyOutcome::DenseAdvanced { .. }
         | ApplyOutcome::DenseCardinalityExceeded { .. }
-        | ApplyOutcome::DenseOverflow) => {
+        | ApplyOutcome::DenseOverflow
+        | ApplyOutcome::DenseBatchAdvanced { .. }
+        | ApplyOutcome::DenseBatchCardinalityExceeded { .. }
+        | ApplyOutcome::DenseBatchOverflow) => {
             unreachable!("dense ApplyOutcome {other:?} returned from a SetFormatVersion entry")
         }
     }

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -399,6 +399,38 @@ impl OpenraftHighWaterHost for StandaloneHost {
         }
     }
 
+    async fn submit_advance_dense_batch(
+        &self,
+        entries: &[(tsoracle_core::SeqKey, u32)],
+    ) -> Result<Vec<u64>, ConsensusError> {
+        let payload: Vec<crate::log_entry::DenseAdvance> = entries
+            .iter()
+            .map(|(key, count)| crate::log_entry::DenseAdvance {
+                key: key.clone(),
+                count: *count,
+            })
+            .collect();
+        match self
+            .raft
+            .client_write(HighWaterCommand::AdvanceDenseBatch { entries: payload })
+            .await
+        {
+            Ok(resp) => match resp.data.outcome {
+                crate::type_config::ApplyOutcome::DenseBatchAdvanced { starts } => Ok(starts),
+                crate::type_config::ApplyOutcome::DenseBatchCardinalityExceeded { cap } => {
+                    Err(ConsensusError::SeqKeyCardinalityExceeded { cap })
+                }
+                crate::type_config::ApplyOutcome::DenseBatchOverflow => {
+                    Err(ConsensusError::SeqOverflow)
+                }
+                other => Err(ConsensusError::PermanentDriver(
+                    format!("unexpected ApplyOutcome for AdvanceDenseBatch: {other:?}").into(),
+                )),
+            },
+            Err(e) => Err(classify_client_write_error(e)),
+        }
+    }
+
     async fn current_dense_seq(&self, key: &tsoracle_core::SeqKey) -> Result<u64, ConsensusError> {
         // Issue the same linearizable read barrier as `current_high_water` so
         // the local SM read below reflects every committed write from any prior

--- a/crates/tsoracle-driver-openraft/src/standalone.rs
+++ b/crates/tsoracle-driver-openraft/src/standalone.rs
@@ -600,6 +600,16 @@ mod tests {
         ));
     }
 
+    /// The `unreachable!` arm in `classify_activation_outcome` covers every
+    /// dense `ApplyOutcome` variant, including the batch variants added in this
+    /// release. Driving any one of them proves the arm compiles and runs; the
+    /// test deliberately panics via `should_panic`.
+    #[test]
+    #[should_panic(expected = "dense ApplyOutcome")]
+    fn classify_activation_outcome_dense_batch_advanced_is_unreachable() {
+        classify_activation_outcome(ApplyOutcome::DenseBatchAdvanced { starts: vec![0] }, 7).ok();
+    }
+
     #[test]
     fn membership_changed_since_gate_is_a_distinct_variant() {
         // Pin that the variant is constructible and matchable; it is the

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -756,15 +756,67 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                         outcome,
                     }
                 }
-                // The full all-or-nothing apply for this arm lands with the rest
-                // of the batch path. Until BATCH_WRITE_VERSION is activated
-                // cluster-wide, an AdvanceDenseBatch entry is never appended, so
-                // it cannot reach apply.
-                EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch { .. }) => {
-                    unreachable!(
-                        "AdvanceDenseBatch apply not yet implemented; entry must \
-                         not be appended before BATCH_WRITE_VERSION is activated"
-                    )
+                EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch { entries }) => {
+                    let mut core = self.core.lock();
+                    // Phase 1: cardinality. Count distinct keys not already
+                    // present; a duplicate entry on the same key counts once
+                    // (set semantics), so the new-key count uses a BTreeSet.
+                    let new_keys: std::collections::BTreeSet<&str> = entries
+                        .iter()
+                        .map(|e| e.key.as_str())
+                        .filter(|k| !core.dense.contains_key(*k))
+                        .collect();
+                    let outcome =
+                        if core.dense.len() as u64 + new_keys.len() as u64 > core.dense_cap {
+                            ApplyOutcome::DenseBatchCardinalityExceeded {
+                                cap: core.dense_cap,
+                            }
+                        } else {
+                            // Phase 2: sequential fold into a scratch map seeded
+                            // lazily from current counters. Each entry's start is the
+                            // running value in the scratch map (or the stored value if
+                            // not yet in the scratch map); the running value
+                            // accumulates across repeats, so a duplicate key yields
+                            // adjacent non-overlapping blocks and the overflow check
+                            // is against the ACCUMULATED value — not the shared
+                            // pre-batch counter. Any overflow rejects the whole batch.
+                            let mut scratch: std::collections::BTreeMap<&str, u64> =
+                                std::collections::BTreeMap::new();
+                            let mut starts: Vec<u64> = Vec::with_capacity(entries.len());
+                            let mut overflow = false;
+                            for entry in entries {
+                                let key_str = entry.key.as_str();
+                                let running = scratch
+                                    .get(key_str)
+                                    .copied()
+                                    .or_else(|| core.dense.get(key_str).copied())
+                                    .unwrap_or(0);
+                                starts.push(running);
+                                match running.checked_add(u64::from(entry.count)) {
+                                    Some(next) => {
+                                        scratch.insert(key_str, next);
+                                    }
+                                    None => {
+                                        overflow = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if overflow {
+                                ApplyOutcome::DenseBatchOverflow
+                            } else {
+                                // Phase 3: commit. Only now mutate the durable map.
+                                for (key_str, next) in scratch {
+                                    core.dense.insert(key_str.to_string(), next);
+                                }
+                                ApplyOutcome::DenseBatchAdvanced { starts }
+                            }
+                        };
+                    core.last_applied = Some(log_id);
+                    HighWaterApplied {
+                        value: core.current_value,
+                        outcome,
+                    }
                 }
                 EntryPayload::Membership(membership) => {
                     let mut core = self.core.lock();
@@ -2889,6 +2941,196 @@ mod tests {
             sm_mut.dense_value("x"),
             u64::MAX,
             "overflow must not modify the counter"
+        );
+    }
+
+    // ---- AdvanceDenseBatch apply tests ----
+    //
+    // These tests pin the all-or-nothing semantics of the batch apply arm:
+    //  1. A successful batch advances ALL counters atomically; starts are
+    //     the pre-advance values in request order (including duplicate-key
+    //     blocks which are adjacent and non-overlapping within a single batch).
+    //  2. A cardinality violation rejects the ENTIRE batch — no counter moves,
+    //     not even keys already in the map.
+    //  3. An overflow caused by ACCUMULATED advances across duplicate entries
+    //     rejects the ENTIRE batch — a per-entry-against-prestate check would
+    //     pass both entries individually, so the sequential fold is the only
+    //     correct approach.
+    //
+    // Outcome is verified by observing `dense_value` before and after each
+    // apply (the same mechanism the single-key AdvanceDense tests use), since
+    // `ApplyOutcome` is only delivered via the openraft responder channel,
+    // which the test harness does not wire.
+
+    use crate::log_entry::DenseAdvance;
+
+    #[tokio::test]
+    async fn dense_batch_applies_atomically_and_gaplessly() {
+        // A two-key batch: both keys start absent (counter = 0) and the batch
+        // advances "orders" by 5 and "users" by 2. After the batch both counters
+        // must reflect exactly those advances — gaplessly starting from 0.
+        let mut sm = HighWaterStateMachine::new_with_dense_cap(8);
+
+        // Pre-condition: both keys absent.
+        assert_eq!(sm.dense_value("orders"), 0);
+        assert_eq!(sm.dense_value("users"), 0);
+
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch {
+                entries: vec![
+                    DenseAdvance {
+                        key: dense_key("orders"),
+                        count: 5,
+                    },
+                    DenseAdvance {
+                        key: dense_key("users"),
+                        count: 2,
+                    },
+                ],
+            }),
+        )
+        .await;
+
+        // Post-condition: both counters advanced from 0.
+        assert_eq!(
+            sm.dense_value("orders"),
+            5,
+            "first batch: orders must advance from 0 to 5"
+        );
+        assert_eq!(
+            sm.dense_value("users"),
+            2,
+            "first batch: users must advance from 0 to 2"
+        );
+        // High-water must be untouched.
+        assert_eq!(
+            sm.current_value().await,
+            0,
+            "AdvanceDenseBatch must not touch the high-water"
+        );
+
+        // Second batch: advance "orders" by 3 — start must be 5 (current value).
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch {
+                entries: vec![DenseAdvance {
+                    key: dense_key("orders"),
+                    count: 3,
+                }],
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            sm.dense_value("orders"),
+            8,
+            "second batch: orders must advance from 5 to 8"
+        );
+        assert_eq!(
+            sm.dense_value("users"),
+            2,
+            "users must be unchanged by a batch that does not mention it"
+        );
+    }
+
+    #[tokio::test]
+    async fn dense_batch_cardinality_is_atomic() {
+        // Cap = 1: only one distinct key is permitted. Seed "a" with a first
+        // batch (1 key, accepted), then submit a batch of ["a", "b"] — "b" is
+        // new and would push the count to 2 > cap. The ENTIRE batch must be
+        // rejected atomically: "a" must NOT advance and "b" must remain absent.
+        let mut sm = HighWaterStateMachine::new_with_dense_cap(1);
+
+        // Seed "a" at 1.
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch {
+                entries: vec![DenseAdvance {
+                    key: dense_key("a"),
+                    count: 1,
+                }],
+            }),
+        )
+        .await;
+        assert_eq!(sm.dense_value("a"), 1, "seed apply must succeed");
+
+        // The cardinality-exceeded batch: "a" already exists (no new key there)
+        // but "b" is new and would push the distinct-key count to 2 > cap=1.
+        apply_one(
+            &mut sm,
+            2,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch {
+                entries: vec![
+                    DenseAdvance {
+                        key: dense_key("a"),
+                        count: 1,
+                    },
+                    DenseAdvance {
+                        key: dense_key("b"),
+                        count: 1,
+                    },
+                ],
+            }),
+        )
+        .await;
+
+        // Atomic rejection: neither "a" nor "b" must move.
+        assert_eq!(
+            sm.dense_value("a"),
+            1,
+            "cardinality rejection must not advance existing key a"
+        );
+        assert_eq!(
+            sm.dense_value("b"),
+            0,
+            "cardinality rejection must leave new key b absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn dense_batch_overflow_is_atomic_and_accumulates_duplicates() {
+        // Seed "k" near the ceiling so that two entries on "k" within a single
+        // batch — each advancing by 4 — ACCUMULATE to an overflow: the running
+        // value after the first entry is (u64::MAX - 5 + 4) = u64::MAX - 1,
+        // and after the second entry checked_add(u64::MAX - 1, 4) overflows.
+        // A naive per-entry check against the pre-batch stored value (u64::MAX - 5)
+        // would pass both (each count=4 fits), so the sequential fold over a
+        // scratch map is the only correct implementation.
+        //
+        // The batch must be rejected entirely: "k" must remain at u64::MAX - 5.
+        let mut sm = HighWaterStateMachine::new_with_dense_cap(8);
+        {
+            let mut core = sm.core.lock();
+            core.dense.insert("k".to_string(), u64::MAX - 5);
+        }
+
+        apply_one(
+            &mut sm,
+            1,
+            EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch {
+                entries: vec![
+                    DenseAdvance {
+                        key: dense_key("k"),
+                        count: 4,
+                    },
+                    DenseAdvance {
+                        key: dense_key("k"),
+                        count: 4,
+                    },
+                ],
+            }),
+        )
+        .await;
+
+        // Entire batch must be rejected: k stays at u64::MAX - 5.
+        assert_eq!(
+            sm.dense_value("k"),
+            u64::MAX - 5,
+            "overflow from accumulated duplicate advances must not modify any counter"
         );
     }
 

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -61,8 +61,8 @@ use tsoracle_codec::{
     VersionedCodec, decode_framed, decode_postcard_exact, encode_framed, encode_postcard,
 };
 use tsoracle_openraft_toolkit::{
-    ActiveWriteVersion, BASELINE_WRITE_VERSION, DENSE_WRITE_VERSION, MAX_READABLE_VERSION,
-    MIN_READABLE_VERSION, codec_io_error,
+    ActiveWriteVersion, BASELINE_WRITE_VERSION, BATCH_WRITE_VERSION, DENSE_WRITE_VERSION,
+    MAX_READABLE_VERSION, MIN_READABLE_VERSION, codec_io_error,
 };
 
 use crate::log_entry::{HighWaterCommand, SetFormatVersionPayload};
@@ -142,6 +142,10 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
             // Ungated — production reads dense snapshots from v5-activated
             // clusters without any feature flag.
             v if v == DENSE_WRITE_VERSION => decode_postcard_exact(body),
+            // v6 (BATCH_WRITE_VERSION): snapshot layout is byte-identical to v5;
+            // batch adds a log command, not snapshot state, so the same decoder
+            // applies.
+            v if v == BATCH_WRITE_VERSION => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -174,6 +178,10 @@ impl VersionedCodec for HighWaterStateMachineSnapshot {
             }
             // v5: the current (dense) layout encodes directly. Ungated.
             v if v == DENSE_WRITE_VERSION => encode_postcard(self),
+            // v6 (BATCH_WRITE_VERSION): snapshot layout is byte-identical to v5;
+            // batch adds a log command, not snapshot state, so the same encoder
+            // applies.
+            v if v == BATCH_WRITE_VERSION => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -193,6 +201,10 @@ impl VersionedCodec for PersistedSnapshot {
             // inside gains dense bytes). Ungated — production reads v5
             // envelopes once activated.
             v if v == DENSE_WRITE_VERSION => decode_postcard_exact(body),
+            // v6 (BATCH_WRITE_VERSION): envelope layout is byte-identical to v5;
+            // batch adds a log command, not snapshot state, so the same decoder
+            // applies.
+            v if v == BATCH_WRITE_VERSION => decode_postcard_exact(body),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -206,6 +218,10 @@ impl VersionedCodec for PersistedSnapshot {
             v if v == BASELINE_WRITE_VERSION => encode_postcard(self),
             // v5: envelope layout unchanged; real ungated arm for production.
             v if v == DENSE_WRITE_VERSION => encode_postcard(self),
+            // v6 (BATCH_WRITE_VERSION): envelope layout is byte-identical to v5;
+            // batch adds a log command, not snapshot state, so the same encoder
+            // applies.
+            v if v == BATCH_WRITE_VERSION => encode_postcard(self),
             other => Err(tsoracle_codec::CodecError::VersionUnsupported {
                 min: MIN_READABLE_VERSION,
                 max: MAX_READABLE_VERSION,
@@ -1607,8 +1623,9 @@ mod tests {
         // MAX_READABLE_VERSION] and reject anything outside it. This is
         // what makes an OLD-version on-disk snapshot readable after the
         // active version moves forward. Asserted against the codec range
-        // directly so it covers the full readable range [MIN = 4, MAX = 5] —
-        // iterating v4 (decode-and-lift) and v5 (direct decode).
+        // directly so it covers the full readable range [MIN = 4, MAX = 6] —
+        // iterating v4 (decode-and-lift), v5 (direct decode), and v6
+        // (byte-identical to v5).
         // Empty dense map + cap 0 so the v4 encode arm (which projects to the
         // frozen V4 struct) is lossless; assert_eq!(decoded, payload) holds
         // for every version in the readable range because the decode-and-lift
@@ -2557,6 +2574,39 @@ mod tests {
         );
         assert_eq!(decoded.dense, dense, "dense map must survive roundtrip");
         assert_eq!(decoded.dense_cap, 500, "dense_cap must survive roundtrip");
+    }
+
+    #[test]
+    fn snapshot_payload_round_trips_at_v6() {
+        use tsoracle_codec::{decode_framed, encode_framed};
+        use tsoracle_openraft_toolkit::BATCH_WRITE_VERSION;
+
+        let mut dense = std::collections::BTreeMap::new();
+        dense.insert("orders".to_string(), 9u64);
+
+        let payload = HighWaterStateMachineSnapshot {
+            current_value: 777,
+            last_applied: Some(log_id(9)),
+            last_membership: StoredMem::default(),
+            dense: dense.clone(),
+            dense_cap: 32,
+        };
+
+        let framed = encode_framed(BATCH_WRITE_VERSION, &payload).expect("v6 encode");
+        assert_eq!(framed[0], BATCH_WRITE_VERSION, "leading byte must be v6");
+
+        let decoded: HighWaterStateMachineSnapshot = decode_framed(
+            tsoracle_openraft_toolkit::MIN_READABLE_VERSION,
+            tsoracle_openraft_toolkit::MAX_READABLE_VERSION,
+            &framed,
+        )
+        .expect("v6 decode");
+        assert_eq!(
+            decoded, payload,
+            "v6 roundtrip must produce the original payload"
+        );
+        assert_eq!(decoded.dense, dense, "dense map must survive v6 roundtrip");
+        assert_eq!(decoded.dense_cap, 32, "dense_cap must survive v6 roundtrip");
     }
 
     #[test]

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -756,6 +756,16 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
                         outcome,
                     }
                 }
+                // The full all-or-nothing apply for this arm lands with the rest
+                // of the batch path. Until BATCH_WRITE_VERSION is activated
+                // cluster-wide, an AdvanceDenseBatch entry is never appended, so
+                // it cannot reach apply.
+                EntryPayload::Normal(HighWaterCommand::AdvanceDenseBatch { .. }) => {
+                    unreachable!(
+                        "AdvanceDenseBatch apply not yet implemented; entry must \
+                         not be appended before BATCH_WRITE_VERSION is activated"
+                    )
+                }
                 EntryPayload::Membership(membership) => {
                     let mut core = self.core.lock();
                     core.last_membership = StoredMembership::new(Some(log_id), membership.clone());

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -131,6 +131,17 @@ pub enum ApplyOutcome {
     /// An `AdvanceDense` applied as a deterministic rejection: the counter would
     /// exceed u64::MAX.
     DenseOverflow,
+    /// An `AdvanceDenseBatch` applied successfully: `starts[i]` is the
+    /// pre-advance dense counter for request entry `i` (its block's first
+    /// ordinal), in request order. `value` on the enclosing `HighWaterApplied`
+    /// is the high-water, untouched.
+    DenseBatchAdvanced { starts: Vec<u64> },
+    /// An `AdvanceDenseBatch` applied as a deterministic rejection: applying it
+    /// would exceed the immutable genesis cardinality cap. No counter moved.
+    DenseBatchCardinalityExceeded { cap: u64 },
+    /// An `AdvanceDenseBatch` applied as a deterministic rejection: some key's
+    /// accumulated advance would exceed u64::MAX. No counter moved.
+    DenseBatchOverflow,
 }
 
 /// Per-entry apply result.
@@ -277,6 +288,14 @@ mod tests {
             ApplyOutcome::FormatActivated { target: 4 },
             ApplyOutcome::FormatActivationNoop { target: 4 },
             ApplyOutcome::FormatActivationTargetOutOfRange { target: 1 },
+            ApplyOutcome::DenseAdvanced { start: 99 },
+            ApplyOutcome::DenseCardinalityExceeded { cap: 1024 },
+            ApplyOutcome::DenseOverflow,
+            ApplyOutcome::DenseBatchAdvanced {
+                starts: vec![0, 1, u64::MAX],
+            },
+            ApplyOutcome::DenseBatchCardinalityExceeded { cap: 1024 },
+            ApplyOutcome::DenseBatchOverflow,
         ] {
             let applied = HighWaterApplied {
                 value: 42,

--- a/crates/tsoracle-driver-openraft/tests/dense_advance.rs
+++ b/crates/tsoracle-driver-openraft/tests/dense_advance.rs
@@ -51,7 +51,9 @@ use futures::StreamExt;
 use tokio::time::timeout;
 use tsoracle_consensus::{ConsensusDriver, ConsensusError, LeaderState};
 use tsoracle_core::{Epoch, SeqKey};
-use tsoracle_driver_openraft::{CapabilitySource, NodeCapabilities, OpenraftPeer, StandaloneHost};
+use tsoracle_driver_openraft::{
+    CapabilitySource, NodeCapabilities, OpenraftHighWaterHost, OpenraftPeer, StandaloneHost,
+};
 use tsoracle_openraft_toolkit::DENSE_WRITE_VERSION;
 
 use common::{TestCluster, build_single_node, build_three_node, eventually_eq};
@@ -318,4 +320,82 @@ async fn three_node_follower_converges_on_dense_seq() {
         .await
         .expect("load_dense_seq on leader");
     assert_eq!(seq, 7, "leader load_dense_seq = 7 after advance by 7");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: advance_dense_batch — post-activation via StandaloneHost
+// ---------------------------------------------------------------------------
+
+/// After activating write version 6 (BATCH_WRITE_VERSION), `advance_dense_batch`
+/// on a single-node cluster must return gapless block starts for each key in
+/// the batch. `load_dense_seq` must reflect the committed counters.
+///
+/// The test activates version 5 first (required before version 6), then
+/// activates version 6, and issues a two-key batch. Each key's start must be
+/// gapless from its own counter (starting at 0 for new keys), and a second
+/// batch call must produce contiguous block starts.
+#[tokio::test(start_paused = true)]
+async fn advance_dense_batch_after_activation_is_gapless() {
+    use tsoracle_openraft_toolkit::BATCH_WRITE_VERSION;
+
+    let (host, cluster) = single_node_leader_host().await;
+    let driver = &cluster.drivers[0];
+
+    // Activate DENSE_WRITE_VERSION (5) first — required stepping-stone.
+    host.initiate_format_activation(DENSE_WRITE_VERSION, &UnusedSource)
+        .await
+        .expect("dense (v5) activation must succeed on a single-node cluster");
+
+    // Now activate BATCH_WRITE_VERSION (6).
+    host.initiate_format_activation(BATCH_WRITE_VERSION, &UnusedSource)
+        .await
+        .expect("batch (v6) activation must succeed on a single-node cluster");
+
+    assert_eq!(
+        host.active_write_version(),
+        BATCH_WRITE_VERSION,
+        "cell must read BATCH_WRITE_VERSION after activation"
+    );
+
+    let key_orders = SeqKey::try_new("orders").unwrap();
+    let key_invoices = SeqKey::try_new("invoices").unwrap();
+
+    // First batch: advance "orders" by 5 and "invoices" by 3, both new keys.
+    let starts = host
+        .submit_advance_dense_batch(&[(key_orders.clone(), 5), (key_invoices.clone(), 3)])
+        .await
+        .expect("batch advance after batch activation");
+    assert_eq!(starts.len(), 2, "one start per batch entry");
+    assert_eq!(starts[0], 0, "orders: first advance starts at 0");
+    assert_eq!(
+        starts[1], 0,
+        "invoices: first advance starts at 0 (independent)"
+    );
+
+    // `load_dense_seq` must reflect the committed counters.
+    let seq_orders = driver
+        .load_dense_seq(&key_orders)
+        .await
+        .expect("load_dense_seq for orders");
+    assert_eq!(seq_orders, 5, "orders counter = 5 after batch advance");
+    let seq_invoices = driver
+        .load_dense_seq(&key_invoices)
+        .await
+        .expect("load_dense_seq for invoices");
+    assert_eq!(seq_invoices, 3, "invoices counter = 3 after batch advance");
+
+    // Second batch on the same keys: starts must be contiguous with the first.
+    let starts2 = host
+        .submit_advance_dense_batch(&[(key_orders.clone(), 2), (key_invoices.clone(), 4)])
+        .await
+        .expect("second batch advance");
+    assert_eq!(starts2.len(), 2);
+    assert_eq!(
+        starts2[0], 5,
+        "orders: second advance starts where first ended"
+    );
+    assert_eq!(
+        starts2[1], 3,
+        "invoices: second advance starts where first ended"
+    );
 }

--- a/crates/tsoracle-driver-openraft/tests/generate_fuzz_seeds.rs
+++ b/crates/tsoracle-driver-openraft/tests/generate_fuzz_seeds.rs
@@ -31,6 +31,13 @@
 //!
 //! Idempotent. Re-run after any change to `HighWaterCommand` or
 //! `HighWaterStateMachineSnapshot` to refresh the seeds.
+//!
+//! **Scope**: `generate_log_entry_decode_seeds` seeds only the baseline
+//! `Advance` variant for the `log_entry_decode` corpus. The `AdvanceDense` and
+//! `AdvanceDenseBatch` variants' decode paths are covered by the
+//! `openraft_dense_command_decode` and `openraft_advance_dense_batch_decode`
+//! fuzz targets respectively, which grow their own coverage-guided corpora
+//! rather than relying on hand-seeded entries.
 
 use std::fs;
 use std::path::PathBuf;

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -51,11 +51,11 @@ pub const MIN_READABLE_VERSION: u8 = 4;
 /// Newest on-disk/wire format version this binary has a parser for. Only ever
 /// grows. Decode accepts `[MIN_READABLE_VERSION, MAX_READABLE_VERSION]`.
 ///
-/// Today this is 5 (`DENSE_WRITE_VERSION`): a v5-capable binary can read both
-/// the v4 baseline layout and the v5 dense layout. A node writes
-/// `BASELINE_WRITE_VERSION` (4) until a committed `SetFormatVersion` activation
-/// advances the active write version through the all-members gate.
-pub const MAX_READABLE_VERSION: u8 = 5;
+/// Today this is 6 (`BATCH_WRITE_VERSION`): a v6-capable binary can read the
+/// v4 baseline layout, the v5 dense layout, and the v6 batch layout. A node
+/// writes `BASELINE_WRITE_VERSION` (4) until a committed `SetFormatVersion`
+/// activation advances the active write version through the all-members gate.
+pub const MAX_READABLE_VERSION: u8 = 6;
 
 // Compile-time guard: the readable range must be non-empty (`MIN <= MAX`) or
 // every decode rejects every record. Catches a future inverted-constants edit
@@ -76,6 +76,12 @@ pub const BASELINE_WRITE_VERSION: u8 = 4;
 /// version has been activated to at least this value through the all-members
 /// gate — otherwise an older member could receive an entry it cannot decode.
 pub const DENSE_WRITE_VERSION: u8 = 5;
+
+/// The write version that introduces the `AdvanceDenseBatch` log command. The
+/// state-machine snapshot shape is unchanged from `DENSE_WRITE_VERSION` — this
+/// version gates which *commands* may be appended, not the snapshot layout, so
+/// a v6 snapshot is byte-identical to a v5 one.
+pub const BATCH_WRITE_VERSION: u8 = 6;
 
 /// Process-shared, runtime-mutable active write version.
 ///
@@ -187,10 +193,11 @@ mod tests {
     #[test]
     fn version_constants_are_at_expected_values() {
         assert_eq!(MIN_READABLE_VERSION, 4);
-        // MAX is 5 to cover the dense write version (DENSE_WRITE_VERSION).
-        assert_eq!(MAX_READABLE_VERSION, 5);
+        // MAX is 6 to cover the batch write version (BATCH_WRITE_VERSION).
+        assert_eq!(MAX_READABLE_VERSION, 6);
         assert_eq!(BASELINE_WRITE_VERSION, 4);
         assert_eq!(DENSE_WRITE_VERSION, 5);
+        assert_eq!(BATCH_WRITE_VERSION, 6);
     }
 
     #[test]

--- a/crates/tsoracle-openraft-toolkit/src/codec.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec.rs
@@ -231,8 +231,8 @@ mod tests {
 
     #[test]
     fn recover_takes_the_max_of_present_lower_bounds() {
-        // MAX_READABLE_VERSION (5) > BASELINE_WRITE_VERSION (4), so these
-        // assertions exercise the genuine multi-version max (4 vs 5).
+        // MAX_READABLE_VERSION (6) > BASELINE_WRITE_VERSION (4), so these
+        // assertions exercise the genuine multi-version max (4 vs 6).
         assert_eq!(
             recover_active_write_version(Some(MAX_READABLE_VERSION), None).unwrap(),
             MAX_READABLE_VERSION

--- a/crates/tsoracle-openraft-toolkit/src/lib.rs
+++ b/crates/tsoracle-openraft-toolkit/src/lib.rs
@@ -40,9 +40,9 @@ pub mod lifecycle;
 pub mod test_fakes;
 
 pub use codec::{
-    ActiveWriteVersion, BASELINE_WRITE_VERSION, CodecError, DENSE_WRITE_VERSION,
-    MAX_READABLE_VERSION, MIN_READABLE_VERSION, codec_io_error, decode, encode,
-    recover_active_write_version,
+    ActiveWriteVersion, BASELINE_WRITE_VERSION, BATCH_WRITE_VERSION, CodecError,
+    DENSE_WRITE_VERSION, MAX_READABLE_VERSION, MIN_READABLE_VERSION, codec_io_error, decode,
+    encode, recover_active_write_version,
 };
 pub use codec_provider::{DefaultLogStoreCodec, LogStoreCodec};
 pub use lifecycle::{

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -769,8 +769,8 @@ mod record_codec_tests {
     fn version_constants_are_at_expected_values() {
         assert_eq!(BASELINE_WRITE_VERSION, 4);
         assert_eq!(MIN_READABLE_VERSION, 4);
-        // MAX is 5 to cover the dense write version (DENSE_WRITE_VERSION).
-        assert_eq!(MAX_READABLE_VERSION, 5);
+        // MAX is 6 to cover the batch write version (BATCH_WRITE_VERSION).
+        assert_eq!(MAX_READABLE_VERSION, 6);
     }
 }
 

--- a/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
+++ b/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
@@ -109,7 +109,7 @@ message GetSeqResponse {
 }
 
 message SeqRequestEntry {
-  string key = 1;   // bounded UTF-8 sequence key
+  string key = 1; // bounded UTF-8 sequence key
   uint32 count = 2; // must be >= 1
 }
 

--- a/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
+++ b/crates/tsoracle-proto/proto/tsoracle/v1/tso.proto
@@ -44,6 +44,15 @@ service TsoService {
   // delivered to the client is a spent (but non-duplicate) ordinal block —
   // clients must treat an ambiguous failure as `SeqUncertain` and not retry.
   rpc GetSeq(GetSeqRequest) returns (GetSeqResponse);
+
+  // Atomically allocate contiguous dense blocks for several DISTINCT keys in
+  // one call. All-or-nothing: either every key advances or none does. The
+  // response lists one grant per request entry, in request order, plus the
+  // single leader epoch that issued the batch. Same leadership routing and
+  // `tsoracle-leader-hint-bin` trailer as `GetSeq`. Like `GetSeq` this is
+  // non-idempotent: an ambiguous failure means the whole batch may or may not
+  // have committed — clients treat it as `SeqUncertain` and must not retry.
+  rpc GetSeqBatch(GetSeqBatchRequest) returns (GetSeqBatchResponse);
 }
 
 message GetTsRequest {
@@ -97,6 +106,32 @@ message GetSeqResponse {
   // Always populated on a successful response; the client seats its confirmed
   // leader cache from it (a missing epoch on success is a protocol violation).
   EpochWire epoch = 4;
+}
+
+message SeqRequestEntry {
+  string key = 1;   // bounded UTF-8 sequence key
+  uint32 count = 2; // must be >= 1
+}
+
+message GetSeqBatchRequest {
+  // 1..=max_seq_batch_keys entries; keys must be distinct (a duplicate is
+  // rejected with INVALID_ARGUMENT).
+  repeated SeqRequestEntry entries = 1;
+}
+
+message SeqGrantEntry {
+  string key = 1;
+  uint64 start = 2; // block is [start, start+count)
+  uint32 count = 3;
+}
+
+message GetSeqBatchResponse {
+  // One grant per request entry, in the SAME order as the request.
+  repeated SeqGrantEntry grants = 1;
+  // The single leader epoch that committed the whole batch (one atomic apply,
+  // one epoch). Always populated on success; bundled so a half-populated epoch
+  // is unrepresentable, matching GetSeqResponse.epoch.
+  EpochWire epoch = 2;
 }
 
 // Carried in the `tsoracle-leader-hint-bin` binary metadata trailer when the

--- a/crates/tsoracle-server/src/heartbeat.rs
+++ b/crates/tsoracle-server/src/heartbeat.rs
@@ -156,6 +156,7 @@ mod tests {
         let core = std::sync::Arc::new(ServingCore::new(
             Duration::from_secs(3),
             tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
         ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
@@ -232,6 +233,7 @@ mod tests {
         let core = std::sync::Arc::new(ServingCore::new(
             Duration::from_secs(3),
             tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
         ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
@@ -274,6 +276,7 @@ mod tests {
         let core = std::sync::Arc::new(ServingCore::new(
             Duration::from_secs(3),
             tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
         ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
@@ -320,6 +323,7 @@ mod tests {
         let core = std::sync::Arc::new(ServingCore::new(
             Duration::from_secs(3),
             tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
         ));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 

--- a/crates/tsoracle-server/src/persist_disposition.rs
+++ b/crates/tsoracle-server/src/persist_disposition.rs
@@ -108,7 +108,8 @@ pub(crate) fn classify(error: ConsensusError) -> PersistDisposition {
         dense_error @ (ConsensusError::DenseUnsupported
         | ConsensusError::SeqKeyCardinalityExceeded { .. }
         | ConsensusError::SeqOverflow
-        | ConsensusError::DenseNotActivated { .. }) => {
+        | ConsensusError::DenseNotActivated { .. }
+        | ConsensusError::DenseBatchNotActivated { .. }) => {
             PersistDisposition::Permanent(Box::new(dense_error))
         }
     }
@@ -202,6 +203,27 @@ mod tests {
                 );
                 // The concrete type is preserved (downcast succeeds), proving we
                 // boxed the real error rather than a stringified copy.
+                assert!(source.downcast_ref::<ConsensusError>().is_some());
+            }
+            other => panic!("expected Permanent, got a different disposition: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dense_batch_not_activated_is_permanent() {
+        // The batch-not-activated variant is unreachable on the high-water
+        // persist path, but classify must still route it as Permanent (non-
+        // retryable) with its real Display preserved, like its dense siblings.
+        let disposition = classify(ConsensusError::DenseBatchNotActivated {
+            required: 6,
+            active: 5,
+        });
+        match disposition {
+            PersistDisposition::Permanent(source) => {
+                assert_eq!(
+                    source.to_string(),
+                    "dense batch sequences require write version 6 but the cluster is at 5; activate the format first"
+                );
                 assert!(source.downcast_ref::<ConsensusError>().is_some());
             }
             other => panic!("expected Permanent, got a different disposition: {other:?}"),

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -144,6 +144,16 @@ pub struct Reporter {
     pub seq_values_issued: ReporterCounter,
     pub seq_cardinality_rejected: ReporterCounter,
 
+    // get_seq_batch hot path. Batch keeps its OWN values/cardinality counters
+    // (rather than sharing the single-key ones) so the `tsoracle.get_seq.*`
+    // single-key series stays free of batch traffic and each RPC is separately
+    // observable.
+    pub get_seq_batch_requests: ReporterCounter,
+    pub get_seq_batch_success: ReporterCounter,
+    pub seq_batch_keys: ReporterHistogram,
+    pub seq_batch_values_issued: ReporterCounter,
+    pub seq_batch_cardinality_rejected: ReporterCounter,
+
     // leader / fence
     pub not_leader: ReporterCounter,
     pub leader_transitions: ReporterCounter,
@@ -173,6 +183,13 @@ impl Reporter {
             seq_values_issued: ReporterCounter::new("tsoracle.get_seq.values_issued"),
             seq_cardinality_rejected: ReporterCounter::new(
                 "tsoracle.get_seq.cardinality_rejected.total",
+            ),
+            get_seq_batch_requests: ReporterCounter::new("tsoracle.get_seq.batch.requests.total"),
+            get_seq_batch_success: ReporterCounter::new("tsoracle.get_seq.batch.success.total"),
+            seq_batch_keys: ReporterHistogram::new("tsoracle.get_seq.batch.keys"),
+            seq_batch_values_issued: ReporterCounter::new("tsoracle.get_seq.batch.values_issued"),
+            seq_batch_cardinality_rejected: ReporterCounter::new(
+                "tsoracle.get_seq.batch.cardinality_rejected.total",
             ),
             not_leader: ReporterCounter::new("tsoracle.not_leader.total"),
             leader_transitions: ReporterCounter::new("tsoracle.leader_transition.total"),

--- a/crates/tsoracle-server/src/server.rs
+++ b/crates/tsoracle-server/src/server.rs
@@ -49,6 +49,12 @@ pub enum BuildError {
     /// misconfiguration surfaces immediately rather than at first request.
     #[error("max_seq_count must be >= 1 (0 would reject every GetSeq request)")]
     ZeroMaxSeqCount,
+    /// `max_seq_batch_keys` was set to 0. Every `GetSeqBatch` request would
+    /// then be rejected as exceeding the batch-key cap (the minimum is 1
+    /// entry), silently disabling `GetSeqBatch`. Rejected at build time so the
+    /// misconfiguration surfaces immediately rather than at first request.
+    #[error("max_seq_batch_keys must be >= 1 (0 would reject every GetSeqBatch request)")]
+    ZeroMaxSeqBatchKeys,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -109,6 +115,7 @@ pub struct ServerBuilder {
     shutdown_grace: Duration,
     heartbeat_interval: Duration,
     max_seq_count: u32,
+    max_seq_batch_keys: u32,
     #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
     tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
@@ -123,6 +130,7 @@ impl Default for ServerBuilder {
             shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
             heartbeat_interval: Duration::from_secs(10),
             max_seq_count: tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            max_seq_batch_keys: tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: None,
         }
@@ -213,10 +221,28 @@ impl ServerBuilder {
         self
     }
 
+    /// Cap on the number of `(key, count)` entries accepted in one
+    /// `GetSeqBatch` request. Defaults to
+    /// [`tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS`] (`128`).
+    ///
+    /// This is a soft anti-abuse guardrail bounding fan-out and the size of
+    /// one atomic consensus entry. A value of `0` is rejected by
+    /// [`Self::build`] with [`BuildError::ZeroMaxSeqBatchKeys`]: it would
+    /// make every `GetSeqBatch` call fail, silently disabling the RPC, so the
+    /// misconfiguration is surfaced at build time. Deployment-specific tuning;
+    /// clients need no rebuild after changing this.
+    pub fn max_seq_batch_keys(mut self, max_seq_batch_keys: u32) -> Self {
+        self.max_seq_batch_keys = max_seq_batch_keys;
+        self
+    }
+
     pub fn build(self) -> Result<Server, BuildError> {
         let consensus = self.consensus.ok_or(BuildError::MissingConsensusDriver)?;
         if self.max_seq_count == 0 {
             return Err(BuildError::ZeroMaxSeqCount);
+        }
+        if self.max_seq_batch_keys == 0 {
+            return Err(BuildError::ZeroMaxSeqBatchKeys);
         }
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
         Ok(Server {
@@ -226,7 +252,11 @@ impl ServerBuilder {
             failover_advance: self.failover_advance,
             shutdown_grace: self.shutdown_grace,
             heartbeat_interval: self.heartbeat_interval,
-            core: Arc::new(ServingCore::new(self.window_ahead, self.max_seq_count)),
+            core: Arc::new(ServingCore::new(
+                self.window_ahead,
+                self.max_seq_count,
+                self.max_seq_batch_keys,
+            )),
             reporter: Arc::new(crate::reporter::Reporter::new()),
             #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
             tls_config: self.tls_config,
@@ -1147,6 +1177,34 @@ mod tests {
             .expect("max_seq_count(1) must build");
     }
 
+    #[test]
+    fn build_accepts_max_seq_batch_keys_of_one() {
+        // 1 is the smallest usable batch cap: a single-entry batch is valid, so
+        // the cap must build (the guard rejects only 0).
+        Server::builder()
+            .consensus_driver(Arc::new(crate::test_fakes::InMemoryDriver::new()))
+            .max_seq_batch_keys(1)
+            .build()
+            .expect("max_seq_batch_keys(1) must build");
+    }
+
+    #[test]
+    fn zero_max_seq_batch_keys_is_rejected() {
+        // max_seq_batch_keys(0) makes every GetSeqBatch call fail as
+        // "batch has N entries; the maximum is 0" — the RPC is silently dead.
+        // build() must fail-fast rather than ship a server where GetSeqBatch
+        // can never succeed.
+        match Server::builder()
+            .consensus_driver(Arc::new(crate::test_fakes::InMemoryDriver::new()))
+            .max_seq_batch_keys(0)
+            .build()
+        {
+            Err(BuildError::ZeroMaxSeqBatchKeys) => {}
+            Err(other) => panic!("expected ZeroMaxSeqBatchKeys, got {other:?}"),
+            Ok(_) => panic!("max_seq_batch_keys(0) must be rejected at build, but build succeeded"),
+        }
+    }
+
     #[tokio::test]
     async fn join_to_server_result_passes_through_clean_outcome() {
         // Ok(Ok(())) — task finished cleanly; forward verbatim.
@@ -1268,6 +1326,7 @@ mod tests {
         let core = Arc::new(ServingCore::new(
             Duration::from_secs(3),
             tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
         ));
         core.publish_serving();
 
@@ -1305,6 +1364,7 @@ mod tests {
         let core = Arc::new(ServingCore::new(
             Duration::from_secs(3),
             tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
         ));
         core.publish_serving();
 

--- a/crates/tsoracle-server/src/service.rs
+++ b/crates/tsoracle-server/src/service.rs
@@ -28,8 +28,9 @@ use tonic::{Request, Response, Status};
 use tsoracle_consensus::ConsensusError;
 use tsoracle_core::{CommitOutcome, CoreError, Epoch, PeerEndpoint};
 use tsoracle_proto::v1::{
-    EpochWire, GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetSeqRequest, GetSeqResponse,
-    GetTsRequest, GetTsResponse, LeaderHint, tso_service_server::TsoService,
+    EpochWire, GetCurrentMaxSafeRequest, GetCurrentMaxSafeResponse, GetSeqBatchRequest,
+    GetSeqBatchResponse, GetSeqRequest, GetSeqResponse, GetTsRequest, GetTsResponse, LeaderHint,
+    SeqGrantEntry, tso_service_server::TsoService,
 };
 
 use crate::leader_hint::not_leader_status;
@@ -328,6 +329,161 @@ impl TsoService for TsoServiceImpl {
             // permanent fault (PermanentDriver, AdvanceOutOfRange) the client
             // MUST NOT silently retry → INTERNAL, matching the ConsensusError
             // contract and the get_ts extension path's PersistDisposition split.
+            Err(ConsensusError::TransientDriver(source)) => {
+                Err(Status::unavailable(source.to_string()))
+            }
+            Err(other) => Err(Status::internal(other.to_string())),
+        }
+    }
+
+    async fn get_seq_batch(
+        &self,
+        req: Request<GetSeqBatchRequest>,
+    ) -> Result<Response<GetSeqBatchResponse>, Status> {
+        let GetSeqBatchRequest { entries } = req.into_inner();
+
+        self.server.reporter.get_seq_batch_requests.increment(1);
+
+        if !self.server.core.is_serving() {
+            return Err(not_leader_status(
+                &self.server.reporter,
+                leader_hint_from(&self.server),
+            ));
+        }
+
+        // Batch-shape validation (pre-commit, all INVALID_ARGUMENT).
+        if entries.is_empty() {
+            return Err(Status::invalid_argument(
+                "batch must contain at least one entry",
+            ));
+        }
+        let max_keys = self.server.core.max_seq_batch_keys();
+        if entries.len() as u32 > max_keys {
+            return Err(Status::invalid_argument(format!(
+                "batch has {} entries; the maximum is {max_keys}",
+                entries.len()
+            )));
+        }
+        // Distinct keys. A duplicate is a client bug (the caller coalesces its
+        // own counts) and is rejected before any consensus append.
+        let mut seen = std::collections::HashSet::with_capacity(entries.len());
+        for entry in &entries {
+            if !seen.insert(entry.key.as_str()) {
+                return Err(Status::invalid_argument(format!(
+                    "duplicate key in batch: {}",
+                    entry.key
+                )));
+            }
+        }
+
+        // Per-entry leadership/key/count validation, reusing the single-key core
+        // gate. Build the validated (SeqKey, count) list in request order.
+        let mut validated: Vec<(tsoracle_core::SeqKey, u32)> = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            match self.server.core.seq_validate(&entry.key, entry.count) {
+                Ok(seq_key) => validated.push((seq_key, entry.count)),
+                Err(tsoracle_core::CoreError::NotLeader) => {
+                    return Err(not_leader_status(
+                        &self.server.reporter,
+                        leader_hint_from(&self.server),
+                    ));
+                }
+                Err(tsoracle_core::CoreError::SeqKeyEmpty)
+                | Err(tsoracle_core::CoreError::SeqKeyTooLong { .. }) => {
+                    return Err(Status::invalid_argument("invalid sequence key"));
+                }
+                Err(tsoracle_core::CoreError::SeqCountZero)
+                | Err(tsoracle_core::CoreError::SeqCountTooLarge { .. }) => {
+                    return Err(Status::invalid_argument(
+                        "count must be between 1 and the maximum",
+                    ));
+                }
+                Err(other) => return Err(Status::internal(other.to_string())),
+            }
+        }
+
+        let epoch = match self.server.core.current_epoch() {
+            Some(e) => e,
+            None => {
+                return Err(not_leader_status(
+                    &self.server.reporter,
+                    leader_hint_from(&self.server),
+                ));
+            }
+        };
+
+        match self
+            .server
+            .consensus
+            .advance_dense_batch(&validated, epoch)
+            .await
+        {
+            Ok(starts) => {
+                // A conforming driver returns exactly one start per entry, in
+                // request order. Guard it: a buggy/custom driver returning too
+                // few (or too many) would otherwise let `zip` silently truncate
+                // and emit a response with fewer grants than requested,
+                // violating the proto's one-grant-per-entry contract. The
+                // durable advance already happened, so this is a post-commit
+                // server invariant breach -> Internal (not a retry-safe error).
+                if starts.len() != validated.len() {
+                    return Err(Status::internal(format!(
+                        "driver returned {} starts for a {}-entry batch",
+                        starts.len(),
+                        validated.len()
+                    )));
+                }
+                let (hi, lo) = epoch.to_wire();
+                let mut grants = Vec::with_capacity(validated.len());
+                let mut total: u64 = 0;
+                for ((seq_key, count), start) in validated.iter().zip(starts.iter()) {
+                    let grant =
+                        tsoracle_core::SeqGrant::try_new(seq_key.clone(), *start, *count, epoch)
+                            .map_err(core_status)?;
+                    total += u64::from(grant.count());
+                    grants.push(SeqGrantEntry {
+                        key: grant.key().as_str().to_string(),
+                        start: grant.start(),
+                        count: grant.count(),
+                    });
+                }
+                self.server.reporter.get_seq_batch_success.increment(1);
+                self.server
+                    .reporter
+                    .seq_batch_keys
+                    .record(grants.len() as f64);
+                self.server
+                    .reporter
+                    .seq_batch_values_issued
+                    .increment(total);
+                Ok(Response::new(GetSeqBatchResponse {
+                    grants,
+                    epoch: Some(EpochWire { hi, lo }),
+                }))
+            }
+            Err(ConsensusError::SeqKeyCardinalityExceeded { cap }) => {
+                self.server
+                    .reporter
+                    .seq_batch_cardinality_rejected
+                    .increment(1);
+                Err(Status::resource_exhausted(format!(
+                    "dense key cardinality cap {cap} reached"
+                )))
+            }
+            Err(ConsensusError::SeqOverflow) => {
+                Err(Status::failed_precondition("dense counter overflow"))
+            }
+            Err(ConsensusError::NotLeader { .. }) | Err(ConsensusError::Fenced { .. }) => Err(
+                not_leader_status(&self.server.reporter, leader_hint_from(&self.server)),
+            ),
+            Err(ConsensusError::DenseUnsupported) => Err(Status::unimplemented(
+                "dense sequences are not supported by this consensus driver",
+            )),
+            Err(ConsensusError::DenseBatchNotActivated { required, active }) => {
+                Err(Status::failed_precondition(format!(
+                    "dense batch format not yet activated (cluster at write version {active}, requires {required})"
+                )))
+            }
             Err(ConsensusError::TransientDriver(source)) => {
                 Err(Status::unavailable(source.to_string()))
             }

--- a/crates/tsoracle-server/src/serving_core.rs
+++ b/crates/tsoracle-server/src/serving_core.rs
@@ -88,10 +88,17 @@ pub(crate) struct ServingCore {
     /// `seq_validate` enforces the operator-configured policy without a
     /// back-reference to `Server`.
     max_seq_count: u32,
+    /// Cap on the number of `(key, count)` entries accepted in one
+    /// `GetSeqBatch` request, from
+    /// [`ServerBuilder::max_seq_batch_keys`](crate::ServerBuilder::max_seq_batch_keys)
+    /// (default [`tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS`]). Held here so
+    /// `max_seq_batch_keys()` can enforce the policy without a back-reference
+    /// to `Server`.
+    max_seq_batch_keys: u32,
 }
 
 impl ServingCore {
-    pub(crate) fn new(window_ahead: Duration, max_seq_count: u32) -> Self {
+    pub(crate) fn new(window_ahead: Duration, max_seq_count: u32, max_seq_batch_keys: u32) -> Self {
         let (state_tx, _) = watch::channel(ServingState::NotServing {
             leader_endpoint: None,
             leader_epoch: None,
@@ -104,6 +111,7 @@ impl ServingCore {
             extension_gate: RwLock::new(()),
             window_ahead,
             max_seq_count,
+            max_seq_batch_keys,
         }
     }
 
@@ -228,6 +236,12 @@ impl ServingCore {
             .validate_request(key, count, self.max_seq_count)
     }
 
+    /// Operator-configured cap on the number of `(key, count)` entries accepted
+    /// in one `GetSeqBatch` request.
+    pub(crate) fn max_seq_batch_keys(&self) -> u32 {
+        self.max_seq_batch_keys
+    }
+
     pub(crate) fn commit_extension(
         &self,
         actual: u64,
@@ -317,7 +331,11 @@ mod tests {
         // lands even when no receiver is subscribed (`receiver_count == 0`). Were
         // a publish site to use `send`, this would be silently dropped and a
         // leaderless-then-leader core could stay NotServing forever.
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         assert_eq!(core.state_tx.receiver_count(), 0);
 
         let hint = PeerEndpoint::try_from("new-leader:9000").unwrap();
@@ -341,7 +359,11 @@ mod tests {
         // the read barrier on the current task; if step_down tried to take the
         // write lock it would deadlock here (single-threaded runtime, lock held
         // by us). Reaching the assertion proves it never touches the gate.
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         let slot = core.extension_slot().await;
         let _barrier = slot.drain_barrier().await;
 
@@ -359,7 +381,11 @@ mod tests {
         // extension readers to drain. `try_write` is a deterministic probe of
         // that exclusion (no timing): it fails while a read barrier is held and
         // succeeds once it is released.
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         let slot = core.extension_slot().await;
         let barrier = slot.drain_barrier().await;
 
@@ -381,7 +407,11 @@ mod tests {
         // A fresh core is NotLeader (no epoch). prepare_extension must surface
         // that as `NotLeader` so the caller emits a redirect, and would_grant is
         // false.
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         let slot = core.extension_slot().await;
         assert!(matches!(
             slot.prepare_extension(1, 1_000),
@@ -396,7 +426,11 @@ mod tests {
         // `ServingState`; it must agree with `serving_state`'s variant across
         // every transition. Fresh core is NotServing -> false; publish_serving
         // -> true; step_down -> false again.
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         assert!(!core.is_serving(), "fresh core is NotServing");
         assert!(matches!(
             core.serving_state(),
@@ -419,7 +453,11 @@ mod tests {
 
     #[test]
     fn try_grant_without_leadership_is_not_leader() {
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         assert!(matches!(core.try_grant(1, 1), Err(CoreError::NotLeader)));
     }
 
@@ -428,7 +466,11 @@ mod tests {
         // become_leader(floor, ceiling, epoch) seeds a serveable
         // window; a grant at the floor returns timestamps stamped with the
         // seeded epoch.
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
             .expect("seed must succeed (ceiling >= floor)");
         let grant = core.try_grant(1_000, 1).expect("grant must succeed");
@@ -442,7 +484,11 @@ mod tests {
         // the call site. Seed a serveable window first so the clear is
         // observable, then assert both effects: NotServing with no leader hint,
         // and a now-cleared allocator (try_grant -> NotLeader).
-        let core = ServingCore::new(Duration::from_secs(3), tsoracle_core::DEFAULT_MAX_SEQ_COUNT);
+        let core = ServingCore::new(
+            Duration::from_secs(3),
+            tsoracle_core::DEFAULT_MAX_SEQ_COUNT,
+            tsoracle_core::DEFAULT_MAX_SEQ_BATCH_KEYS,
+        );
         core.seed_on_leadership_gained(1_000, 5_000, Epoch(3))
             .expect("seed must succeed (ceiling >= floor)");
         assert!(core.try_grant(1_000, 1).is_ok(), "seeded core must grant");

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -56,7 +56,8 @@ use crate::{Server, ServerError, ServingState};
 use crate::leader_hint::not_leader_status;
 #[cfg(any(feature = "tls-rustls", feature = "tls-native"))]
 use tsoracle_proto::v1::{
-    GetSeqRequest, GetSeqResponse, GetTsRequest, GetTsResponse, LeaderHint,
+    GetSeqBatchRequest, GetSeqBatchResponse, GetSeqRequest, GetSeqResponse, GetTsRequest,
+    GetTsResponse, LeaderHint,
     tso_service_server::{TsoService, TsoServiceServer},
 };
 
@@ -320,6 +321,19 @@ impl TsoService for FixedHintService {
         &self,
         _request: tonic::Request<GetSeqRequest>,
     ) -> Result<tonic::Response<GetSeqResponse>, tonic::Status> {
+        Err(not_leader_status(
+            &crate::reporter::Reporter::for_tests(),
+            LeaderHint {
+                leader_endpoint: Some(self.hint_endpoint.clone()),
+                leader_epoch: None,
+            },
+        ))
+    }
+
+    async fn get_seq_batch(
+        &self,
+        _request: tonic::Request<GetSeqBatchRequest>,
+    ) -> Result<tonic::Response<GetSeqBatchResponse>, tonic::Status> {
         Err(not_leader_status(
             &crate::reporter::Reporter::for_tests(),
             LeaderHint {

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -182,6 +182,15 @@ impl TsoService for MalformedHintService {
             "get_seq not implemented in test stub",
         ))
     }
+
+    async fn get_seq_batch(
+        &self,
+        _request: tonic::Request<tsoracle_proto::v1::GetSeqBatchRequest>,
+    ) -> Result<tonic::Response<tsoracle_proto::v1::GetSeqBatchResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "get_seq_batch not implemented in test stub",
+        ))
+    }
 }
 
 /// Bind a malformed-hint fake server on a random port. Returns its socket

--- a/e2e/kube/README.md
+++ b/e2e/kube/README.md
@@ -74,6 +74,8 @@ The "an old-only reader rejects a too-new record at the version gate rather than
 
 This lane covers the complementary system-level guarantee: the all-members gate ensures a v4-only member is never *exposed* to a v5 record (the `MEMBERS_BELOW_TARGET` rejection in step 3).
 
+The lane also activates write version 6 after version 5 and asserts `GetSeqBatch` gaplessness post-activation: the driver probes `get_seq_batch` over two independent keys (`orders-a`, `orders-b`) on every loop iteration, recording pre-activation `FailedPrecondition` / `Unimplemented` responses as not-serving (not errors) and verifying zero gaplessness violations once version 6 is active.
+
 ## Deploying to EKS (staging)
 
 The kind flow above is fully local. To deploy the same `openraft-standalone` cluster onto the real **staging** EKS cluster (arm64, real EBS) for a manual smoke test, the Kubernetes manifests live in the **infra** repo at `k8s/tsoracle-e2e/`; this repo only builds and pushes the images.

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -437,6 +437,38 @@ async fn sustain_load_with_seq(
                 seq.record_err();
             }
         }
+        // Batch probe: exercises GetSeqBatch across the v5→v6 activation boundary.
+        // Pre-activation (DenseBatchNotActivated / no RPC on old nodes) is
+        // expected — classified as not-serving, not an error.  Post-activation
+        // the two keys are tracked independently for gaplessness.
+        match client
+            .get_seq_batch(&[("orders-a", 1), ("orders-b", 1)])
+            .await
+        {
+            Ok(blocks) => {
+                for (key, block) in [("orders-a", &blocks[0]), ("orders-b", &blocks[1])] {
+                    seq.record_block(key, block.start, block.count);
+                }
+            }
+            // Pre-activation (batch format not yet active, or routed to a node
+            // without the RPC) is an expected state, not an error.
+            Err(ClientError::Rpc(status))
+                if matches!(
+                    status.code(),
+                    tonic::Code::FailedPrecondition | tonic::Code::Unimplemented
+                ) =>
+            {
+                seq.record_not_serving()
+            }
+            Err(ClientError::SeqUncertain) => {
+                seq.record_uncertain("orders-a");
+                seq.record_uncertain("orders-b");
+            }
+            Err(error) => {
+                eprintln!("mixed-version-soak: get_seq_batch error: {error}");
+                seq.record_err();
+            }
+        }
     }
     let ts_ok = tracker.report_within_error_tolerance("mixed-version-soak", MAX_SOAK_ERROR_RATE);
     let seq_ok = seq.report_within_error_tolerance("mixed-version-soak-seq", MAX_SOAK_ERROR_RATE);

--- a/e2e/kube/driver/src/main.rs
+++ b/e2e/kube/driver/src/main.rs
@@ -75,6 +75,13 @@ enum Mode {
     /// `--seq-expect=failed-precondition`; after activation, `--seq-expect=served`.
     /// Uses the client's leader-hint routing so it reaches the leader.
     GetSeqProbe,
+    /// One-shot GetSeqBatch probe used by the mixed-version orchestrator to
+    /// assert the batch-format (write version 6) activation transition: before
+    /// activation it must observe `--seq-expect=failed-precondition`; after, a
+    /// served batch of blocks for two distinct keys. The single-key dense path
+    /// (write version 5) may already be active when this runs — only the batch
+    /// path gates on write version 6.
+    GetSeqBatchProbe,
 }
 
 #[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
@@ -184,6 +191,9 @@ async fn main() -> Result<()> {
         }
         Mode::GetSeqProbe => {
             run_get_seq_probe(&cli.endpoints, &cli.seq_key, &cli.seq_expect, tls).await?
+        }
+        Mode::GetSeqBatchProbe => {
+            run_get_seq_batch_probe(&cli.endpoints, &cli.seq_expect, tls).await?
         }
     };
     if !passed {
@@ -506,6 +516,50 @@ async fn run_get_seq_probe(
         }
         (expect, other) => {
             eprintln!("get-seq-probe: expected {expect:?} but got {other:?} -> FAIL");
+            Ok(false)
+        }
+    }
+}
+
+/// One-shot `GetSeqBatch` probe for the mixed-version orchestrator's write
+/// version 6 (batch) activation assertion. Mirrors [`run_get_seq_probe`] but
+/// exercises the atomic multi-key path over two distinct keys. `Served` asserts
+/// a gapless block per key; `FailedPrecondition` asserts the pre-activation
+/// `DenseBatchNotActivated` rejection.
+async fn run_get_seq_batch_probe(
+    endpoints: &[String],
+    expect: &SeqExpect,
+    tls: Option<ClientTlsConfig>,
+) -> Result<bool> {
+    use tsoracle_client::ClientError;
+
+    let builder = ClientBuilder::endpoints(endpoints.to_vec()).retry_policy(generous_policy());
+    let client = apply_tls(builder, tls)
+        .build()
+        .await
+        .context("build get-seq-batch-probe client")?;
+
+    let result = client
+        .get_seq_batch(&[("orders-a", 1), ("orders-b", 1)])
+        .await;
+    match (expect, &result) {
+        (SeqExpect::Served, Ok(blocks)) => {
+            println!(
+                "get-seq-batch-probe: SERVED {} blocks (orders-a start={}, orders-b start={}) -> PASS",
+                blocks.len(),
+                blocks[0].start,
+                blocks[1].start
+            );
+            Ok(true)
+        }
+        (SeqExpect::FailedPrecondition, Err(ClientError::Rpc(status)))
+            if status.code() == tonic::Code::FailedPrecondition =>
+        {
+            println!("get-seq-batch-probe: FAILED_PRECONDITION (batch not activated) -> PASS");
+            Ok(true)
+        }
+        (expect, other) => {
+            eprintln!("get-seq-batch-probe: expected {expect:?} but got {other:?} -> FAIL");
             Ok(false)
         }
     }

--- a/e2e/kube/run-mixed-version-assertions.sh
+++ b/e2e/kube/run-mixed-version-assertions.sh
@@ -12,18 +12,20 @@ here="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=./_assertions_lib.sh
 source "$here/_assertions_lib.sh"
 
-# Activation target. DENSE_WRITE_VERSION is 5 (the real dense layout); this
-# is the genuine target the all-members gate must accept once all pods are
-# v5-capable. If DENSE_WRITE_VERSION bumps, this constant trips a visible
-# mismatch on the next run rather than silently activating to an unintended
-# version.
+# Dense activation target. DENSE_WRITE_VERSION is 5 (the real dense layout); the
+# v5-capable baseline can already read it, so it activates successfully once all
+# pods are up (it is NOT the gate-rejection target here — see below). Activated
+# post-rollout so GetSeq serves and the batch path's "still gated at v5"
+# independence can be asserted before v6 is activated. If DENSE_WRITE_VERSION
+# bumps, this constant trips a visible mismatch rather than silently activating
+# an unintended version.
 ACTIVATION_TARGET=5
-# Batch activation target. BATCH_WRITE_VERSION is 6 (the atomic GetSeqBatch log
-# command). Activated AFTER ACTIVATION_TARGET so the soak exercises the genuine
-# v5->v6 progression; the all-members gate accepts it once every pod is
-# v6-capable (post-full-rollout). Same bump-trips-a-visible-mismatch guard as
-# ACTIVATION_TARGET: if BATCH_WRITE_VERSION moves, this constant no longer
-# matches and the run fails loudly rather than activating an unintended version.
+# Batch activation target AND the all-members gate-rejection target. The
+# v5-capable baseline can read 5 but NOT 6 (BATCH_WRITE_VERSION), so 6 is the
+# genuine version the gate must reject while a v5-only member is still present
+# (the realistic v5->v6 upgrade), and the version activated last once every pod
+# is v6-capable. Same bump-trips-a-visible-mismatch guard: if BATCH_WRITE_VERSION
+# moves, this constant no longer matches and the run fails loudly.
 BATCH_ACTIVATION_TARGET=6
 # Loopback admin port; matches deploy/entrypoint.sh:12 ADMIN_PORT default
 # and the chart values.yaml ports.admin entry added in Task 7.
@@ -114,16 +116,18 @@ try_activate_format() {
 }
 
 # Assert activation to $1 is rejected by the ALL-MEMBERS GATE specifically
-# (rc=2 MEMBERS_BELOW_TARGET on a v5-capable leader), NOT by a v4 leader's
-# local-range check (rc=4). With partition=1 two of three pods are v5-capable
-# and exactly one (ordinal 0) is v4. If the current leader is the v4 pod it
-# answers rc=4; we gracefully restart it (default-grace SIGTERM fires the
-# leadership handoff onto a caught-up v5 voter) and retry. Bounded attempts.
+# (rc=2 MEMBERS_BELOW_TARGET on a v6-capable leader), NOT by the v5 baseline
+# leader's local-range check (rc=4). Called with the v6 target, against which
+# the v5 baseline is genuinely below-target. With partition=1 two of three pods
+# are v6-capable and exactly one (ordinal 0) is the v5 baseline. If the current
+# leader is that v5 baseline pod it answers rc=4 (it cannot read the v6 target);
+# we gracefully restart it (default-grace SIGTERM fires the leadership handoff
+# onto a caught-up v6 voter) and retry. Bounded attempts.
 assert_gate_rejection() {
     local target="$1"
-    local v4_leader
+    local below_target_leader
     for _attempt in 1 2 3; do
-        v4_leader=""
+        below_target_leader=""
         local pods
         pods=$(kubectl get pods -l app.kubernetes.io/name=tsoracle \
             -o jsonpath='{.items[*].metadata.name}')
@@ -135,11 +139,11 @@ assert_gate_rejection() {
                 --target "$target" >&2 || rc=$?
             case "$rc" in
                 2)
-                    echo "gate held: activate-format(target=$target) -> MEMBERS_BELOW_TARGET on v5 leader $pod"
+                    echo "gate held: activate-format(target=$target) -> MEMBERS_BELOW_TARGET on v6 leader $pod"
                     return 0
                     ;;
-                3) continue ;;                 # follower; skip
-                4) v4_leader="$pod" ;;          # v4 leader; record, will hand off
+                3) continue ;;                          # follower; skip
+                4) below_target_leader="$pod" ;;        # v5 baseline leader; record, will hand off
                 0)
                     echo "FAIL: activation unexpectedly SUCCEEDED in mixed state on $pod"
                     return 1
@@ -150,13 +154,13 @@ assert_gate_rejection() {
                     ;;
             esac
         done
-        if [ -n "$v4_leader" ]; then
-            echo "leader is v4 ($v4_leader); gracefully restarting to hand off to a v5 voter"
-            kubectl delete pod "$v4_leader"     # default grace -> SIGTERM -> #423 handoff
+        if [ -n "$below_target_leader" ]; then
+            echo "leader is the v5 baseline ($below_target_leader); gracefully restarting to hand off to a v6 voter"
+            kubectl delete pod "$below_target_leader"   # default grace -> SIGTERM -> #423 handoff
             kubectl rollout status sts/tsoracle --timeout=120s
         fi
     done
-    echo "FAIL: could not establish a v5 leader for the gate assertion"
+    echo "FAIL: could not establish a v6 leader for the gate assertion"
     return 1
 }
 
@@ -190,17 +194,17 @@ kubectl apply -f "$here/driver/job-mixed-version-soak.yaml"
 wait_soak_live tsoracle-e2e-mixed-version-soak \
     "mixed-version-soak: first GetTs ok" 60
 
-echo "== step 2: partition=1; roll ordinals 1 and 2 to :e2e-next (ordinal 0 stays v4) =="
+echo "== step 2: partition=1; roll ordinals 1 and 2 to :e2e-next (ordinal 0 stays the v5 baseline) =="
 kubectl patch sts/tsoracle --type=strategic \
     -p '{"spec":{"updateStrategy":{"rollingUpdate":{"partition":1}}}}'
 kubectl set image sts/tsoracle "tsoracle=${NEXT_IMAGE}"
 wait_pod_image_and_ready tsoracle-2 "${NEXT_IMAGE}" 120
 wait_pod_image_and_ready tsoracle-1 "${NEXT_IMAGE}" 120
 
-echo "== step 3: all-members gate MUST reject (v5 leader, v4 member present) =="
-assert_gate_rejection "$ACTIVATION_TARGET"
+echo "== step 3: all-members gate MUST reject v6 activation (v6 leader, v5 baseline member present) =="
+assert_gate_rejection "$BATCH_ACTIVATION_TARGET"
 
-echo "== step 4: partition=0; complete the rollout (all v5-capable) =="
+echo "== step 4: partition=0; complete the rollout (all v6-capable) =="
 kubectl patch sts/tsoracle --type=strategic \
     -p '{"spec":{"updateStrategy":{"rollingUpdate":{"partition":0}}}}'
 kubectl rollout status sts/tsoracle --timeout=180s

--- a/e2e/kube/run-mixed-version-assertions.sh
+++ b/e2e/kube/run-mixed-version-assertions.sh
@@ -18,6 +18,13 @@ source "$here/_assertions_lib.sh"
 # mismatch on the next run rather than silently activating to an unintended
 # version.
 ACTIVATION_TARGET=5
+# Batch activation target. BATCH_WRITE_VERSION is 6 (the atomic GetSeqBatch log
+# command). Activated AFTER ACTIVATION_TARGET so the soak exercises the genuine
+# v5->v6 progression; the all-members gate accepts it once every pod is
+# v6-capable (post-full-rollout). Same bump-trips-a-visible-mismatch guard as
+# ACTIVATION_TARGET: if BATCH_WRITE_VERSION moves, this constant no longer
+# matches and the run fails loudly rather than activating an unintended version.
+BATCH_ACTIVATION_TARGET=6
 # Loopback admin port; matches deploy/entrypoint.sh:12 ADMIN_PORT default
 # and the chart values.yaml ports.admin entry added in Task 7.
 ADMIN_PORT=51002
@@ -165,6 +172,19 @@ get_seq_probe() {
         --seq-key=orders --seq-expect="$expect"
 }
 
+# One-shot GetSeqBatch probe (write version 6 path) over two distinct keys.
+# EXPECT in {failed-precondition, served}. Runs to completion; non-zero exit =
+# FAIL.
+get_seq_batch_probe() {
+    local expect="$1"
+    "$TIMEOUT_CMD" 60s kubectl run "seq-batch-probe-${expect}-$$" \
+        --image=tsoracle-e2e-driver:latest --image-pull-policy=IfNotPresent \
+        --restart=Never --rm -i --command -- \
+        kube-e2e-driver --mode=get-seq-batch-probe \
+        --endpoints=tsoracle-0.tsoracle-peer:5051,tsoracle-1.tsoracle-peer:5051,tsoracle-2.tsoracle-peer:5051 \
+        --seq-expect="$expect"
+}
+
 echo "== step 1: start mixed-version soak (load is live before any perturbation) =="
 kubectl apply -f "$here/driver/job-mixed-version-soak.yaml"
 wait_soak_live tsoracle-e2e-mixed-version-soak \
@@ -193,6 +213,18 @@ try_activate_format "$ACTIVATION_TARGET" OK
 
 echo "== step 7: post-activation GetSeq MUST serve a block =="
 get_seq_probe served
+
+# The batch path (write version 6) gates ABOVE the dense path (write version 5).
+# With only v5 active, GetSeqBatch must still be FAILED_PRECONDITION — proving
+# the batch gate is independent of and higher than the dense gate.
+echo "== step 7b: pre-batch-activation GetSeqBatch MUST be FAILED_PRECONDITION (v5 active, v6 not) =="
+get_seq_batch_probe failed-precondition
+
+echo "== step 7c: batch activation (write version 6) MUST succeed (all members v6-capable) =="
+try_activate_format "$BATCH_ACTIVATION_TARGET" OK
+
+echo "== step 7d: post-activation GetSeqBatch MUST serve blocks =="
+get_seq_batch_probe served
 
 echo "== step 8: drain the soak (GetTs monotone + GetSeq gapless + <error budget) =="
 wait_job tsoracle-e2e-mixed-version-soak 180

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -291,6 +291,20 @@ impl RaftStateMachine<HostTypeConfig> for HostStateMachine {
                         tso: Some(core.high_water),
                     }
                 }
+                EntryPayload::Normal(HostCommand::Tso(HighWaterCommand::AdvanceDenseBatch {
+                    ..
+                })) => {
+                    // The piggyback example does not implement batch dense sequence
+                    // state. This arm satisfies exhaustiveness; a real piggyback
+                    // host that supports batch advances would forward this entry to
+                    // its embedded `HighWaterStateMachine`.
+                    let mut core = self.core.lock();
+                    core.last_applied = Some(log_id);
+                    HostApplied {
+                        kv: None,
+                        tso: Some(core.high_water),
+                    }
+                }
                 EntryPayload::Membership(membership) => {
                     let mut core = self.core.lock();
                     core.last_membership = StoredMembership::new(Some(log_id), membership.clone());

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -440,6 +440,16 @@ impl OpenraftHighWaterHost for PiggybackHost {
         Err(ConsensusError::DenseUnsupported)
     }
 
+    async fn submit_advance_dense_batch(
+        &self,
+        _entries: &[(tsoracle_core::SeqKey, u32)],
+    ) -> Result<Vec<u64>, ConsensusError> {
+        // Dense sequences are not implemented in the piggyback example.
+        // The driver gate (`active_write_version < BATCH_WRITE_VERSION`)
+        // prevents this from ever being called in normal operation.
+        Err(ConsensusError::DenseUnsupported)
+    }
+
     async fn current_dense_seq(&self, _key: &tsoracle_core::SeqKey) -> Result<u64, ConsensusError> {
         // Dense sequences are not implemented in the piggyback example.
         Err(ConsensusError::DenseUnsupported)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -146,6 +146,14 @@ bench             = false
 doctest           = false
 
 [[bin]]
+name              = "openraft_advance_dense_batch_decode"
+path              = "fuzz_targets/openraft_advance_dense_batch_decode.rs"
+test              = false
+doc               = false
+bench             = false
+doctest           = false
+
+[[bin]]
 name              = "codec_roundtrip"
 path              = "fuzz_targets/codec_roundtrip.rs"
 test              = false

--- a/fuzz/fuzz_targets/openraft_advance_dense_batch_decode.rs
+++ b/fuzz/fuzz_targets/openraft_advance_dense_batch_decode.rs
@@ -1,0 +1,42 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use tsoracle_driver_openraft::OpenraftEntry;
+use tsoracle_openraft_toolkit::decode;
+
+// The AdvanceDenseBatch command is an attacker-reachable wire/disk format once
+// write version 6 is activated. Decoding arbitrary bytes must never panic —
+// every malformed input (bad variant index, truncated vec length, empty or
+// oversized embedded SeqKey, trailing bytes) must surface as a decode error,
+// never an unwrap/slice panic. This mirrors `openraft_dense_command_decode`'s
+// entry portion exactly: `decode` is an EXACT-version decoder, not the
+// log-store readable-range gate, so this asserts only the no-panic property —
+// it deliberately makes NO out-of-range-rejection assertion (the range gate
+// lives in the log store's `decode_entry_record`, covered by a unit test).
+fuzz_target!(|data: &[u8]| {
+    if let Some((&version, body)) = data.split_first() {
+        let _ = decode::<OpenraftEntry>(version, body);
+    }
+});


### PR DESCRIPTION
## Summary

Adds a `GetSeqBatch` RPC that allocates contiguous dense sequence blocks for several distinct keys in one round-trip, atomically (all-or-nothing). Previously a caller needing blocks for N keys had to make N sequential `GetSeq` calls, each its own consensus round-trip. `GetSeqBatch` collapses that into one request carrying `repeated (key, count)` and one response carrying `repeated (key, start, count)` plus the single leader epoch that committed the whole batch.

The hard part is not the wire format but the failure semantics: `GetSeq` is deliberately non-idempotent (a committed-but-undelivered advance is a spent block), so the batch is applied as a single replicated log entry and the whole batch shares one all-or-nothing outcome — preserving exactly today's single-key uncertainty model rather than introducing a partial-commit mix.

## Design

- **Atomic apply.** A new `AdvanceDenseBatch` consensus log entry is applied by a validate-then-fold: cardinality is checked against the set of distinct new keys, then a sequential `checked_add` fold runs over a scratch map seeded from current counters, and the durable map is mutated only on full success. A rejection (cardinality or overflow) moves no counter. The fold accumulates per key, so a duplicate key produces adjacent, non-overlapping blocks and overflow is checked against the accumulated value rather than the shared pre-state.
- **Version gating.** Introduces write version 6 (`BATCH_WRITE_VERSION`), behind the existing activation machinery. The openraft proposer refuses to append a batch entry until version 6 is active cluster-wide (`DenseBatchNotActivated`), and a second line of defense in the log-entry codec refuses to even serialize an `AdvanceDenseBatch` below version 6, so a gate regression fails the write at the leader instead of committing a poison entry an un-upgraded follower could not decode. The state-machine snapshot shape is unchanged (v6 is byte-identical to v5 in both the payload and envelope codecs).
- **Driver parity.** Works on the openraft driver (gated) and the single-node file driver (ungated — no replicated log, one durable write per batch). The paxos driver inherits the unsupported default and returns `UNIMPLEMENTED`, matching single-key `GetSeq`.
- **Non-idempotent client.** `Client::get_seq_batch` pre-rejects only universally-invalid input (empty batch, duplicate key, empty/oversized key, zero count) and forwards the rest. It mirrors the single-key retry loop exactly: pre-send failures retry (leader-hint chase), and any ambiguous post-send failure surfaces as a single whole-batch `SeqUncertain` that is never transparently retried. Because positional request-to-grant mapping makes a malformed response silently wrong, the client validates the whole response (grant count, per-index key/count, epoch presence) and treats any mismatch as `SeqUncertain`.
- **Validation and observability.** The server rejects duplicate keys and over-cap batches (`max_seq_batch_keys`, a new soft guardrail) before any consensus append, guards that the driver returned exactly one start per entry, and records batch traffic under its own `tsoracle.get_seq.batch.*` metrics so the single-key series stays clean.

## Rollout

No flag day: deploy version-6-capable binaries cluster-wide, then activate write version 6 via the existing `tsoracle admin` flow. The mixed-version e2e lane now drives the full v5 → v6 progression and asserts gate independence (with only v5 active, batch is still `FAILED_PRECONDITION`; after activating v6 it serves).

## Test Plan

- [x] `cargo test --workspace --all-features` (green locally)
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` (clean locally)
- [x] Fuzz: new `openraft_advance_dense_batch_decode` target runs in the PR/nightly fuzz lanes
- [x] Kubernetes mixed-version e2e lane: batch gaplessness asserted across the v5 → v6 activation boundary
- [x] Atomicity is unit-tested on both drivers: cardinality and overflow rejections leave every counter unmoved; duplicate-key accumulation yields adjacent starts