### PR TITLE
feat(admin): capability reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,6 +3236,8 @@ dependencies = [
  "humantime",
  "parking_lot",
  "rcgen",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -25,6 +25,8 @@ bt         = ["tsoracle-server/bt"]
 anyhow                = "1"
 humantime             = "2"
 clap                  = { workspace = true }
+serde                 = { workspace = true }
+serde_json            = { workspace = true }
 tokio                 = { workspace = true, features = ["signal"] }
 tracing               = { workspace = true }
 tracing-subscriber    = { workspace = true }

--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -53,8 +53,9 @@ pub enum Cmd {
 #[cfg(feature = "openraft")]
 #[derive(Subcommand, Debug)]
 pub enum AdminCmd {
-    /// List current members.
-    Members(AdminEndpointArgs),
+    /// List current members. With `--capabilities`, also gather and show each
+    /// member's format-version capabilities.
+    Members(MembersArgs),
     /// Add a non-voting learner.
     AddLearner(AddLearnerArgs),
     /// Promote a learner to voter.
@@ -68,6 +69,10 @@ pub enum AdminCmd {
     /// 4=local-range-rejected (TARGET_OUT_OF_RANGE — receiving node's
     /// MAX_READABLE_VERSION < target), 1=other failure.
     ActivateFormat(ActivateFormatArgs),
+    /// Report every member's format-version capabilities (min/max readable and
+    /// active write version). Read-only; answerable by any node. Use before
+    /// `activate-format` to confirm the cluster is ready for a target version.
+    Capabilities(CapabilitiesArgs),
 }
 
 #[cfg(feature = "openraft")]
@@ -86,10 +91,26 @@ pub struct AdminClientTlsArgs {
 
 #[cfg(feature = "openraft")]
 #[derive(Parser, Debug)]
-pub struct AdminEndpointArgs {
+pub struct MembersArgs {
     /// Any node's admin endpoint, e.g. `https://127.0.0.1:50561`.
     #[arg(long)]
     pub endpoint: String,
+    /// Also gather and display each member's format-version capabilities.
+    #[arg(long)]
+    pub capabilities: bool,
+    #[command(flatten)]
+    pub tls: AdminClientTlsArgs,
+}
+
+#[cfg(feature = "openraft")]
+#[derive(Parser, Debug)]
+pub struct CapabilitiesArgs {
+    /// Any node's admin endpoint, e.g. `https://127.0.0.1:50561`.
+    #[arg(long)]
+    pub endpoint: String,
+    /// Emit the report as JSON instead of the aligned table.
+    #[arg(long)]
+    pub json: bool,
     #[command(flatten)]
     pub tls: AdminClientTlsArgs,
 }
@@ -291,4 +312,66 @@ pub struct InitArgs {
 
 pub fn parse_duration(input: &str) -> Result<Duration, String> {
     humantime::parse_duration(input).map_err(|e| e.to_string())
+}
+
+#[cfg(all(test, feature = "openraft"))]
+mod admin_capabilities_parse_tests {
+    use super::{AdminCmd, Cli, Cmd};
+    use clap::Parser;
+
+    #[test]
+    fn capabilities_parses_endpoint() {
+        let cli = Cli::try_parse_from([
+            "tsoracle",
+            "admin",
+            "capabilities",
+            "--endpoint",
+            "http://127.0.0.1:51002",
+        ])
+        .unwrap();
+        match cli.cmd {
+            Some(Cmd::Admin(AdminCmd::Capabilities(args))) => {
+                assert_eq!(args.endpoint, "http://127.0.0.1:51002");
+                assert!(!args.json);
+            }
+            other => panic!("expected Capabilities, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn capabilities_json_flag_sets_true() {
+        let cli = Cli::try_parse_from([
+            "tsoracle",
+            "admin",
+            "capabilities",
+            "--endpoint",
+            "http://x",
+            "--json",
+        ])
+        .unwrap();
+        match cli.cmd {
+            Some(Cmd::Admin(AdminCmd::Capabilities(args))) => assert!(args.json),
+            other => panic!("expected Capabilities, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn members_capabilities_flag_sets_true() {
+        let cli = Cli::try_parse_from([
+            "tsoracle",
+            "admin",
+            "members",
+            "--endpoint",
+            "http://x",
+            "--capabilities",
+        ])
+        .unwrap();
+        match cli.cmd {
+            Some(Cmd::Admin(AdminCmd::Members(args))) => {
+                assert_eq!(args.endpoint, "http://x");
+                assert!(args.capabilities);
+            }
+            other => panic!("expected Members, got {other:?}"),
+        }
+    }
 }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -435,6 +435,164 @@ fn classify_activation(resp: &ChangeResponse) -> ActivationOutcome {
 }
 
 #[cfg(feature = "openraft")]
+fn role_label(role: i32) -> &'static str {
+    use tsoracle_standalone::admin_proto::MemberRole;
+    match MemberRole::try_from(role) {
+        Ok(MemberRole::Voter) => "voter",
+        Ok(MemberRole::Learner) => "learner",
+        _ => "unknown",
+    }
+}
+
+#[cfg(feature = "openraft")]
+fn render_capabilities_table(
+    report: &tsoracle_standalone::admin_proto::CapabilityReport,
+) -> String {
+    let mut out = String::from("node  min_readable  max_readable  active_write\n");
+    for member in &report.members {
+        if member.reachable {
+            out.push_str(&format!(
+                "{:<4}  {:<12}  {:<12}  {}\n",
+                member.id,
+                member.min_readable_version,
+                member.max_readable_version,
+                member.active_write_version
+            ));
+        } else {
+            let detail = if member.unreachable_detail.is_empty() {
+                String::new()
+            } else {
+                format!("    ({})", member.unreachable_detail)
+            };
+            out.push_str(&format!(
+                "{:<4}  {:<12}  {:<12}  {}{}\n",
+                member.id, "-", "-", "unreachable", detail
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(feature = "openraft")]
+fn render_members_with_caps(report: &tsoracle_standalone::admin_proto::CapabilityReport) -> String {
+    let leader = if report.has_leader {
+        report.leader.to_string()
+    } else {
+        "none".to_string()
+    };
+    let mut out = format!("leader: {leader}\n");
+    for member in &report.members {
+        let caps = if member.reachable {
+            format!(
+                "min_readable={} max_readable={} active_write={}",
+                member.min_readable_version,
+                member.max_readable_version,
+                member.active_write_version
+            )
+        } else if member.unreachable_detail.is_empty() {
+            "capabilities=unreachable".to_string()
+        } else {
+            format!("capabilities=unreachable ({})", member.unreachable_detail)
+        };
+        out.push_str(&format!(
+            "  id={} role={} raft={} service={} admin={} {}\n",
+            member.id,
+            role_label(member.role),
+            member.raft_addr,
+            member.service_endpoint,
+            member.admin_endpoint,
+            caps
+        ));
+    }
+    out
+}
+
+#[cfg(feature = "openraft")]
+#[derive(serde::Serialize)]
+struct JsonMember {
+    id: u64,
+    role: String,
+    raft_addr: String,
+    service_endpoint: String,
+    admin_endpoint: String,
+    reachable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_readable_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_readable_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active_write_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unreachable_detail: Option<String>,
+}
+
+#[cfg(feature = "openraft")]
+#[derive(serde::Serialize)]
+struct JsonReport {
+    leader: Option<u64>,
+    members: Vec<JsonMember>,
+}
+
+#[cfg(feature = "openraft")]
+fn to_json_report(report: &tsoracle_standalone::admin_proto::CapabilityReport) -> JsonReport {
+    let members = report
+        .members
+        .iter()
+        .map(|member| {
+            let (min_r, max_r, active_w, detail) = if member.reachable {
+                (
+                    Some(member.min_readable_version),
+                    Some(member.max_readable_version),
+                    Some(member.active_write_version),
+                    None,
+                )
+            } else {
+                (None, None, None, Some(member.unreachable_detail.clone()))
+            };
+            JsonMember {
+                id: member.id,
+                role: role_label(member.role).to_string(),
+                raft_addr: member.raft_addr.clone(),
+                service_endpoint: member.service_endpoint.clone(),
+                admin_endpoint: member.admin_endpoint.clone(),
+                reachable: member.reachable,
+                min_readable_version: min_r,
+                max_readable_version: max_r,
+                active_write_version: active_w,
+                unreachable_detail: detail,
+            }
+        })
+        .collect();
+    JsonReport {
+        leader: if report.has_leader {
+            Some(report.leader)
+        } else {
+            None
+        },
+        members,
+    }
+}
+
+#[cfg(feature = "openraft")]
+async fn call_report_capabilities(
+    client: &mut tsoracle_standalone::admin_proto::membership_admin_client::MembershipAdminClient<
+        tonic::transport::Channel,
+    >,
+) -> anyhow::Result<tsoracle_standalone::admin_proto::CapabilityReport> {
+    use tsoracle_standalone::admin_proto::ReportCapabilitiesRequest;
+    match client
+        .report_capabilities(ReportCapabilitiesRequest {})
+        .await
+    {
+        Ok(resp) => Ok(resp.into_inner()),
+        Err(status) if status.code() == tonic::Code::Unimplemented => {
+            anyhow::bail!("this node's driver does not support format capabilities (openraft only)")
+        }
+        Err(status) => Err(anyhow::Error::new(status).context("report_capabilities")),
+    }
+}
+
+#[cfg(feature = "openraft")]
 async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
     use cli::AdminCmd;
     use tsoracle_standalone::admin_proto::membership_admin_client::MembershipAdminClient;
@@ -525,6 +683,11 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
             let tls = admin_client_tls(&args.tls)?;
             let channel = admin_connect(&args.endpoint, tls.as_ref()).await?;
             let mut client = MembershipAdminClient::new(channel);
+            if args.capabilities {
+                let report = call_report_capabilities(&mut client).await?;
+                print!("{}", render_members_with_caps(&report));
+                return Ok(());
+            }
             let view = client
                 .list_members(ListMembersRequest {})
                 .await
@@ -619,6 +782,102 @@ async fn dispatch_admin(cmd: cli::AdminCmd) -> Result<()> {
                 .await?,
             )
         }
+        AdminCmd::Capabilities(args) => {
+            let tls = admin_client_tls(&args.tls)?;
+            let channel = admin_connect(&args.endpoint, tls.as_ref()).await?;
+            let mut client = MembershipAdminClient::new(channel);
+            let report = call_report_capabilities(&mut client).await?;
+            if args.json {
+                let json = serde_json::to_string_pretty(&to_json_report(&report))
+                    .context("serialize capabilities json")?;
+                println!("{json}");
+            } else {
+                print!("{}", render_capabilities_table(&report));
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(all(test, feature = "openraft"))]
+mod capabilities_render_tests {
+    use super::{render_capabilities_table, render_members_with_caps, to_json_report};
+    use tsoracle_standalone::admin_proto::{CapabilityReport, MemberCapabilities, MemberRole};
+
+    fn reachable(id: u64) -> MemberCapabilities {
+        MemberCapabilities {
+            id,
+            role: MemberRole::Voter as i32,
+            raft_addr: format!("h{id}:1"),
+            service_endpoint: format!("h{id}:2"),
+            admin_endpoint: format!("h{id}:3"),
+            reachable: true,
+            min_readable_version: 4,
+            max_readable_version: 6,
+            active_write_version: 4,
+            unreachable_detail: String::new(),
+        }
+    }
+
+    fn unreachable(id: u64) -> MemberCapabilities {
+        MemberCapabilities {
+            id,
+            role: MemberRole::Voter as i32,
+            raft_addr: format!("h{id}:1"),
+            service_endpoint: format!("h{id}:2"),
+            admin_endpoint: format!("h{id}:3"),
+            reachable: false,
+            min_readable_version: 0,
+            max_readable_version: 0,
+            active_write_version: 0,
+            unreachable_detail: "connection refused".to_string(),
+        }
+    }
+
+    fn report() -> CapabilityReport {
+        CapabilityReport {
+            members: vec![reachable(1), unreachable(3)],
+            has_leader: true,
+            leader: 1,
+        }
+    }
+
+    #[test]
+    fn table_has_header_and_reachable_and_unreachable_rows() {
+        let out = render_capabilities_table(&report());
+        let mut lines = out.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "node  min_readable  max_readable  active_write"
+        );
+        let reachable_row = lines.next().unwrap();
+        assert!(reachable_row.starts_with('1'));
+        assert!(reachable_row.contains('4') && reachable_row.contains('6'));
+        let unreachable_row = lines.next().unwrap();
+        assert!(unreachable_row.starts_with('3'));
+        assert!(unreachable_row.contains("unreachable"));
+        assert!(unreachable_row.contains("(connection refused)"));
+    }
+
+    #[test]
+    fn members_view_augments_each_line_with_caps() {
+        let out = render_members_with_caps(&report());
+        assert!(out.contains("leader: 1"));
+        assert!(out.contains("id=1") && out.contains("active_write=4"));
+        assert!(
+            out.contains("id=3") && out.contains("capabilities=unreachable (connection refused)")
+        );
+    }
+
+    #[test]
+    fn json_omits_version_fields_when_unreachable() {
+        let json = serde_json::to_string(&to_json_report(&report())).unwrap();
+        assert!(json.contains("\"leader\":1"));
+        assert!(json.contains("\"active_write_version\":4"));
+        assert!(json.contains("\"unreachable_detail\":\"connection refused\""));
+        let unreachable_obj = json.split("\"id\":3").nth(1).unwrap();
+        assert!(!unreachable_obj.contains("active_write_version"));
+        assert!(unreachable_obj.contains("\"reachable\":false"));
     }
 }
 

--- a/crates/tsoracle-driver-openraft/src/capabilities.rs
+++ b/crates/tsoracle-driver-openraft/src/capabilities.rs
@@ -209,6 +209,33 @@ pub async fn gather_with<S: CapabilitySource>(
     Ok(gathered)
 }
 
+/// Tolerant sibling of [`gather_with`]: query every member for its
+/// capabilities, but instead of failing closed on the first unreachable peer,
+/// capture each member's result. Returns one entry per member, in membership
+/// order, with the local node answered directly from `local_capabilities`.
+///
+/// Where [`gather_with`] backs the activation gate (which must refuse to
+/// proceed on a member it cannot confirm), this backs the read-only
+/// capabilities report (which must surface an unreachable member rather than
+/// hide the whole cluster behind one failure).
+pub async fn report_with<S: CapabilitySource>(
+    local_node: NodeId,
+    local_capabilities: NodeCapabilities,
+    membership: &[(NodeId, S::Node)],
+    source: &S,
+) -> Vec<(NodeId, Result<NodeCapabilities, String>)> {
+    let mut reports = Vec::with_capacity(membership.len());
+    for (node_id, member) in membership {
+        let result = if *node_id == local_node {
+            Ok(local_capabilities)
+        } else {
+            source.query(*node_id, member).await
+        };
+        reports.push((*node_id, result));
+    }
+    reports
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -457,5 +484,50 @@ mod tests {
             err,
             FormatActivationError::MemberUnreachable { node_id: 2, .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn report_with_answers_local_directly_and_queries_remotes() {
+        let source = FakeSource {
+            responses: HashMap::from([(2u64, Ok(caps(3, 5)))]),
+        };
+        let membership: Vec<(NodeId, ())> = vec![(1, ()), (2, ())];
+        let reports = report_with(1, caps(3, 4), &membership, &source).await;
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0].0, 1);
+        assert_eq!(reports[0].1.as_ref().unwrap().active_write_version, 3);
+        assert_eq!(reports[1].0, 2);
+        assert_eq!(reports[1].1.as_ref().unwrap().max_readable_version, 5);
+    }
+
+    #[tokio::test]
+    async fn report_with_captures_unreachable_without_short_circuiting() {
+        // Node 2 is unreachable; node 3 must still be reported (gather_with
+        // would have bailed at node 2). This is the tolerant contract.
+        let source = FakeSource {
+            responses: HashMap::from([
+                (2u64, Err("connection refused".to_string())),
+                (3u64, Ok(caps(3, 4))),
+            ]),
+        };
+        let membership: Vec<(NodeId, ())> = vec![(1, ()), (2, ()), (3, ())];
+        let reports = report_with(1, caps(3, 4), &membership, &source).await;
+        assert_eq!(reports.len(), 3);
+        assert!(reports[0].1.is_ok());
+        assert_eq!(reports[1].1.as_ref().unwrap_err(), "connection refused");
+        assert!(
+            reports[2].1.is_ok(),
+            "node 3 reported despite node 2 failing"
+        );
+    }
+
+    #[tokio::test]
+    async fn report_with_empty_membership_is_empty() {
+        let source = FakeSource {
+            responses: HashMap::new(),
+        };
+        let membership: Vec<(NodeId, ())> = vec![];
+        let reports = report_with(1, caps(3, 4), &membership, &source).await;
+        assert!(reports.is_empty());
     }
 }

--- a/crates/tsoracle-driver-openraft/src/lib.rs
+++ b/crates/tsoracle-driver-openraft/src/lib.rs
@@ -46,6 +46,7 @@ pub const DEFAULT_DENSE_CARDINALITY_CAP: u64 = 10_000;
 
 pub use capabilities::{
     CapabilitySource, FormatActivationError, NodeCapabilities, all_members_can_read, gather_with,
+    report_with,
 };
 pub use driver::OpenraftDriver;
 pub use host::OpenraftHighWaterHost;

--- a/crates/tsoracle-standalone/proto/admin.proto
+++ b/crates/tsoracle-standalone/proto/admin.proto
@@ -47,6 +47,12 @@ service MembershipAdmin {
   // unit variant); the operator (or shell orchestrator) re-issues against a
   // known leader rather than auto-redirecting.
   rpc ActivateFormat(ActivateFormatRequest) returns (ChangeResponse);
+  // Report every current member's format-version capabilities (read-only,
+  // answerable by any node). The openraft driver gathers tolerantly: an
+  // unreachable member is returned with `reachable=false` and a detail
+  // string rather than failing the whole call. paxos/file return
+  // UNIMPLEMENTED (they have no format-migration surface).
+  rpc ReportCapabilities(ReportCapabilitiesRequest) returns (CapabilityReport);
 }
 
 // A node's role in the current membership.
@@ -106,6 +112,33 @@ message ActivateFormatRequest {
   // Target format version. proto3 has no uint8, so encoded as uint32; the
   // handler validates the value fits u8 before forwarding.
   uint32 target = 1;
+}
+
+message ReportCapabilitiesRequest {}
+
+// One member's identity plus its format-version capabilities. proto3 has no
+// uint8, so the three versions are uint32 (server-produced u8 values, widened).
+// When `reachable` is false the version fields are 0 and `unreachable_detail`
+// carries why the member could not be queried.
+message MemberCapabilities {
+  uint64 id = 1;
+  MemberRole role = 2;
+  string raft_addr = 3;
+  string service_endpoint = 4;
+  string admin_endpoint = 5;
+  bool reachable = 6;
+  uint32 min_readable_version = 7;
+  uint32 max_readable_version = 8;
+  uint32 active_write_version = 9;
+  string unreachable_detail = 10;
+}
+
+// Cluster-wide capability snapshot. `has_leader` + `leader` jointly encode
+// `Option<u64>` exactly as in `MembershipView`.
+message CapabilityReport {
+  repeated MemberCapabilities members = 1;
+  bool has_leader = 2;
+  uint64 leader = 3;
 }
 
 // Typed error kinds for `ChangeResponse`. Adding a new variant is backwards

--- a/crates/tsoracle-standalone/src/admin/mod.rs
+++ b/crates/tsoracle-standalone/src/admin/mod.rs
@@ -86,6 +86,39 @@ pub struct NewMember {
     pub admin_endpoint: String,
 }
 
+/// A member's format-version capabilities, or the reason it could not be
+/// reached. The read-only capabilities report carries one of these per member.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilityState {
+    /// The member answered: the oldest/newest formats its binary can read and
+    /// the version it is actively writing right now.
+    Reported {
+        min_readable: u8,
+        max_readable: u8,
+        active_write: u8,
+    },
+    /// The member could not be queried; `detail` is the human-readable reason.
+    Unreachable { detail: String },
+}
+
+/// One member's identity (reusing [`MemberEntry`]) plus its capability state.
+/// Reusing `MemberEntry` lets the `capabilities` table and the `members
+/// --capabilities` listing render from the same report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemberCapability {
+    pub member: MemberEntry,
+    pub caps: CapabilityState,
+}
+
+/// A cluster-wide snapshot of every member's format capabilities, built from a
+/// single membership read on the queried node so membership, roles, leader,
+/// and the gather target stay consistent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityReport {
+    pub members: Vec<MemberCapability>,
+    pub leader: Option<u64>,
+}
+
 /// Membership-admin failure modes.
 #[derive(Debug, thiserror::Error)]
 pub enum AdminError {
@@ -141,6 +174,12 @@ pub trait MembershipAdmin: Send + Sync {
     /// `Unsupported` on drivers without zero-downtime format migration
     /// (file, paxos).
     async fn activate_format(&self, target: u8) -> Result<(), AdminError>;
+
+    /// Report every current member's format-version capabilities (read-only,
+    /// answerable on any node). The openraft impl gathers tolerantly — an
+    /// unreachable member is reported, not fatal. Drivers without the
+    /// format-migration surface (file, paxos) return `Unsupported`.
+    async fn report_capabilities(&self) -> Result<CapabilityReport, AdminError>;
 }
 
 /// Admin handle for drivers without runtime membership (file, and — in this
@@ -171,6 +210,10 @@ impl MembershipAdmin for UnsupportedAdmin {
         Err(AdminError::Unsupported)
     }
     async fn activate_format(&self, _target: u8) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+
+    async fn report_capabilities(&self) -> Result<CapabilityReport, AdminError> {
         Err(AdminError::Unsupported)
     }
 }
@@ -217,6 +260,15 @@ mod tests {
         let admin = UnsupportedAdmin::new(empty_view());
         assert!(matches!(
             admin.activate_format(5).await,
+            Err(AdminError::Unsupported)
+        ));
+    }
+
+    #[tokio::test]
+    async fn unsupported_admin_rejects_report_capabilities() {
+        let admin = UnsupportedAdmin::new(empty_view());
+        assert!(matches!(
+            admin.report_capabilities().await,
             Err(AdminError::Unsupported)
         ));
     }

--- a/crates/tsoracle-standalone/src/admin/openraft.rs
+++ b/crates/tsoracle-standalone/src/admin/openraft.rs
@@ -33,7 +33,8 @@ use tokio::sync::Mutex;
 use tsoracle_driver_openraft::{HighWaterStateMachine, OpenraftPeer, TypeConfig};
 
 use crate::admin::{
-    AdminError, MemberEntry, MemberRole, MembershipAdmin, MembershipView, NewMember,
+    AdminError, CapabilityReport, CapabilityState, MemberCapability, MemberEntry, MemberRole,
+    MembershipAdmin, MembershipView, NewMember,
 };
 
 /// Map a `change_membership` / `add_learner` error into an `AdminError`,
@@ -110,6 +111,60 @@ fn voter_ids(view: &MembershipView) -> BTreeSet<u64> {
         .filter(|entry| entry.role == MemberRole::Voter)
         .map(|entry| entry.id)
         .collect()
+}
+
+/// Build a [`CapabilityReport`] from a single membership snapshot and the
+/// per-member capability results gathered over that exact set. Pure: it never
+/// reads `raft.metrics()`, so the report rows correspond one-to-one with the
+/// `members` slice handed in.
+fn assemble_report(
+    leader: Option<u64>,
+    voters: &BTreeSet<u64>,
+    members: &[(u64, OpenraftPeer)],
+    caps: &[(
+        u64,
+        Result<tsoracle_driver_openraft::NodeCapabilities, String>,
+    )],
+) -> CapabilityReport {
+    let caps_by_id: std::collections::HashMap<
+        u64,
+        &Result<tsoracle_driver_openraft::NodeCapabilities, String>,
+    > = caps.iter().map(|(id, result)| (*id, result)).collect();
+
+    let members = members
+        .iter()
+        .map(|(id, node)| {
+            let caps = match caps_by_id.get(id) {
+                Some(Ok(capability)) => CapabilityState::Reported {
+                    min_readable: capability.min_readable_version,
+                    max_readable: capability.max_readable_version,
+                    active_write: capability.active_write_version,
+                },
+                Some(Err(detail)) => CapabilityState::Unreachable {
+                    detail: detail.clone(),
+                },
+                None => CapabilityState::Unreachable {
+                    detail: "no capability report".to_string(),
+                },
+            };
+            MemberCapability {
+                member: MemberEntry {
+                    id: *id,
+                    role: if voters.contains(id) {
+                        MemberRole::Voter
+                    } else {
+                        MemberRole::Learner
+                    },
+                    raft_addr: node.addr.clone(),
+                    service_endpoint: node.service_endpoint.clone(),
+                    admin_endpoint: node.admin_endpoint.clone(),
+                },
+                caps,
+            }
+        })
+        .collect();
+
+    CapabilityReport { members, leader }
 }
 
 /// openraft-backed membership admin. Holds a clone of the `Raft` handle
@@ -253,11 +308,50 @@ impl MembershipAdmin for OpenraftMembershipAdmin {
             .await
             .map_err(map_activation_error)
     }
+
+    async fn report_capabilities(&self) -> Result<CapabilityReport, AdminError> {
+        let (leader, voters, local_id, members) = {
+            let metrics = self.raft.metrics().borrow_watched().clone();
+            let voters: BTreeSet<u64> = metrics.membership_config.voter_ids().collect();
+            let members: Vec<(u64, OpenraftPeer)> = metrics
+                .membership_config
+                .nodes()
+                .map(|(id, node)| (*id, node.clone()))
+                .collect();
+            (metrics.current_leader, voters, metrics.id, members)
+        };
+        let local_capabilities =
+            tsoracle_driver_openraft::NodeCapabilities::local(self.host.active_write_version());
+        let caps = tsoracle_driver_openraft::report_with(
+            local_id,
+            local_capabilities,
+            &members,
+            &*self.source,
+        )
+        .await;
+        Ok(assemble_report(leader, &voters, &members, &caps))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn peer(addr: &str) -> OpenraftPeer {
+        OpenraftPeer {
+            addr: format!("{addr}:1"),
+            service_endpoint: format!("{addr}:2"),
+            admin_endpoint: format!("{addr}:3"),
+        }
+    }
+
+    fn ncaps(min: u8, max: u8, active: u8) -> tsoracle_driver_openraft::NodeCapabilities {
+        tsoracle_driver_openraft::NodeCapabilities {
+            min_readable_version: min,
+            max_readable_version: max,
+            active_write_version: active,
+        }
+    }
 
     #[test]
     fn voters_with_adds_the_id() {
@@ -269,6 +363,62 @@ mod tests {
     fn voters_without_removes_the_id() {
         let current = BTreeSet::from([1, 2, 3]);
         assert_eq!(voters_without(&current, 3), BTreeSet::from([1, 2]));
+    }
+
+    #[test]
+    fn assemble_report_builds_one_row_per_member_with_roles_and_caps() {
+        let members = vec![(1u64, peer("a")), (2u64, peer("b"))];
+        let voters = BTreeSet::from([1u64]);
+        let caps = vec![(1u64, Ok(ncaps(4, 6, 4))), (2u64, Ok(ncaps(4, 5, 4)))];
+        let report = assemble_report(Some(1), &voters, &members, &caps);
+
+        assert_eq!(report.leader, Some(1));
+        assert_eq!(report.members.len(), 2);
+        assert_eq!(report.members[0].member.id, 1);
+        assert_eq!(report.members[0].member.role, MemberRole::Voter);
+        assert_eq!(
+            report.members[0].caps,
+            crate::admin::CapabilityState::Reported {
+                min_readable: 4,
+                max_readable: 6,
+                active_write: 4,
+            }
+        );
+        assert_eq!(report.members[1].member.role, MemberRole::Learner);
+        assert_eq!(report.members[1].member.raft_addr, "b:1");
+    }
+
+    #[test]
+    fn assemble_report_marks_failed_query_unreachable_with_detail() {
+        let members = vec![(1u64, peer("a")), (2u64, peer("b"))];
+        let voters = BTreeSet::from([1u64, 2u64]);
+        let caps = vec![
+            (1u64, Ok(ncaps(4, 6, 4))),
+            (2u64, Err("connection refused".to_string())),
+        ];
+        let report = assemble_report(None, &voters, &members, &caps);
+        assert_eq!(report.leader, None);
+        assert_eq!(
+            report.members[1].caps,
+            crate::admin::CapabilityState::Unreachable {
+                detail: "connection refused".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn assemble_report_marks_member_absent_from_caps_unreachable() {
+        // A member in the snapshot but missing from the caps slice is
+        // Unreachable, never silently dropped.
+        let members = vec![(1u64, peer("a")), (2u64, peer("b"))];
+        let voters = BTreeSet::from([1u64, 2u64]);
+        let caps = vec![(1u64, Ok(ncaps(4, 6, 4)))];
+        let report = assemble_report(None, &voters, &members, &caps);
+        assert_eq!(report.members.len(), 2);
+        assert!(matches!(
+            report.members[1].caps,
+            crate::admin::CapabilityState::Unreachable { .. }
+        ));
     }
 
     #[test]

--- a/crates/tsoracle-standalone/src/admin/service.rs
+++ b/crates/tsoracle-standalone/src/admin/service.rs
@@ -36,8 +36,9 @@ use crate::admin_proto::membership_admin_server::{
     MembershipAdmin as GrpcAdmin, MembershipAdminServer,
 };
 use crate::admin_proto::{
-    ActivateFormatRequest, AddLearnerRequest, AdminErrorKind, ChangeResponse, ListMembersRequest,
-    MemberEntry, MemberRole, MembershipView, PromoteRequest, RemoveNodeRequest,
+    ActivateFormatRequest, AddLearnerRequest, AdminErrorKind, CapabilityReport, ChangeResponse,
+    ListMembersRequest, MemberCapabilities, MemberEntry, MemberRole, MembershipView,
+    PromoteRequest, RemoveNodeRequest, ReportCapabilitiesRequest,
 };
 
 /// Admin RPCs carry only ids and host:port strings, so a tight decode/encode
@@ -212,6 +213,65 @@ impl GrpcAdmin for AdminServiceImpl {
         Ok(Response::new(change_response(
             self.admin.activate_format(target).await,
         )))
+    }
+
+    async fn report_capabilities(
+        &self,
+        _req: Request<ReportCapabilitiesRequest>,
+    ) -> Result<Response<CapabilityReport>, Status> {
+        let report = self
+            .admin
+            .report_capabilities()
+            .await
+            .map_err(|err| match err {
+                AdminError::Unsupported => {
+                    Status::unimplemented("format capabilities are not supported by this driver")
+                }
+                other => Status::internal(other.to_string()),
+            })?;
+        let members = report
+            .members
+            .into_iter()
+            .map(|entry| {
+                let (reachable, min_readable, max_readable, active_write, detail) = match entry.caps
+                {
+                    crate::admin::CapabilityState::Reported {
+                        min_readable,
+                        max_readable,
+                        active_write,
+                    } => (
+                        true,
+                        u32::from(min_readable),
+                        u32::from(max_readable),
+                        u32::from(active_write),
+                        String::new(),
+                    ),
+                    crate::admin::CapabilityState::Unreachable { detail } => {
+                        (false, 0, 0, 0, detail)
+                    }
+                };
+                MemberCapabilities {
+                    id: entry.member.id,
+                    role: match entry.member.role {
+                        crate::admin::MemberRole::Voter => MemberRole::Voter as i32,
+                        crate::admin::MemberRole::Learner => MemberRole::Learner as i32,
+                    },
+                    raft_addr: entry.member.raft_addr,
+                    service_endpoint: entry.member.service_endpoint,
+                    admin_endpoint: entry.member.admin_endpoint,
+                    reachable,
+                    min_readable_version: min_readable,
+                    max_readable_version: max_readable,
+                    active_write_version: active_write,
+                    unreachable_detail: detail,
+                }
+            })
+            .collect();
+        Ok(Response::new(CapabilityReport {
+            members,
+            has_leader: report.leader.is_some(),
+            leader: report.leader.unwrap_or_default(),
+        }))
     }
 }
 

--- a/crates/tsoracle-standalone/tests/activation_admin_rpc.rs
+++ b/crates/tsoracle-standalone/tests/activation_admin_rpc.rs
@@ -73,6 +73,12 @@ impl MembershipAdmin for ProgrammableAdmin {
             .take()
             .expect("activate_format called more than once")
     }
+
+    async fn report_capabilities(
+        &self,
+    ) -> Result<tsoracle_standalone::admin::CapabilityReport, AdminError> {
+        Err(AdminError::Unsupported)
+    }
 }
 
 fn handler(admin: ProgrammableAdmin) -> impl GrpcAdmin {

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -71,11 +71,9 @@ mod openraft_driver {
         DriverConfig, MemberAddr, OpenraftConfig, RaftTuning, StandaloneError, build,
     };
 
-    // The boot-and-drain test below is the only consumer of these imports +
-    // `build_openraft_with_listeners` + `lease_port`. Gating them on
-    // `test-support` keeps the `--no-default-features --features openraft`
-    // build (config-error tests only) warning-clean.
-    #[cfg(feature = "test-support")]
+    // The default-feature openraft tests use `lease_port`; the
+    // `build_openraft_with_listeners` seam and leadership-stream helpers are
+    // test-support-only.
     use crate::common::lease_port;
     #[cfg(feature = "test-support")]
     use std::time::Duration;

--- a/crates/tsoracle-standalone/tests/capabilities_admin_rpc.rs
+++ b/crates/tsoracle-standalone/tests/capabilities_admin_rpc.rs
@@ -1,0 +1,157 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Handler-layer test for `ReportCapabilities`. Drives `AdminServiceImpl`
+//! directly with a fake `MembershipAdmin` to pin two contracts: an
+//! `Unsupported` trait error becomes gRPC `UNIMPLEMENTED`, and a
+//! `CapabilityReport` maps to the proto message with reachable rows carrying
+//! the three version fields and unreachable rows carrying the detail.
+
+#![cfg(all(feature = "openraft", feature = "test-support"))]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tonic::{Code, Request};
+use tsoracle_standalone::admin::{
+    AdminError, CapabilityReport, CapabilityState, MemberCapability, MemberEntry, MemberRole,
+    MembershipAdmin, MembershipView, NewMember,
+};
+use tsoracle_standalone::admin_proto::ReportCapabilitiesRequest;
+use tsoracle_standalone::admin_proto::membership_admin_server::MembershipAdmin as GrpcAdmin;
+
+/// Fake admin that returns a preconfigured `report_capabilities` outcome and
+/// `Unsupported` for everything else.
+struct CapabilityAdmin {
+    result: tokio::sync::Mutex<Option<Result<CapabilityReport, AdminError>>>,
+}
+
+impl CapabilityAdmin {
+    fn new(result: Result<CapabilityReport, AdminError>) -> Self {
+        Self {
+            result: tokio::sync::Mutex::new(Some(result)),
+        }
+    }
+}
+
+#[async_trait]
+impl MembershipAdmin for CapabilityAdmin {
+    async fn list_members(&self) -> Result<MembershipView, AdminError> {
+        Err(AdminError::Unsupported)
+    }
+
+    async fn add_learner(&self, _: NewMember) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+
+    async fn promote(&self, _: u64) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+
+    async fn remove(&self, _: u64) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+
+    async fn activate_format(&self, _: u8) -> Result<(), AdminError> {
+        Err(AdminError::Unsupported)
+    }
+
+    async fn report_capabilities(&self) -> Result<CapabilityReport, AdminError> {
+        self.result
+            .lock()
+            .await
+            .take()
+            .expect("report_capabilities called more than once")
+    }
+}
+
+fn handler(admin: CapabilityAdmin) -> impl GrpcAdmin {
+    tsoracle_standalone::admin::test_support::admin_service(Arc::new(admin))
+}
+
+fn entry(id: u64) -> MemberEntry {
+    MemberEntry {
+        id,
+        role: MemberRole::Voter,
+        raft_addr: format!("h{id}:1"),
+        service_endpoint: format!("h{id}:2"),
+        admin_endpoint: format!("h{id}:3"),
+    }
+}
+
+#[tokio::test]
+async fn unsupported_maps_to_unimplemented_status() {
+    let handler = handler(CapabilityAdmin::new(Err(AdminError::Unsupported)));
+    let status = handler
+        .report_capabilities(Request::new(ReportCapabilitiesRequest {}))
+        .await
+        .expect_err("Unsupported must surface as a gRPC Status");
+    assert_eq!(status.code(), Code::Unimplemented);
+}
+
+#[tokio::test]
+async fn reachable_and_unreachable_rows_map_to_proto() {
+    let report = CapabilityReport {
+        leader: Some(1),
+        members: vec![
+            MemberCapability {
+                member: entry(1),
+                caps: CapabilityState::Reported {
+                    min_readable: 4,
+                    max_readable: 6,
+                    active_write: 4,
+                },
+            },
+            MemberCapability {
+                member: entry(2),
+                caps: CapabilityState::Unreachable {
+                    detail: "connection refused".to_string(),
+                },
+            },
+        ],
+    };
+    let handler = handler(CapabilityAdmin::new(Ok(report)));
+    let proto = handler
+        .report_capabilities(Request::new(ReportCapabilitiesRequest {}))
+        .await
+        .expect("ok")
+        .into_inner();
+
+    assert!(proto.has_leader);
+    assert_eq!(proto.leader, 1);
+    assert_eq!(proto.members.len(), 2);
+
+    let reachable = &proto.members[0];
+    assert!(reachable.reachable);
+    assert_eq!(reachable.min_readable_version, 4);
+    assert_eq!(reachable.max_readable_version, 6);
+    assert_eq!(reachable.active_write_version, 4);
+    assert!(reachable.unreachable_detail.is_empty());
+
+    let unreachable = &proto.members[1];
+    assert!(!unreachable.reachable);
+    assert_eq!(unreachable.min_readable_version, 0);
+    assert_eq!(unreachable.max_readable_version, 0);
+    assert_eq!(unreachable.active_write_version, 0);
+    assert_eq!(unreachable.unreachable_detail, "connection refused");
+}


### PR DESCRIPTION
## Summary

Adds a read-only admin capability report for format-version readiness:

- adds tolerant openraft capability gathering via `report_with`
- adds driver-agnostic capability report types and `MembershipAdmin::report_capabilities`
- exposes a `ReportCapabilities` gRPC RPC with `UNIMPLEMENTED` for unsupported drivers
- adds `tsoracle admin capabilities`, `tsoracle admin capabilities --json`, and `tsoracle admin members --capabilities`
- fixes a default-feature standalone test import issue surfaced by the workspace gate

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the [DCO requirement](../CONTRIBUTING.md#developer-certificate-of-origin) (use `git commit -s`).
- [x] `cargo test --workspace --all-features`
- [x] `cargo test --workspace`
- [x] `cargo build --workspace --examples`
- [x] `cargo clippy -p tsoracle-driver-openraft -p tsoracle-standalone -p tsoracle --all-features`
