### PR TITLE
feat: enable metrics feature in all published images

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -53,11 +53,11 @@ jobs:
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
       - name: Build file + openraft + umbrella and smoke
         run: |
-          docker build -f deploy/Dockerfile --build-arg FEATURES=file -t tsoracle-file:pr .
+          docker build -f deploy/Dockerfile --build-arg FEATURES=file,metrics -t tsoracle-file:pr .
           docker run --rm --entrypoint tsoracle tsoracle-file:pr --help | head -1
-          docker build -f deploy/Dockerfile --build-arg FEATURES=openraft -t tsoracle-openraft:pr .
+          docker build -f deploy/Dockerfile --build-arg FEATURES=openraft,metrics -t tsoracle-openraft:pr .
           docker run --rm --entrypoint tsoracle tsoracle-openraft:pr --help | head -1
-          docker build -f deploy/Dockerfile -t tsoracle:pr .
+          docker build -f deploy/Dockerfile --build-arg FEATURES=file,openraft,paxos,metrics -t tsoracle:pr .
           docker run --rm --entrypoint tsoracle tsoracle:pr --help | head -1
           curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
           ./linux-amd64/helm lint deploy/charts/tsoracle
@@ -72,25 +72,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # `variant` selects which driver subset is compiled into the binary; the
-        # paired `image` / `features` columns (via include:) decouple the matrix
-        # label from the image name and the cargo features so the `umbrella`
-        # row can build the fat image as plain `tsoracle` with default features
-        # (empty FEATURES => Dockerfile builds without --no-default-features).
+        # `variant` selects which driver subset is compiled into the binary.
+        # Every published image includes the `metrics` feature so tsoracle
+        # emits the documented Prometheus-ready signals.
         variant: [file, openraft, umbrella]
         arch: [amd64, arm64]
         include:
           - variant: file
             image: tsoracle-file
-            features: file
+            features: file,metrics
             description: 'tsoracle with the file driver — single-node timestamp & sequence oracle'
           - variant: openraft
             image: tsoracle-openraft
-            features: openraft
+            features: openraft,metrics
             description: 'tsoracle with the openraft driver — distributed, fault-tolerant timestamp & sequence oracle'
           - variant: umbrella
             image: tsoracle
-            features: ''
+            features: file,openraft,paxos,metrics
             description: 'tsoracle with all drivers bundled (file, openraft & OmniPaxos) — distributed timestamp & sequence oracle'
           - arch: amd64
             runner: ubuntu-latest

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -18,6 +18,7 @@ default    = ["file", "openraft", "paxos"]
 file       = ["tsoracle-standalone/file"]
 openraft   = ["tsoracle-standalone/openraft"]
 paxos      = ["tsoracle-standalone/paxos"]
+metrics    = ["tsoracle-server/metrics", "tsoracle-standalone/metrics"]
 reflection = ["tsoracle-server/reflection"]
 bt         = ["tsoracle-server/bt"]
 

--- a/crates/tsoracle-standalone/Cargo.toml
+++ b/crates/tsoracle-standalone/Cargo.toml
@@ -24,6 +24,11 @@ paxos    = [
     "dep:prost", "dep:postcard", "dep:parking_lot", "dep:tokio-stream",
     "tonic/tls-aws-lc",
 ]
+metrics  = [
+    "tsoracle-server/metrics",
+    "tsoracle-driver-openraft?/metrics",
+    "tsoracle-driver-paxos?/metrics",
+]
 # Gates `admin::test_support`, a tiny public seam exposing the otherwise
 # `pub(crate)` `AdminServiceImpl` constructor so an integration test can
 # drive the gRPC handler with a fake `MembershipAdmin`. Off in production.


### PR DESCRIPTION
## Summary

Published container images previously shipped without the `metrics` cargo feature, so the binaries did not emit the documented Prometheus-ready signals unless rebuilt by hand. This wires `metrics` through the build graph and turns it on for every released image.

- Add a `metrics` feature to `tsoracle-bin` and `tsoracle-standalone` that fans out to `tsoracle-server/metrics` and the optional driver metrics features. The standalone feature uses weak `?/metrics` deps so it only activates `tsoracle-driver-openraft` / `tsoracle-driver-paxos` metrics when those optional drivers are already compiled in — a `file,metrics` build is not forced to pull in the consensus drivers.
- Compile every published image with `metrics` enabled:
  - `file` → `file,metrics`
  - `openraft` → `openraft,metrics`
  - `umbrella` → `file,openraft,paxos,metrics` (explicit list replaces the previous empty-`FEATURES`/default-features path)
- Align the PR smoke-build step in the same workflow with the matching feature sets.

## Verification

- `cargo check -p tsoracle --features metrics` — clean
- Pre-commit `cargo fmt --check` + `cargo clippy` — clean