### PR TITLE
feat(bin): expose Prometheus metrics exporter in tsoracle binary

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -54,11 +54,11 @@ jobs:
       - name: Build file + openraft + umbrella and smoke
         run: |
           docker build -f deploy/Dockerfile --build-arg FEATURES=file,metrics -t tsoracle-file:pr .
-          docker run --rm --entrypoint tsoracle tsoracle-file:pr --help | head -1
+          docker run --rm --entrypoint tsoracle tsoracle-file:pr serve file --help | grep -q -- --metrics-listen
           docker build -f deploy/Dockerfile --build-arg FEATURES=openraft,metrics -t tsoracle-openraft:pr .
-          docker run --rm --entrypoint tsoracle tsoracle-openraft:pr --help | head -1
+          docker run --rm --entrypoint tsoracle tsoracle-openraft:pr serve openraft --help | grep -q -- --metrics-listen
           docker build -f deploy/Dockerfile --build-arg FEATURES=file,openraft,paxos,metrics -t tsoracle:pr .
-          docker run --rm --entrypoint tsoracle tsoracle:pr --help | head -1
+          docker run --rm --entrypoint tsoracle tsoracle:pr serve paxos --help | grep -q -- --metrics-listen
           curl -fsSL https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz | tar xz
           ./linux-amd64/helm lint deploy/charts/tsoracle
           PATH="$PWD/linux-amd64:$PATH" sh deploy/charts/tsoracle/tests/render.sh
@@ -73,8 +73,8 @@ jobs:
       fail-fast: false
       matrix:
         # `variant` selects which driver subset is compiled into the binary.
-        # Every published image includes the `metrics` feature so tsoracle
-        # emits the documented Prometheus-ready signals.
+        # Every published image includes the `metrics` feature so the stock
+        # binary emits and exports the documented Prometheus signals.
         variant: [file, openraft, umbrella]
         arch: [amd64, arm64]
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3234,6 +3234,7 @@ dependencies = [
  "clap",
  "futures",
  "humantime",
+ "metrics-exporter-prometheus",
  "parking_lot",
  "rcgen",
  "serde",

--- a/crates/tsoracle-bin/Cargo.toml
+++ b/crates/tsoracle-bin/Cargo.toml
@@ -18,7 +18,11 @@ default    = ["file", "openraft", "paxos"]
 file       = ["tsoracle-standalone/file"]
 openraft   = ["tsoracle-standalone/openraft"]
 paxos      = ["tsoracle-standalone/paxos"]
-metrics    = ["tsoracle-server/metrics", "tsoracle-standalone/metrics"]
+metrics    = [
+    "dep:metrics-exporter-prometheus",
+    "tsoracle-server/metrics",
+    "tsoracle-standalone/metrics",
+]
 reflection = ["tsoracle-server/reflection"]
 bt         = ["tsoracle-server/bt"]
 
@@ -28,6 +32,7 @@ humantime             = "2"
 clap                  = { workspace = true }
 serde                 = { workspace = true }
 serde_json            = { workspace = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
 tokio                 = { workspace = true, features = ["signal"] }
 tracing               = { workspace = true }
 tracing-subscriber    = { workspace = true }

--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -190,6 +190,14 @@ pub struct CommonServeArgs {
     /// Log level.
     #[arg(long, default_value = "info")]
     pub log: String,
+    /// Prometheus /metrics listen address.
+    #[cfg(feature = "metrics")]
+    #[arg(long, default_value = "127.0.0.1:9551")]
+    pub metrics_listen: SocketAddr,
+    /// Disable the Prometheus metrics exporter.
+    #[cfg(feature = "metrics")]
+    #[arg(long)]
+    pub no_metrics: bool,
     /// PEM server certificate chain for the client gRPC API (enables TLS).
     #[arg(long)]
     pub tls_cert: Option<std::path::PathBuf>,
@@ -373,5 +381,61 @@ mod admin_capabilities_parse_tests {
             }
             other => panic!("expected Members, got {other:?}"),
         }
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod metrics_args_tests {
+    use super::{Cli, Cmd, ServeCmd};
+    use clap::Parser;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn serve_metrics_args_default_to_loopback_exporter() {
+        let cli = Cli::try_parse_from([
+            "tsoracle",
+            "serve",
+            "file",
+            "--state-dir",
+            "/tmp/tsoracle-data",
+        ])
+        .unwrap();
+        let Some(Cmd::Serve(serve)) = cli.cmd else {
+            panic!("expected serve command");
+        };
+        let ServeCmd::File(args) = *serve else {
+            panic!("expected file args");
+        };
+        assert_eq!(
+            args.common.metrics_listen,
+            SocketAddr::from(([127, 0, 0, 1], 9551))
+        );
+        assert!(!args.common.no_metrics);
+    }
+
+    #[test]
+    fn serve_metrics_args_allow_override_and_disable() {
+        let cli = Cli::try_parse_from([
+            "tsoracle",
+            "serve",
+            "file",
+            "--metrics-listen",
+            "0.0.0.0:9551",
+            "--no-metrics",
+            "--state-dir",
+            "/tmp/tsoracle-data",
+        ])
+        .unwrap();
+        let Some(Cmd::Serve(serve)) = cli.cmd else {
+            panic!("expected serve command");
+        };
+        let ServeCmd::File(args) = *serve else {
+            panic!("expected file args");
+        };
+        assert_eq!(
+            args.common.metrics_listen,
+            SocketAddr::from(([0, 0, 0, 0], 9551))
+        );
+        assert!(args.common.no_metrics);
     }
 }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -233,6 +233,31 @@ fn client_tls_config(
     }
 }
 
+#[cfg(feature = "metrics")]
+fn install_metrics_exporter(common: &CommonServeArgs) -> Result<()> {
+    if common.no_metrics {
+        tracing::info!("Prometheus metrics exporter disabled");
+        return Ok(());
+    }
+
+    metrics_exporter_prometheus::PrometheusBuilder::new()
+        .with_http_listener(common.metrics_listen)
+        .install()
+        .with_context(|| {
+            format!(
+                "install Prometheus metrics exporter on {}",
+                common.metrics_listen
+            )
+        })?;
+    tracing::info!(addr = %common.metrics_listen, "Prometheus metrics exporter listening");
+    Ok(())
+}
+
+#[cfg(not(feature = "metrics"))]
+fn install_metrics_exporter(_common: &CommonServeArgs) -> Result<()> {
+    Ok(())
+}
+
 /// Assemble the peer `PeerTlsConfig` from the all-or-nothing flag trio.
 #[cfg(any(feature = "openraft", feature = "paxos"))]
 fn peer_tls_config(
@@ -321,6 +346,8 @@ async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_new(&common.log).unwrap_or_else(|_| EnvFilter::new("info")))
         .init();
+
+    install_metrics_exporter(&common)?;
 
     let mut node: Standalone = tsoracle_standalone::build(cfg)
         .await

--- a/crates/tsoracle-bin/tests/heartbeat_subprocess.rs
+++ b/crates/tsoracle-bin/tests/heartbeat_subprocess.rs
@@ -72,6 +72,14 @@ enum AwaitOutcome {
     Timeout(SocketAddr),
 }
 
+#[cfg(feature = "metrics")]
+fn disable_metrics_exporter_for_test(cmd: &mut Command) {
+    cmd.arg("--no-metrics");
+}
+
+#[cfg(not(feature = "metrics"))]
+fn disable_metrics_exporter_for_test(_cmd: &mut Command) {}
+
 /// Wait for each address in `ready_idx` to start accepting connections,
 /// racing every wait against the child exiting early.
 async fn await_listening(
@@ -134,6 +142,7 @@ where
     for attempt in 0..MAX_ATTEMPTS {
         let addrs = bind_unused_set(n_ports).await;
         let mut cmd = build(&addrs);
+        disable_metrics_exporter_for_test(&mut cmd);
         // tracing_subscriber::fmt() (the binary's default) writes to STDOUT, so
         // pipe stdout to capture heartbeat log lines. Also pipe stderr to detect
         // EADDRINUSE on early-exit retry logic.

--- a/crates/tsoracle-bin/tests/smoke.rs
+++ b/crates/tsoracle-bin/tests/smoke.rs
@@ -78,6 +78,14 @@ enum AwaitOutcome {
     Timeout(SocketAddr),
 }
 
+#[cfg(feature = "metrics")]
+fn disable_metrics_exporter_for_test(cmd: &mut Command) {
+    cmd.arg("--no-metrics");
+}
+
+#[cfg(not(feature = "metrics"))]
+fn disable_metrics_exporter_for_test(_cmd: &mut Command) {}
+
 /// Wait for each address in `ready_idx` to start accepting connections,
 /// racing every wait against the child exiting early. Returns
 /// `Ready` only after every selected addr has accepted.
@@ -134,6 +142,7 @@ where
     for attempt in 0..MAX_ATTEMPTS {
         let addrs = bind_unused_set(n_ports).await;
         let mut cmd = build(&addrs);
+        disable_metrics_exporter_for_test(&mut cmd);
         cmd.stderr(Stdio::piped()).kill_on_drop(true);
         let mut child = cmd.spawn().expect("spawn tsoracle");
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -33,7 +33,13 @@ fi
 : "${WINDOW_AHEAD:=3s}"
 : "${FAILOVER_ADVANCE:=1s}"
 : "${LOG_LEVEL:=info}"
-common="--window-ahead ${WINDOW_AHEAD} --failover-advance ${FAILOVER_ADVANCE} --log ${LOG_LEVEL}"
+metrics=""
+if [ "${NO_METRICS:-false}" = "true" ]; then
+    metrics="--no-metrics"
+elif [ -n "${METRICS_LISTEN:-}" ]; then
+    metrics="--metrics-listen ${METRICS_LISTEN}"
+fi
+common="--window-ahead ${WINDOW_AHEAD} --failover-advance ${FAILOVER_ADVANCE} --log ${LOG_LEVEL} ${metrics}"
 
 case "$DRIVER" in
 file)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -52,6 +52,8 @@ Default is 1 second. On leadership gain, the new leader first computes `serving_
 - `tsoracle.client.driver.in_flight` — 0 or 1 indicating whether the driver currently has an outgoing batch in flight (gauge)
 - `tsoracle.client.driver.abandoned_waiters.total` — waiters whose result could not be delivered because the caller dropped its `get_ts()` future (a client-side timeout or cancellation) before the driver finished delivering (counter). An occasional bump is benign; a sustained or spiking rate is a cancellation storm — callers are giving up before the oracle answers, usually because client deadlines are tighter than current end-to-end latency (correlate with `tsoracle.client.connect.duration` and the server's `get_ts` latency) or because a leader election is making requests time out (correlate with `tsoracle.client.not_leader.total` / `tsoracle.client.leader_pivots.total`).
 
+The stock `tsoracle serve` binary installs a Prometheus exporter when built with the `metrics` feature; published images enable it. It listens on `127.0.0.1:9551` by default, can be moved with `--metrics-listen <host:port>`, and can be disabled with `--no-metrics`. The container entrypoint exposes the same controls as `METRICS_LISTEN` and `NO_METRICS=true`.
+
 Both libraries are exporter-agnostic: embedders install whichever recorder they want (`metrics-exporter-prometheus`, `metrics-exporter-influx`, a custom sink) before constructing the `Server` or `Client`. The example below wires Prometheus over an HTTP listener for a process that hosts either side:
 
 ```toml


### PR DESCRIPTION
## Summary

- Install a Prometheus exporter in the stock `tsoracle serve` binary when the `metrics` feature is enabled.
- Add `--metrics-listen` / `--no-metrics` CLI controls and matching container entrypoint env vars (`METRICS_LISTEN`, `NO_METRICS=true`).
- Tighten release-image PR smoke checks so built images must expose the metrics CLI flags, and document the stock binary behavior.
- Keep metrics-enabled subprocess tests from contending on the default exporter port by disabling the exporter inside those smoke helpers.

## Why

`origin/main` now builds published images with the crate-level `metrics` feature, but the binary still needs a recorder/exporter installed before metrics can be scraped. Without this, tsoracle emits through the `metrics` facade but does not expose `/metrics` for Prometheus.

## Validation

- `cargo check -p tsoracle --no-default-features --features file,metrics`
- `cargo check -p tsoracle --no-default-features --features openraft,metrics`
- `cargo check -p tsoracle --no-default-features --features file,openraft,paxos,metrics`
- `cargo test -p tsoracle --no-default-features --features file,metrics`
- runtime smoke: started `target/debug/tsoracle serve file` with `--metrics-listen 127.0.0.1:<port>` and successfully curled `/metrics`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-images.yml")'`
- `shellcheck deploy/entrypoint.sh`
- pre-commit hook: `cargo fmt --check` and `cargo clippy`