### PR TITLE
fix(stress): disable metrics exporter in spawned process-topology nodes

### DIFF
--- a/benchmarks/stress/src/topology/process/child.rs
+++ b/benchmarks/stress/src/topology/process/child.rs
@@ -141,6 +141,10 @@ pub async fn spawn_into(
         .arg(&handle.data_dir)
         .arg("--log")
         .arg("warn")
+        // The harness scrapes no metrics, and the exporter otherwise binds a
+        // fixed port (127.0.0.1:9551) that collides across the parallel
+        // process tests and kill/respawn cycles. Accepted in every build.
+        .arg("--no-metrics")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);

--- a/crates/tsoracle-bin/src/cli.rs
+++ b/crates/tsoracle-bin/src/cli.rs
@@ -194,8 +194,9 @@ pub struct CommonServeArgs {
     #[cfg(feature = "metrics")]
     #[arg(long, default_value = "127.0.0.1:9551")]
     pub metrics_listen: SocketAddr,
-    /// Disable the Prometheus metrics exporter.
-    #[cfg(feature = "metrics")]
+    /// Disable the Prometheus metrics exporter. Accepted in every build so
+    /// scripts and test harnesses can pass it unconditionally; it is a no-op
+    /// when the binary is compiled without the `metrics` feature.
     #[arg(long)]
     pub no_metrics: bool,
     /// PEM server certificate chain for the client gRPC API (enables TLS).
@@ -436,6 +437,35 @@ mod metrics_args_tests {
             args.common.metrics_listen,
             SocketAddr::from(([0, 0, 0, 0], 9551))
         );
+        assert!(args.common.no_metrics);
+    }
+}
+
+#[cfg(all(test, not(feature = "metrics")))]
+mod no_metrics_flag_without_feature_tests {
+    use super::{Cli, Cmd, ServeCmd};
+    use clap::Parser;
+
+    // The stress process harness (and other scripts) pass `--no-metrics`
+    // unconditionally; it must parse even in builds compiled without the
+    // `metrics` feature, where it is a documented no-op.
+    #[test]
+    fn serve_accepts_no_metrics_without_feature() {
+        let cli = Cli::try_parse_from([
+            "tsoracle",
+            "serve",
+            "file",
+            "--no-metrics",
+            "--state-dir",
+            "/tmp/tsoracle-data",
+        ])
+        .unwrap();
+        let Some(Cmd::Serve(serve)) = cli.cmd else {
+            panic!("expected serve command");
+        };
+        let ServeCmd::File(args) = *serve else {
+            panic!("expected file args");
+        };
         assert!(args.common.no_metrics);
     }
 }

--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -254,7 +254,10 @@ fn install_metrics_exporter(common: &CommonServeArgs) -> Result<()> {
 }
 
 #[cfg(not(feature = "metrics"))]
-fn install_metrics_exporter(_common: &CommonServeArgs) -> Result<()> {
+fn install_metrics_exporter(common: &CommonServeArgs) -> Result<()> {
+    if common.no_metrics {
+        tracing::debug!("--no-metrics ignored: built without the `metrics` feature");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## What

Pass `--no-metrics` to `tsoracle` when the stress process-topology harness spawns it, and make `--no-metrics` parseable in every build (not just `metrics`-feature builds).

## Why

#608 made the `tsoracle` binary install a Prometheus exporter on a **hardcoded `127.0.0.1:9551`** by default (when built with the `metrics` feature). The process-topology harness gives each spawned node a unique `--listen` port but **not** a unique metrics port, so whenever two instances are alive on one host at once, the second fails to bind 9551 with `Address already in use` and aborts startup.

This broke the `test` CI lane (`cargo test --workspace --all-features`, which compiles the binary with `metrics` on):

```
thread 'process_killer_loop_smoke_maintains_invariants' panicked at benchmarks/stress/tests/smoke.rs:152
Error: install Prometheus metrics exporter on 127.0.0.1:9551
    failed to create HTTP listener: Address already in use (os error 98)
```

Two paths collide on 9551, both newly possible after #608:
- cargo runs the process smoke tests in parallel — `process_steady_smoke_completes_clean` and `process_killer_loop_smoke_maintains_invariants` each spawn a `serve file` process.
- the killer-loop scenario kills and respawns the node before the killed socket is reaped.

Which test loses the race is nondeterministic (CI hit `killer-loop`; reproduced locally on `steady`).

## How

The harness scrapes no metrics, so spawned children should not run an exporter at all.

- `benchmarks/stress/src/topology/process/child.rs` — spawn `tsoracle serve file … --no-metrics`.
- `crates/tsoracle-bin/src/cli.rs` — ungate `--no-metrics` so it parses regardless of build features (documented no-op without the `metrics` feature). This is required because other lanes (`stress smoke`, `stress-nightly`) build the binary **without** `metrics` and run the same spawn code, so clap must accept the flag there too. `--metrics-listen` stays gated since it is meaningless without the feature.
- `crates/tsoracle-bin/src/main.rs` — the no-metrics-build install fn now reads the flag, avoiding `dead_code` under `-D warnings`.
- Added a unit test asserting `--no-metrics` parses without the `metrics` feature.

## Verification

- Reproduced the original failure first (os error 48 on macOS = the `EADDRINUSE` CI hit as error 98).
- Process smoke tests pass with the `metrics` binary (the failing config): `2 passed`.
- New unit test passes in the no-metrics build; existing `metrics_args_tests` still pass under the feature.
- `clippy --all-targets -- -D warnings` clean for `tsoracle` (both feature configs) and `stress`.
- The exact CI `smoke (process)` command runs clean: `violations: 0`.