### PR TITLE
docs: replace stale line-number citations with symbol references

### DIFF
--- a/crates/tsoracle-bin/tests/smoke.rs
+++ b/crates/tsoracle-bin/tests/smoke.rs
@@ -126,7 +126,7 @@ async fn await_listening(
 /// - `build` constructs the `Command` for each attempt and is called once
 ///   per retry. The closure captures stable test state (tempdirs, certs);
 ///   `--bootstrap` is idempotent so reusing a `raft_dir` across attempts
-///   is safe (`drivers/openraft/mod.rs:284-285`).
+///   is safe.
 async fn retry_spawn<F>(
     n_ports: usize,
     ready_idx: &[usize],

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -31,7 +31,7 @@
 //!
 //! The `+1` is load-bearing: a prior leader at physical_ms = prior_max could
 //! have served logical = LOGICAL_MAX, so the new leader MUST start strictly
-//! above prior_max. `tests/leader_watch.rs:46` pins this arithmetically.
+//! above prior_max. The `leader_watch` integration tests pin this arithmetically.
 
 use futures::StreamExt;
 use std::sync::Arc;

--- a/crates/tsoracle-server/tests/serve_shutdown.rs
+++ b/crates/tsoracle-server/tests/serve_shutdown.rs
@@ -171,7 +171,7 @@ async fn serve_with_listener_translates_watch_panic_to_server_error() {
     // `catch_unwind` in `into_router`, which republishes NotServing and
     // re-raises. The outer serve loop then surfaces it as
     // `ServerError::WatchPanic`. This path exercises the catch_unwind
-    // branch (server.rs:200-210), `panic_payload_to_string`, and the
+    // branch in `into_router`, `panic_payload_to_string`, and the
     // join-handle error mapping in `join_to_server_result`.
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
 

--- a/crates/tsoracle-standalone/src/admin/openraft.rs
+++ b/crates/tsoracle-standalone/src/admin/openraft.rs
@@ -61,7 +61,7 @@ fn map_write_error(err: RaftError<TypeConfig, ClientWriteError<TypeConfig>>) -> 
 
 /// Map a `FormatActivationError` into an `AdminError` using the dedicated
 /// kinds added above. `NotLeader` is a unit variant in
-/// `FormatActivationError` (see capabilities.rs:107-110), so the resulting
+/// `FormatActivationError`, so the resulting
 /// `AdminError::NotLeader.leader_admin_endpoint` is always None — the
 /// CLI cannot auto-redirect to the leader for activation; the operator
 /// (or shell orchestrator) must re-issue against a known leader.

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -341,14 +341,13 @@ async fn build_openraft_inner(
 
     // Wrap host in Arc so both the driver and the membership admin can hold
     // it. OpenraftDriver has two constructors: `new(host: H)` and
-    // `from_arc(host: Arc<H>)` — use the Arc form here (driver.rs:77).
+    // `from_arc(host: Arc<H>)` — use the Arc form here.
     let host = std::sync::Arc::new(StandaloneHost::new(raft, state_machine_for_host));
     let driver = OpenraftDriver::from_arc(host.clone());
 
-    // First production caller of PeerCapabilitySource (it has been
-    // #[allow(dead_code)] in network.rs:273-285 waiting for this wire-up).
-    // The peer TLS config is `Option<PeerTlsMaterial>`; extract the client
-    // side with `.as_ref().map(|m| m.client.clone())`.
+    // First production caller of `PeerCapabilitySource`. The peer TLS config
+    // is `Option<PeerTlsMaterial>`; extract the client side with
+    // `.as_ref().map(|m| m.client.clone())`.
     let capability_source = std::sync::Arc::new(
         crate::drivers::openraft::network::PeerCapabilitySource::new(
             peer_tls.as_ref().map(|m| m.client.clone()),


### PR DESCRIPTION
## Summary

Doc and prose comments that cite other files by line number (`file.rs:NN`) rot as code moves and actively mislead readers chasing them. This replaces each such citation in durable source comments with a symbol reference, which the compiler keeps honest.

Resolves the systemic maintenance smell flagged in #630, including its two confirmed stale references plus four more found by sweeping the tree.

## Changes

| File | Stale citation | Fix |
|------|----------------|-----|
| `tsoracle-standalone/.../openraft/mod.rs` | `network.rs:273-285` `#[allow(dead_code)]` | Removed — the claim was already false; `PeerCapabilitySource` is wired and no such attribute exists |
| `tsoracle-standalone/.../openraft/mod.rs` | `driver.rs:77` | Dropped; the comment already names `from_arc` |
| `tsoracle-standalone/.../admin/openraft.rs` | `capabilities.rs:107-110` | Dropped; the comment already names `FormatActivationError` |
| `tsoracle-server/src/fence.rs` | `tests/leader_watch.rs:46` | Reference the `leader_watch` integration tests by name |
| `tsoracle-server/tests/serve_shutdown.rs` | `server.rs:200-210` | Reference the `into_router` branch; the line range had already drifted to unrelated code |
| `tsoracle-bin/tests/smoke.rs` | `drivers/openraft/mod.rs:284-285` | Dropped; the line range had already drifted to unrelated code |

The two test-file citations were already stale — their targets now point at completely unrelated code — which is concrete evidence of exactly the drift #630 describes. They are durable committed source comments (not the point-in-time artifacts the issue's non-goal excludes), so they are in scope for the general-pattern sweep.

## Verification (issue exit criteria)

- `cargo doc --no-deps` builds for all affected crates.
- `grep -rnE '[a-z_/]+\.rs:[0-9]+' --include='*.rs' crates/` returns nothing — no source comment cites another file by line number.
- `cargo check --tests` passes for `tsoracle-server` and `tsoracle` (bin).
- Pre-commit `cargo fmt --check` and `cargo clippy` clean.

Closes #630
