### PR TITLE
fix(release-plz): trigger release-pr on manual dispatch instead of every push

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,6 +1,19 @@
 name: release-plz
 
+# Split triggers, each event drives exactly one job (see the `if:` guards below):
+#   - workflow_dispatch (manual, Actions tab "Run workflow") fires ONLY the
+#     `release-pr` job. This is deliberate: the Release PR is opened/updated on
+#     demand instead of on every push, so we don't churn a Release PR on each
+#     commit to main. Cut a release by manually dispatching this workflow.
+#   - push to main fires ONLY the `release` job. Merging the Release PR is itself
+#     a push to main, so the merge still auto-tags + cargo-publishes the bumped
+#     crates — publish-on-merge is unchanged.
 on:
+  # Manual trigger (Actions tab → "Run workflow") — drives `release-pr` only,
+  # so the Release PR is opened/updated on demand instead of on every commit.
+  workflow_dispatch:
+  # Push to main — drives `release` only; a Release PR merge is a push to main,
+  # so publish-on-merge still happens automatically.
   push:
     branches:
       - main
@@ -16,6 +29,9 @@ jobs:
   # Publishes (tags + cargo publish + GitHub Release) whenever the release PR
   # has been merged into main. No-op on every other push.
   release:
+    # Publish only on push to main (i.e. a merged Release PR), never on manual
+    # dispatch — `release-pr` owns the manual path.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: release-plz release
     runs-on: ubuntu-latest
     environment: crates-io
@@ -260,10 +276,12 @@ jobs:
             --clobber \
             --repo "$GITHUB_REPOSITORY"
 
-  # Opens or updates the release PR whenever main moves. The PR contains the
-  # version bumps + CHANGELOG diffs; merging it triggers the `release` job
-  # above on the next push.
+  # Opens or updates the release PR. The PR contains the version bumps +
+  # CHANGELOG diffs; merging it triggers the `release` job above on the next
+  # push. Manual only: runs on workflow_dispatch so the Release PR is cut on
+  # demand rather than on every push to main.
   release-pr:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     name: release-plz PR
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What

Change the `release-plz` workflow so the **Release PR is opened/updated on demand** (manual `workflow_dispatch`) instead of automatically on every push to `main`.

## Why

Currently the `release-pr` job runs on every push to `main`, so release-plz opens or updates a Release PR after each commit. This makes cutting a release an explicit, manual action. Mirrors the same change already landed in the sibling `cg-graph` repo.

## How

Split the triggers so each event drives exactly one job, gated via `github.event_name`:

- **`workflow_dispatch`** (Actions tab → "Run workflow") → fires **only** `release-pr`. Cut a release on demand.
- **`push` to `main`** → fires **only** `release`. Merging a Release PR is itself a push to `main`, so **publish-on-merge is unchanged** — the merge still auto-tags + `cargo publish`es.

| Job | Before | After |
|---|---|---|
| `release-pr` | (unguarded, ran on every push) | `github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'` |
| `release` | (unguarded, ran on every push) | `github.event_name == 'push' && github.ref == 'refs/heads/main'` |

Note: unlike `cg-graph` (where both jobs already carried an `if: github.ref == 'refs/heads/main'` guard), neither job here was previously guarded, so this also adds the explicit `if:` conditions.

## Notes

- The "Run workflow" button only appears once this lands on `main` (GitHub reads `workflow_dispatch` from the default branch).
- Validated with `actionlint` (no findings).