### PR TITLE
chore(server): drop blanket dead_code allows in reporter/heartbeat

### DIFF
--- a/crates/tsoracle-server/src/heartbeat.rs
+++ b/crates/tsoracle-server/src/heartbeat.rs
@@ -26,8 +26,6 @@
 //! leader-watch task in the `Server::into_router_parts()` spawn site so both
 //! the embedder path (`into_router()`) and the daemon path (`serve*`) get it.
 
-#![allow(dead_code)]
-
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/tsoracle-server/src/reporter.rs
+++ b/crates/tsoracle-server/src/reporter.rs
@@ -28,11 +28,6 @@
 //! both the global `metrics::` recorder (Prometheus path, unchanged) and a
 //! local `Arc<AtomicU64>` that the heartbeat task can read without depending
 //! on any installed recorder.
-//!
-//! **Scaffold note**: items are introduced here and wired up in later plan
-//! tasks (T3–T11). `#![allow(dead_code)]` is present for that reason and
-//! will become unnecessary once the call sites land in Task 7.
-#![allow(dead_code)]
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -41,6 +36,9 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tsoracle_core::IgnoreReason;
 
 pub struct ReporterCounter {
+    // Read only by the `metrics`-gated recorder forward in `increment`; with the
+    // `metrics` feature off the local atomic is the counter's sole live state.
+    #[cfg_attr(not(feature = "metrics"), allow(dead_code))]
     name: &'static str,
     local: Arc<AtomicU64>,
 }
@@ -59,12 +57,17 @@ impl ReporterCounter {
         self.local.fetch_add(n, Ordering::Relaxed);
     }
 
+    // Read only by the heartbeat task, which is compiled solely under `tracing`.
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     pub(crate) fn snapshot(&self) -> u64 {
         self.local.load(Ordering::Relaxed)
     }
 }
 
 pub struct ReporterHistogram {
+    // Read only by the `metrics`-gated recorder forward in `record`; with the
+    // `metrics` feature off the histogram carries no local state.
+    #[cfg_attr(not(feature = "metrics"), allow(dead_code))]
     name: &'static str,
 }
 
@@ -98,6 +101,8 @@ impl ReporterTimestamp {
     }
 
     /// `None` if never touched, else the most recent unix-ms.
+    // Read only by the heartbeat task, which is compiled solely under `tracing`.
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     pub(crate) fn snapshot(&self) -> Option<u64> {
         let v = self.local.load(Ordering::Relaxed);
         (v != 0).then_some(v)


### PR DESCRIPTION
## Summary

Removes the module-level `#![allow(dead_code)]` blanket suppressions and the stale plan-task comments from `reporter.rs` and `heartbeat.rs`, replacing them with precise per-item annotations only where the compiler genuinely needs them.

- **`heartbeat.rs`** — blanket allow deleted with no replacement. The module is already `#[cfg(feature = "tracing")]`-gated in `lib.rs`, and under `tracing` every item is reachable (`run_heartbeat` ← `server.rs`, the rest ← `run_heartbeat`/tests). The allow was pure stale scaffold.
- **`reporter.rs`** — blanket allow and the stale scaffold note deleted. The four items the compiler then flags are annotated precisely, each with a justification comment mirroring the existing `heartbeat_interval` treatment in `server.rs`:
  - `ReporterCounter.name`, `ReporterHistogram.name` (private fields) — `#[cfg_attr(not(feature = "metrics"), allow(dead_code))]`; read only by the `metrics`-gated recorder forward.
  - `ReporterCounter::snapshot`, `ReporterTimestamp::snapshot` (`pub(crate)`) — `#[cfg_attr(not(feature = "tracing"), allow(dead_code))]`; read only by the `tracing`-gated heartbeat.

The public counter fields (`started_at`, `heartbeat_task_panicked`, the per-RPC counters) need no annotation: they are `pub` fields of the re-exported `Reporter`, so they are exempt from dead-code analysis — exactly the private-item deadness the blanket allow was wrongly masking.

Closes #627

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the [DCO requirement](../CONTRIBUTING.md#developer-certificate-of-origin) (use `git commit -s`).
- [x] `cargo build -p tsoracle-server` compiles with no warnings across `--no-default-features`, `--no-default-features --features tracing`, `--no-default-features --features metrics`, default, and `--all-features`.
- [x] `cargo clippy -p tsoracle-server --all-targets -- -D warnings` passes on `--no-default-features`, default, and `--all-features`.
- [x] `cargo test -p tsoracle-server --all-features` passes (every binary green); default test suite green.
