### PR TITLE
chore(ci): stop Dependabot bumping openraft from the fuzz config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     directory: /fuzz
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "openraft*"
     groups:
       fuzz:
         patterns:


### PR DESCRIPTION
## Problem

The `/fuzz` cargo Dependabot config can see workspace-inherited dependencies through the fuzz crate's path dependencies into the workspace, but its directory scope only lets it regenerate `fuzz/Cargo.lock`. When it bumped openraft to `0.10.0-alpha.21` in #639 it rewrote the requirement in the root `Cargo.toml` and left the root `Cargo.lock` pinning `alpha.20`, so every `--locked` workspace CI job (build, lint, test, cross-platform) failed at cargo resolution before compiling anything.

This will recur on every openraft release: openraft is the only prerelease-pinned dependency in the root manifest, and a prerelease bump is exactly the case where Dependabot rewrites the requirement string instead of doing a lockfile-only update. Stable-range workspace deps (`tonic = "0.14"`, `rocksdb = "0.24"`, …) update in-range without touching the manifest, which is why earlier fuzz-group PRs never hit this.

## Fix

Ignore the `openraft*` family in the `/fuzz` config. openraft bumps stay manual like every other workspace dependency, and the fuzz-lockfile guard from #471 already forces `fuzz/Cargo.lock` to resync when the workspace pin moves. The glob also covers `openraft-macros`/`-rt`/`-rt-tokio` so a lockfile-only bump can't skew them out of lockstep with the parent crate.

An `ignore` rule is used rather than a group `exclude-patterns` entry because excluding openraft from the group would just make Dependabot open it as a separate individual PR with the same defect.