### PR TITLE
chore(github): consolidate CODEOWNERS to a single root-level entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,4 @@
 # separately by the auto-issue composite action's inline target -> @user
 # map in .github/actions/fuzz-auto-issue/action.yml.
 
-/crates/tsoracle-driver-file/   @SebastianThiebaud @crmerrill @idmao
-/crates/tsoracle-proto/         @SebastianThiebaud @crmerrill @idmao
-/fuzz/                          @SebastianThiebaud @crmerrill @idmao
-/.github/workflows/fuzz-*.yml   @SebastianThiebaud @crmerrill @idmao
-/.github/actions/fuzz-*/        @SebastianThiebaud @crmerrill @idmao
+*   @SebastianThiebaud @crmerrill @idmao


### PR DESCRIPTION
## What

Replaces the per-path CODEOWNERS entries (fuzz, proto, driver-file) with a single root-level `*` entry listing all three maintainers.

## Why

Branch protection on `main` now requires code-owner review on every PR. Under the previous file, only the fuzz/proto/driver-file paths had owners, so changes anywhere else in the tree carried no code-owner requirement at all — the review gate was vacuous for most of the codebase. A root-level entry makes the requirement meaningful repo-wide.

Listing all three maintainers keeps the gate satisfiable for any PR author: since authors cannot approve their own PRs, every PR still has two eligible code owners regardless of who opens it (including bot-authored dependabot and release-plz PRs, where any maintainer approval counts).

The per-path entries became redundant rather than wrong — they listed the same three people, and CODEOWNERS is last-match-wins, so a root entry with the identical owner set subsumes them.