### PR TITLE
fix(standalone): fail fast when a peer or admin server task dies

### DIFF
--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -345,6 +345,31 @@ async fn admin_connect(
         .with_context(|| format!("connect {endpoint}"))
 }
 
+/// Resolve when the node should stop serving clients. Two ways in:
+///
+/// - the OS shutdown signal — graceful: run the driver's pre-shutdown drain
+///   (openraft: leadership handoff) before the gRPC server stops accepting;
+/// - a transport server died (`fatal` tripped) — fail fast: skip the drain,
+///   since the node is already degraded and the priority is a quick exit so
+///   an orchestrator can restart it, not a best-effort handoff over a
+///   possibly-broken transport.
+async fn wait_for_stop(
+    shutdown_signal: impl std::future::Future<Output = ()>,
+    fatal: tsoracle_standalone::FatalSignal,
+    drain: Option<std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>>,
+) {
+    tokio::select! {
+        () = shutdown_signal => {
+            if let Some(drain) = drain {
+                drain.await;
+            }
+        }
+        component = fatal.tripped() => {
+            tracing::error!(component, "transport server died; shutting down to fail fast");
+        }
+    }
+}
+
 async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_new(&common.log).unwrap_or_else(|_| EnvFilter::new("info")))
@@ -375,19 +400,22 @@ async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
     println!("serving on {local_addr}");
     tracing::info!(addr = %local_addr, "tsoracle serving");
 
-    // On drain, run the driver's pre-shutdown step (openraft: leadership
-    // handoff) BEFORE the gRPC server stops accepting, then let serve drain.
-    let shutdown = async move {
-        tsoracle_server::shutdown_signal().await;
-        if let Some(drain) = drain {
-            drain.await;
-        }
-    };
+    // Stop on the OS shutdown signal (graceful: drain first) or on a fatal
+    // transport failure (fail fast: a node whose peer/admin server died must
+    // not keep running as a zombie).
+    let fatal = node.fatal_signal();
+    let shutdown = wait_for_stop(tsoracle_server::shutdown_signal(), fatal.clone(), drain);
     let result = server
         .serve_with_listener(listener, shutdown)
         .await
         .context("serve");
     node.shutdown().await;
+    if let Some(component) = fatal.check() {
+        // Non-zero exit so an orchestrator restarts the node.
+        return Err(anyhow::anyhow!(
+            "{component} terminated unexpectedly; exiting"
+        ));
+    }
     result
 }
 
@@ -908,6 +936,52 @@ mod capabilities_render_tests {
         let unreachable_obj = json.split("\"id\":3").nth(1).unwrap();
         assert!(!unreachable_obj.contains("active_write_version"));
         assert!(unreachable_obj.contains("\"reachable\":false"));
+    }
+}
+
+#[cfg(test)]
+mod wait_for_stop_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use tsoracle_standalone::FatalSignal;
+
+    use super::wait_for_stop;
+
+    type DrainFuture = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
+
+    fn drain_probe() -> (Arc<AtomicBool>, Option<DrainFuture>) {
+        let drained = Arc::new(AtomicBool::new(false));
+        let drain_flag = drained.clone();
+        let drain: DrainFuture = Box::pin(async move {
+            drain_flag.store(true, Ordering::SeqCst);
+        });
+        (drained, Some(drain))
+    }
+
+    /// A fatal transport failure stops the node without any OS signal, and
+    /// skips the graceful drain: the node is already degraded, so the
+    /// priority is a fast exit and restart, not a leadership handoff.
+    #[tokio::test]
+    async fn fatal_trip_stops_without_signal_and_skips_drain() {
+        let fatal = FatalSignal::new();
+        let (drained, drain) = drain_probe();
+        fatal.trip("peer server");
+        wait_for_stop(std::future::pending(), fatal, drain).await;
+        assert!(
+            !drained.load(Ordering::SeqCst),
+            "fatal path must skip the graceful drain"
+        );
+    }
+
+    /// The OS-signal path keeps the existing graceful order: drain runs
+    /// before the stop future resolves.
+    #[tokio::test]
+    async fn signal_path_runs_drain_before_stopping() {
+        let fatal = FatalSignal::new();
+        let (drained, drain) = drain_probe();
+        wait_for_stop(std::future::ready(()), fatal, drain).await;
+        assert!(drained.load(Ordering::SeqCst));
     }
 }
 

--- a/crates/tsoracle-standalone/src/admin/service.rs
+++ b/crates/tsoracle-standalone/src/admin/service.rs
@@ -26,8 +26,6 @@
 
 use std::sync::Arc;
 
-use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
 
@@ -275,26 +273,29 @@ impl GrpcAdmin for AdminServiceImpl {
     }
 }
 
-/// Spawn the admin gRPC server on `listener` under a cancel token. The caller
-/// is responsible for the `TcpListener::bind` (the openraft driver build path
-/// does this immediately before calling us). Keeping the bind in the caller
-/// lets test-only entry points hand in a `TcpListener` that has been held
-/// continuously since `lease_port()` — eliminating the close/rebind race
-/// window where another `bind(:0)` could snatch the freshly-freed ephemeral
-/// port. When `admin_tls` is `Some`, the server requires a client certificate
-/// signed by the configured admin CA (mTLS). Returns the actual bound
-/// `SocketAddr` (resolves :0 to the OS-picked port) for caller-side
-/// observability — stored on `Standalone::admin_listen_addr`.
+/// Spawn the admin gRPC server on `listener` under transport supervision.
+/// The caller is responsible for the `TcpListener::bind` (the openraft driver
+/// build path does this immediately before calling us). Keeping the bind in
+/// the caller lets test-only entry points hand in a `TcpListener` that has
+/// been held continuously since `lease_port()` — eliminating the close/rebind
+/// race window where another `bind(:0)` could snatch the freshly-freed
+/// ephemeral port. When `admin_tls` is `Some`, the server requires a client
+/// certificate signed by the configured admin CA (mTLS). An unexpected exit
+/// of the spawned server trips `fatal` so the node fails fast instead of
+/// running on without its admin surface. Returns the supervised transport
+/// handle plus the actual bound `SocketAddr` (resolves :0 to the OS-picked
+/// port) for caller-side observability — stored on
+/// `Standalone::admin_listen_addr`.
 pub(crate) async fn serve_admin(
     admin: Arc<dyn MembershipAdmin>,
     listener: tokio::net::TcpListener,
     admin_tls: Option<crate::admin_tls::AdminTlsMaterial>,
-) -> Result<(oneshot::Sender<()>, JoinHandle<()>, std::net::SocketAddr), std::io::Error> {
+    fatal: crate::FatalSignal,
+) -> Result<(crate::TransportHandle, std::net::SocketAddr), std::io::Error> {
     let bound = listener.local_addr()?;
     let service = MembershipAdminServer::new(AdminServiceImpl::new(admin))
         .max_decoding_message_size(MAX_ADMIN_MESSAGE_BYTES)
         .max_encoding_message_size(MAX_ADMIN_MESSAGE_BYTES);
-    let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
     let mut builder = tonic::transport::Server::builder();
     if let Some(material) = admin_tls {
         // tls_config() on a pre-validated ServerTlsConfig cannot fail in
@@ -305,17 +306,10 @@ pub(crate) async fn serve_admin(
             std::io::Error::new(std::io::ErrorKind::InvalidInput, err.to_string())
         })?;
     }
-    let join = tokio::spawn(async move {
-        let shutdown = async {
-            let _ = cancel_rx.await;
-        };
-        if let Err(err) = builder
+    let handle = crate::TransportHandle::spawn_supervised("admin server", fatal, move |shutdown| {
+        builder
             .add_service(service)
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
-            .await
-        {
-            tracing::error!(error = ?err, "admin server died");
-        }
     });
-    Ok((cancel_tx, join, bound))
+    Ok((handle, bound))
 }

--- a/crates/tsoracle-standalone/src/drivers/file.rs
+++ b/crates/tsoracle-standalone/src/drivers/file.rs
@@ -29,7 +29,7 @@ use tsoracle_driver_file::FileDriver;
 
 use crate::config::FileConfig;
 use crate::error::StandaloneError;
-use crate::{Standalone, TransportHandle};
+use crate::{FatalSignal, Standalone, TransportHandle};
 
 /// One-shot seeded initialization for the file driver (migration setup).
 pub fn init_file_seeded(state_dir: &Path, seed_physical_ms: u64) -> Result<(), StandaloneError> {
@@ -59,6 +59,8 @@ pub(crate) fn build_file(cfg: FileConfig) -> Result<Standalone, StandaloneError>
         )),
         admin_transport: crate::TransportHandle::noop(),
         admin_listen_addr: None,
+        // No transport servers, so nothing can ever trip it.
+        fatal: FatalSignal::new(),
     })
 }
 

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 
 use openraft::{Config, Raft};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options};
-use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
 use tsoracle_consensus::ConsensusDriver;
 use tsoracle_driver_openraft::{
@@ -42,7 +41,7 @@ use tsoracle_openraft_toolkit::{
 
 use crate::config::OpenraftConfig;
 use crate::error::StandaloneError;
-use crate::{Standalone, TransportHandle};
+use crate::{FatalSignal, Standalone, TransportHandle};
 
 use network::{MAX_PEER_MESSAGE_BYTES, PeerFactory, WriteVersionSource, server as peer_server};
 
@@ -300,18 +299,14 @@ async fn build_openraft_inner(
             })?;
     }
     let router = builder.add_service(peer_service);
-    let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
-    let join = tokio::spawn(async move {
-        let shutdown = async {
-            let _ = cancel_rx.await;
-        };
-        if let Err(e) = router
-            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
-            .await
-        {
-            tracing::error!(error = ?e, "raft peer server died");
-        }
-    });
+    // One fail-fast signal for both of this node's transport servers (peer +
+    // admin): an unexpected exit of either must take the whole node down
+    // instead of leaving the consensus driver running unreachable.
+    let fatal = FatalSignal::new();
+    let transport =
+        TransportHandle::spawn_supervised("raft peer server", fatal.clone(), move |shutdown| {
+            router.serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
+        });
 
     // Bootstrap once (after the peer server is listening).
     if cfg.bootstrap {
@@ -375,26 +370,31 @@ async fn build_openraft_inner(
                         source,
                     })?,
             };
-            let (cancel, join, bound) =
-                crate::admin::service::serve_admin(admin.clone(), listener, admin_tls_material)
-                    .await
-                    .map_err(|source| StandaloneError::AdminBind {
-                        addr: listen,
-                        source,
-                    })?;
-            (TransportHandle::new(cancel, join), Some(bound))
+            let (admin_handle, bound) = crate::admin::service::serve_admin(
+                admin.clone(),
+                listener,
+                admin_tls_material,
+                fatal.clone(),
+            )
+            .await
+            .map_err(|source| StandaloneError::AdminBind {
+                addr: listen,
+                source,
+            })?;
+            (admin_handle, Some(bound))
         }
         (None, _) => (TransportHandle::noop(), None),
     };
 
     Ok(Standalone {
         driver: driver as Arc<dyn ConsensusDriver>,
-        transport: TransportHandle::new(cancel_tx, join),
+        transport,
         drain: Some(Box::pin(async move {
             handoff::graceful_leader_handoff(&raft_for_drain, my_id).await
         })),
         admin,
         admin_transport,
         admin_listen_addr,
+        fatal,
     })
 }

--- a/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/paxos/mod.rs
@@ -28,7 +28,6 @@ use std::sync::Arc;
 use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig};
 use parking_lot::Mutex;
 use rocksdb::{ColumnFamilyDescriptor, DB, Options};
-use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
 use tsoracle_consensus::ConsensusDriver;
 use tsoracle_driver_paxos::{HighWaterCommand, PaxosDriver, SnapshotPolicy, StandaloneHost};
@@ -37,7 +36,7 @@ use tsoracle_paxos_toolkit::storage::RocksdbStorage;
 
 use crate::config::PaxosConfig;
 use crate::error::StandaloneError;
-use crate::{Standalone, TransportHandle};
+use crate::{FatalSignal, Standalone, TransportHandle};
 
 use network::{PeerSink, server as peer_server};
 
@@ -166,18 +165,13 @@ async fn build_paxos_inner(
             })?;
     }
     let router = builder.add_service(peer_service);
-    let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
-    let join = tokio::spawn(async move {
-        let shutdown = async {
-            let _ = cancel_rx.await;
-        };
-        if let Err(err) = router
-            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
-            .await
-        {
-            tracing::error!(error = ?err, "paxos peer server died");
-        }
-    });
+    // Fail-fast signal for the peer server: an unexpected exit must take the
+    // whole node down instead of leaving the consensus driver unreachable.
+    let fatal = FatalSignal::new();
+    let transport =
+        TransportHandle::spawn_supervised("paxos peer server", fatal.clone(), move |shutdown| {
+            router.serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
+        });
 
     let admin_view = crate::admin::MembershipView {
         members: cfg
@@ -229,11 +223,12 @@ async fn build_paxos_inner(
     let driver = Arc::new(PaxosDriver::new(host, leader_subscriber));
     Ok(Standalone {
         driver: driver as Arc<dyn ConsensusDriver>,
-        transport: TransportHandle::new(cancel_tx, join),
+        transport,
         drain: None,
         admin: std::sync::Arc::new(crate::admin::UnsupportedAdmin::new(admin_view)),
         admin_transport: crate::TransportHandle::noop(),
         admin_listen_addr: None,
+        fatal,
     })
 }
 

--- a/crates/tsoracle-standalone/src/lib.rs
+++ b/crates/tsoracle-standalone/src/lib.rs
@@ -75,7 +75,7 @@ pub mod admin_proto {
 }
 
 mod transport;
-pub use transport::TransportHandle;
+pub use transport::{FatalSignal, TransportHandle};
 
 #[cfg(any(feature = "openraft", feature = "paxos"))]
 pub(crate) mod peer_tls;
@@ -103,6 +103,10 @@ pub struct Standalone {
     /// `None` when no admin listener was requested or for drivers that do not
     /// serve an admin surface (file, paxos).
     admin_listen_addr: Option<std::net::SocketAddr>,
+    /// Fail-fast signal shared by the transport supervisors: trips when a
+    /// peer or admin server task exits unexpectedly. Inert for the file
+    /// driver, which spawns no servers.
+    fatal: FatalSignal,
 }
 
 impl Standalone {
@@ -126,6 +130,16 @@ impl Standalone {
     /// drivers without an admin surface.
     pub fn admin_listen_addr(&self) -> Option<std::net::SocketAddr> {
         self.admin_listen_addr
+    }
+
+    /// Fail-fast signal: resolves if a peer or admin transport server task
+    /// dies while the node is supposed to be healthy (issue #616's zombie
+    /// mode). The bin selects on [`FatalSignal::tripped`] next to the OS
+    /// shutdown signal and exits non-zero so an orchestrator restarts the
+    /// node instead of leaving the consensus driver running with no peer
+    /// transport.
+    pub fn fatal_signal(&self) -> FatalSignal {
+        self.fatal.clone()
     }
 }
 

--- a/crates/tsoracle-standalone/src/transport.rs
+++ b/crates/tsoracle-standalone/src/transport.rs
@@ -21,8 +21,73 @@
 //  limitations under the License.
 //
 
-use tokio::sync::oneshot;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
+
+/// One-per-node fail-fast signal. Any supervised transport-server task that
+/// exits unexpectedly trips it; the bin's run loop selects on
+/// [`FatalSignal::tripped`] next to the OS shutdown signal and exits non-zero
+/// so an orchestrator restarts the node, instead of leaving a zombie whose
+/// peer/admin surface is dead while the consensus driver keeps running.
+#[derive(Clone)]
+pub struct FatalSignal {
+    component: watch::Sender<Option<&'static str>>,
+}
+
+impl FatalSignal {
+    /// A signal with no failure recorded.
+    pub fn new() -> Self {
+        Self {
+            component: watch::Sender::new(None),
+        }
+    }
+
+    /// Record that `component`'s server task died. The first trip wins —
+    /// later trips keep the original component so the surfaced error names
+    /// the root failure, not a teardown cascade.
+    pub fn trip(&self, component: &'static str) {
+        self.component.send_if_modified(|current| {
+            if current.is_none() {
+                *current = Some(component);
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    /// The component whose server died, if any. Non-blocking.
+    pub fn check(&self) -> Option<&'static str> {
+        *self.component.borrow()
+    }
+
+    /// Resolve with the failed component once the signal trips. Pending
+    /// forever while the node stays healthy.
+    pub async fn tripped(&self) -> &'static str {
+        let mut watcher = self.component.subscribe();
+        loop {
+            if let Some(component) = *watcher.borrow_and_update() {
+                return component;
+            }
+            // `&self` holds a sender, so the channel cannot close while we
+            // wait; if it somehow does, "never trips" is the right reading.
+            if watcher.changed().await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+}
+
+impl Default for FatalSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Owns a spawned peer-transport server and shuts it down cooperatively.
 /// The `file` driver has no peer transport, so it uses [`TransportHandle::noop`].
@@ -46,6 +111,54 @@ impl TransportHandle {
             cancel: Some(cancel),
             join: Some(join),
         }
+    }
+
+    /// Spawn `serve` under supervision. The closure receives the shutdown
+    /// future to hand to `serve_with_incoming_shutdown`, and the returned
+    /// handle cancels it cooperatively exactly like [`TransportHandle::new`].
+    /// Every other way out of the server — an `Err`, a clean return nobody
+    /// asked for, or a panic — trips `fatal` with `component`, so the node
+    /// fails fast instead of running on as a zombie with a dead transport.
+    pub fn spawn_supervised<F, Fut, E>(
+        component: &'static str,
+        fatal: FatalSignal,
+        serve: F,
+    ) -> Self
+    where
+        F: FnOnce(Pin<Box<dyn Future<Output = ()> + Send>>) -> Fut,
+        Fut: Future<Output = Result<(), E>> + Send + 'static,
+        E: std::fmt::Debug + Send + 'static,
+    {
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let stop_requested = Arc::new(AtomicBool::new(false));
+        let stop_observed = stop_requested.clone();
+        let shutdown: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
+            // Resolves on explicit cancel AND on handle drop (`RecvError`):
+            // both mean stop was requested, so a subsequent `Ok` is clean.
+            let _ = cancel_rx.await;
+            stop_observed.store(true, Ordering::Release);
+        });
+        // The server runs in its own task so a panic surfaces here as a
+        // `JoinError` instead of killing the supervisor with it.
+        let server = tokio::spawn(serve(shutdown));
+        let supervisor = tokio::spawn(async move {
+            match server.await {
+                Ok(Ok(())) if stop_requested.load(Ordering::Acquire) => {}
+                Ok(Ok(())) => {
+                    tracing::error!(component, "server exited without a shutdown request");
+                    fatal.trip(component);
+                }
+                Ok(Err(err)) => {
+                    tracing::error!(error = ?err, component, "server died");
+                    fatal.trip(component);
+                }
+                Err(join_error) => {
+                    tracing::error!(error = ?join_error, component, "server task panicked or was aborted");
+                    fatal.trip(component);
+                }
+            }
+        });
+        Self::new(cancel_tx, supervisor)
     }
 
     /// Signal the peer server to stop and wait for the task to finish.
@@ -99,6 +212,147 @@ mod tests {
         // Let the empty task finish before we shut down.
         tokio::task::yield_now().await;
         let mut handle = TransportHandle::new(cancel_tx, join);
+        handle.shutdown().await;
+    }
+
+    /// A fresh signal reports no failure.
+    #[test]
+    fn fatal_signal_starts_untripped() {
+        assert_eq!(FatalSignal::new().check(), None);
+    }
+
+    /// The first component to trip wins; later trips do not overwrite it.
+    #[tokio::test]
+    async fn fatal_trip_records_first_component_only() {
+        let fatal = FatalSignal::new();
+        fatal.trip("peer server");
+        fatal.trip("admin server");
+        assert_eq!(fatal.check(), Some("peer server"));
+        assert_eq!(fatal.tripped().await, "peer server");
+    }
+
+    /// A waiter parked on `tripped()` is woken by a later `trip()`.
+    #[tokio::test]
+    async fn fatal_tripped_wakes_a_pending_waiter() {
+        let fatal = FatalSignal::new();
+        let waiter = tokio::spawn({
+            let fatal = fatal.clone();
+            async move { fatal.tripped().await }
+        });
+        // Let the waiter park before tripping.
+        tokio::task::yield_now().await;
+        fatal.trip("peer server");
+        assert_eq!(waiter.await.unwrap(), "peer server");
+    }
+
+    /// A server future that returns `Err` trips the fatal signal with the
+    /// component label — the zombie-node condition from issue #616.
+    #[tokio::test]
+    async fn supervised_error_exit_trips_fatal() {
+        let fatal = FatalSignal::new();
+        let mut handle =
+            TransportHandle::spawn_supervised("test server", fatal.clone(), |_shutdown| async {
+                Err::<(), std::io::Error>(std::io::Error::other("listener torn down"))
+            });
+        assert_eq!(fatal.tripped().await, "test server");
+        handle.shutdown().await;
+    }
+
+    /// The graceful path — cancel requested, server drains and returns `Ok`
+    /// — must NOT trip the signal.
+    #[tokio::test]
+    async fn supervised_graceful_cancel_does_not_trip() {
+        let fatal = FatalSignal::new();
+        let mut handle = TransportHandle::spawn_supervised(
+            "test server",
+            fatal.clone(),
+            |shutdown| async move {
+                shutdown.await;
+                Ok::<(), std::io::Error>(())
+            },
+        );
+        // Joins the supervisor, so the post-exit bookkeeping has run.
+        handle.shutdown().await;
+        assert_eq!(fatal.check(), None);
+    }
+
+    /// A server that returns `Ok` before anyone asked it to stop is just as
+    /// dead as one that errored: trip.
+    #[tokio::test]
+    async fn supervised_premature_clean_exit_trips_fatal() {
+        let fatal = FatalSignal::new();
+        let mut handle =
+            TransportHandle::spawn_supervised("test server", fatal.clone(), |_shutdown| async {
+                Ok::<(), std::io::Error>(())
+            });
+        assert_eq!(fatal.tripped().await, "test server");
+        handle.shutdown().await;
+    }
+
+    /// A panic inside the server future must also trip the signal — a flat
+    /// task would die with the panic and never report.
+    #[tokio::test]
+    async fn supervised_panic_trips_fatal() {
+        let fatal = FatalSignal::new();
+        let mut handle =
+            TransportHandle::spawn_supervised("test server", fatal.clone(), |_shutdown| async {
+                panic!("server task blew up");
+                #[allow(unreachable_code)]
+                Ok::<(), std::io::Error>(())
+            });
+        assert_eq!(fatal.tripped().await, "test server");
+        handle.shutdown().await;
+    }
+
+    /// Dropping the handle without calling `shutdown()` is intentional
+    /// teardown (the cancel sender drop resolves the shutdown future), not a
+    /// server death: no trip.
+    #[tokio::test]
+    async fn supervised_drop_without_shutdown_does_not_trip() {
+        let fatal = FatalSignal::new();
+        let handle = TransportHandle::spawn_supervised(
+            "test server",
+            fatal.clone(),
+            |shutdown| async move {
+                shutdown.await;
+                Ok::<(), std::io::Error>(())
+            },
+        );
+        drop(handle);
+        for _ in 0..32 {
+            tokio::task::yield_now().await;
+            assert_eq!(fatal.check(), None);
+        }
+    }
+
+    /// End-to-end through real tonic: an incoming stream that errors kills
+    /// `serve_with_incoming_shutdown`, and supervision converts that into a
+    /// fatal trip (whether tonic surfaces it as `Err` or an early `Ok`).
+    #[cfg(feature = "openraft")]
+    #[tokio::test]
+    async fn tonic_incoming_error_propagates_to_fatal() {
+        use std::sync::Arc;
+
+        use crate::admin::service::AdminServiceImpl;
+        use crate::admin::{MembershipAdmin, MembershipView, UnsupportedAdmin};
+        use crate::admin_proto::membership_admin_server::MembershipAdminServer;
+
+        let admin: Arc<dyn MembershipAdmin> = Arc::new(UnsupportedAdmin::new(MembershipView {
+            members: Vec::new(),
+            leader: None,
+        }));
+        let service = MembershipAdminServer::new(AdminServiceImpl::new(admin));
+        let incoming = futures::stream::iter(vec![Err::<tokio::net::TcpStream, std::io::Error>(
+            std::io::Error::other("accept failed"),
+        )]);
+        let fatal = FatalSignal::new();
+        let mut handle =
+            TransportHandle::spawn_supervised("admin server", fatal.clone(), move |shutdown| {
+                tonic::transport::Server::builder()
+                    .add_service(service)
+                    .serve_with_incoming_shutdown(incoming, shutdown)
+            });
+        assert_eq!(fatal.tripped().await, "admin server");
         handle.shutdown().await;
     }
 }

--- a/crates/tsoracle-standalone/tests/build_in_process.rs
+++ b/crates/tsoracle-standalone/tests/build_in_process.rs
@@ -60,6 +60,23 @@ mod file_driver {
         );
         node.shutdown().await;
     }
+
+    /// The file driver spawns no transport servers, so its fail-fast signal
+    /// can never trip — before or after shutdown.
+    #[tokio::test]
+    async fn file_fatal_signal_stays_untripped() {
+        let dir = tempdir().unwrap();
+        let node = build(DriverConfig::File(FileConfig {
+            state_dir: dir.path().join("state"),
+        }))
+        .await
+        .expect("build file driver");
+
+        let fatal = node.fatal_signal();
+        assert_eq!(fatal.check(), None);
+        node.shutdown().await;
+        assert_eq!(fatal.check(), None);
+    }
 }
 
 #[cfg(feature = "openraft")]
@@ -158,6 +175,33 @@ mod openraft_driver {
         let drain = node.take_drain().expect("openraft driver has a drain step");
         drain.await;
         node.shutdown().await;
+    }
+
+    /// Cooperative shutdown of the peer (and absent admin) transport is a
+    /// requested stop, not a server death: the fail-fast signal stays clear.
+    /// The trip path itself is covered by the transport supervision unit
+    /// tests — a real listener can't be forced to error from out here.
+    #[cfg(feature = "test-support")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graceful_shutdown_leaves_fatal_untripped() {
+        let dir = tempdir().unwrap();
+        let (raft_addr, raft_lease) = lease_port().await;
+        let cfg = single_node_cfg(raft_addr, "127.0.0.1:1", dir.path().join("raft"));
+
+        let node = build_openraft_with_listeners(cfg, raft_lease.into_listener(), None)
+            .await
+            .expect("build openraft driver");
+
+        let fatal = node.fatal_signal();
+        assert_eq!(fatal.check(), None);
+        // `shutdown()` joins the supervisor tasks, so a (wrong) trip from the
+        // cooperative stop would be visible immediately after.
+        node.shutdown().await;
+        assert_eq!(
+            fatal.check(),
+            None,
+            "graceful transport shutdown must not trip the fail-fast signal"
+        );
     }
 
     #[tokio::test]
@@ -479,7 +523,14 @@ mod paxos_driver {
             node.take_drain().is_none(),
             "paxos driver has no pre-shutdown drain step"
         );
+        let fatal = node.fatal_signal();
+        assert_eq!(fatal.check(), None);
         node.shutdown().await;
+        assert_eq!(
+            fatal.check(),
+            None,
+            "graceful transport shutdown must not trip the fail-fast signal"
+        );
     }
 
     /// A node absent from its own peer map can never be elected, so `build`


### PR DESCRIPTION
## Summary

When a peer or admin transport server task terminated with an error, the task logged at `error` level and exited — nothing propagated the failure, so the consensus driver kept running as a zombie: no peer RPCs served, no health signal, exit code 0, no orchestrator restart. A raft node in that state silently stops accepting AppendEntries and gets election-evicted cluster-wide. All three spawn sites (openraft peer, paxos peer, admin) had the identical hole.

## Mechanism

- **`TransportHandle::spawn_supervised`** (new, in `transport.rs`): runs the server future in its own task and a supervisor task awaits its `JoinHandle`. Three unexpected exits trip a fail-fast signal: an `Err` return, a clean `Ok` nobody requested, and a panic (surfaced as `JoinError` — a flat task would die with the panic and never report). The cooperative paths stay silent: the shutdown future marks "stop requested" before resolving, and handle drop counts as a requested stop.
- **`FatalSignal`** (new): per-node watch-based signal shared by all of a node's transport supervisors; first trip wins and records which component died. Exposed as `Standalone::fatal_signal()`; inert for the file driver.
- **bin `run_serve`**: the shutdown future is now `wait_for_stop`, selecting the OS shutdown signal (graceful: drain runs first, as before) against the fatal signal (fail fast: drain skipped — the node is already degraded and the priority is a quick exit, not a leadership handoff over a possibly-broken transport). After teardown, a tripped signal returns `Err`, so the process exits non-zero and an orchestrator restarts it.

## Testing

- Supervision unit tests: error exit, premature clean exit, and panic all trip; graceful cancel and drop-without-shutdown do not; first-trip-wins and waiter wakeup for `FatalSignal`.
- A real-tonic test drives `serve_with_incoming_shutdown` with an erroring incoming stream and asserts the failure reaches the fatal signal — pinning the actual upstream failure mode end to end.
- Node-level tests assert graceful `build()` + `shutdown()` leaves the signal untripped for all three drivers (the trip path is not reachable from outside a healthy listener, hence the seam-level coverage above).
- Bin tests pin `wait_for_stop` ordering: fatal resolves without an OS signal and skips the drain; the signal path still drains before stopping.
- `cargo test --workspace --all-features`, clippy, fmt: clean.

Fixes #616