### PR TITLE
ci(release-plz): gate the publish job behind CHANGELOG.md changes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,10 +13,18 @@ on:
   # so the Release PR is opened/updated on demand instead of on every commit.
   workflow_dispatch:
   # Push to main — drives `release` only; a Release PR merge is a push to main,
-  # so publish-on-merge still happens automatically.
+  # so publish-on-merge still happens automatically. Path-gated to CHANGELOG.md
+  # changes: release-plz owns those files (changelog_update = true) and rewrites
+  # them on every release, so a Release PR merge always matches while ordinary
+  # feature/fix commits don't — the publish job no longer runs on every commit.
+  # A stray CHANGELOG edit at most triggers a harmless no-op `release` (it only
+  # publishes crates whose version isn't already tagged). Path filters are ignored
+  # for workflow_dispatch, so the manual `release-pr` path is unaffected.
   push:
     branches:
       - main
+    paths:
+      - '**/CHANGELOG.md'
 
 # Tighten default token scope; each job opts in to what it needs.
 permissions:
@@ -27,7 +35,10 @@ env:
 
 jobs:
   # Publishes (tags + cargo publish + GitHub Release) whenever the release PR
-  # has been merged into main. No-op on every other push.
+  # has been merged into main. The push trigger is path-gated to CHANGELOG.md
+  # changes (see `on:` above), so this no longer fires on ordinary commits; it
+  # runs on release PR merges, and harmlessly no-ops on the rare non-release
+  # CHANGELOG edit.
   release:
     # Publish only on push to main (i.e. a merged Release PR), never on manual
     # dispatch — `release-pr` owns the manual path.


### PR DESCRIPTION
## Problem

The `release` job in `release-plz.yml` (tags + `cargo publish`) triggers on **every push to main**. On the vast majority of commits — which are not Release PR merges — it runs release-plz, finds nothing to publish, and exits. That is wasted CI per commit.

This is release-plz's intended "run `release` every push, it's idempotent" model, but the per-repo setup makes the no-op runs costly.

## Fix

Path-gate the push trigger to `**/CHANGELOG.md` changes.

release-plz owns the per-crate `CHANGELOG.md` files (`changelog_update = true`) and rewrites them on **every** release. Ordinary feature/fix commits never touch them. So:

- A Release PR merge always matches → `release` runs and publishes, exactly as before.
- Ordinary commits don't match → the workflow doesn't trigger at all.

This is deliberately a **path filter** rather than a commit-message match (`startsWith(head_commit.message, 'chore: release')`): it's independent of merge strategy / PR-title convention, and it avoids referencing the injection-prone `github.event.head_commit.message`.

### Safety

- **False positives are harmless.** A rare non-release CHANGELOG edit triggers a no-op `release` — release-plz only publishes crates whose version isn't already tagged.
- **No missed releases.** release-plz never cuts a release without a changelog change (`changelog_update = true`), so a real release always matches the filter; and `release` is idempotent, so a re-run publishes any unpublished backlog.
- **Manual path unchanged.** Path filters don't apply to `workflow_dispatch`, so the manual `release-pr` job is unaffected.
