### PR TITLE
chore(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"


### PR DESCRIPTION
## Summary

CI on `main` is red in the `deny` job across every recent commit. The cause is external, not a code regression: the newly published [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) advisory flags unsoundness in `anyhow`'s `Error::downcast_mut()` (UB when adding context to an error and then downcasting the result) for all versions `< 1.0.103`. `cargo-deny` re-fetches the advisory database on every run, so the workspace lockfile pin at `anyhow 1.0.102` started failing the `deny` job on unchanged history.

This bumps the workspace `Cargo.lock` to the advisory's fixed version, `anyhow 1.0.103`. It is a lockfile-only change — the `anyhow = "1"` requirement in `Cargo.toml` is unchanged, so no published crate is affected and no release is warranted (hence `chore(deps)`, not `fix`). Dependabot bumped the `/fuzz` workspace separately in #652, but the root `/` cargo directory is not tracked by Dependabot, which is why the root lockfile was left behind.

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the [DCO requirement](../CONTRIBUTING.md#developer-certificate-of-origin) (use `git commit -s`).
- [x] Verified locally with `cargo deny check` (all checks): `advisories ok, bans ok, licenses ok, sources ok`.

## Post-merge follow-ups

- [ ] Add the root `/` cargo directory to `.github/dependabot.yml` so future advisory bumps to workspace dependencies are proposed automatically instead of surfacing as a hard `deny`-job failure on `main`.
