### PR TITLE
refactor: consolidate lease API helpers

### DIFF
--- a/crates/tsoracle-client/src/lib.rs
+++ b/crates/tsoracle-client/src/lib.rs
@@ -48,6 +48,7 @@ pub use retry_policy::RetryPolicy;
 pub use seq_attempt::SeqBlock;
 pub use transport::BoxError;
 
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::OnceCell;
@@ -305,6 +306,35 @@ impl Client {
         Ok((endpoint, budget, pair, svc, cell))
     }
 
+    async fn control_plane_rpc<ProtoResponse, Output, Rpc, RpcFuture, Map>(
+        &self,
+        rpc: Rpc,
+        map: Map,
+    ) -> Result<Output, ClientError>
+    where
+        Rpc: FnOnce(TsoServiceClient<Channel>) -> RpcFuture,
+        RpcFuture: Future<Output = Result<tonic::Response<ProtoResponse>, tonic::Status>>,
+        Map: FnOnce(ProtoResponse) -> Result<Output, ClientError>,
+    {
+        let (endpoint, budget, pair, svc, cell) = self.control_plane_client().await?;
+        let rpc_budget = pair.remaining();
+        let err = match tokio::time::timeout(rpc_budget, rpc(svc)).await {
+            Ok(Ok(response)) => return map(response.into_inner()),
+            Ok(Err(status)) => ClientError::Rpc(status),
+            // A timed-out RPC surfaces as `DeadlineExceeded` (transport-class
+            // per `is_transport_failure`), so the eviction tail below drops the
+            // possibly-half-open channel — matching the `get_ts` attempt path.
+            Err(_) => ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
+                "rpc exceeded its share of per_attempt_deadline \
+                 ({rpc_budget:?} of {budget:?})"
+            ))),
+        };
+        if crate::retry_policy::is_transport_failure(&err) {
+            self.pool.evict_if_current(&endpoint, &cell);
+        }
+        Err(err)
+    }
+
     /// Read the leader's current safe-point in physical-millisecond units.
     ///
     /// Targets the cached leader if known, otherwise the first configured
@@ -321,51 +351,19 @@ impl Client {
     /// failure evicts the cached channel so a half-open / black-holing
     /// connection is dropped before the next poll lands on it.
     pub async fn get_current_max_safe(&self) -> Result<MaxSafe, ClientError> {
-        let endpoint = self
-            .pool
-            .cached_leader()
-            .or_else(|| self.pool.iter_round_robin().into_iter().next())
-            .ok_or(ClientError::NoReachableEndpoints)?;
-        let budget = self.pool.retry_policy().per_attempt_deadline;
-        // One budget shared across connect + RPC: a slow connect eats into
-        // the RPC's time rather than each phase getting a fresh full budget,
-        // so a single call never runs longer than ~`per_attempt_deadline`.
-        let pair = crate::budget::PairBudget::start(budget);
-        let (mut svc, cell) =
-            match tokio::time::timeout(budget, self.pool.client_with_cell(&endpoint)).await {
-                Ok(Ok(leased)) => leased,
-                // `client_with_cell` already evicts its own cell on a failed
-                // dial, so there is nothing to evict here.
-                Ok(Err(err)) => return Err(err),
-                Err(_) => {
-                    return Err(ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
-                        "connect exceeded per_attempt_deadline of {budget:?}"
-                    ))));
-                }
-            };
-        let rpc_budget = pair.remaining();
-        let rpc = svc.get_current_max_safe(tsoracle_proto::v1::GetCurrentMaxSafeRequest {});
-        let err = match tokio::time::timeout(rpc_budget, rpc).await {
-            Ok(Ok(response)) => {
-                let inner = response.into_inner();
-                return Ok(MaxSafe {
+        self.control_plane_rpc(
+            |mut svc| async move {
+                svc.get_current_max_safe(tsoracle_proto::v1::GetCurrentMaxSafeRequest {})
+                    .await
+            },
+            |inner| {
+                Ok(MaxSafe {
                     max_safe_physical_ms: inner.max_safe_physical_ms,
                     epoch: Epoch::from_wire(inner.epoch_hi, inner.epoch_lo),
-                });
-            }
-            Ok(Err(status)) => ClientError::Rpc(status),
-            // A timed-out RPC surfaces as `DeadlineExceeded` (transport-class
-            // per `is_transport_failure`), so the eviction tail below drops the
-            // possibly-half-open channel — matching the `get_ts` attempt path.
-            Err(_) => ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
-                "rpc exceeded its share of per_attempt_deadline \
-                 ({rpc_budget:?} of {budget:?})"
-            ))),
-        };
-        if crate::retry_policy::is_transport_failure(&err) {
-            self.pool.evict_if_current(&endpoint, &cell);
-        }
-        Err(err)
+                })
+            },
+        )
+        .await
     }
 
     /// Acquire a stamping lease for an opaque holder group.
@@ -381,106 +379,76 @@ impl Client {
         ttl: Duration,
     ) -> Result<Lease, ClientError> {
         let ttl_ms = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
-        let (endpoint, budget, pair, mut svc, cell) = self.control_plane_client().await?;
-        let rpc_budget = pair.remaining();
-        let rpc = svc.acquire_lease(tsoracle_proto::v1::AcquireLeaseRequest {
-            holder: holder.to_vec(),
-            holder_epoch,
-            ttl_ms,
-        });
-        let err = match tokio::time::timeout(rpc_budget, rpc).await {
-            Ok(Ok(response)) => {
-                let inner = response.into_inner();
-                return Ok(Lease {
+        let holder = holder.to_vec();
+        self.control_plane_rpc(
+            |mut svc| async move {
+                svc.acquire_lease(tsoracle_proto::v1::AcquireLeaseRequest {
+                    holder,
+                    holder_epoch,
+                    ttl_ms,
+                })
+                .await
+            },
+            |inner| {
+                Ok(Lease {
                     lease_id: inner.lease_id,
                     ts_upper_bound: inner.ts_upper_bound,
                     expires_at_ms: inner.expires_at_ms,
                     epoch: required_epoch(inner.epoch, "lease response missing epoch")?,
-                });
-            }
-            Ok(Err(status)) => ClientError::Rpc(status),
-            Err(_) => ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
-                "rpc exceeded its share of per_attempt_deadline \
-                 ({rpc_budget:?} of {budget:?})"
-            ))),
-        };
-        if crate::retry_policy::is_transport_failure(&err) {
-            self.pool.evict_if_current(&endpoint, &cell);
-        }
-        Err(err)
+                })
+            },
+        )
+        .await
     }
 
     /// Renew a live lease, re-arming its acquire-time TTL.
     ///
     /// Single-attempt control-plane call; callers own retry and re-route policy.
     pub async fn renew_lease(&self, lease_id: u64) -> Result<LeaseRenewal, ClientError> {
-        let (endpoint, budget, pair, mut svc, cell) = self.control_plane_client().await?;
-        let rpc_budget = pair.remaining();
-        let rpc = svc.renew_lease(tsoracle_proto::v1::RenewLeaseRequest { lease_id });
-        let err = match tokio::time::timeout(rpc_budget, rpc).await {
-            Ok(Ok(response)) => {
-                let inner = response.into_inner();
-                return Ok(LeaseRenewal {
+        self.control_plane_rpc(
+            |mut svc| async move {
+                svc.renew_lease(tsoracle_proto::v1::RenewLeaseRequest { lease_id })
+                    .await
+            },
+            |inner| {
+                Ok(LeaseRenewal {
                     ts_upper_bound: inner.ts_upper_bound,
                     expires_at_ms: inner.expires_at_ms,
                     epoch: required_epoch(inner.epoch, "lease renewal missing epoch")?,
-                });
-            }
-            Ok(Err(status)) => ClientError::Rpc(status),
-            Err(_) => ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
-                "rpc exceeded its share of per_attempt_deadline \
-                 ({rpc_budget:?} of {budget:?})"
-            ))),
-        };
-        if crate::retry_policy::is_transport_failure(&err) {
-            self.pool.evict_if_current(&endpoint, &cell);
-        }
-        Err(err)
+                })
+            },
+        )
+        .await
     }
 
     /// Release a lease. The server treats unknown or already-released leases as
     /// success, making graceful surrender idempotent.
     pub async fn release_lease(&self, lease_id: u64) -> Result<(), ClientError> {
-        let (endpoint, budget, pair, mut svc, cell) = self.control_plane_client().await?;
-        let rpc_budget = pair.remaining();
-        let rpc = svc.release_lease(tsoracle_proto::v1::ReleaseLeaseRequest { lease_id });
-        let err = match tokio::time::timeout(rpc_budget, rpc).await {
-            Ok(Ok(_response)) => return Ok(()),
-            Ok(Err(status)) => ClientError::Rpc(status),
-            Err(_) => ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
-                "rpc exceeded its share of per_attempt_deadline \
-                 ({rpc_budget:?} of {budget:?})"
-            ))),
-        };
-        if crate::retry_policy::is_transport_failure(&err) {
-            self.pool.evict_if_current(&endpoint, &cell);
-        }
-        Err(err)
+        self.control_plane_rpc(
+            |mut svc| async move {
+                svc.release_lease(tsoracle_proto::v1::ReleaseLeaseRequest { lease_id })
+                    .await
+            },
+            |_inner| Ok(()),
+        )
+        .await
     }
 
     /// Read the lease-aware safe frontier in physical-millisecond units.
     pub async fn get_safe_frontier(&self) -> Result<SafeFrontier, ClientError> {
-        let (endpoint, budget, pair, mut svc, cell) = self.control_plane_client().await?;
-        let rpc_budget = pair.remaining();
-        let rpc = svc.get_safe_frontier(tsoracle_proto::v1::GetSafeFrontierRequest {});
-        let err = match tokio::time::timeout(rpc_budget, rpc).await {
-            Ok(Ok(response)) => {
-                let inner = response.into_inner();
-                return Ok(SafeFrontier {
+        self.control_plane_rpc(
+            |mut svc| async move {
+                svc.get_safe_frontier(tsoracle_proto::v1::GetSafeFrontierRequest {})
+                    .await
+            },
+            |inner| {
+                Ok(SafeFrontier {
                     frontier_physical_ms: inner.frontier_physical_ms,
                     epoch: Epoch::from_wire(inner.epoch_hi, inner.epoch_lo),
-                });
-            }
-            Ok(Err(status)) => ClientError::Rpc(status),
-            Err(_) => ClientError::Rpc(tonic::Status::deadline_exceeded(format!(
-                "rpc exceeded its share of per_attempt_deadline \
-                 ({rpc_budget:?} of {budget:?})"
-            ))),
-        };
-        if crate::retry_policy::is_transport_failure(&err) {
-            self.pool.evict_if_current(&endpoint, &cell);
-        }
-        Err(err)
+                })
+            },
+        )
+        .await
     }
 }
 

--- a/crates/tsoracle-driver-file/src/dense_record.rs
+++ b/crates/tsoracle-driver-file/src/dense_record.rs
@@ -27,8 +27,11 @@
 
 use std::collections::BTreeMap;
 
+use crate::framed_record::{self, FrameError};
+
 pub const MAGIC: &[u8; 4] = b"TSOD";
 pub const VERSION: u8 = 1;
+const MIN_LEN: usize = framed_record::HEADER_LEN + 8 + 4 + framed_record::CRC_LEN;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum DenseRecordError {
@@ -46,60 +49,52 @@ pub enum DenseRecordError {
     NonUtf8Key,
 }
 
+impl From<FrameError> for DenseRecordError {
+    fn from(error: FrameError) -> Self {
+        match error {
+            FrameError::TooShort(len) => DenseRecordError::TooShort(len),
+            FrameError::BadMagic(magic) => DenseRecordError::BadMagic(magic),
+            FrameError::UnsupportedVersion(version) => {
+                DenseRecordError::UnsupportedVersion(version)
+            }
+            FrameError::ChecksumMismatch { stored, computed } => {
+                DenseRecordError::ChecksumMismatch { stored, computed }
+            }
+            FrameError::Malformed => DenseRecordError::Malformed,
+        }
+    }
+}
+
 pub fn encode(map: &BTreeMap<String, u64>, cap: u64) -> Vec<u8> {
     debug_assert!(map.len() <= u32::MAX as usize, "key_count exceeds u32");
-    let mut buf = Vec::with_capacity(4 + 1 + 8 + 4 + map.len() * 24 + 4);
-    buf.extend_from_slice(MAGIC);
-    buf.push(VERSION);
-    buf.extend_from_slice(&cap.to_le_bytes());
-    buf.extend_from_slice(&(map.len() as u32).to_le_bytes());
-    for (key, counter) in map {
-        let kb = key.as_bytes();
-        // key length is bounded by MAX_SEQ_KEY_LEN (<= u16::MAX) at the API edge.
-        debug_assert!(kb.len() <= u16::MAX as usize, "key length exceeds u16");
-        buf.extend_from_slice(&(kb.len() as u16).to_le_bytes());
-        buf.extend_from_slice(kb);
-        buf.extend_from_slice(&counter.to_le_bytes());
-    }
-    let crc = crc32c::crc32c(&buf);
-    buf.extend_from_slice(&crc.to_le_bytes());
-    buf
+    framed_record::encode(MAGIC, VERSION, 8 + 4 + map.len() * 24, |buf| {
+        buf.extend_from_slice(&cap.to_le_bytes());
+        buf.extend_from_slice(&(map.len() as u32).to_le_bytes());
+        for (key, counter) in map {
+            let kb = key.as_bytes();
+            // key length is bounded by MAX_SEQ_KEY_LEN (<= u16::MAX) at the API edge.
+            debug_assert!(kb.len() <= u16::MAX as usize, "key length exceeds u16");
+            buf.extend_from_slice(&(kb.len() as u16).to_le_bytes());
+            buf.extend_from_slice(kb);
+            buf.extend_from_slice(&counter.to_le_bytes());
+        }
+    })
 }
 
 pub fn decode(bytes: &[u8]) -> Result<(BTreeMap<String, u64>, u64), DenseRecordError> {
-    // minimum: magic(4) + version(1) + cap(8) + key_count(4) + crc(4) = 21
-    if bytes.len() < 21 {
-        return Err(DenseRecordError::TooShort(bytes.len()));
-    }
-    if &bytes[0..4] != MAGIC {
-        return Err(DenseRecordError::BadMagic([
-            bytes[0], bytes[1], bytes[2], bytes[3],
-        ]));
-    }
-    if bytes[4] != VERSION {
-        return Err(DenseRecordError::UnsupportedVersion(bytes[4]));
-    }
-    let body = &bytes[..bytes.len() - 4];
-    let stored = u32::from_le_bytes(
-        bytes[bytes.len() - 4..]
-            .try_into()
-            .map_err(|_| DenseRecordError::Malformed)?,
-    );
-    let computed = crc32c::crc32c(body);
-    if stored != computed {
-        return Err(DenseRecordError::ChecksumMismatch { stored, computed });
-    }
+    let body =
+        framed_record::decode(bytes, MAGIC, VERSION, MIN_LEN).map_err(DenseRecordError::from)?;
     let cap = u64::from_le_bytes(
-        bytes[5..13]
+        body[0..8]
             .try_into()
             .map_err(|_| DenseRecordError::Malformed)?,
     );
     let key_count = u32::from_le_bytes(
-        bytes[13..17]
+        body[8..12]
             .try_into()
             .map_err(|_| DenseRecordError::Malformed)?,
     );
-    let mut pos = 17;
+    let mut pos = 12;
     let mut map = BTreeMap::new();
     let mut prev_key: Option<String> = None;
     for _ in 0..key_count {

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -298,50 +298,69 @@ fn write_record(dir: &Path, high_water: u64) -> Result<(), FileDriverError> {
     Ok(())
 }
 
-/// Atomically persist the dense map. Mirrors `write_record`'s tmp+fsync+rename+dir-fsync
-/// protocol (and its failpoint structure) for the dense `dense` file.
-fn write_dense_record(
-    dir: &Path,
-    map: &std::collections::BTreeMap<String, u64>,
-    cap: u64,
-) -> Result<(), FileDriverError> {
-    tsoracle_failpoint::failpoint!("file_driver::dense::before_write", |_arg: Option<
-        String,
-    >|
-     -> Result<
-        (),
-        FileDriverError,
-    > {
-        Err(FileDriverError::Io(std::io::Error::other(
-            "failpoint: file_driver::dense::before_write",
-        )))
-    });
+struct FramedFileWrite {
+    name: &'static str,
+    before_write: &'static str,
+    after_tmp_fsync_before_rename: &'static str,
+    after_rename_before_dir_fsync: &'static str,
+}
 
-    let tmp = dir.join("dense.tmp");
-    let final_path = dir.join("dense");
-    let bytes = dense_record::encode(map, cap);
+const DENSE_FILE_WRITE: FramedFileWrite = FramedFileWrite {
+    name: "dense",
+    before_write: "file_driver::dense::before_write",
+    after_tmp_fsync_before_rename: "file_driver::dense::after_tmp_fsync_before_rename",
+    after_rename_before_dir_fsync: "file_driver::dense::after_rename_before_dir_fsync",
+};
+
+const LEASES_FILE_WRITE: FramedFileWrite = FramedFileWrite {
+    name: "leases",
+    before_write: "file_driver::leases::before_write",
+    after_tmp_fsync_before_rename: "file_driver::leases::after_tmp_fsync_before_rename",
+    after_rename_before_dir_fsync: "file_driver::leases::after_rename_before_dir_fsync",
+};
+
+fn failpoint_io_error(name: &str) -> FileDriverError {
+    FileDriverError::Io(std::io::Error::other(format!("failpoint: {name}")))
+}
+
+/// Atomically persist a framed file through tmp+fsync+rename+dir-fsync.
+fn write_framed_file(
+    dir: &Path,
+    spec: FramedFileWrite,
+    bytes: &[u8],
+) -> Result<(), FileDriverError> {
+    tsoracle_failpoint::failpoint!(
+        spec.before_write,
+        |_arg: Option<String>| -> Result<(), FileDriverError> {
+            Err(failpoint_io_error(spec.before_write))
+        }
+    );
+
+    let tmp = dir.join(format!("{}.tmp", spec.name));
+    let final_path = dir.join(spec.name);
 
     let mut file = fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
         .open(&tmp)?;
-    file.write_all(&bytes)?;
+    file.write_all(bytes)?;
     file.sync_all()?;
     drop(file);
 
-    tsoracle_failpoint::failpoint!(
-        "file_driver::dense::after_tmp_fsync_before_rename",
-        |_arg: Option<String>| -> Result<(), FileDriverError> {
-            Err(FileDriverError::Io(std::io::Error::other(
-                "failpoint: file_driver::dense::after_tmp_fsync_before_rename",
-            )))
-        }
-    );
+    tsoracle_failpoint::failpoint!(spec.after_tmp_fsync_before_rename, |_arg: Option<
+        String,
+    >|
+     -> Result<
+        (),
+        FileDriverError,
+    > {
+        Err(failpoint_io_error(spec.after_tmp_fsync_before_rename))
+    });
 
     fs::rename(&tmp, &final_path)?;
 
-    tsoracle_failpoint::failpoint!("file_driver::dense::after_rename_before_dir_fsync");
+    tsoracle_failpoint::failpoint!(spec.after_rename_before_dir_fsync);
 
     #[cfg(unix)]
     {
@@ -361,63 +380,20 @@ fn write_dense_record(
     Ok(())
 }
 
-/// Atomically persist the lease set. Mirrors `write_record`'s
-/// tmp+fsync+rename+dir-fsync protocol for the `leases` file.
+/// Atomically persist the dense map.
+fn write_dense_record(
+    dir: &Path,
+    map: &std::collections::BTreeMap<String, u64>,
+    cap: u64,
+) -> Result<(), FileDriverError> {
+    let bytes = dense_record::encode(map, cap);
+    write_framed_file(dir, DENSE_FILE_WRITE, &bytes)
+}
+
+/// Atomically persist the lease set.
 fn write_lease_record(dir: &Path, records: &[LeaseRecord]) -> Result<(), FileDriverError> {
-    tsoracle_failpoint::failpoint!("file_driver::leases::before_write", |_arg: Option<
-        String,
-    >|
-     -> Result<
-        (),
-        FileDriverError,
-    > {
-        Err(FileDriverError::Io(std::io::Error::other(
-            "failpoint: file_driver::leases::before_write",
-        )))
-    });
-
-    let tmp = dir.join("leases.tmp");
-    let final_path = dir.join("leases");
     let bytes = lease_record::encode(records);
-
-    let mut file = fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&tmp)?;
-    file.write_all(&bytes)?;
-    file.sync_all()?;
-    drop(file);
-
-    tsoracle_failpoint::failpoint!(
-        "file_driver::leases::after_tmp_fsync_before_rename",
-        |_arg: Option<String>| -> Result<(), FileDriverError> {
-            Err(FileDriverError::Io(std::io::Error::other(
-                "failpoint: file_driver::leases::after_tmp_fsync_before_rename",
-            )))
-        }
-    );
-
-    fs::rename(&tmp, &final_path)?;
-
-    tsoracle_failpoint::failpoint!("file_driver::leases::after_rename_before_dir_fsync");
-
-    #[cfg(unix)]
-    {
-        let dir_file = fs::File::open(dir)?;
-        let fd = dir_file.as_raw_fd();
-        // SAFETY: fd is a valid open directory descriptor for the duration of this call.
-        let rc = unsafe { libc::fsync(fd) };
-        if rc != 0 {
-            return Err(FileDriverError::Io(std::io::Error::last_os_error()));
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let final_file = fs::OpenOptions::new().write(true).open(&final_path)?;
-        final_file.sync_all()?;
-    }
-    Ok(())
+    write_framed_file(dir, LEASES_FILE_WRITE, &bytes)
 }
 
 #[async_trait::async_trait]

--- a/crates/tsoracle-driver-file/src/framed_record.rs
+++ b/crates/tsoracle-driver-file/src/framed_record.rs
@@ -1,0 +1,86 @@
+//
+//  ░▀█▀░█▀▀░█▀█░█▀▄░█▀█░█▀▀░█░░░█▀▀
+//  ░░█░░▀▀█░█░█░█▀▄░█▀█░█░░░█░░░█▀▀
+//  ░░▀░░▀▀▀░▀▀▀░▀░▀░▀░▀░▀▀▀░▀▀▀░▀▀▀
+//
+//  tsoracle — Distributed Timestamp Oracle
+//  https://www.tsoracle.rs
+//
+//  Copyright (c) 2026 Prisma Risk
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+//! Shared framing for versioned, CRC-protected durable records.
+
+pub const HEADER_LEN: usize = 5;
+pub const CRC_LEN: usize = 4;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum FrameError {
+    TooShort(usize),
+    BadMagic([u8; 4]),
+    UnsupportedVersion(u8),
+    ChecksumMismatch { stored: u32, computed: u32 },
+    Malformed,
+}
+
+pub fn encode<F>(
+    magic: &[u8; 4],
+    version: u8,
+    payload_capacity: usize,
+    encode_payload: F,
+) -> Vec<u8>
+where
+    F: FnOnce(&mut Vec<u8>),
+{
+    let mut buf = Vec::with_capacity(HEADER_LEN + payload_capacity + CRC_LEN);
+    buf.extend_from_slice(magic);
+    buf.push(version);
+    encode_payload(&mut buf);
+    let crc = crc32c::crc32c(&buf);
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf
+}
+
+pub fn decode<'a>(
+    bytes: &'a [u8],
+    magic: &[u8; 4],
+    version: u8,
+    minimum_len: usize,
+) -> Result<&'a [u8], FrameError> {
+    if bytes.len() < minimum_len {
+        return Err(FrameError::TooShort(bytes.len()));
+    }
+    if &bytes[0..4] != magic {
+        return Err(FrameError::BadMagic([
+            bytes[0], bytes[1], bytes[2], bytes[3],
+        ]));
+    }
+    if bytes[4] != version {
+        return Err(FrameError::UnsupportedVersion(bytes[4]));
+    }
+
+    let body = &bytes[..bytes.len() - CRC_LEN];
+    let stored = u32::from_le_bytes(
+        bytes[bytes.len() - CRC_LEN..]
+            .try_into()
+            .map_err(|_| FrameError::Malformed)?,
+    );
+    let computed = crc32c::crc32c(body);
+    if stored != computed {
+        return Err(FrameError::ChecksumMismatch { stored, computed });
+    }
+
+    Ok(&body[HEADER_LEN..])
+}

--- a/crates/tsoracle-driver-file/src/lease_record.rs
+++ b/crates/tsoracle-driver-file/src/lease_record.rs
@@ -29,8 +29,11 @@
 
 use tsoracle_core::LeaseRecord;
 
+use crate::framed_record::{self, FrameError};
+
 pub const MAGIC: &[u8; 4] = b"TSOO";
 pub const VERSION: u8 = 1;
+const MIN_LEN: usize = framed_record::HEADER_LEN + 4 + framed_record::CRC_LEN;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum LeaseRecordError {
@@ -46,6 +49,22 @@ pub enum LeaseRecordError {
     Malformed,
 }
 
+impl From<FrameError> for LeaseRecordError {
+    fn from(error: FrameError) -> Self {
+        match error {
+            FrameError::TooShort(len) => LeaseRecordError::TooShort(len),
+            FrameError::BadMagic(magic) => LeaseRecordError::BadMagic(magic),
+            FrameError::UnsupportedVersion(version) => {
+                LeaseRecordError::UnsupportedVersion(version)
+            }
+            FrameError::ChecksumMismatch { stored, computed } => {
+                LeaseRecordError::ChecksumMismatch { stored, computed }
+            }
+            FrameError::Malformed => LeaseRecordError::Malformed,
+        }
+    }
+}
+
 pub fn encode(records: &[LeaseRecord]) -> Vec<u8> {
     debug_assert!(
         records.len() <= u32::MAX as usize,
@@ -55,58 +74,39 @@ pub fn encode(records: &[LeaseRecord]) -> Vec<u8> {
     records.sort_by_key(|r| r.lease_id);
 
     let holder_bytes: usize = records.iter().map(|r| r.holder.len()).sum();
-    let mut buf = Vec::with_capacity(4 + 1 + 4 + records.len() * 43 + holder_bytes + 4);
-    buf.extend_from_slice(MAGIC);
-    buf.push(VERSION);
-    buf.extend_from_slice(&(records.len() as u32).to_le_bytes());
-    for record in &records {
-        debug_assert!(
-            record.holder.len() <= u16::MAX as usize,
-            "holder length exceeds u16"
-        );
-        buf.extend_from_slice(&record.lease_id.to_le_bytes());
-        buf.extend_from_slice(&(record.holder.len() as u16).to_le_bytes());
-        buf.extend_from_slice(&record.holder);
-        buf.extend_from_slice(&record.holder_epoch.to_le_bytes());
-        buf.extend_from_slice(&record.ttl_ms.to_le_bytes());
-        buf.extend_from_slice(&record.ts_upper_bound.to_le_bytes());
-        buf.extend_from_slice(&record.expires_at_ms.to_le_bytes());
-        buf.push(u8::from(record.superseded));
-    }
-    let crc = crc32c::crc32c(&buf);
-    buf.extend_from_slice(&crc.to_le_bytes());
-    buf
+    framed_record::encode(
+        MAGIC,
+        VERSION,
+        4 + records.len() * 43 + holder_bytes,
+        |buf| {
+            buf.extend_from_slice(&(records.len() as u32).to_le_bytes());
+            for record in &records {
+                debug_assert!(
+                    record.holder.len() <= u16::MAX as usize,
+                    "holder length exceeds u16"
+                );
+                buf.extend_from_slice(&record.lease_id.to_le_bytes());
+                buf.extend_from_slice(&(record.holder.len() as u16).to_le_bytes());
+                buf.extend_from_slice(&record.holder);
+                buf.extend_from_slice(&record.holder_epoch.to_le_bytes());
+                buf.extend_from_slice(&record.ttl_ms.to_le_bytes());
+                buf.extend_from_slice(&record.ts_upper_bound.to_le_bytes());
+                buf.extend_from_slice(&record.expires_at_ms.to_le_bytes());
+                buf.push(u8::from(record.superseded));
+            }
+        },
+    )
 }
 
 pub fn decode(bytes: &[u8]) -> Result<Vec<LeaseRecord>, LeaseRecordError> {
-    if bytes.len() < 13 {
-        return Err(LeaseRecordError::TooShort(bytes.len()));
-    }
-    if &bytes[0..4] != MAGIC {
-        return Err(LeaseRecordError::BadMagic([
-            bytes[0], bytes[1], bytes[2], bytes[3],
-        ]));
-    }
-    if bytes[4] != VERSION {
-        return Err(LeaseRecordError::UnsupportedVersion(bytes[4]));
-    }
-    let body = &bytes[..bytes.len() - 4];
-    let stored = u32::from_le_bytes(
-        bytes[bytes.len() - 4..]
-            .try_into()
-            .map_err(|_| LeaseRecordError::Malformed)?,
-    );
-    let computed = crc32c::crc32c(body);
-    if stored != computed {
-        return Err(LeaseRecordError::ChecksumMismatch { stored, computed });
-    }
-
+    let body =
+        framed_record::decode(bytes, MAGIC, VERSION, MIN_LEN).map_err(LeaseRecordError::from)?;
     let record_count = u32::from_le_bytes(
-        body[5..9]
+        body[0..4]
             .try_into()
             .map_err(|_| LeaseRecordError::Malformed)?,
     );
-    let mut pos = 9;
+    let mut pos = 4;
     let mut records = Vec::with_capacity(record_count as usize);
     let mut prev_id = None;
     for _ in 0..record_count {

--- a/crates/tsoracle-driver-file/src/lib.rs
+++ b/crates/tsoracle-driver-file/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod dense_record;
 mod driver;
+mod framed_record;
 mod lease_record;
 pub mod record;
 

--- a/crates/tsoracle-server/src/lease_flow.rs
+++ b/crates/tsoracle-server/src/lease_flow.rs
@@ -47,18 +47,14 @@ use crate::leader_hint::not_leader_status;
 use crate::persist_disposition::{PersistDisposition, classify};
 use crate::server::Server;
 use crate::service::{core_status, leader_hint_from};
+use crate::serving_core::ExtensionSlot;
 
 pub(crate) async fn acquire_lease(
     server: &Arc<Server>,
     req: AcquireLeaseRequest,
 ) -> Result<AcquireLeaseResponse, Status> {
     server.reporter.lease_acquire_requests.increment(1);
-    if !server.core.is_serving() {
-        return Err(not_leader_status(
-            &server.reporter,
-            leader_hint_from(server),
-        ));
-    }
+    ensure_serving(server)?;
     validate_lease_request(
         &req.holder,
         req.ttl_ms,
@@ -75,12 +71,7 @@ pub(crate) async fn acquire_lease(
         .map_err(lease_status)?
     {
         AcquireDecision::Idempotent(live) => {
-            let Some(epoch) = server.core.current_epoch() else {
-                return Err(not_leader_status(
-                    &server.reporter,
-                    leader_hint_from(server),
-                ));
-            };
+            let epoch = current_epoch_or_not_leader(server)?;
             server.reporter.lease_acquire_success.increment(1);
             return Ok(AcquireLeaseResponse {
                 lease_id: live.lease_id,
@@ -93,28 +84,7 @@ pub(crate) async fn acquire_lease(
     };
 
     let _gate = slot.drain_barrier().await;
-    let (requested, epoch) = match slot.prepare_extension(now_ms, req.ttl_ms) {
-        Ok(prepared) => prepared,
-        Err(CoreError::NotLeader) => {
-            return Err(not_leader_status(
-                &server.reporter,
-                leader_hint_from(server),
-            ));
-        }
-        Err(other) => return Err(core_status(other)),
-    };
-    let actual = persist_bound(server, requested, epoch).await?;
-    if let CommitOutcome::Ignored(_) = server
-        .core
-        .commit_extension(actual, epoch)
-        .map_err(core_status)?
-    {
-        return Err(not_leader_status(
-            &server.reporter,
-            leader_hint_from(server),
-        ));
-    }
-
+    let (actual, epoch) = persist_extension_bound(server, &slot, now_ms, req.ttl_ms).await?;
     let record = LeaseRecord {
         lease_id: actual,
         holder: req.holder,
@@ -127,14 +97,17 @@ pub(crate) async fn acquire_lease(
     // A crash after the high-water advance but before this persist burns a
     // forward range and records no lease. That is safe: timestamps are never
     // reissued, and a retry receives a fresh grant.
-    let set = server
-        .core
-        .lease_projected_live_set(Some(&record), supersedes, None, now_ms);
-    persist_lease_set(server, &set, epoch).await?;
-    server
-        .core
-        .lease_commit(Some(record.clone()), supersedes, None, epoch, now_ms)
-        .map_err(core_status)?;
+    persist_lease_mutation(
+        server,
+        LeaseMutation {
+            upsert: Some(record.clone()),
+            supersede: supersedes,
+            remove: None,
+        },
+        epoch,
+        now_ms,
+    )
+    .await?;
     server.reporter.lease_acquire_success.increment(1);
     Ok(AcquireLeaseResponse {
         lease_id: record.lease_id,
@@ -149,12 +122,7 @@ pub(crate) async fn renew_lease(
     req: RenewLeaseRequest,
 ) -> Result<RenewLeaseResponse, Status> {
     server.reporter.lease_renew_requests.increment(1);
-    if !server.core.is_serving() {
-        return Err(not_leader_status(
-            &server.reporter,
-            leader_hint_from(server),
-        ));
-    }
+    ensure_serving(server)?;
 
     let now_ms = server.clock.now_ms();
     let slot = server.core.extension_slot().await;
@@ -164,38 +132,20 @@ pub(crate) async fn renew_lease(
         .map_err(lease_status)?;
 
     let _gate = slot.drain_barrier().await;
-    let (requested, epoch) = match slot.prepare_extension(now_ms, record.ttl_ms) {
-        Ok(prepared) => prepared,
-        Err(CoreError::NotLeader) => {
-            return Err(not_leader_status(
-                &server.reporter,
-                leader_hint_from(server),
-            ));
-        }
-        Err(other) => return Err(core_status(other)),
-    };
-    let actual = persist_bound(server, requested, epoch).await?;
-    if let CommitOutcome::Ignored(_) = server
-        .core
-        .commit_extension(actual, epoch)
-        .map_err(core_status)?
-    {
-        return Err(not_leader_status(
-            &server.reporter,
-            leader_hint_from(server),
-        ));
-    }
-
+    let (actual, epoch) = persist_extension_bound(server, &slot, now_ms, record.ttl_ms).await?;
     record.ts_upper_bound = actual;
     record.expires_at_ms = now_ms.saturating_add(record.ttl_ms);
-    let set = server
-        .core
-        .lease_projected_live_set(Some(&record), None, None, now_ms);
-    persist_lease_set(server, &set, epoch).await?;
-    server
-        .core
-        .lease_commit(Some(record.clone()), None, None, epoch, now_ms)
-        .map_err(core_status)?;
+    persist_lease_mutation(
+        server,
+        LeaseMutation {
+            upsert: Some(record.clone()),
+            supersede: None,
+            remove: None,
+        },
+        epoch,
+        now_ms,
+    )
+    .await?;
     server.reporter.lease_renew_success.increment(1);
     Ok(RenewLeaseResponse {
         ts_upper_bound: record.ts_upper_bound,
@@ -209,35 +159,53 @@ pub(crate) async fn release_lease(
     req: ReleaseLeaseRequest,
 ) -> Result<ReleaseLeaseResponse, Status> {
     server.reporter.lease_release_requests.increment(1);
-    if !server.core.is_serving() {
-        return Err(not_leader_status(
-            &server.reporter,
-            leader_hint_from(server),
-        ));
-    }
+    ensure_serving(server)?;
 
     let now_ms = server.clock.now_ms();
     let slot = server.core.extension_slot().await;
     if server.core.lease_prepare_release(req.lease_id).is_none() {
         return Ok(ReleaseLeaseResponse {});
     }
-    let Some(epoch) = server.core.current_epoch() else {
-        return Err(not_leader_status(
-            &server.reporter,
-            leader_hint_from(server),
-        ));
-    };
+    let epoch = current_epoch_or_not_leader(server)?;
 
     let _gate = slot.drain_barrier().await;
-    let set = server
-        .core
-        .lease_projected_live_set(None, None, Some(req.lease_id), now_ms);
-    persist_lease_set(server, &set, epoch).await?;
+    persist_lease_mutation(
+        server,
+        LeaseMutation {
+            upsert: None,
+            supersede: None,
+            remove: Some(req.lease_id),
+        },
+        epoch,
+        now_ms,
+    )
+    .await?;
+    Ok(ReleaseLeaseResponse {})
+}
+
+struct LeaseMutation {
+    upsert: Option<LeaseRecord>,
+    supersede: Option<u64>,
+    remove: Option<u64>,
+}
+
+fn not_leader(server: &Arc<Server>) -> Status {
+    not_leader_status(&server.reporter, leader_hint_from(server))
+}
+
+fn ensure_serving(server: &Arc<Server>) -> Result<(), Status> {
+    if server.core.is_serving() {
+        Ok(())
+    } else {
+        Err(not_leader(server))
+    }
+}
+
+fn current_epoch_or_not_leader(server: &Arc<Server>) -> Result<Epoch, Status> {
     server
         .core
-        .lease_commit(None, None, Some(req.lease_id), epoch, now_ms)
-        .map_err(core_status)?;
-    Ok(ReleaseLeaseResponse {})
+        .current_epoch()
+        .ok_or_else(|| not_leader(server))
 }
 
 fn lease_status(error: LeaseError) -> Status {
@@ -255,26 +223,55 @@ fn lease_status(error: LeaseError) -> Status {
 async fn persist_bound(server: &Arc<Server>, requested: u64, epoch: Epoch) -> Result<u64, Status> {
     match server.consensus.persist_high_water(requested, epoch).await {
         Ok(actual) => Ok(actual),
-        Err(error) => match classify(error) {
-            PersistDisposition::SteppedDown { fenced_by } => {
-                server.core.step_down(None, fenced_by);
-                Err(not_leader_status(
-                    &server.reporter,
-                    leader_hint_from(server),
-                ))
-            }
-            PersistDisposition::Transient(source) => {
-                Err(Status::unavailable(format!("persist: {source}")))
-            }
-            PersistDisposition::Permanent(source) => {
-                Err(Status::internal(format!("persist: {source}")))
-            }
-            PersistDisposition::OutOfRange(at_least) => Err(Status::internal(format!(
-                "persist: {}",
-                ConsensusError::AdvanceOutOfRange(at_least)
-            ))),
-        },
+        Err(error) => Err(persist_error_status(server, "persist", error)),
     }
+}
+
+async fn persist_extension_bound(
+    server: &Arc<Server>,
+    slot: &ExtensionSlot<'_>,
+    now_ms: u64,
+    ttl_ms: u64,
+) -> Result<(u64, Epoch), Status> {
+    let (requested, epoch) = match slot.prepare_extension(now_ms, ttl_ms) {
+        Ok(prepared) => prepared,
+        Err(CoreError::NotLeader) => return Err(not_leader(server)),
+        Err(other) => return Err(core_status(other)),
+    };
+    let actual = persist_bound(server, requested, epoch).await?;
+    if let CommitOutcome::Ignored(_) = server
+        .core
+        .commit_extension(actual, epoch)
+        .map_err(core_status)?
+    {
+        return Err(not_leader(server));
+    }
+    Ok((actual, epoch))
+}
+
+async fn persist_lease_mutation(
+    server: &Arc<Server>,
+    mutation: LeaseMutation,
+    epoch: Epoch,
+    now_ms: u64,
+) -> Result<(), Status> {
+    let set = server.core.lease_projected_live_set(
+        mutation.upsert.as_ref(),
+        mutation.supersede,
+        mutation.remove,
+        now_ms,
+    );
+    persist_lease_set(server, &set, epoch).await?;
+    server
+        .core
+        .lease_commit(
+            mutation.upsert,
+            mutation.supersede,
+            mutation.remove,
+            epoch,
+            now_ms,
+        )
+        .map_err(core_status)
 }
 
 async fn persist_lease_set(
@@ -287,27 +284,28 @@ async fn persist_lease_set(
         Err(ConsensusError::LeasesUnsupported) => Err(Status::unimplemented(
             "leases are not supported by this consensus driver",
         )),
-        Err(ConsensusError::NotLeader { .. }) => {
-            server.core.step_down(None, None);
-            Err(not_leader_status(
-                &server.reporter,
-                leader_hint_from(server),
-            ))
+        Err(error) => Err(persist_error_status(server, "persist leases", error)),
+    }
+}
+
+fn persist_error_status(
+    server: &Arc<Server>,
+    context: &'static str,
+    error: ConsensusError,
+) -> Status {
+    match classify(error) {
+        PersistDisposition::SteppedDown { fenced_by } => {
+            server.core.step_down(None, fenced_by);
+            not_leader(server)
         }
-        Err(ConsensusError::Fenced { current, .. }) => {
-            server.core.step_down(None, Some(current));
-            Err(not_leader_status(
-                &server.reporter,
-                leader_hint_from(server),
-            ))
+        PersistDisposition::Transient(source) => {
+            Status::unavailable(format!("{context}: {source}"))
         }
-        Err(ConsensusError::TransientDriver(source)) => {
-            Err(Status::unavailable(format!("persist leases: {source}")))
-        }
-        Err(ConsensusError::PermanentDriver(source)) => {
-            Err(Status::internal(format!("persist leases: {source}")))
-        }
-        Err(other) => Err(Status::internal(other.to_string())),
+        PersistDisposition::Permanent(source) => Status::internal(format!("{context}: {source}")),
+        PersistDisposition::OutOfRange(at_least) => Status::internal(format!(
+            "{context}: {}",
+            ConsensusError::AdvanceOutOfRange(at_least)
+        )),
     }
 }
 

--- a/crates/tsoracle-server/src/test_support.rs
+++ b/crates/tsoracle-server/src/test_support.rs
@@ -48,7 +48,8 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::service::Routes;
-use tonic::transport::{Endpoint, Server as TonicServer};
+use tonic::transport::{Channel, Endpoint, Server as TonicServer};
+use tsoracle_proto::v1::tso_service_client::TsoServiceClient;
 
 use crate::{Server, ServerError, ServingState};
 
@@ -243,6 +244,32 @@ pub async fn wait_for_grpc_handshake(
             }
         }
     }
+}
+
+/// Wait for tonic readiness and connect a generated TSO client to `booted`.
+pub async fn connect_tso_client(addr: SocketAddr) -> TsoServiceClient<Channel> {
+    wait_for_grpc_handshake(addr, Duration::from_secs(5))
+        .await
+        .expect("test server must accept a gRPC handshake");
+    TsoServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect generated TSO client to test server")
+}
+
+/// Boot a server, run the caller's leadership transition, wait until it serves,
+/// and return a connected generated TSO client.
+pub async fn boot_leader_server<F>(
+    server: Server,
+    become_leader: F,
+) -> (BootedServer, TsoServiceClient<Channel>)
+where
+    F: FnOnce(),
+{
+    let mut booted = boot_server(server).await;
+    become_leader();
+    wait_until_serving(&mut booted.state_rx).await;
+    let client = connect_tso_client(booted.addr).await;
+    (booted, client)
 }
 
 /// TLS-aware counterpart to [`wait_for_grpc_handshake`]. Probes the server

--- a/crates/tsoracle-server/tests/lease_api.rs
+++ b/crates/tsoracle-server/tests/lease_api.rs
@@ -37,7 +37,7 @@ use tsoracle_proto::v1::{
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::{InMemoryDriver, MockClock};
 use tsoracle_server::test_support::{
-    boot_server, wait_for_grpc_handshake, wait_until_not_serving, wait_until_serving,
+    boot_leader_server, wait_until_not_serving, wait_until_serving,
 };
 
 const START_MS: u64 = 1_000_000;
@@ -58,16 +58,7 @@ async fn boot_leader(
         .failover_advance(Duration::from_millis(200))
         .build()
         .unwrap();
-    let mut booted = boot_server(server).await;
-    driver.become_leader(epoch);
-    wait_until_serving(&mut booted.state_rx).await;
-    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
-        .await
-        .unwrap();
-    let client = TsoServiceClient::connect(format!("http://{}", booted.addr))
-        .await
-        .unwrap();
-    (booted, client)
+    boot_leader_server(server, || driver.become_leader(epoch)).await
 }
 
 fn acquire_req(holder: &[u8], holder_epoch: u64, ttl_ms: u64) -> AcquireLeaseRequest {
@@ -418,15 +409,7 @@ async fn failed_lease_persist_fails_the_rpc_without_committing() {
         .failover_advance(Duration::from_millis(200))
         .build()
         .unwrap();
-    let mut booted = boot_server(server).await;
-    driver.become_leader(Epoch(1));
-    wait_until_serving(&mut booted.state_rx).await;
-    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
-        .await
-        .unwrap();
-    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
-        .await
-        .unwrap();
+    let (booted, mut client) = boot_leader_server(server, || driver.become_leader(Epoch(1))).await;
 
     driver.fail_leases(true);
     assert_eq!(

--- a/crates/tsoracle-server/tests/safe_frontier.rs
+++ b/crates/tsoracle-server/tests/safe_frontier.rs
@@ -31,7 +31,7 @@ use tsoracle_proto::v1::{
 };
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::{InMemoryDriver, MockClock};
-use tsoracle_server::test_support::{boot_server, wait_for_grpc_handshake, wait_until_serving};
+use tsoracle_server::test_support::{boot_leader_server, boot_server, connect_tso_client};
 
 const START_MS: u64 = 1_000_000;
 
@@ -49,16 +49,7 @@ async fn boot_leader(
         .failover_advance(Duration::from_millis(200))
         .build()
         .unwrap();
-    let mut booted = boot_server(server).await;
-    driver.become_leader(Epoch(1));
-    wait_until_serving(&mut booted.state_rx).await;
-    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
-        .await
-        .unwrap();
-    let client = TsoServiceClient::connect(format!("http://{}", booted.addr))
-        .await
-        .unwrap();
-    (booted, client)
+    boot_leader_server(server, || driver.become_leader(Epoch(1))).await
 }
 
 fn acquire_req(holder: &[u8], holder_epoch: u64, ttl_ms: u64) -> AcquireLeaseRequest {
@@ -88,12 +79,7 @@ async fn follower_returns_zero_frontier_and_zero_epoch() {
         .build()
         .unwrap();
     let booted = boot_server(server).await;
-    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
-        .await
-        .unwrap();
-    let mut client = TsoServiceClient::connect(format!("http://{}", booted.addr))
-        .await
-        .unwrap();
+    let mut client = connect_tso_client(booted.addr).await;
 
     let resp = client
         .get_safe_frontier(GetSafeFrontierRequest {})

--- a/crates/tsoracle-tests/tests/client_lease.rs
+++ b/crates/tsoracle-tests/tests/client_lease.rs
@@ -29,7 +29,7 @@ use tsoracle_client::{Client, ClientError};
 use tsoracle_core::Epoch;
 use tsoracle_server::Server;
 use tsoracle_server::test_fakes::{InMemoryDriver, MockClock};
-use tsoracle_server::test_support::{boot_server, wait_for_grpc_handshake, wait_until_serving};
+use tsoracle_server::test_support::boot_leader_server;
 
 const START_MS: u64 = 1_000_000;
 
@@ -47,12 +47,8 @@ async fn boot_client() -> (
         .failover_advance(Duration::from_millis(200))
         .build()
         .unwrap();
-    let mut booted = boot_server(server).await;
-    driver.become_leader(Epoch(1));
-    wait_until_serving(&mut booted.state_rx).await;
-    wait_for_grpc_handshake(booted.addr, Duration::from_secs(5))
-        .await
-        .unwrap();
+    let (booted, _proto_client) =
+        boot_leader_server(server, || driver.become_leader(Epoch(1))).await;
     let client = Client::connect(vec![format!("http://{}", booted.addr)])
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- Share dense/lease durable-record framing while preserving the TSOD and TSOO byte layouts.
- Reuse the dense/lease atomic framed-file write path and keep existing failpoint names.
- Consolidate client control-plane RPC envelope handling, lease serving-flow persist helpers, and lease test boot helpers.

Closes #662

## Tests
- cargo test -p tsoracle-driver-file --all-features record
- cargo test -p tsoracle-client --all-features
- cargo test -p tsoracle-server --all-features --test lease_api --test safe_frontier
- cargo test -p tsoracle-tests --test client_lease
- python3 scripts/check-ts-header.py crates/tsoracle-driver-file/src/framed_record.rs
- CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh
- cargo test -p tsoracle-driver-file --all-features --test dense_failpoints --test failpoints
- cargo clippy -p tsoracle-driver-file -p tsoracle-client -p tsoracle-server -p tsoracle-tests --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- pre-commit: cargo fmt --check
- pre-commit: cargo clippy