### PR TITLE
feat(openraft): upgrade to alpha.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,9 +1798,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40148cf75ead81993d5910bc72275e542e4e01a90241bf1905236843fe3009d"
+checksum = "4508198f563f7a088cfb1aababd875bccfccdbee61aea54b871a49adb867002e"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -1802,7 +1811,7 @@ dependencies = [
  "derive_more",
  "display-more",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "maplit",
  "openraft-macros",
  "openraft-rt",
@@ -1818,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec23cd291c763fb17d8dabf7cc4eacaefd45d02e52a4df88ce50c702f030689"
+checksum = "f364deb4022e81b5fb1425e78b7600144ca87abb22af5c53a1b49adf2b673dcf"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -1831,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c2d12e376df204612bb2016d652ea2d48b8edeaa04263facbe2fc7a11e3ef"
+checksum = "f231fdc5b4419530a5b374da49ecb2b52efc401446aa2138937bde7b7590c293"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1844,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8c01f2a456a864282bc4eaf76f1f78ab040d80416fd30fd15b8ab88faa337a"
+checksum = "0bdb85613581297e2bf55a6ee713c0066aeb30fb404cccd5ef0d177e1cb0e879"
 dependencies = [
  "futures-util",
  "openraft-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ tonic-prost-build  = "0.14"
 tonic-reflection   = "0.14"
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-openraft           = { version = "0.10.0-alpha.21", features = ["serde", "type-alias"] }
+openraft           = { version = "0.10.0-alpha.29", features = ["serde", "type-alias"] }
 rocksdb            = { version = "0.24", default-features = false, features = ["lz4"] }
 
 [profile.release]

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -71,7 +71,7 @@ use crate::type_config::{ApplyOutcome, HighWaterApplied, TypeConfig};
 
 type LogId = LogIdOf<TypeConfig>;
 type SnapMeta = SnapshotMetaOf<TypeConfig>;
-type SnapOf = SnapshotOf<TypeConfig>;
+type SnapOf = SnapshotOf<TypeConfig, Cursor<Vec<u8>>>;
 type SnapData = Cursor<Vec<u8>>;
 type StoredMem = StoredMembershipOf<TypeConfig>;
 
@@ -535,6 +535,8 @@ impl HighWaterStateMachine {
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
+    type SnapshotData = Cursor<Vec<u8>>;
+
     async fn build_snapshot(&mut self) -> Result<SnapOf, io::Error> {
         // Build the payload + meta under the lock, then release it before
         // calling the store: `SnapshotStore::save` may do disk I/O (rocksdb
@@ -587,6 +589,7 @@ impl RaftSnapshotBuilder<TypeConfig> for HighWaterStateMachine {
 }
 
 impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
+    type SnapshotData = Cursor<Vec<u8>>;
     type SnapshotBuilder = Self;
 
     async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMem), io::Error> {

--- a/crates/tsoracle-driver-openraft/src/type_config.rs
+++ b/crates/tsoracle-driver-openraft/src/type_config.rs
@@ -27,8 +27,6 @@
 //! inherits the toolkit's defaults (`NodeId = u64`, `Term = u64`, `LeaderId =
 //! leader_id_adv::LeaderId<u64, u64>`, `Responder = OneshotResponder`).
 
-use std::io::Cursor;
-
 use serde::{Deserialize, Serialize};
 use tsoracle_core::PeerEndpoint;
 use tsoracle_openraft_toolkit::declare_raft_types_ext;
@@ -164,7 +162,6 @@ declare_raft_types_ext! {
         Node            = OpenraftPeer,
         AppData         = HighWaterCommand,
         AppDataResponse = HighWaterApplied,
-        SnapshotData    = Cursor<Vec<u8>>,
 }
 
 /// The concrete raft log entry for this type config, as decoded from the log

--- a/crates/tsoracle-driver-openraft/tests/common/mod.rs
+++ b/crates/tsoracle-driver-openraft/tests/common/mod.rs
@@ -120,6 +120,8 @@ pub struct UnreachablePeer {
 }
 
 impl RaftNetworkV2<TypeConfig> for UnreachablePeer {
+    type SnapshotData = std::io::Cursor<Vec<u8>>;
+
     async fn append_entries(
         &mut self,
         _rpc: AppendEntriesRequest<TypeConfig>,
@@ -145,7 +147,7 @@ impl RaftNetworkV2<TypeConfig> for UnreachablePeer {
     async fn full_snapshot(
         &mut self,
         _vote: VoteOf<TypeConfig>,
-        _snapshot: SnapshotOf<TypeConfig>,
+        _snapshot: SnapshotOf<TypeConfig, Self::SnapshotData>,
         _cancel: impl std::future::Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
     ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {

--- a/crates/tsoracle-openraft-toolkit/src/codec_provider.rs
+++ b/crates/tsoracle-openraft-toolkit/src/codec_provider.rs
@@ -138,7 +138,6 @@ mod tests {
             Node            = ProbePeer,
             AppData         = ProbeData,
             AppDataResponse = ProbeApplied,
-            SnapshotData    = std::io::Cursor<Vec<u8>>,
     }
 
     #[test]

--- a/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/meta.rs
@@ -161,7 +161,6 @@ mod tests {
             Node            = MetaPeer,
             AppData         = MetaData,
             AppDataResponse = MetaApplied,
-            SnapshotData    = std::io::Cursor<Vec<u8>>,
     }
 
     #[test]

--- a/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/src/log_store/mod.rs
@@ -730,7 +730,6 @@ mod record_codec_tests {
             Node            = RecPeer,
             AppData         = RecData,
             AppDataResponse = RecApplied,
-            SnapshotData    = std::io::Cursor<Vec<u8>>,
     }
 
     type RecEntry = openraft::type_config::alias::EntryOf<RecConfig>;
@@ -805,7 +804,6 @@ mod active_write_version_wiring_tests {
             Node            = WirePeer,
             AppData         = WireData,
             AppDataResponse = WireApplied,
-            SnapshotData    = std::io::Cursor<Vec<u8>>,
     }
 
     fn open_empty_store() -> (

--- a/crates/tsoracle-openraft-toolkit/src/macros.rs
+++ b/crates/tsoracle-openraft-toolkit/src/macros.rs
@@ -24,12 +24,15 @@
 //! Macros for declaring an openraft `RaftTypeConfig` with sensible defaults.
 //!
 //! Consumers supply only the slots that actually vary (`Node`, `AppData`,
-//! `AppDataResponse`, `SnapshotData`, optionally `NodeId`/`Entry`/`AsyncRuntime`/
-//! `Responder`); everything else is inherited from the defaults below.
+//! `AppDataResponse`, optionally `NodeId`/`Entry`/`AsyncRuntime`/`Responder`);
+//! everything else is inherited from the defaults below. Snapshot data is
+//! associated with openraft's state-machine and network traits rather than
+//! `RaftTypeConfig`. The legacy `SnapshotData` slot is still accepted and
+//! ignored so existing macro invocations can migrate independently.
 //!
 //! # Why a direct trait impl instead of wrapping `openraft::declare_raft_types!`
 //!
-//! openraft 0.10.0-alpha.20's `declare_raft_types!` macro does not accept a
+//! openraft 0.10.0-alpha.29's `declare_raft_types!` macro does not accept a
 //! `Responder<T> = ...` override — its `Responder<T>` slot has a `where` clause
 //! that the macro's `$type_id:ident = $type:ty` entry grammar can't express.
 //! The openraft test file (`raft/declare_raft_types_test.rs`) calls this out
@@ -52,8 +55,6 @@
 ///   `Clone + Default + Eq + PartialEq + Debug + Serialize + DeserializeOwned + Send + Sync + 'static`)
 /// - `AppData` — log entry payload (openraft's `D`)
 /// - `AppDataResponse` — state-machine apply result (openraft's `R`)
-/// - `SnapshotData` — snapshot wire format (must satisfy openraft's
-///   `AsyncRead + AsyncSeek + AsyncWrite + Unpin + Send + 'static`)
 ///
 /// Optional overrides:
 /// - `NodeId` (default `u64`)
@@ -64,6 +65,9 @@
 ///   where `C` and `T` are the GAT's in-scope `Self` and `T` (i.e. write the
 ///   override as `openraft::impls::OneshotResponder<Self, T>`). Default
 ///   `openraft::impls::OneshotResponder<Self, T>`.
+/// - `SnapshotData` — deprecated compatibility slot; snapshot data is now
+///   declared on `RaftStateMachine`, `RaftSnapshotBuilder`, and
+///   `RaftNetworkV2`.
 ///
 /// Inherited (non-overridable) defaults:
 /// - `Term = u64`
@@ -83,7 +87,6 @@
 ///         Node            = MyPeer,
 ///         AppData         = MyLogEntry,
 ///         AppDataResponse = MyAppliedState,
-///         SnapshotData    = std::io::Cursor<Vec<u8>>,
 /// }
 /// ```
 #[macro_export]
@@ -95,7 +98,7 @@ macro_rules! declare_raft_types_ext {
         $( Entry           = $entry:ty , )?
         AppData            = $app_data:ty ,
         AppDataResponse    = $app_resp:ty ,
-        SnapshotData       = $snap:ty ,
+        $( SnapshotData    = $snap:ty , )?
         $( AsyncRuntime    = $runtime:ty , )?
         $( Responder       = $responder:ty , )?
     ) => {
@@ -111,7 +114,6 @@ macro_rules! declare_raft_types_ext {
             type LeaderId     = ::openraft::impls::leader_id_adv::LeaderId<Self::Term, Self::NodeId>;
             type Vote         = ::openraft::impls::Vote<Self::LeaderId>;
             type Entry        = $crate::__first_or_default_entry!($( $entry, )?);
-            type SnapshotData = $snap;
             type AsyncRuntime = $crate::__first_or_default_runtime!($( $runtime, )?);
             type Responder<T>
                 = $crate::__first_or_default_responder!($( $responder, )?)

--- a/crates/tsoracle-openraft-toolkit/src/test_fakes/mem_network.rs
+++ b/crates/tsoracle-openraft-toolkit/src/test_fakes/mem_network.rs
@@ -39,7 +39,7 @@ use openraft::error::{
 use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
 use openraft::raft::{
     AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, TransferLeaderRequest,
-    VoteRequest, VoteResponse,
+    TransferLeaderResponse, VoteRequest, VoteResponse,
 };
 use openraft::storage::RaftStateMachine;
 use openraft::type_config::alias::{SnapshotOf, VoteOf};
@@ -50,7 +50,7 @@ use crate::test_fakes::partition::PartitionController;
 /// Receiver-side dispatch trait. Wraps a concrete `Raft<C, SM>` so the
 /// network registry doesn't need to be parameterized over `SM`.
 #[async_trait]
-trait RaftAdapter<C: RaftTypeConfig>: Send + Sync + 'static {
+trait RaftAdapter<C: RaftTypeConfig, SD: OptionalSend + 'static>: Send + Sync + 'static {
     async fn append_entries(
         &self,
         req: AppendEntriesRequest<C>,
@@ -61,18 +61,23 @@ trait RaftAdapter<C: RaftTypeConfig>: Send + Sync + 'static {
     async fn install_full_snapshot(
         &self,
         vote: VoteOf<C>,
-        snapshot: SnapshotOf<C>,
+        snapshot: SnapshotOf<C, SD>,
     ) -> Result<SnapshotResponse<C>, Fatal<C>>;
 
-    async fn transfer_leader(&self, req: TransferLeaderRequest<C>) -> Result<(), Fatal<C>>;
+    async fn transfer_leader(
+        &self,
+        req: TransferLeaderRequest<C>,
+    ) -> Result<TransferLeaderResponse<C>, Fatal<C>>;
 }
+
+type RaftAdapterHandle<C, SD> = Arc<dyn RaftAdapter<C, SD>>;
 
 struct RaftHandle<C: RaftTypeConfig, SM: RaftStateMachine<C>> {
     raft: Raft<C, SM>,
 }
 
 #[async_trait]
-impl<C, SM> RaftAdapter<C> for RaftHandle<C, SM>
+impl<C, SM> RaftAdapter<C, SM::SnapshotData> for RaftHandle<C, SM>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C> + 'static,
@@ -91,25 +96,30 @@ where
     async fn install_full_snapshot(
         &self,
         vote: VoteOf<C>,
-        snapshot: SnapshotOf<C>,
+        snapshot: SnapshotOf<C, SM::SnapshotData>,
     ) -> Result<SnapshotResponse<C>, Fatal<C>> {
         self.raft.install_full_snapshot(vote, snapshot).await
     }
 
-    async fn transfer_leader(&self, req: TransferLeaderRequest<C>) -> Result<(), Fatal<C>> {
+    async fn transfer_leader(
+        &self,
+        req: TransferLeaderRequest<C>,
+    ) -> Result<TransferLeaderResponse<C>, Fatal<C>> {
         self.raft.handle_transfer_leader(req).await
     }
 }
 
 /// In-memory network registry. One per cluster.
-pub struct MemNetwork<C: RaftTypeConfig> {
-    nodes: RwLock<HashMap<C::NodeId, Arc<dyn RaftAdapter<C>>>>,
+pub struct MemNetwork<C: RaftTypeConfig, SD: OptionalSend + 'static = std::io::Cursor<Vec<u8>>> {
+    nodes: RwLock<HashMap<C::NodeId, RaftAdapterHandle<C, SD>>>,
     partitions: Arc<PartitionController<C::NodeId>>,
 }
 
-impl<C: RaftTypeConfig> MemNetwork<C>
+impl<C, SD> MemNetwork<C, SD>
 where
+    C: RaftTypeConfig,
     C::NodeId: Copy,
+    SD: OptionalSend + 'static,
 {
     /// Build a fresh, empty in-memory network with no peers registered and no
     /// partitions installed.
@@ -123,7 +133,7 @@ where
     /// Mint a `RaftNetworkFactory` whose `new_client` calls will route to peers
     /// registered on this network, tagging outgoing RPCs as originating from
     /// `self_id`.
-    pub fn factory_for(self: &Arc<Self>, self_id: C::NodeId) -> MemNetworkFactory<C> {
+    pub fn factory_for(self: &Arc<Self>, self_id: C::NodeId) -> MemNetworkFactory<C, SD> {
         MemNetworkFactory {
             net: Arc::clone(self),
             self_id,
@@ -134,9 +144,9 @@ where
     /// factory to `id` dispatch into this handle.
     pub fn register<SM>(&self, id: C::NodeId, raft: Raft<C, SM>)
     where
-        SM: RaftStateMachine<C> + 'static,
+        SM: RaftStateMachine<C, SnapshotData = SD> + 'static,
     {
-        let handle: Arc<dyn RaftAdapter<C>> = Arc::new(RaftHandle { raft });
+        let handle: RaftAdapterHandle<C, SD> = Arc::new(RaftHandle { raft });
         self.nodes.write().unwrap().insert(id, handle);
     }
 
@@ -146,23 +156,28 @@ where
         Arc::clone(&self.partitions)
     }
 
-    fn dispatch(&self, target: &C::NodeId) -> Option<Arc<dyn RaftAdapter<C>>> {
+    fn dispatch(&self, target: &C::NodeId) -> Option<RaftAdapterHandle<C, SD>> {
         self.nodes.read().unwrap().get(target).cloned()
     }
 }
 
 /// Factory handed to `Raft::new`. One per node; carries the node's own id so
 /// partition checks know which side of the wire the RPC is leaving from.
-pub struct MemNetworkFactory<C: RaftTypeConfig> {
-    net: Arc<MemNetwork<C>>,
+pub struct MemNetworkFactory<
+    C: RaftTypeConfig,
+    SD: OptionalSend + 'static = std::io::Cursor<Vec<u8>>,
+> {
+    net: Arc<MemNetwork<C, SD>>,
     self_id: C::NodeId,
 }
 
-impl<C: RaftTypeConfig> RaftNetworkFactory<C> for MemNetworkFactory<C>
+impl<C, SD> RaftNetworkFactory<C> for MemNetworkFactory<C, SD>
 where
+    C: RaftTypeConfig,
     C::NodeId: Copy,
+    SD: OptionalSend + 'static,
 {
-    type Network = MemNetworkPeer<C>;
+    type Network = MemNetworkPeer<C, SD>;
 
     async fn new_client(&mut self, target: C::NodeId, _node: &C::Node) -> Self::Network {
         MemNetworkPeer {
@@ -175,16 +190,21 @@ where
 
 /// Per-target client. Looks the target up in the shared registry on every RPC
 /// so a node can be reopened mid-test and have its replacement picked up.
-pub struct MemNetworkPeer<C: RaftTypeConfig> {
-    net: Arc<MemNetwork<C>>,
+pub struct MemNetworkPeer<C: RaftTypeConfig, SD: OptionalSend + 'static = std::io::Cursor<Vec<u8>>>
+{
+    net: Arc<MemNetwork<C, SD>>,
     from: C::NodeId,
     to: C::NodeId,
 }
 
-impl<C: RaftTypeConfig> RaftNetworkV2<C> for MemNetworkPeer<C>
+impl<C, SD> RaftNetworkV2<C> for MemNetworkPeer<C, SD>
 where
+    C: RaftTypeConfig,
     C::NodeId: Copy,
+    SD: OptionalSend + 'static,
 {
+    type SnapshotData = SD;
+
     async fn append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
@@ -236,7 +256,7 @@ where
     async fn full_snapshot(
         &mut self,
         vote: VoteOf<C>,
-        snapshot: SnapshotOf<C>,
+        snapshot: SnapshotOf<C, Self::SnapshotData>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
@@ -266,7 +286,7 @@ where
         &mut self,
         req: TransferLeaderRequest<C>,
         _option: RPCOption,
-    ) -> Result<(), RPCError<C>> {
+    ) -> Result<TransferLeaderResponse<C>, RPCError<C>> {
         if !self.net.partitions.is_reachable(self.from, self.to) {
             return Err(RPCError::Network(NetworkError::from_string(format!(
                 "mem-network: partitioned {:?} -> {:?}",

--- a/crates/tsoracle-openraft-toolkit/tests/common/mod.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/common/mod.rs
@@ -52,7 +52,6 @@ declare_raft_types_ext! {
         Node            = TestPeer,
         AppData         = TestAppData,
         AppDataResponse = TestAppliedState,
-        SnapshotData    = std::io::Cursor<Vec<u8>>,
 }
 
 /// Concrete `LeaderId` / `CommittedLeaderId` type used by `TestTypeConfig`.

--- a/crates/tsoracle-openraft-toolkit/tests/log_store_conformance.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/log_store_conformance.rs
@@ -23,7 +23,7 @@
 
 #![cfg(feature = "rocksdb-log-store")]
 
-//! Drives openraft 0.10.0-alpha.20's bundled `Suite::test_all` against the
+//! Drives openraft 0.10.0-alpha.29's bundled `Suite::test_all` against the
 //! rocksdb-backed [`RocksdbLogStore`].
 //!
 //! The bundled suite tests `RaftLogStorage` and `RaftStateMachine` together
@@ -74,7 +74,7 @@ fn err_src(msg: impl ToString) -> <TestTypeConfig as RaftTypeConfig>::ErrorSourc
 
 type TestLogId = LogIdOf<TestTypeConfig>;
 type TestSnapshotMeta = SnapshotMetaOf<TestTypeConfig>;
-type TestSnapshot = SnapshotOf<TestTypeConfig>;
+type TestSnapshot = SnapshotOf<TestTypeConfig, Cursor<Vec<u8>>>;
 type TestStoredMembership = StoredMembershipOf<TestTypeConfig>;
 
 #[derive(Clone, Default)]
@@ -104,6 +104,7 @@ struct SnapshotPayload {
 }
 
 impl RaftStateMachine<TestTypeConfig> for StubStateMachine {
+    type SnapshotData = Cursor<Vec<u8>>;
     type SnapshotBuilder = Self;
 
     async fn applied_state(
@@ -173,6 +174,8 @@ impl RaftStateMachine<TestTypeConfig> for StubStateMachine {
 }
 
 impl RaftSnapshotBuilder<TestTypeConfig> for StubStateMachine {
+    type SnapshotData = Cursor<Vec<u8>>;
+
     async fn build_snapshot(&mut self) -> Result<TestSnapshot, io::Error> {
         let mut s = self.state.lock().unwrap();
         s.snapshot_counter += 1;

--- a/crates/tsoracle-openraft-toolkit/tests/macro_smoke.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/macro_smoke.rs
@@ -55,7 +55,6 @@ declare_raft_types_ext! {
         Node            = TestPeer,
         AppData         = TestAppData,
         AppDataResponse = TestAppliedState,
-        SnapshotData    = std::io::Cursor<Vec<u8>>,
 }
 
 // Same config with every optional override exercised, to confirm the override

--- a/crates/tsoracle-openraft-toolkit/tests/mem_network_negative.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/mem_network_negative.rs
@@ -52,7 +52,7 @@ fn new_peer_targeting(
     net: &Arc<MemNetwork<TestTypeConfig>>,
     from: u64,
     to: u64,
-) -> impl RaftNetworkV2<TestTypeConfig> {
+) -> impl RaftNetworkV2<TestTypeConfig, SnapshotData = std::io::Cursor<Vec<u8>>> {
     let mut factory = net.factory_for(from);
     futures::executor::block_on(factory.new_client(
         to,
@@ -66,7 +66,7 @@ fn sample_vote() -> VoteOf<TestTypeConfig> {
     Vote::new(1, 1)
 }
 
-fn sample_snapshot() -> SnapshotOf<TestTypeConfig> {
+fn sample_snapshot() -> SnapshotOf<TestTypeConfig, std::io::Cursor<Vec<u8>>> {
     Snapshot {
         meta: SnapshotMeta::default(),
         snapshot: std::io::Cursor::new(Vec::new()),

--- a/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
@@ -61,12 +61,11 @@ declare_raft_types_ext! {
         Node            = SmokeNode,
         AppData         = SmokeCmd,
         AppDataResponse = SmokeApplied,
-        SnapshotData    = std::io::Cursor<Vec<u8>>,
 }
 
 type LogId = LogIdOf<SmokeConfig>;
 type SnapMeta = SnapshotMetaOf<SmokeConfig>;
-type SnapOf = SnapshotOf<SmokeConfig>;
+type SnapOf = SnapshotOf<SmokeConfig, std::io::Cursor<Vec<u8>>>;
 type StoredMem = StoredMembershipOf<SmokeConfig>;
 
 #[derive(Clone)]
@@ -103,6 +102,8 @@ impl Default for SmokeStateMachine {
 }
 
 impl RaftSnapshotBuilder<SmokeConfig> for SmokeStateMachine {
+    type SnapshotData = std::io::Cursor<Vec<u8>>;
+
     async fn build_snapshot(&mut self) -> Result<SnapOf, io::Error> {
         let core = self.core.lock();
         let meta = SnapMeta {
@@ -120,6 +121,7 @@ impl RaftSnapshotBuilder<SmokeConfig> for SmokeStateMachine {
 }
 
 impl RaftStateMachine<SmokeConfig> for SmokeStateMachine {
+    type SnapshotData = std::io::Cursor<Vec<u8>>;
     type SnapshotBuilder = Self;
 
     async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMem), io::Error> {

--- a/crates/tsoracle-standalone/src/drivers/openraft/handoff.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/handoff.rs
@@ -36,6 +36,7 @@ use std::time::Duration;
 
 use openraft::Raft;
 use openraft::async_runtime::watch::WatchReceiver;
+use openraft::storage::RaftStateMachine;
 
 use tsoracle_driver_openraft::TypeConfig;
 
@@ -70,7 +71,7 @@ pub(crate) fn pick_handoff_target(
 /// error or timeout falls through to a normal drain.
 pub(crate) async fn graceful_leader_handoff<SM>(raft: &Raft<TypeConfig, SM>, me: NodeId)
 where
-    SM: Send + Sync + 'static,
+    SM: RaftStateMachine<TypeConfig> + Send + Sync + 'static,
 {
     if raft.current_leader().await != Some(me) {
         return;

--- a/crates/tsoracle-standalone/src/drivers/openraft/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/network.rs
@@ -50,8 +50,9 @@ use openraft::errors::ReplicationClosed;
 use openraft::network::{RPCOption, RaftNetworkFactory, RaftNetworkV2};
 use openraft::raft::{
     AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, TransferLeaderRequest,
-    VoteRequest, VoteResponse,
+    TransferLeaderResponse, VoteRequest, VoteResponse,
 };
+use openraft::storage::RaftStateMachine;
 use openraft::type_config::alias::{SnapshotOf, VoteOf};
 use tokio::sync::Mutex;
 use tonic::transport::{Channel, ClientTlsConfig};
@@ -376,6 +377,8 @@ impl PeerNetwork {
 }
 
 impl RaftNetworkV2<TypeConfig> for PeerNetwork {
+    type SnapshotData = Cursor<Vec<u8>>;
+
     async fn append_entries(
         &mut self,
         rpc: AppendEntriesRequest<TypeConfig>,
@@ -411,13 +414,11 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
         &mut self,
         req: TransferLeaderRequest<TypeConfig>,
         option: RPCOption,
-    ) -> Result<(), RPCError<TypeConfig>> {
+    ) -> Result<TransferLeaderResponse<TypeConfig>, RPCError<TypeConfig>> {
         let mut c = self.client().await?;
         let payload =
             postcard::to_stdvec(&req).map_err(|err| RPCError::Network(NetworkError::new(&err)))?;
-        // The reply payload is empty by contract; we only care that the RPC
-        // landed within the deadline.
-        unary_call(
+        let reply = unary_call(
             &self.pool,
             self.target,
             &self.addr,
@@ -428,7 +429,9 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
             }),
         )
         .await?;
-        Ok(())
+        let response = postcard::from_bytes(&reply.payload)
+            .map_err(|err| RPCError::Network(NetworkError::new(&err)))?;
+        Ok(response)
     }
 
     async fn vote(
@@ -469,7 +472,7 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
     async fn full_snapshot(
         &mut self,
         vote: VoteOf<TypeConfig>,
-        snapshot: SnapshotOf<TypeConfig>,
+        snapshot: SnapshotOf<TypeConfig, Self::SnapshotData>,
         cancel: impl Future<Output = ReplicationClosed> + openraft::OptionalSend + 'static,
         _option: RPCOption,
     ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {
@@ -541,13 +544,19 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
 // PeerServiceImpl — tonic server, demuxes RaftMessage → Raft API calls.
 // ---------------------------------------------------------------------------
 
-pub struct PeerServiceImpl<SM = ()> {
+pub struct PeerServiceImpl<SM>
+where
+    SM: RaftStateMachine<TypeConfig, SnapshotData = Cursor<Vec<u8>>>,
+{
     pub raft: openraft::Raft<TypeConfig, SM>,
     pub active_write_version: WriteVersionSource,
 }
 
 #[tonic::async_trait]
-impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
+impl<SM> RaftPeerService for PeerServiceImpl<SM>
+where
+    SM: RaftStateMachine<TypeConfig, SnapshotData = Cursor<Vec<u8>>> + Send + Sync + 'static,
+{
     async fn append_entries(
         &self,
         request: tonic::Request<RaftMessage>,
@@ -601,12 +610,15 @@ impl<SM: Send + Sync + 'static> RaftPeerService for PeerServiceImpl<SM> {
             .map_err(tonic::Status::invalid_argument)?;
         let body: TransferLeaderRequest<TypeConfig> = postcard::from_bytes(&message.payload)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
-        self.raft
+        let response = self
+            .raft
             .handle_transfer_leader(body)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
+        let payload =
+            postcard::to_stdvec(&response).map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(tonic::Response::new(RaftMessage {
-            payload: Vec::new(),
+            payload,
             format_version: wire::stamp((self.active_write_version)()),
         }))
     }
@@ -761,10 +773,13 @@ where
 /// `active_write_version` source is consulted to stamp `format_version` on
 /// every response body (read per-RPC so a future activation flip is picked up
 /// live).
-pub fn server<SM: Send + Sync + 'static>(
+pub fn server<SM>(
     raft: openraft::Raft<TypeConfig, SM>,
     active_write_version: WriteVersionSource,
-) -> RaftPeerServiceServer<PeerServiceImpl<SM>> {
+) -> RaftPeerServiceServer<PeerServiceImpl<SM>>
+where
+    SM: RaftStateMachine<TypeConfig, SnapshotData = Cursor<Vec<u8>>> + Send + Sync + 'static,
+{
     RaftPeerServiceServer::new(PeerServiceImpl {
         raft,
         active_write_version,

--- a/examples/openraft-piggyback/src/host_service.rs
+++ b/examples/openraft-piggyback/src/host_service.rs
@@ -105,7 +105,6 @@ declare_raft_types_ext! {
         Node            = HostPeer,
         AppData         = HostCommand,
         AppDataResponse = HostApplied,
-        SnapshotData    = Cursor<Vec<u8>>,
 }
 
 // ---------- Snapshot payload ----------
@@ -181,7 +180,11 @@ impl HostStateMachine {
 }
 
 impl RaftSnapshotBuilder<HostTypeConfig> for HostStateMachine {
-    async fn build_snapshot(&mut self) -> Result<SnapshotOf<HostTypeConfig>, io::Error> {
+    type SnapshotData = Cursor<Vec<u8>>;
+
+    async fn build_snapshot(
+        &mut self,
+    ) -> Result<SnapshotOf<HostTypeConfig, Self::SnapshotData>, io::Error> {
         let (bytes, meta) = {
             let mut core = self.core.lock();
             core.snapshot_idx += 1;
@@ -211,6 +214,7 @@ impl RaftSnapshotBuilder<HostTypeConfig> for HostStateMachine {
 }
 
 impl RaftStateMachine<HostTypeConfig> for HostStateMachine {
+    type SnapshotData = Cursor<Vec<u8>>;
     type SnapshotBuilder = Self;
 
     async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMem), io::Error> {
@@ -350,7 +354,7 @@ impl RaftStateMachine<HostTypeConfig> for HostStateMachine {
 
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<SnapshotOf<HostTypeConfig>>, io::Error> {
+    ) -> Result<Option<SnapshotOf<HostTypeConfig, Self::SnapshotData>>, io::Error> {
         let core = self.core.lock();
         Ok(core
             .current_snapshot

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -891,6 +891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,9 +1054,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40148cf75ead81993d5910bc72275e542e4e01a90241bf1905236843fe3009d"
+checksum = "4508198f563f7a088cfb1aababd875bccfccdbee61aea54b871a49adb867002e"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -1058,7 +1067,7 @@ dependencies = [
  "derive_more",
  "display-more",
  "futures-util",
- "itertools",
+ "itertools 0.15.0",
  "maplit",
  "openraft-macros",
  "openraft-rt",
@@ -1074,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec23cd291c763fb17d8dabf7cc4eacaefd45d02e52a4df88ce50c702f030689"
+checksum = "f364deb4022e81b5fb1425e78b7600144ca87abb22af5c53a1b49adf2b673dcf"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -1087,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c2d12e376df204612bb2016d652ea2d48b8edeaa04263facbe2fc7a11e3ef"
+checksum = "f231fdc5b4419530a5b374da49ecb2b52efc401446aa2138937bde7b7590c293"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1100,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8c01f2a456a864282bc4eaf76f1f78ab040d80416fd30fd15b8ab88faa337a"
+checksum = "0bdb85613581297e2bf55a6ee713c0066aeb30fb404cccd5ef0d177e1cb0e879"
 dependencies = [
  "futures-util",
  "openraft-rt",
@@ -1295,7 +1304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -1316,7 +1325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",


### PR DESCRIPTION
## Summary

- upgrade OpenRaft and its runtime crates from 0.10.0-alpha.21 to 0.10.0-alpha.29
- migrate snapshot data from RaftTypeConfig to the state-machine, snapshot-builder, and network associated types
- propagate the new transfer-leader response through the in-memory and gRPC transports
- retain the legacy SnapshotData macro slot as an ignored compatibility input

## Testing

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace --all-features
- cargo check --workspace --all-targets
- cargo check --manifest-path fuzz/Cargo.toml --all-targets
- cargo test -p tsoracle-openraft-toolkit --all-features
- cargo test -p tsoracle-driver-openraft -p tsoracle-standalone --all-features
- cargo test --workspace --all-features (one transient TLS smoke timeout; isolated retry passed)

## Release packaging

make release-dry-run packages and verifies the upgraded toolkit, then stops while verifying the driver because cargo publish resolves the already-published toolkit 1.2.0 macro. The release PR must bump and publish the toolkit and dependent OpenRaft crates together.