### PR TITLE
fix(server): register shutdown signals before startup readiness

### DIFF
--- a/crates/tsoracle-bin/src/main.rs
+++ b/crates/tsoracle-bin/src/main.rs
@@ -375,6 +375,11 @@ async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
         .with_env_filter(EnvFilter::try_new(&common.log).unwrap_or_else(|_| EnvFilter::new("info")))
         .init();
 
+    // Install the process signal handlers before bootstrap or listener
+    // readiness. The returned future retains signals received during startup
+    // until the server begins polling it.
+    let shutdown_signal = tsoracle_server::shutdown_signal();
+
     install_metrics_exporter(&common)?;
 
     let mut node: Standalone = tsoracle_standalone::build(cfg)
@@ -406,7 +411,7 @@ async fn run_serve(common: CommonServeArgs, cfg: DriverConfig) -> Result<()> {
     // transport failure (fail fast: a node whose peer/admin server died must
     // not keep running as a zombie).
     let fatal = node.fatal_signal();
-    let shutdown = wait_for_stop(tsoracle_server::shutdown_signal(), fatal.clone(), drain);
+    let shutdown = wait_for_stop(shutdown_signal, fatal.clone(), drain);
     let result = server
         .serve_with_listener(listener, shutdown)
         .await

--- a/crates/tsoracle-bin/tests/smoke.rs
+++ b/crates/tsoracle-bin/tests/smoke.rs
@@ -253,9 +253,8 @@ async fn sigterm_triggers_graceful_shutdown() {
     let binary_path = env!("CARGO_BIN_EXE_tsoracle");
     let state_dir = tempdir().unwrap();
 
-    // Wait until the SIGTERM handler is live: it is registered when the
-    // shutdown future is first polled, which happens once tonic is serving —
-    // i.e. by the time the listener is accepting connections.
+    // `run_serve` registers SIGTERM before bootstrap and before binding the
+    // listener, so TCP readiness also proves the handler is already live.
     let (mut child, _addrs) = retry_spawn(1, &[0], Duration::from_secs(10), |addrs| {
         let mut cmd = Command::new(binary_path);
         cmd.arg("serve")

--- a/crates/tsoracle-server/src/signal.rs
+++ b/crates/tsoracle-server/src/signal.rs
@@ -33,6 +33,10 @@
 /// kills the process mid-flight and a supervisor SIGKILLs it after the grace
 /// period. On non-unix targets only Ctrl-C is available.
 ///
+/// On Unix, calling this function installs both signal handlers synchronously,
+/// before the returned future is first polled. Call it before advertising
+/// process readiness so a shutdown request cannot race handler registration.
+///
 /// ```no_run
 /// # async fn run(server: tsoracle_server::Server) -> Result<(), tsoracle_server::ServerError> {
 /// let addr = "0.0.0.0:50551".parse().unwrap();
@@ -42,30 +46,54 @@
 /// # }
 /// ```
 #[cfg(unix)]
-pub async fn shutdown_signal() {
+pub fn shutdown_signal() -> impl std::future::Future<Output = ()> + Send + 'static {
     use tokio::signal::unix::{SignalKind, signal};
 
-    let mut sigterm = match signal(SignalKind::terminate()) {
-        Ok(stream) => stream,
-        Err(_error) => {
-            // Installing the SIGTERM handler only fails on resource exhaustion
-            // or an invalid signal — neither expected here. Degrade to Ctrl-C
-            // rather than refuse to shut down an otherwise-healthy node.
-            #[cfg(feature = "tracing")]
-            tracing::warn!(error = %_error, "could not install SIGTERM handler; only Ctrl-C will trigger shutdown");
-            let _ = tokio::signal::ctrl_c().await;
-            #[cfg(feature = "tracing")]
-            tracing::info!(signal = "SIGINT", "shutdown signal received");
-            return;
-        }
-    };
+    // `signal(...)` registers with Tokio synchronously. Keep both calls outside
+    // the async block so the default terminate-the-process dispositions are
+    // replaced before the returned future can be parked behind server startup.
+    let sigterm = signal(SignalKind::terminate());
+    let sigint = signal(SignalKind::interrupt());
 
-    let _signal_name = tokio::select! {
-        _ = tokio::signal::ctrl_c() => "SIGINT",
-        _ = sigterm.recv() => "SIGTERM",
-    };
-    #[cfg(feature = "tracing")]
-    tracing::info!(signal = _signal_name, "shutdown signal received");
+    async move {
+        let _signal_name = match (sigterm, sigint) {
+            (Ok(mut sigterm), Ok(mut sigint)) => {
+                tokio::select! {
+                    _ = sigint.recv() => "SIGINT",
+                    _ = sigterm.recv() => "SIGTERM",
+                }
+            }
+            (Ok(mut sigterm), Err(_sigint_error)) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    error = %_sigint_error,
+                    "could not install SIGINT handler; only SIGTERM will trigger shutdown"
+                );
+                let _ = sigterm.recv().await;
+                "SIGTERM"
+            }
+            (Err(_sigterm_error), Ok(mut sigint)) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    error = %_sigterm_error,
+                    "could not install SIGTERM handler; only SIGINT will trigger shutdown"
+                );
+                let _ = sigint.recv().await;
+                "SIGINT"
+            }
+            (Err(_sigterm_error), Err(_sigint_error)) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    sigterm_error = %_sigterm_error,
+                    sigint_error = %_sigint_error,
+                    "could not install SIGTERM or SIGINT handler"
+                );
+                std::future::pending::<&'static str>().await
+            }
+        };
+        #[cfg(feature = "tracing")]
+        tracing::info!(signal = _signal_name, "shutdown signal received");
+    }
 }
 
 /// Resolves when the process receives Ctrl-C. See the unix variant for the full

--- a/crates/tsoracle-server/tests/shutdown_signal_sigint.rs
+++ b/crates/tsoracle-server/tests/shutdown_signal_sigint.rs
@@ -34,16 +34,12 @@ use nix::sys::signal::{Signal, raise};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn shutdown_signal_resolves_on_sigint() {
-    let waiter = tokio::spawn(tsoracle_server::shutdown_signal());
-
-    // The `select!` polls `ctrl_c()` (SIGINT) on first poll, installing the
-    // handler that replaces the default terminate-the-process disposition. Wait
-    // for that before raising SIGINT.
-    tokio::time::sleep(Duration::from_millis(250)).await;
+    // As with SIGTERM, registration must happen when the future is constructed,
+    // not when it is first polled.
+    let waiter = tsoracle_server::shutdown_signal();
     raise(Signal::SIGINT).expect("raising SIGINT at our own process must succeed");
 
     tokio::time::timeout(Duration::from_secs(5), waiter)
         .await
-        .expect("shutdown_signal must resolve within 5s of SIGINT")
-        .expect("the shutdown_signal task must not panic");
+        .expect("shutdown_signal must resolve within 5s of SIGINT");
 }

--- a/crates/tsoracle-server/tests/shutdown_signal_sigterm.rs
+++ b/crates/tsoracle-server/tests/shutdown_signal_sigterm.rs
@@ -49,18 +49,13 @@ async fn shutdown_signal_resolves_on_sigterm() {
         .with_test_writer()
         .try_init();
 
-    let waiter = tokio::spawn(tsoracle_server::shutdown_signal());
-
-    // `shutdown_signal` installs the SIGTERM handler the first time the spawned
-    // task is polled — replacing the default "terminate the process"
-    // disposition. Wait until it is parked on the handler before raising the
-    // signal so the raise cannot kill the test process through the default
-    // disposition.
-    tokio::time::sleep(Duration::from_millis(250)).await;
+    // Construct but do not poll the future before raising SIGTERM. The helper
+    // must replace the default terminate-the-process disposition synchronously
+    // so a signal received during process startup is retained for later.
+    let waiter = tsoracle_server::shutdown_signal();
     raise(Signal::SIGTERM).expect("raising SIGTERM at our own process must succeed");
 
     tokio::time::timeout(Duration::from_secs(5), waiter)
         .await
-        .expect("shutdown_signal must resolve within 5s of SIGTERM")
-        .expect("the shutdown_signal task must not panic");
+        .expect("shutdown_signal must resolve within 5s of SIGTERM");
 }

--- a/examples/openraft-standalone/src/main.rs
+++ b/examples/openraft-standalone/src/main.rs
@@ -92,6 +92,7 @@ fn parse_members(input: &str) -> Result<BTreeMap<u64, MemberAddr>> {
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
     let cli = Cli::parse();
+    let shutdown_signal = tsoracle_server::shutdown_signal();
     let members = cli.members.as_deref().map(parse_members).transpose()?;
     let peer_tls = match (cli.peer_tls_cert, cli.peer_tls_key, cli.peer_tls_ca) {
         (None, None, None) => None,
@@ -122,7 +123,7 @@ async fn main() -> Result<()> {
         cli.id, cli.tso_addr
     );
     let shutdown = async move {
-        tsoracle_server::shutdown_signal().await;
+        shutdown_signal.await;
         if let Some(drain) = drain {
             drain.await;
         }

--- a/examples/paxos-standalone/src/main.rs
+++ b/examples/paxos-standalone/src/main.rs
@@ -57,6 +57,7 @@ struct Cli {
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
     let cli = Cli::parse();
+    let shutdown_signal = tsoracle_server::shutdown_signal();
     let peer_tls = match (cli.peer_tls_cert, cli.peer_tls_key, cli.peer_tls_ca) {
         (None, None, None) => None,
         (Some(cert), Some(key), Some(ca)) => Some(PeerTlsConfig { cert, key, ca }),
@@ -84,7 +85,7 @@ async fn main() -> Result<()> {
         cli.node_id, cli.tso_listen
     );
     let shutdown = async move {
-        tsoracle_server::shutdown_signal().await;
+        shutdown_signal.await;
         if let Some(drain) = drain {
             drain.await;
         }


### PR DESCRIPTION
## Summary

- install Unix SIGTERM and SIGINT handlers synchronously when `shutdown_signal()` is constructed, before its future is first polled
- construct the shutdown future before bootstrap and listener readiness in the CLI and standalone examples
- make the signal regression tests deliver signals before polling the future, removing the timing sleep that allowed the startup race
- fix the intermittent `sigterm_triggers_graceful_shutdown` failure observed in the [LeakSanitizer nightly](https://github.com/prisma-risk/tsoracle/actions/runs/29631555035/job/88046036278)

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the [DCO requirement](../CONTRIBUTING.md#developer-certificate-of-origin) (use `git commit -s`).
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (pre-commit hook)
- [x] `cargo test -p tsoracle-server -p tsoracle --all-features`
- [x] `cargo check -p tsoracle-server --no-default-features`
- [x] Run `sigterm_triggers_graceful_shutdown` 20 consecutive times

## Post-merge follow-ups

- [ ] Confirm the next scheduled `leak (nightly)` run on `main` completes without the SIGTERM smoke failure.