### PR TITLE
fix(deps): update h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,9 +1151,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Updates `h2` to 0.4.16, the patched release for **[RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258)**.

## The advisory

`h2` accepted and queued empty DATA frames without limit. A peer that opens a stream and never drains it can drive unbounded memory growth, or panic the process once the length overflows. Rated low severity; denial-of-service category. Patched in 0.4.16, with **no patched release on the 0.3 line**.

`h2` is transitive here — reached through `hyper` and the AWS smithy client, not declared directly — so the fix is a lockfile bump.