### PR TITLE
chore: bump toolchain to 1.96.1 and MSRV to 1.96

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25  # v2
         with:
-          rust-version: "1.88"
+          rust-version: "1.96"
 
   critical-path:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ default-members = [
 [workspace.package]
 version      = "1.0.0"
 edition      = "2024"
-rust-version = "1.88"
+rust-version = "1.96"
 license      = "Apache-2.0"
 repository   = "https://github.com/prisma-risk/tsoracle"
 homepage     = "https://github.com/prisma-risk/tsoracle"

--- a/benchmarks/stress/src/supervisor.rs
+++ b/benchmarks/stress/src/supervisor.rs
@@ -339,26 +339,27 @@ impl Supervisor {
         //     fence freshness is the authoritative cross-leadership check over
         //     a tighter window; suppressing here avoids a duplicate report of
         //     the same boundary regression.
-        if !monotonicity_flagged && !chaos_covered {
-            if let Some(prior) = self.state.completed_high_water {
-                // `issued_at >= prior.recv_time` is the happens-before test.
-                // We also require `recv_time >= prior.recv_time`: it is normally
-                // implied (recv_time >= issued_at), but the latency path already
-                // guards against an apparent backward clock, so we keep both and
-                // stay quiet if the two stamps disagree under skew.
-                if sample.issued_at >= prior.recv_time
-                    && sample.recv_time >= prior.recv_time
-                    && sample.ts <= prior.ts
-                {
-                    self.state.violations.push(Violation {
-                        kind: ViolationKind::CrossClientRealtimeMonotonicity {
-                            prior_completed_ts: prior.ts,
-                            got: sample.ts,
-                            sample: sample.clone(),
-                        },
-                        at: Instant::now(),
-                    });
-                }
+        if !monotonicity_flagged
+            && !chaos_covered
+            && let Some(prior) = self.state.completed_high_water
+        {
+            // `issued_at >= prior.recv_time` is the happens-before test.
+            // We also require `recv_time >= prior.recv_time`: it is normally
+            // implied (recv_time >= issued_at), but the latency path already
+            // guards against an apparent backward clock, so we keep both and
+            // stay quiet if the two stamps disagree under skew.
+            if sample.issued_at >= prior.recv_time
+                && sample.recv_time >= prior.recv_time
+                && sample.ts <= prior.ts
+            {
+                self.state.violations.push(Violation {
+                    kind: ViolationKind::CrossClientRealtimeMonotonicity {
+                        prior_completed_ts: prior.ts,
+                        got: sample.ts,
+                        sample: sample.clone(),
+                    },
+                    at: Instant::now(),
+                });
             }
         }
         // Advance the completed high-water on every sample (gates above only

--- a/benchmarks/stress/src/topology/paxos.rs
+++ b/benchmarks/stress/src/topology/paxos.rs
@@ -611,11 +611,11 @@ mod tests {
         let deadline = StdInstant::now() + Duration::from_secs(30);
         let mut new_leader = None;
         while StdInstant::now() < deadline {
-            if let Some(candidate) = topology.controller.current_leader() {
-                if candidate != original_leader {
-                    new_leader = Some(candidate);
-                    break;
-                }
+            if let Some(candidate) = topology.controller.current_leader()
+                && candidate != original_leader
+            {
+                new_leader = Some(candidate);
+                break;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }

--- a/benchmarks/stress/src/topology/raft.rs
+++ b/benchmarks/stress/src/topology/raft.rs
@@ -511,11 +511,11 @@ mod tests {
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
         let mut new_leader = None;
         while std::time::Instant::now() < deadline {
-            if let Some(candidate) = topology.controller.current_leader() {
-                if candidate != original_leader {
-                    new_leader = Some(candidate);
-                    break;
-                }
+            if let Some(candidate) = topology.controller.current_leader()
+                && candidate != original_leader
+            {
+                new_leader = Some(candidate);
+                break;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }

--- a/crates/tsoracle-client/src/driver.rs
+++ b/crates/tsoracle-client/src/driver.rs
@@ -1092,10 +1092,11 @@ mod tests {
 
         fn counter(snapshot: &[RecordedMetric], name: &str) -> u64 {
             for (composite, _unit, _desc, value) in snapshot {
-                if composite.kind() == MetricKind::Counter && composite.key().name() == name {
-                    if let DebugValue::Counter(n) = value {
-                        return *n;
-                    }
+                if composite.kind() == MetricKind::Counter
+                    && composite.key().name() == name
+                    && let DebugValue::Counter(n) = value
+                {
+                    return *n;
                 }
             }
             0

--- a/crates/tsoracle-driver-file/src/dense_record.rs
+++ b/crates/tsoracle-driver-file/src/dense_record.rs
@@ -128,10 +128,10 @@ pub fn decode(bytes: &[u8]) -> Result<(BTreeMap<String, u64>, u64), DenseRecordE
         // and (b) rejects non-canonical orderings, making decode canonical so
         // that re-encoding a decoded record reproduces the exact input bytes
         // (the strict round-trip the fuzz target asserts).
-        if let Some(prev) = &prev_key {
-            if key <= *prev {
-                return Err(DenseRecordError::Malformed);
-            }
+        if let Some(prev) = &prev_key
+            && key <= *prev
+        {
+            return Err(DenseRecordError::Malformed);
         }
         prev_key = Some(key.clone());
         map.insert(key, counter);

--- a/crates/tsoracle-driver-file/src/driver.rs
+++ b/crates/tsoracle-driver-file/src/driver.rs
@@ -766,7 +766,7 @@ mod lease_tests {
             ttl_ms: 10_000,
             ts_upper_bound: lease_id * 100,
             expires_at_ms: lease_id * 100 + 10_000,
-            superseded: lease_id % 2 == 0,
+            superseded: lease_id.is_multiple_of(2),
         }
     }
 

--- a/crates/tsoracle-driver-openraft/src/log_codec.rs
+++ b/crates/tsoracle-driver-openraft/src/log_codec.rs
@@ -54,13 +54,12 @@ impl LogStoreCodec<TypeConfig> for OpenraftLogCodec {
         // to propose one before activation; this is the second line so a gate
         // regression fails the write here at the leader rather than committing a
         // poison entry a pre-v6 follower cannot decode.
-        if version < tsoracle_openraft_toolkit::BATCH_WRITE_VERSION {
-            if let openraft::EntryPayload::Normal(
+        if version < tsoracle_openraft_toolkit::BATCH_WRITE_VERSION
+            && let openraft::EntryPayload::Normal(
                 crate::log_entry::HighWaterCommand::AdvanceDenseBatch { .. },
             ) = &entry.payload
-            {
-                return Err(CodecError::NotRepresentable { version });
-            }
+        {
+            return Err(CodecError::NotRepresentable { version });
         }
         encode_postcard(entry)
     }

--- a/crates/tsoracle-driver-openraft/src/state_machine.rs
+++ b/crates/tsoracle-driver-openraft/src/state_machine.rs
@@ -431,10 +431,10 @@ impl HighWaterStateMachine {
             // `decode_framed` accepted the byte above, so it is within
             // `[MIN, MAX_READABLE_VERSION]` and never exceeds what this binary
             // can write.
-            if let Some(&snapshot_version) = bytes.first() {
-                if snapshot_version > active_write_version.get() {
-                    active_write_version.set(snapshot_version);
-                }
+            if let Some(&snapshot_version) = bytes.first()
+                && snapshot_version > active_write_version.get()
+            {
+                active_write_version.set(snapshot_version);
             }
         }
         let state_machine = Self {
@@ -905,11 +905,11 @@ impl RaftStateMachine<TypeConfig> for HighWaterStateMachine {
         // v4-encode `NotRepresentable` guard on its next `build_snapshot`. The
         // byte is already within `[MIN, MAX_READABLE_VERSION]` (decode_framed
         // accepted it above), so this never exceeds what this binary can write.
-        if let Some(&snapshot_version) = bytes.first() {
-            if snapshot_version > self.active_write_version.get() {
-                self.active_write_version.set(snapshot_version);
-                crate::observability::record_active_write_version(snapshot_version);
-            }
+        if let Some(&snapshot_version) = bytes.first()
+            && snapshot_version > self.active_write_version.get()
+        {
+            self.active_write_version.set(snapshot_version);
+            crate::observability::record_active_write_version(snapshot_version);
         }
 
         let persisted = PersistedSnapshot {

--- a/crates/tsoracle-driver-openraft/tests/dense_advance.rs
+++ b/crates/tsoracle-driver-openraft/tests/dense_advance.rs
@@ -122,10 +122,10 @@ async fn find_leader_idx(cluster: &TestCluster) -> usize {
     timeout(Duration::from_secs(10), async {
         loop {
             for (idx, node) in cluster.nodes.iter().enumerate() {
-                if let Some(l) = node.raft.current_leader().await {
-                    if l == node.id {
-                        return idx;
-                    }
+                if let Some(l) = node.raft.current_leader().await
+                    && l == node.id
+                {
+                    return idx;
                 }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/tsoracle-driver-openraft/tests/dense_snapshot.rs
+++ b/crates/tsoracle-driver-openraft/tests/dense_snapshot.rs
@@ -188,10 +188,10 @@ async fn dense_map_survives_snapshot_build_and_log_purge() {
         let mut inspector = log_inspector;
         loop {
             let state = inspector.get_log_state().await.unwrap();
-            if let Some(purged) = state.last_purged_log_id {
-                if purged.index >= snapshot_log_id.index {
-                    return purged;
-                }
+            if let Some(purged) = state.last_purged_log_id
+                && purged.index >= snapshot_log_id.index
+            {
+                return purged;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }

--- a/crates/tsoracle-driver-openraft/tests/format_metrics.rs
+++ b/crates/tsoracle-driver-openraft/tests/format_metrics.rs
@@ -82,10 +82,11 @@ fn install_recorder() -> Snapshotter {
 
 fn counter_value(snapshot: &[RecordedMetric], name: &str) -> u64 {
     for (composite, _unit, _desc, value) in snapshot {
-        if composite.kind() == MetricKind::Counter && composite.key().name() == name {
-            if let DebugValue::Counter(n) = value {
-                return *n;
-            }
+        if composite.kind() == MetricKind::Counter
+            && composite.key().name() == name
+            && let DebugValue::Counter(n) = value
+        {
+            return *n;
         }
     }
     0
@@ -93,10 +94,11 @@ fn counter_value(snapshot: &[RecordedMetric], name: &str) -> u64 {
 
 fn gauge_value(snapshot: &[RecordedMetric], name: &str) -> Option<f64> {
     for (composite, _unit, _desc, value) in snapshot {
-        if composite.kind() == MetricKind::Gauge && composite.key().name() == name {
-            if let DebugValue::Gauge(g) = value {
-                return Some(g.into_inner());
-            }
+        if composite.kind() == MetricKind::Gauge
+            && composite.key().name() == name
+            && let DebugValue::Gauge(g) = value
+        {
+            return Some(g.into_inner());
         }
     }
     None

--- a/crates/tsoracle-driver-openraft/tests/partition_churn.rs
+++ b/crates/tsoracle-driver-openraft/tests/partition_churn.rs
@@ -42,10 +42,10 @@ async fn find_leader_idx(cluster: &TestCluster) -> usize {
     timeout(Duration::from_secs(10), async {
         loop {
             for (idx, node) in cluster.nodes.iter().enumerate() {
-                if let Some(l) = node.raft.current_leader().await {
-                    if l == node.id {
-                        return idx;
-                    }
+                if let Some(l) = node.raft.current_leader().await
+                    && l == node.id
+                {
+                    return idx;
                 }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
@@ -62,10 +62,10 @@ async fn find_leader_excluding(cluster: &TestCluster, exclude_idx: usize) -> usi
                 if idx == exclude_idx {
                     continue;
                 }
-                if let Some(l) = node.raft.current_leader().await {
-                    if l == node.id {
-                        return idx;
-                    }
+                if let Some(l) = node.raft.current_leader().await
+                    && l == node.id
+                {
+                    return idx;
                 }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/tsoracle-driver-openraft/tests/snapshot_restart.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_restart.rs
@@ -130,10 +130,10 @@ async fn snapshot_persists_across_restart_when_log_is_purged() {
         let mut inspector = log_inspector;
         loop {
             let state = inspector.get_log_state().await.unwrap();
-            if let Some(purged) = state.last_purged_log_id {
-                if purged.index >= snapshot_log_id.index {
-                    return purged;
-                }
+            if let Some(purged) = state.last_purged_log_id
+                && purged.index >= snapshot_log_id.index
+            {
+                return purged;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }

--- a/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
+++ b/crates/tsoracle-driver-openraft/tests/snapshot_transfer.rs
@@ -99,10 +99,10 @@ async fn find_leader_idx(nodes: &[SnapshotNode]) -> usize {
     timeout(Duration::from_secs(10), async {
         loop {
             for (idx, node) in nodes.iter().enumerate() {
-                if let Some(leader) = node.raft.current_leader().await {
-                    if leader == node.id {
-                        return idx;
-                    }
+                if let Some(leader) = node.raft.current_leader().await
+                    && leader == node.id
+                {
+                    return idx;
                 }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
@@ -215,10 +215,10 @@ async fn isolated_follower_catches_up_via_snapshot_transfer() {
     let leader_snapshot_log_id = timeout(Duration::from_secs(10), async move {
         loop {
             let metrics = leader_raft.metrics().borrow_watched().clone();
-            if let Some(snapshot_log_id) = metrics.snapshot {
-                if snapshot_log_id.index >= 5 {
-                    return snapshot_log_id;
-                }
+            if let Some(snapshot_log_id) = metrics.snapshot
+                && snapshot_log_id.index >= 5
+            {
+                return snapshot_log_id;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }

--- a/crates/tsoracle-driver-openraft/tests/three_node.rs
+++ b/crates/tsoracle-driver-openraft/tests/three_node.rs
@@ -44,10 +44,10 @@ async fn find_leader_idx(cluster: &TestCluster) -> usize {
     timeout(Duration::from_secs(10), async {
         loop {
             for (idx, node) in cluster.nodes.iter().enumerate() {
-                if let Some(l) = node.raft.current_leader().await {
-                    if l == node.id {
-                        return idx;
-                    }
+                if let Some(l) = node.raft.current_leader().await
+                    && l == node.id
+                {
+                    return idx;
                 }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/tsoracle-driver-paxos/src/driver.rs
+++ b/crates/tsoracle-driver-paxos/src/driver.rs
@@ -641,10 +641,11 @@ mod tests {
 
         fn counter(snapshot: &[RecordedMetric], name: &str) -> u64 {
             for (composite, _u, _d, value) in snapshot {
-                if composite.kind() == MetricKind::Counter && composite.key().name() == name {
-                    if let DebugValue::Counter(n) = value {
-                        return *n;
-                    }
+                if composite.kind() == MetricKind::Counter
+                    && composite.key().name() == name
+                    && let DebugValue::Counter(n) = value
+                {
+                    return *n;
                 }
             }
             0

--- a/crates/tsoracle-driver-paxos/src/state_machine.rs
+++ b/crates/tsoracle-driver-paxos/src/state_machine.rs
@@ -809,10 +809,11 @@ mod drain_tests {
 
         fn counter(snapshot: &[RecordedMetric], name: &str) -> u64 {
             for (composite, _u, _d, value) in snapshot {
-                if composite.kind() == MetricKind::Counter && composite.key().name() == name {
-                    if let DebugValue::Counter(n) = value {
-                        return *n;
-                    }
+                if composite.kind() == MetricKind::Counter
+                    && composite.key().name() == name
+                    && let DebugValue::Counter(n) = value
+                {
+                    return *n;
                 }
             }
             0
@@ -820,10 +821,11 @@ mod drain_tests {
 
         fn gauge(snapshot: &[RecordedMetric], name: &str) -> Option<f64> {
             for (composite, _u, _d, value) in snapshot {
-                if composite.kind() == MetricKind::Gauge && composite.key().name() == name {
-                    if let DebugValue::Gauge(g) = value {
-                        return Some(g.into_inner());
-                    }
+                if composite.kind() == MetricKind::Gauge
+                    && composite.key().name() == name
+                    && let DebugValue::Gauge(g) = value
+                {
+                    return Some(g.into_inner());
                 }
             }
             None

--- a/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
+++ b/crates/tsoracle-driver-paxos/tests/submit_advance_attribution.rs
@@ -98,10 +98,10 @@ async fn submit_advance_commits_an_attributable_barrier_for_this_call() {
             LogEntry::Decided(HighWaterCommand::Advance(AdvancePayload { at_least: 42 })) => {
                 saw_this_calls_advance = true;
             }
-            LogEntry::Decided(HighWaterCommand::Barrier { node, .. }) if *node == leader_id => {
-                if saw_this_calls_advance {
-                    barrier_from_this_node_after_advance = true;
-                }
+            LogEntry::Decided(HighWaterCommand::Barrier { node, .. })
+                if *node == leader_id && saw_this_calls_advance =>
+            {
+                barrier_from_this_node_after_advance = true;
             }
             _ => {}
         }

--- a/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
+++ b/crates/tsoracle-openraft-toolkit/tests/mem_network_smoke.rs
@@ -241,10 +241,10 @@ async fn three_node_mem_network_elects_and_replicates() {
     let leader_id = timeout(Duration::from_secs(10), async {
         loop {
             for (id, raft, _, _) in nodes.iter() {
-                if let Some(l) = raft.current_leader().await {
-                    if l == *id {
-                        return *id;
-                    }
+                if let Some(l) = raft.current_leader().await
+                    && l == *id
+                {
+                    return *id;
                 }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
+++ b/crates/tsoracle-paxos-toolkit/src/lifecycle/mod.rs
@@ -336,10 +336,10 @@ where
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
         }
-        if let Some(handle) = self.handle.take() {
-            if let Err(err) = handle.await {
-                error!(error = ?err, "paxos runner task terminated abnormally");
-            }
+        if let Some(handle) = self.handle.take()
+            && let Err(err) = handle.await
+        {
+            error!(error = ?err, "paxos runner task terminated abnormally");
         }
         // The tick task drops `outbound_tx` as it exits, closing the queue so
         // the sender task finishes once it has drained — unless it is wedged

--- a/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
+++ b/crates/tsoracle-paxos-toolkit/tests/failpoints.rs
@@ -135,10 +135,8 @@ fn counter_with_op(
             .key()
             .labels()
             .any(|label| label.key() == "op" && label.value() == expected_op);
-        if has_op {
-            if let DebugValue::Counter(n) = value {
-                return *n;
-            }
+        if has_op && let DebugValue::Counter(n) = value {
+            return *n;
         }
     }
     0

--- a/crates/tsoracle-server/src/fence.rs
+++ b/crates/tsoracle-server/src/fence.rs
@@ -73,8 +73,7 @@ const FENCE_TRANSIENT_RETRY_WARN_INTERVAL: u32 = 20;
 fn warn_on_stuck_fence(transient_retries: u32) -> bool {
     transient_retries >= FENCE_TRANSIENT_RETRY_WARN_AFTER
         && (transient_retries - FENCE_TRANSIENT_RETRY_WARN_AFTER)
-            % FENCE_TRANSIENT_RETRY_WARN_INTERVAL
-            == 0
+            .is_multiple_of(FENCE_TRANSIENT_RETRY_WARN_INTERVAL)
 }
 
 /// Debug-only guard that a driver-surfaced [`LeaderState`] honors the

--- a/crates/tsoracle-server/tests/metrics.rs
+++ b/crates/tsoracle-server/tests/metrics.rs
@@ -61,10 +61,11 @@ fn install_recorder() -> Snapshotter {
 
 fn counter_value(snapshot: &[RecordedMetric], name: &str) -> u64 {
     for (composite, _unit, _desc, value) in snapshot {
-        if composite.kind() == MetricKind::Counter && composite.key().name() == name {
-            if let DebugValue::Counter(n) = value {
-                return *n;
-            }
+        if composite.kind() == MetricKind::Counter
+            && composite.key().name() == name
+            && let DebugValue::Counter(n) = value
+        {
+            return *n;
         }
     }
     0
@@ -72,10 +73,11 @@ fn counter_value(snapshot: &[RecordedMetric], name: &str) -> u64 {
 
 fn histogram_sample_count(snapshot: &[RecordedMetric], name: &str) -> usize {
     for (composite, _unit, _desc, value) in snapshot {
-        if composite.kind() == MetricKind::Histogram && composite.key().name() == name {
-            if let DebugValue::Histogram(samples) = value {
-                return samples.len();
-            }
+        if composite.kind() == MetricKind::Histogram
+            && composite.key().name() == name
+            && let DebugValue::Histogram(samples) = value
+        {
+            return samples.len();
         }
     }
     0

--- a/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/mod.rs
@@ -309,24 +309,24 @@ async fn build_openraft_inner(
         });
 
     // Bootstrap once (after the peer server is listening).
-    if cfg.bootstrap {
-        if let Some(members) = cfg.initial_membership {
-            let nodes: BTreeMap<u64, OpenraftPeer> = members
-                .into_iter()
-                .map(|(id, m)| {
-                    (
-                        id,
-                        OpenraftPeer {
-                            addr: m.raft_addr,
-                            service_endpoint: m.service_endpoint,
-                            admin_endpoint: m.admin_endpoint,
-                        },
-                    )
-                })
-                .collect();
-            if let Err(e) = raft.initialize(nodes).await {
-                tracing::warn!(error = ?e, "initialize() returned an error (expected if already initialized)");
-            }
+    if cfg.bootstrap
+        && let Some(members) = cfg.initial_membership
+    {
+        let nodes: BTreeMap<u64, OpenraftPeer> = members
+            .into_iter()
+            .map(|(id, m)| {
+                (
+                    id,
+                    OpenraftPeer {
+                        addr: m.raft_addr,
+                        service_endpoint: m.service_endpoint,
+                        admin_endpoint: m.admin_endpoint,
+                    },
+                )
+            })
+            .collect();
+        if let Err(e) = raft.initialize(nodes).await {
+            tracing::warn!(error = ?e, "initialize() returned an error (expected if already initialized)");
         }
     }
 

--- a/crates/tsoracle-standalone/src/drivers/openraft/network.rs
+++ b/crates/tsoracle-standalone/src/drivers/openraft/network.rs
@@ -503,8 +503,7 @@ impl RaftNetworkV2<TypeConfig> for PeerNetwork {
             })
             .collect::<Vec<_>>();
 
-        let outbound =
-            futures::stream::iter(std::iter::once(header_chunk).chain(data_chunks.into_iter()));
+        let outbound = futures::stream::iter(std::iter::once(header_chunk).chain(data_chunks));
 
         let mut c = self.client().await.map_err(|e| match e {
             RPCError::Network(n) => StreamingError::Network(n),

--- a/crates/tsoracle-standalone/src/transport.rs
+++ b/crates/tsoracle-standalone/src/transport.rs
@@ -168,10 +168,10 @@ impl TransportHandle {
             // Receiver dropped (task already gone) is fine.
             let _ = cancel.send(());
         }
-        if let Some(join) = self.join.take() {
-            if let Err(err) = join.await {
-                tracing::warn!(error = ?err, "peer transport task join error");
-            }
+        if let Some(join) = self.join.take()
+            && let Err(err) = join.await
+        {
+            tracing::warn!(error = ?err, "peer transport task join error");
         }
     }
 }

--- a/crates/tsoracle-tests/tests/client_metrics.rs
+++ b/crates/tsoracle-tests/tests/client_metrics.rs
@@ -77,10 +77,11 @@ fn install_recorder() -> Snapshotter {
 fn counter_value(snapshot: &[RecordedMetric], name: &str) -> u64 {
     let mut total = 0u64;
     for (composite, _unit, _desc, value) in snapshot {
-        if composite.kind() == MetricKind::Counter && composite.key().name() == name {
-            if let DebugValue::Counter(n) = value {
-                total = total.saturating_add(*n);
-            }
+        if composite.kind() == MetricKind::Counter
+            && composite.key().name() == name
+            && let DebugValue::Counter(n) = value
+        {
+            total = total.saturating_add(*n);
         }
     }
     total
@@ -100,10 +101,8 @@ fn counter_value_with_label(
             .key()
             .labels()
             .any(|l| l.key() == label_key && l.value() == label_value);
-        if matches_label {
-            if let DebugValue::Counter(n) = value {
-                return *n;
-            }
+        if matches_label && let DebugValue::Counter(n) = value {
+            return *n;
         }
     }
     0
@@ -112,10 +111,11 @@ fn counter_value_with_label(
 fn histogram_sample_count(snapshot: &[RecordedMetric], name: &str) -> usize {
     let mut total = 0usize;
     for (composite, _unit, _desc, value) in snapshot {
-        if composite.kind() == MetricKind::Histogram && composite.key().name() == name {
-            if let DebugValue::Histogram(samples) = value {
-                total = total.saturating_add(samples.len());
-            }
+        if composite.kind() == MetricKind::Histogram
+            && composite.key().name() == name
+            && let DebugValue::Histogram(samples) = value
+        {
+            total = total.saturating_add(samples.len());
         }
     }
     total

--- a/e2e/kube/driver/src/seq_tracker.rs
+++ b/e2e/kube/driver/src/seq_tracker.rs
@@ -49,10 +49,10 @@ impl SeqTracker {
     pub fn record_block(&mut self, key: &str, start: u64, count: u32) {
         self.calls += 1;
         self.serving = true;
-        if let Some(&expected) = self.expected_next.get(key) {
-            if start != expected {
-                self.gap_violations += 1;
-            }
+        if let Some(&expected) = self.expected_next.get(key)
+            && start != expected
+        {
+            self.gap_violations += 1;
         }
         self.expected_next
             .insert(key.to_string(), start + u64::from(count));

--- a/e2e/kube/driver/src/tracker.rs
+++ b/e2e/kube/driver/src/tracker.rs
@@ -46,10 +46,10 @@ impl<T: Ord + Copy> Tracker<T> {
 
     pub fn record_ok(&mut self, ts: T) {
         self.calls += 1;
-        if let Some(prev) = self.last {
-            if ts <= prev {
-                self.violations += 1;
-            }
+        if let Some(prev) = self.last
+            && ts <= prev
+        {
+            self.violations += 1;
         }
         self.last = Some(ts);
     }

--- a/examples/openraft-piggyback/src/demo.rs
+++ b/examples/openraft-piggyback/src/demo.rs
@@ -183,10 +183,10 @@ async fn wait_for_leader(nodes: &[Node]) -> anyhow::Result<usize> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         for (idx, node) in nodes.iter().enumerate() {
-            if let Some(leader_id) = node.raft.current_leader().await {
-                if leader_id == node.id {
-                    return Ok(idx);
-                }
+            if let Some(leader_id) = node.raft.current_leader().await
+                && leader_id == node.id
+            {
+                return Ok(idx);
             }
         }
         if Instant::now() >= deadline {
@@ -229,10 +229,10 @@ async fn build_client(nodes: &[Node]) -> anyhow::Result<TsoClient> {
 /// the demo runs single-threaded against committed in-process state.
 async fn high_water_of_leader(nodes: &[Node]) -> u64 {
     for node in nodes {
-        if let Some(leader_id) = node.raft.current_leader().await {
-            if leader_id == node.id {
-                return node.sm.high_water().await;
-            }
+        if let Some(leader_id) = node.raft.current_leader().await
+            && leader_id == node.id
+        {
+            return node.sm.high_water().await;
         }
     }
     0
@@ -351,11 +351,11 @@ pub async fn run_demo() -> anyhow::Result<DemoOutcome> {
     let new_leader_id = loop {
         let mut found_id: Option<u64> = None;
         for survivor in &survivors {
-            if let Some(leader_id) = survivor.raft.current_leader().await {
-                if leader_id == survivor.id {
-                    found_id = Some(survivor.id);
-                    break;
-                }
+            if let Some(leader_id) = survivor.raft.current_leader().await
+                && leader_id == survivor.id
+            {
+                found_id = Some(survivor.id);
+                break;
             }
         }
         if let Some(leader_id) = found_id {

--- a/examples/openraft-standalone/README.md
+++ b/examples/openraft-standalone/README.md
@@ -10,7 +10,7 @@ If your service already runs openraft for other state and you want TSO to share 
 
 ## Prerequisites
 
-- Rust 1.88+ (workspace toolchain).
+- Rust 1.96+ (workspace toolchain).
 - `protoc` installed (`brew install protobuf` on macOS).
 - For `GetTs` smoke tests: `grpcurl` (optional but convenient).
 

--- a/examples/paxos-piggyback/src/demo.rs
+++ b/examples/paxos-piggyback/src/demo.rs
@@ -279,10 +279,10 @@ async fn wait_for_leader(nodes: &[Node]) -> anyhow::Result<usize> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         for (idx, node) in nodes.iter().enumerate() {
-            if let Some(leader_id) = node.omnipaxos.lock().get_current_leader() {
-                if leader_id == node.id {
-                    return Ok(idx);
-                }
+            if let Some(leader_id) = node.omnipaxos.lock().get_current_leader()
+                && leader_id == node.id
+            {
+                return Ok(idx);
             }
         }
         if Instant::now() >= deadline {
@@ -467,11 +467,11 @@ pub async fn run_demo() -> anyhow::Result<DemoOutcome> {
             if idx == leader_idx {
                 continue;
             }
-            if let Some(leader_id) = node.omnipaxos.lock().get_current_leader() {
-                if leader_id == node.id {
-                    new_leader_idx = Some(idx);
-                    break;
-                }
+            if let Some(leader_id) = node.omnipaxos.lock().get_current_leader()
+                && leader_id == node.id
+            {
+                new_leader_idx = Some(idx);
+                break;
             }
         }
         if new_leader_idx.is_some() {

--- a/examples/paxos-standalone/README.md
+++ b/examples/paxos-standalone/README.md
@@ -10,7 +10,7 @@ If your service already runs OmniPaxos for other state and you want TSO to share
 
 ## Prerequisites
 
-- Rust 1.88+ (workspace toolchain).
+- Rust 1.96+ (workspace toolchain).
 - `protoc` installed (`brew install protobuf` on macOS).
 - For `GetTs` smoke tests: `grpcurl` (optional but convenient).
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "1.88"
+channel    = "1.96.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Aligns the repo with the fleet-wide Rust toolchain standard: `rust-toolchain.toml` now pins channel `1.96.1` (was `1.88`) and `[workspace.package]` declares `rust-version = "1.96"` (was `1.88`). All 29 workspace members already inherit the MSRV via `rust-version.workspace = true`, so no member manifest needed changes; the raised floor is carried in the published crates' metadata and therefore to their consumers. The `fuzz/` project (own nightly toolchain) and `scripts/og-image` are excluded from the workspace and untouched.

Fallout from moving clippy from 1.88 to 1.96, fixed mechanically with no behavior change: `collapsible_if` now fires on nested `if`/`if let` that can merge into edition-2024 let chains (collapsed across ~30 callsites in crates, tests, examples, benchmarks, and the kube e2e driver), `manual_is_multiple_of` replaces two `% n == 0` checks with `.is_multiple_of(n)`, and one redundant `.into_iter()` in a `chain()` call was dropped. Two example READMEs that named "Rust 1.88+" now say "Rust 1.96+".

CI implications: the CI jobs install `stable` via `dtolnay/rust-toolchain`, but `rust-toolchain.toml` overrides it for every cargo invocation, so runners will auto-fetch 1.96.1 on the first post-merge run (a one-time cache miss for `Swatinem/rust-cache` keys). The `deny` job's `cargo-deny-action` pinned `rust-version: "1.88"` explicitly; it is bumped to `"1.96"` so that job's toolchain can read manifests declaring the new MSRV.

## Test plan

- [x] All commits in this PR carry a `Signed-off-by` trailer per the [DCO requirement](../CONTRIBUTING.md#developer-certificate-of-origin) (use `git commit -s`).
- [x] `cargo fmt --all -- --check` on 1.96.1
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` on 1.96.1
- [x] `cargo test --workspace --all-features --locked` on 1.96.1 (macOS)
- [x] `cargo deny check`
- [x] `CRITICAL_PATH_STRICT=1 ./scripts/check-critical-path.sh`
- [x] `python3 scripts/check-ts-header.py`
- [x] Left to CI: buf checks (no `.proto` changes), cross-platform `tsoracle-driver-file` on Linux/Windows, coverage, stress smoke, fuzz lockfile (fuzz untouched, own nightly toolchain).
