### PR TITLE
fix(deploy): stop liveness owning the boot window

### DIFF
--- a/deploy/charts/tsoracle/templates/deployment.yaml
+++ b/deploy/charts/tsoracle/templates/deployment.yaml
@@ -47,17 +47,24 @@ spec:
           ports:
             - name: tso
               containerPort: {{ .Values.ports.client }}
+          {{- /* Startup owns the boot window so liveness does not. Without it, liveness restarted the container at 40s, and a container killed mid-boot is retried with the same deadline rather than a larger one — a permanent crash loop for a node whose store replay or peer catch-up runs long. Startup shares the liveness target, which is what it should do; that all three probes are one tcpSocket check is the known gap recorded in values.yaml. */}}
+          startupProbe:
+            tcpSocket:
+              port: tso
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           readinessProbe:
             tcpSocket:
               port: tso
-            initialDelaySeconds: 2
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           livenessProbe:
             tcpSocket:
               port: tso
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/charts/tsoracle/templates/statefulset.yaml
+++ b/deploy/charts/tsoracle/templates/statefulset.yaml
@@ -77,17 +77,24 @@ spec:
               containerPort: {{ .Values.ports.client }}
             - name: admin
               containerPort: {{ .Values.ports.admin }}
+          {{- /* Startup owns the boot window so liveness does not. Without it, liveness restarted the container at 40s, and a container killed mid-boot is retried with the same deadline rather than a larger one — a permanent crash loop for a node whose store replay or peer catch-up runs long. Startup shares the liveness target, which is what it should do; that all three probes are one tcpSocket check is the known gap recorded in values.yaml. */}}
+          startupProbe:
+            tcpSocket:
+              port: tso
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           readinessProbe:
             tcpSocket:
               port: tso
-            initialDelaySeconds: 2
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           livenessProbe:
             tcpSocket:
               port: tso
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/charts/tsoracle/tests/policy-values.yaml
+++ b/deploy/charts/tsoracle/tests/policy-values.yaml
@@ -1,0 +1,5 @@
+# Minimal values that make this chart render on its own, so the shared probe
+# policy gate has something to inspect. It exists to render, not to describe
+# production: every value here is a placeholder chosen for being obviously fake.
+driver: file
+replicas: 1

--- a/deploy/charts/tsoracle/values.yaml
+++ b/deploy/charts/tsoracle/values.yaml
@@ -23,6 +23,23 @@ persistence:
   size: 1Gi
   storageClassName: ""
 resources: {}
+# Kubernetes probe surface, shared by both the file-driver Deployment and the HA StatefulSet.
+#
+# startup.periodSeconds * startup.failureThreshold is the cold-boot budget, and it exists so liveness does not own the boot window: a container killed mid-boot is retried with the same deadline, never a larger one, so a node whose store replay or peer catch-up runs long would crash-loop rather than start slowly. liveness.initialDelaySeconds covers the same budget independently, because kubernetes/kubernetes#105308 means the startup gate does not reliably suppress liveness.
+#
+# KNOWN GAP: all three probes are the same tcpSocket check, because tsoracle exposes no health surface. Readiness therefore reports only that the port accepts connections — it cannot distinguish a node that can mint timestamps from one that is up but has lost quorum, so an HA replica that cannot serve stays in the client Service. Closing this needs a real readiness signal (a gRPC health service with distinct liveness and readiness services, as cg-notify and cg-compute expose), and what "ready" means for the oracle is a design decision rather than a chart one. Until then the fleet probe policy reports probes-must-differ against this chart, correctly.
+probes:
+  startup:
+    periodSeconds: 5
+    failureThreshold: 24      # 120s cold-boot budget, covering store replay and peer catch-up
+  readiness:
+    initialDelaySeconds: 2
+    periodSeconds: 5
+    failureThreshold: 3
+  liveness:
+    initialDelaySeconds: 120  # >= startup.periodSeconds * startup.failureThreshold
+    periodSeconds: 10
+    failureThreshold: 3
 terminationGracePeriodSeconds: 30
 # The image runs as non-root uid 10001; fsGroup makes a freshly-provisioned PVC
 # group-writable so RocksDB/file-driver state can be created (required on most


### PR DESCRIPTION
## Summary

Part of a fleet-wide probe audit; [rust-workflows#74](https://github.com/prisma-risk/rust-workflows/pull/74) adds the shared gate. This is the one chart of eleven that **cannot fully conform** without a code change, and this PR is deliberate about which half it fixes.

### Fixed

Neither workload had a `startupProbe`, so liveness owned the boot window: `initialDelaySeconds: 10`, `periodSeconds: 10`, `failureThreshold: 3` — killed at **t≈40s**. CrashLoopBackOff doesn't rescue that, because each attempt gets the same 40s. On an HA driver, every replica is in that window simultaneously, so a cold cluster start has no quorum to converge toward.

- **`startupProbe` with a 120s budget** on both the file-driver Deployment and the HA StatefulSet, sized for store replay and peer catch-up.
- **`liveness.initialDelaySeconds` 10 → 120**, covering it independently ([kubernetes/kubernetes#105308](https://github.com/kubernetes/kubernetes/issues/105308)).
- **Probe timings templatized** into a `probes` block shared by both workloads.

`terminationGracePeriodSeconds` is already explicit at 30 and untouched.

### Not fixed, and recorded in the chart

All three probes are the **same `tcpSocket` check**, because tsoracle exposes no health surface at all — no HTTP health routes, no `tonic_health` service. Readiness therefore reports only that the port accepts connections. It cannot distinguish a node that can mint timestamps from one that is up but has **lost quorum**, so an HA replica that cannot serve stays in the client Service.

The shared policy correctly reports `probes-must-differ` against this chart, and I've left it reporting rather than papering over it — deleting the redundant readiness probe would clear the check without changing anything real.

Closing it means adding a gRPC health service with distinct `liveness` and `readiness` services, the way cg-notify and cg-compute already do. What "ready" means for the fleet's timestamp oracle — leader only? a follower that can forward? a fresh lease frontier? — is a design decision for this repo's owners, not something a probe-configuration sweep should decide. A `KNOWN GAP` note in `values.yaml` records the reasoning so the next reader doesn't have to redo it.

## Test plan

- [x] `sh deploy/charts/tsoracle/tests/render.sh` still passes across all driver profiles, including `helm lint`.
- [x] Both workloads render clean against the shared probe policy checker except the recorded `probes-must-differ`.
- [x] Verified across the `driver=file` and `driver=openraft` profiles, since the two workloads carry separate probe blocks.

## Post-merge follow-ups

- [ ] Add a gRPC health service with distinct liveness and readiness services, then point readiness at it and drop the `KNOWN GAP` note.
- [ ] This repo does not call the shared `chart-ci.yml` at all, so it gets no automatic probe-policy coverage. Wiring it up needs the `runner` input, since tsoracle builds on GitHub-hosted runners rather than the `prisma-risk-*` pool.
